### PR TITLE
Add a JSON output format

### DIFF
--- a/.github/workflows/coq-windows.yml
+++ b/.github/workflows/coq-windows.yml
@@ -43,7 +43,7 @@ jobs:
         @ECHO ON
         SET CYGROOT=C:\cygwin64
         SET CYGCACHE=%CYGROOT%\var\cache\setup
-        setup-x86_64.exe -qnNdO -R %CYGROOT% -l %CYGCACHE% -s %CYGMIRROR% -P rsync -P patch -P diffutils -P make -P unzip -P m4 -P findutils -P time -P wget -P curl -P git -P mingw64-x86_64-binutils,mingw64-x86_64-gcc-core,mingw64-x86_64-gcc-g++,mingw64-x86_64-pkg-config,mingw64-x86_64-windows_default_manifest -P mingw64-x86_64-headers,mingw64-x86_64-runtime,mingw64-x86_64-pthreads,mingw64-x86_64-zlib -P python3 -P python2 -P python
+        setup-x86_64.exe -qnNdO -R %CYGROOT% -l %CYGCACHE% -s %CYGMIRROR% -P rsync -P patch -P diffutils -P make -P unzip -P m4 -P findutils -P time -P wget -P curl -P git -P jq -P mingw64-x86_64-binutils,mingw64-x86_64-gcc-core,mingw64-x86_64-gcc-g++,mingw64-x86_64-pkg-config,mingw64-x86_64-windows_default_manifest -P mingw64-x86_64-headers,mingw64-x86_64-runtime,mingw64-x86_64-pthreads,mingw64-x86_64-zlib -P python3 -P python2 -P python
         SET TARGET_ARCH=x86_64-w64-mingw32
         SET CD_MFMT=%cd:\=/%
         SET RESULT_INSTALLDIR_CFMT=%CD_MFMT:C:/=/cygdrive/c/%

--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -1,0 +1,19 @@
+name: Test Generated JSON
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  test-go:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: submodules-init
+      uses: snickerbockers/submodules-init@v4
+    - name: make only-test-json-files
+      run: make only-test-json-files EXTERNAL_DEPENDENCIES=1

--- a/_CoqProject
+++ b/_CoqProject
@@ -179,6 +179,7 @@ src/Spec/Test/X25519.v
 src/Stringification/C.v
 src/Stringification/Go.v
 src/Stringification/IR.v
+src/Stringification/JSON.v
 src/Stringification/Java.v
 src/Stringification/Language.v
 src/Stringification/Rust.v

--- a/fiat-json/src/README.md
+++ b/fiat-json/src/README.md
@@ -1,0 +1,280 @@
+This folder contains JSON representations of the files.  The format is
+a bit ad-hoc; here is a partial description:
+
+The types of the fields:
+
+Let `string` be the standard string type, let `[t]` stand for an array
+whose elements have type `t`, and let `t | u` denote the union of
+types `t` and `u`.  String literals will be used as singleton types
+containing only themselves, and we will use braces (`{` and `}`) for
+standard JSON objects/dictionaries.
+
+Let us define the following types:
+
+- `datatype`, which is either the literal `"(auto)"`, a string
+  matching the regex `/(u|i)\d+/`, standing for an unsigned (u) or
+  signed (i) integer of a given number of bits, or a string matching
+  the regex `/(u|i)\d+\[\d+\]/`, standing for an array of the given
+  length of the given integer type
+
+- `varname`, either the literal `"_"` (for unused variables) or a
+  string matching `/x\d+/`
+
+- `name`, which is either `varname`, a string matching
+  `/(arg|out)\d+\[\d+\]/` for input/output arrays, the literal `&`
+  followed by a `varname` (for references), or the literal `*`
+  followed by a `varname` for dereferences.  These last two are very
+  rare, and we make an effort to avoid them in code generation.
+
+- `operation`, a string which is one of `=`, `dereference`, `>>`,
+  `<<`, `&` (infix bitwise and), `|` (infix bitwise or), `~` (bitwise
+  negation), `!` (boolean negation), `+`, `*`, `-`, `mulx`,
+  `addcarryx`, `subborrowx`, `cmovznz`, or `static_cast`
+
+- `number`, a string which is either a decimal numeral or a
+  hexadecimal numeral
+
+Let us define one more type.  The recursive type of expressions
+(corresponding to lines of code or expressions) `expr` has the format:
+
+```json
+{
+"datatype" : datatype,
+"name"     : [name],
+"operation": operation,
+"arguments": [ name | expr | number ]
+}
+```
+
+It describes a line of code or an expression:
+
+- whose output type is specified by `"datatype"` (`"(auto)"` means
+  that the type should be inferred automatically, and is generally
+  used only in assignment statements),
+
+- whose output(s) are stored in the variables in `"name"` (an empty
+  list means that the value is used immediately in the enclosing
+  expression),
+
+- whose kind of function / operation is given by the `"operation"`
+  field, and
+
+- whose arguments are the in the arguments field, which may be either
+  subexpressions or variable names
+
+The format of top-level functions is:
+
+```json
+{
+"operation": string,
+"arguments": [{"datatype": datatype, "name": varname}],
+"returns": [{"datatype": datatype, "name": varname}],
+"body": [expr]
+}
+```
+
+Note that here `"operation"` is just the name of the function, and may
+be something like `fiat_25519_carry_mul`.
+
+Note that errors in the pretty-printing process may be encoded with
+`#error ...`; these can be detected by running the code through a JSON
+validator, as the resulting code will not be valid JSON.
+
+
+-----------------------
+
+
+Here a few examples:
+
+`uint64_t x1 = (arg1[1]);` corresponds to a JSON-Object such as:
+```json
+{
+"datatype": "u64",
+"name": ["x1"],
+"operation": "=",
+"arguments": ["arg1[1]"]
+}
+```
+
+
+```c
+fiat_p256_mulx_u64(&x5, &x6, x4, (arg1[3]));
+```
+would correspond to:
+```json
+{
+"datatype": "u64",
+"name": ["x5", "x6"],
+"operation": "mulx",
+"arguments": ["x4", "arg1[3]"]
+}
+```
+from the combination "mulx" and "u64" we can infer, which elements from
+the name-property is high/low limb.
+
+```c
+fiat_p256_subborrowx_u64(&x180, &x181, x179, x171, UINT64_C(0xffffffff00000001));
+```
+would correspond to
+```json
+{
+"datatype": "u64",
+"name": ["x180", "x181"],
+"operation": "subborrowx",
+"arguments": ["x179", "x171", "0xffffffff00000001"]
+}
+```
+also, we can infer from subborrowx which arguments have which meaning
+and which varibable in "name" contains the carry out.
+
+```c
+uint64_t x173 = ((uint64_t)x172 + x153);
+```
+```json
+{
+"datatype": "u64",
+"name": ["x173"],
+"operation": "+",
+"arguments": ["x172", "x153"]
+}
+```
+
+```c
+fiat_p256_cmovznz_u64(&x184, x183, x174, x165);
+```
+```json
+{
+"datatype": "u64",
+"name": ["x184"],
+"operation": "cmovznz",
+"arguments": ["x183", "x174", "x165"]
+}
+```
+`cmovznz` means semantically `names[0] = arguments[0] == 0 ? arguments[1] :
+arguments[2]`, or replaced: `x184 <- x183 == 0 ? x174 : x165`;
+
+
+```c
+fiat_25519_uint128 x14 = ((fiat_25519_uint128)(arg1[2]) * (arg1[1]));
+```
+{
+"datatype": "u128",
+"name": ["x14"],
+"operation": "*",
+"arguments": ["arg1[2]", "arg1[1]"]
+}
+```
+
+```c
+uint64_t x45 = (x44 >> 51);
+```
+```json
+{
+"datatype": "u64",
+"name": ["x45"],
+"operation": ">>",
+"arguments": ["x44", "51"]
+}
+```
+Note that, at least currently, `arguments[1]` will always be an immediate
+value
+
+```c
+fiat_25519_uint1 x48 = (fiat_25519_uint1)(x47 >> 51);
+```
+```json
+{
+"datatype": "u1",
+"name": ["x48"],
+"operation": ">>",
+"arguments": ["x47", "51"]
+}
+```
+
+```c
+uint64_t x105 = (x92 + (x83 + (x75 + (x68 + (x62 + (x57 + (x53 + (x50 + (x48 + x1)))))))));
+```
+```json
+{
+ "datatype": "u64",
+ "name": ["x105"],
+ "operation": "+",
+ "arguments": [
+  "x92"
+  ,
+  {
+   "datatype": "u64",
+   "name": [],
+   "operation": "+",
+   "arguments": [
+    "x83"
+    ,
+    {
+     "datatype": "u64",
+     "name": [],
+     "operation": "+",
+     "arguments": [
+      "x75"
+      ,
+      {
+       "datatype": "u64",
+       "name": [],
+       "operation": "+",
+       "arguments": [
+        "x68"
+        ,
+        {
+         "datatype": "u64",
+         "name": [],
+         "operation": "+",
+         "arguments": [
+          "x62"
+          ,
+          {
+           "datatype": "u64",
+           "name": [],
+           "operation": "+",
+           "arguments": [
+            "x57"
+            ,
+            {
+             "datatype": "u64",
+             "name": [],
+             "operation": "+",
+             "arguments": [
+              "x53"
+              ,
+              {
+               "datatype": "u64",
+               "name": [],
+               "operation": "+",
+               "arguments": [
+                "x50"
+                ,
+                {
+                 "datatype": "u64",
+                 "name": [],
+                 "operation": "+",
+                 "arguments": [
+                  "x48"
+                  ,
+                  "x1"
+                 ]
+                }
+               ]
+              }
+             ]
+            }
+           ]
+          }
+         ]
+        }
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}
+```

--- a/fiat-json/src/curve25519_32.json
+++ b/fiat-json/src/curve25519_32.json
@@ -1,0 +1,13382 @@
+[
+  {
+    "operation": "fiat_25519_addcarryx_u26",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              },
+              "arg2"
+            ]
+          },
+          "arg3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x1",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_subborrowx_u26",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "i32",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "i32",
+            "name": [],
+            "operation": "-",
+            "arguments": [
+              {
+                "datatype": "i32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              },
+              {
+                "datatype": "i32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "i32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "i1",
+        "name": [
+          "x2"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "i1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_addcarryx_u25",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              },
+              "arg2"
+            ]
+          },
+          "arg3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x1",
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_subborrowx_u25",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "i32",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "i32",
+            "name": [],
+            "operation": "-",
+            "arguments": [
+              {
+                "datatype": "i32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              },
+              {
+                "datatype": "i32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "i32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "i1",
+        "name": [
+          "x2"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "i1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_cmovznz_u32",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u1",
+        "name": [
+          "x1"
+        ],
+        "operation": "!",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "!",
+            "arguments": [
+              "arg1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "-",
+                "arguments": [
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "0x0"
+                    ]
+                  },
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x1"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "|",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "arg3"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "~",
+                "arguments": [
+                  "x2"
+                ]
+              },
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_carry_mul",
+    "arguments": [
+      {
+        "datatype": "u32[10]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[10]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[10]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[9]",
+                  "0x26"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[8]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[7]",
+                  "0x26"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[6]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[5]",
+                  "0x26"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[4]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[3]",
+                  "0x26"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[2]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[1]",
+                  "0x26"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[9]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[8]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[7]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[6]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[5]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[4]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[3]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[2]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[9]",
+                  "0x26"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[8]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[7]",
+                  "0x26"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[6]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[5]",
+                  "0x26"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[4]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[3]",
+                  "0x26"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[9]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[8]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[7]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[6]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[5]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[4]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[9]",
+                  "0x26"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[8]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[7]",
+                  "0x26"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[6]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[5]",
+                  "0x26"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[9]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[8]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[7]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[6]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[9]",
+                  "0x26"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[8]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[7]",
+                  "0x26"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[9]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[8]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[9]",
+                  "0x26"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[1]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[3]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[1]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x63"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x65"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x67"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[5]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x69"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[3]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x71"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[1]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x73"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x75"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x76"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x77"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x80"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x82"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[7]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x85"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[5]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x86"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[3]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[1]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x91"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x93"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x94"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x95"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x97"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x99"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x101"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x100",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x45",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x44",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x42",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x39",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x35",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x30",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x24",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x17",
+                                          "x9"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x101",
+          "26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x103"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x101"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x104"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x91",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x82",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x74",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x67",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x61",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x56",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x52",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x49",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x47",
+                                          "x46"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x105"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x92",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x83",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x75",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x68",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x62",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x57",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x53",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x50",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x48",
+                                          "x1"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x106"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x93",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x84",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x76",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x69",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x63",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x58",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x54",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x51",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x10",
+                                          "x2"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x107"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x94",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x85",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x77",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x70",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x64",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x59",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x55",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x18",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x11",
+                                          "x3"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x108"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x95",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x86",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x78",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x71",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x65",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x60",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x25",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x19",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x12",
+                                          "x4"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x109"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x96",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x87",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x79",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x72",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x66",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x31",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x26",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x20",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x13",
+                                          "x5"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x110"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x97",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x88",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x80",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x73",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x36",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x32",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x27",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x21",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x14",
+                                          "x6"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x111"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x98",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x89",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x81",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x40",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x37",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x33",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x28",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x22",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x15",
+                                          "x7"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x112"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x99",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x90",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x43",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x41",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x38",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x34",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x29",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x23",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x16",
+                                          "x8"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x113"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x102",
+          "x112"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x114"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x113",
+          "25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x115"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x113"
+            ]
+          },
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x116"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x114",
+          "x111"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x117"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x116",
+          "26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x118"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x116"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x119"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x117",
+          "x110"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x120"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x119",
+          "25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x121"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x119"
+            ]
+          },
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x122"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x120",
+          "x109"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x123"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x122",
+          "26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x124"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x122"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x125"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x123",
+          "x108"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x126"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x125",
+          "25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x127"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x125"
+            ]
+          },
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x128"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x126",
+          "x107"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x129"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x128",
+          "26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x130"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x128"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x131"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x129",
+          "x106"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x132"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x131",
+          "25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x133"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x131"
+            ]
+          },
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x134"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x132",
+          "x105"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x135"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x134",
+          "26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x136"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x134"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x137"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x135",
+          "x104"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x138"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x137",
+          "25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x139"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x137"
+            ]
+          },
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x140"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x138",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x141"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x103"
+            ]
+          },
+          "x140"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x142"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x141",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x143"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x141"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x144"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x142",
+          "x115"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x145"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x144",
+              "25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x146"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x144",
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x147"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x145"
+            ]
+          },
+          "x118"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x143"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x146"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x147"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x121"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x124"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x127"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x130"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x133"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x136"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x139"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_carry_square",
+    "arguments": [
+      {
+        "datatype": "u32[10]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[10]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[9]",
+          "0x13"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x1",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[9]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[8]",
+          "0x13"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[8]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[7]",
+          "0x13"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x7",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[7]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[6]",
+          "0x13"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x10"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[6]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[5]",
+          "0x13"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[5]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[4]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[3]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[2]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[1]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x1",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "*",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x2"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x7",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x10"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "*",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x2"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "*",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x8"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          "x11"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x13",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          "x11"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "*",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x2"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "*",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x8"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x14",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x15"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg1[3]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x15"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "*",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x2"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x9",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x14",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x15"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x16",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x17"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x63"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg1[1]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x65"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x67"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x69"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x15"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x71"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x17"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x73"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x73",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x55",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x48",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x42",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x37",
+                          "x33"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x75"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x74",
+          "26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x76"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x74"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x77"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x64",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x56",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x49",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x43",
+                      "x38"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x65",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x57",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x50",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x44",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x39",
+                          "x19"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x66",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x58",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x51",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x45",
+                      "x20"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x80"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x67",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x59",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x52",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x46",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x22",
+                          "x21"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x68",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x60",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x53",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x25",
+                      "x23"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x82"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x69",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x61",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x54",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x29",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x26",
+                          "x24"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x70",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x62",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x34",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x30",
+                      "x27"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x71",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x63",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x40",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x35",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x31",
+                          "x28"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x85"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x72",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x47",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x41",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x36",
+                      "x32"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x86"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x75",
+          "x85"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x86",
+          "25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x88"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x86"
+            ]
+          },
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x87",
+          "x84"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x89",
+          "26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x91"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x89"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x90",
+          "x83"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x93"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x92",
+          "25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x94"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x92"
+            ]
+          },
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x95"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x93",
+          "x82"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x95",
+          "26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x97"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x95"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x96",
+          "x81"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x99"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x98",
+          "25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x100"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x98"
+            ]
+          },
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x101"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x99",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x101",
+          "26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x103"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x101"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x104"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x102",
+          "x79"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x105"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x104",
+          "25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x106"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x104"
+            ]
+          },
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x107"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x105",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x108"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x107",
+          "26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x109"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x107"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x110"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x108",
+          "x77"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x111"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x110",
+          "25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x112"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x110"
+            ]
+          },
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x113"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x111",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x114"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x76"
+            ]
+          },
+          "x113"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x115"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x114",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x116"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x114"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x117"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x115",
+          "x88"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x118"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x117",
+              "25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x119"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x117",
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x120"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x118"
+            ]
+          },
+          "x91"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x116"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x119"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x120"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x94"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x97"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x100"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x103"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x106"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x109"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x112"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_carry",
+    "arguments": [
+      {
+        "datatype": "u32[10]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[10]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "26"
+            ]
+          },
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x2",
+              "25"
+            ]
+          },
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x3",
+              "26"
+            ]
+          },
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x4",
+              "25"
+            ]
+          },
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x5",
+              "26"
+            ]
+          },
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x6",
+              "25"
+            ]
+          },
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x7",
+              "26"
+            ]
+          },
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x8",
+              "25"
+            ]
+          },
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x9",
+              "26"
+            ]
+          },
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x1",
+              "0x3ffffff"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "*",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": ">>",
+                "arguments": [
+                  "x10",
+                  "25"
+                ]
+              },
+              "0x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": ">>",
+                    "arguments": [
+                      "x11",
+                      "26"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "0x1ffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x11",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x12",
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": ">>",
+                    "arguments": [
+                      "x12",
+                      "25"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x3",
+              "0x3ffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x4",
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x5",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x6",
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x7",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x8",
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x9",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x10",
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x13"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x14"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x15"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x17"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x19"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x21"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x22"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_add",
+    "arguments": [
+      {
+        "datatype": "u32[10]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[10]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[10]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[4]",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[5]",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[6]",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[7]",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[8]",
+          "arg2[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[9]",
+          "arg2[9]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x10"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_sub",
+    "arguments": [
+      {
+        "datatype": "u32[10]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[10]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[10]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x7ffffda",
+              "arg1[0]"
+            ]
+          },
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x3fffffe",
+              "arg1[1]"
+            ]
+          },
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x7fffffe",
+              "arg1[2]"
+            ]
+          },
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x3fffffe",
+              "arg1[3]"
+            ]
+          },
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x7fffffe",
+              "arg1[4]"
+            ]
+          },
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x3fffffe",
+              "arg1[5]"
+            ]
+          },
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x7fffffe",
+              "arg1[6]"
+            ]
+          },
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x3fffffe",
+              "arg1[7]"
+            ]
+          },
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x7fffffe",
+              "arg1[8]"
+            ]
+          },
+          "arg2[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x3fffffe",
+              "arg1[9]"
+            ]
+          },
+          "arg2[9]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x10"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_opp",
+    "arguments": [
+      {
+        "datatype": "u32[10]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[10]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x7ffffda",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x3fffffe",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x7fffffe",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x3fffffe",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x7fffffe",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x3fffffe",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x7fffffe",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x3fffffe",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x7fffffe",
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x3fffffe",
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x10"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_selectznz",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[10]",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32[10]",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[10]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[0]",
+          "arg3[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[1]",
+          "arg3[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[2]",
+          "arg3[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[3]",
+          "arg3[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[4]",
+          "arg3[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[5]",
+          "arg3[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[6]",
+          "arg3[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[7]",
+          "arg3[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[8]",
+          "arg3[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[9]",
+          "arg3[9]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x10"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_to_bytes",
+    "arguments": [
+      {
+        "datatype": "u32[10]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u8[32]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u16",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "0x3ffffed"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x8",
+          "arg1[4]",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x10",
+          "arg1[5]",
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x12",
+          "arg1[6]",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x14",
+          "arg1[7]",
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x16",
+          "arg1[8]",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x18",
+          "arg1[9]",
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x20",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x21",
+              "0x3ffffed"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x3",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x21",
+              "0x1ffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x5",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x21",
+              "0x3ffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x7",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x21",
+              "0x1ffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x9",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x21",
+              "0x3ffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          "x11",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x21",
+              "0x1ffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x34",
+          "x35"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x33",
+          "x13",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x21",
+              "0x3ffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x36",
+          "x37"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x35",
+          "x15",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x21",
+              "0x1ffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x38",
+          "x39"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x37",
+          "x17",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x21",
+              "0x3ffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x40",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x39",
+          "x19",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x21",
+              "0x1ffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x40",
+          "6"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x43"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x38",
+          "4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x36",
+          "3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x45"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x34",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x30",
+          "6"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x47"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x28",
+          "5"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x48"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x26",
+          "3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x49"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x24",
+          "2"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x50"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x22"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x51"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x22",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x52"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x51"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x53"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x51",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x54"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x53"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x55"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x53",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x56"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x49",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x55"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x57"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x56"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x58"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x56",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x59"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x58"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x60"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x58",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x61"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x60"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x62"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x60",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x63"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x48",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x62"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x64"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x63"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x65"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x63",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x66"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x65"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x67"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x65",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x68"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x67"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x69"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x67",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x70"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x47",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x69"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x71"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x70"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x72"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x70",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x73"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x72"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x74"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x72",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x75"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x74"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x76"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x74",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x77"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x46",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x76"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x78"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x77"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x79"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x77",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x80"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x79"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x81"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x79",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x82"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x81"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x83"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x81",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x84"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x32"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x85"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x32",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x86"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x85"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x87"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x85",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x88"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x87"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x89"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x87",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x90"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x45",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x89"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x91"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x90"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x92"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x90",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x93"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x92"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x94"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x92",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x95"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x94"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x96"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x94",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x97"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x44",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x96"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x98"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x97"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x99"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x97",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x100"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x99"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x101"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x99",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x102"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x101"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x103"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x101",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x104"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x43",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x103"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x105"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x104"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x106"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x104",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x107"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x106"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x108"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x106",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x109"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x108"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x110"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x108",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x111"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x42",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x110"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x112"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x111"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x113"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x111",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x114"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x113"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x115"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x113",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x116"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x115"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x117"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x115",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x50"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x52"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x54"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x57"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x59"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x61"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x64"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x66"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x68"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x71"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x73"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x75"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x78"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x80"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x82"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x83"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[16]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x84"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[17]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x86"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[18]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x88"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[19]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x91"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[20]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x93"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[21]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x95"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[22]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x98"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[23]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x100"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[24]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x102"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[25]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x105"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[26]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x107"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[27]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x109"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[28]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x112"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[29]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x114"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[30]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x116"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[31]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x117"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_from_bytes",
+    "arguments": [
+      {
+        "datatype": "u8[32]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[10]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[31]"
+            ]
+          },
+          "18"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[30]"
+            ]
+          },
+          "10"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[29]"
+            ]
+          },
+          "2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[28]"
+            ]
+          },
+          "20"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[27]"
+            ]
+          },
+          "12"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[26]"
+            ]
+          },
+          "4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[25]"
+            ]
+          },
+          "21"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[24]"
+            ]
+          },
+          "13"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[23]"
+            ]
+          },
+          "5"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[22]"
+            ]
+          },
+          "23"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[21]"
+            ]
+          },
+          "15"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[20]"
+            ]
+          },
+          "7"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[19]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[18]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[17]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x16"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[16]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          "18"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          "10"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          "2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          "19"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          "11"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          "3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          "21"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          "13"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          "5"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          "22"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          "14"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          "6"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x32"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x31",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x30",
+          "x33"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x29",
+          "x34"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x35",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x37"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x35",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x28",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x37"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x27",
+          "x38"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x26",
+          "x39"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x40",
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x42"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x40",
+              "25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x43"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x25",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x24",
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x45"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x23",
+          "x44"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x45",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x47"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x45",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x48"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x22",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x47"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x49"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x21",
+          "x48"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x50"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x20",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x51"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x50",
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x52"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x50",
+              "25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x53"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x19",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x52"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x54"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x18",
+          "x53"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x55"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x17",
+          "x54"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x56"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x15",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x57"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x14",
+          "x56"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x58"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x13",
+          "x57"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x59"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x58",
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x60"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x58",
+              "25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x61"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x12",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x60"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x62"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x11",
+          "x61"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x63"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x10",
+          "x62"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x64"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x63",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x65"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x63",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x66"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x9",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x65"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x67"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x8",
+          "x66"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x68"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x7",
+          "x67"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x69"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x68",
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x70"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x68",
+              "25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x71"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x6",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x70"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x72"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x5",
+          "x71"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x73"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x4",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x74"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x73",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x75"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x73",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x76"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x3",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x75"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x77"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x2",
+          "x76"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x78"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x1",
+          "x77"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x36"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x41"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x46"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x51"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x55"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x59"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x64"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x69"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x74"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x78"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_carry_scmul_121666",
+    "arguments": [
+      {
+        "datatype": "u32[10]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[10]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1db42"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1db42"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1db42"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1db42"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1db42"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1db42"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1db42"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1db42"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1db42"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1db42"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x10",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x10"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x11"
+            ]
+          },
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x13",
+              "25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x13"
+            ]
+          },
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          },
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x16",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x17"
+            ]
+          },
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x19",
+              "25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x19"
+            ]
+          },
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x20"
+            ]
+          },
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x22",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x22"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x23"
+            ]
+          },
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x25",
+              "25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x25"
+            ]
+          },
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x26"
+            ]
+          },
+          "x4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x28",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x29"
+            ]
+          },
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x31",
+              "25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x31"
+            ]
+          },
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x32"
+            ]
+          },
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x34",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x34"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x35"
+            ]
+          },
+          "x1"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x37",
+              "25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x37"
+            ]
+          },
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x38",
+          "0x13"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x12",
+          "x40"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x42"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x41",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x43"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x41",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          },
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x45"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x44",
+              "25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x44",
+          "0x1ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x47"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x45"
+            ]
+          },
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x43"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x46"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x47"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x21"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x24"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x27"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x30"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x33"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x36"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x39"
+        ]
+      }
+    ]
+  }
+]

--- a/fiat-json/src/curve25519_64.json
+++ b/fiat-json/src/curve25519_64.json
@@ -1,0 +1,6782 @@
+[
+  {
+    "operation": "fiat_25519_addcarryx_u51",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              },
+              "arg2"
+            ]
+          },
+          "arg3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x1",
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_subborrowx_u51",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "i64",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "i64",
+            "name": [],
+            "operation": "-",
+            "arguments": [
+              {
+                "datatype": "i64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              },
+              {
+                "datatype": "i64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "i64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "i1",
+        "name": [
+          "x2"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "i1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_cmovznz_u64",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u1",
+        "name": [
+          "x1"
+        ],
+        "operation": "!",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "!",
+            "arguments": [
+              "arg1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "-",
+                "arguments": [
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "0x0"
+                    ]
+                  },
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x1"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "|",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "arg3"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "~",
+                "arguments": [
+                  "x2"
+                ]
+              },
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_carry_mul",
+    "arguments": [
+      {
+        "datatype": "u64[5]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[5]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[5]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u128",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[4]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x2"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[3]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x3"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[2]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x4"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[1]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x5"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[4]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x6"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[3]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x7"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[2]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x8"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[4]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x9"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[3]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x10"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[4]",
+                  "0x13"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x11"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x12"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x13"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x14"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x15"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x16"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x17"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x18"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x19"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x20"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x21"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x22"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x23"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x24"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x25"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x26"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x25",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x10",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x9",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x7",
+                      "x4"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x26",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x26"
+            ]
+          },
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x29"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x21",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x17",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x14",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x12",
+                      "x11"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x30"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x22",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x18",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x15",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x13",
+                      "x1"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x31"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x23",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x19",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x16",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x5",
+                      "x2"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x32"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x24",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x20",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x8",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x6",
+                      "x3"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x33"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x27"
+            ]
+          },
+          "x32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x33",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x33"
+            ]
+          },
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x36"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x34"
+            ]
+          },
+          "x31"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x36",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x36"
+            ]
+          },
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x39"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x37"
+            ]
+          },
+          "x30"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x39",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x39"
+            ]
+          },
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x42"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          },
+          "x29"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x42",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          },
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x43",
+          "0x13"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x28",
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x46",
+          "51"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x46",
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x47",
+          "x35"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x50"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x49",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x49",
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x50"
+            ]
+          },
+          "x38"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x48"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x51"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x52"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x41"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x44"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_carry_square",
+    "arguments": [
+      {
+        "datatype": "u64[5]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[5]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[4]",
+          "0x13"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x1",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[4]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[3]",
+          "0x13"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x4",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[3]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[2]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[1]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x9"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x10"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x11"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x12"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x13"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x5"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x14"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x15"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x16"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x17"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x7"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x18"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x19"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x20"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x21"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x7"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x22"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x23"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x24"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x23",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x15",
+              "x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x24",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          },
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x27"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x19",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x16",
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x28"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x20",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x17",
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x29"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x21",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x18",
+              "x10"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x30"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x22",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x12",
+              "x11"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x31"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x25"
+            ]
+          },
+          "x30"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x31",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x31"
+            ]
+          },
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x34"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x32"
+            ]
+          },
+          "x29"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x34",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x34"
+            ]
+          },
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x37"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x35"
+            ]
+          },
+          "x28"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x37",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x37"
+            ]
+          },
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x40"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          },
+          "x27"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x40",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          },
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x41",
+          "0x13"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x26",
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x44",
+          "51"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x44",
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x45",
+          "x33"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x48"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x47",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x47",
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x48"
+            ]
+          },
+          "x36"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x46"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x49"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x50"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x39"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x42"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_carry",
+    "arguments": [
+      {
+        "datatype": "u64[5]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[5]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "51"
+            ]
+          },
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x2",
+              "51"
+            ]
+          },
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x3",
+              "51"
+            ]
+          },
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x4",
+              "51"
+            ]
+          },
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x1",
+              "0x7ffffffffffff"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "*",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": ">>",
+                "arguments": [
+                  "x5",
+                  "51"
+                ]
+              },
+              "0x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": ">>",
+                    "arguments": [
+                      "x6",
+                      "51"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "0x7ffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x6",
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x7",
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": ">>",
+                    "arguments": [
+                      "x7",
+                      "51"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x3",
+              "0x7ffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x4",
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x5",
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x10"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x11"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x12"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_add",
+    "arguments": [
+      {
+        "datatype": "u64[5]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[5]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[5]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[4]",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_sub",
+    "arguments": [
+      {
+        "datatype": "u64[5]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[5]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[5]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0xfffffffffffda",
+              "arg1[0]"
+            ]
+          },
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0xffffffffffffe",
+              "arg1[1]"
+            ]
+          },
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0xffffffffffffe",
+              "arg1[2]"
+            ]
+          },
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0xffffffffffffe",
+              "arg1[3]"
+            ]
+          },
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0xffffffffffffe",
+              "arg1[4]"
+            ]
+          },
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_opp",
+    "arguments": [
+      {
+        "datatype": "u64[5]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[5]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0xfffffffffffda",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0xffffffffffffe",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0xffffffffffffe",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0xffffffffffffe",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0xffffffffffffe",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_selectznz",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[5]",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64[5]",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[5]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[0]",
+          "arg3[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[1]",
+          "arg3[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[2]",
+          "arg3[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[3]",
+          "arg3[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[4]",
+          "arg3[4]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_to_bytes",
+    "arguments": [
+      {
+        "datatype": "u64[5]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u8[32]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "0x7ffffffffffed"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x8",
+          "arg1[4]",
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x10",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x11",
+              "0x7ffffffffffed"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x13",
+          "x3",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x11",
+              "0x7ffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x15",
+          "x5",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x11",
+              "0x7ffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x17",
+          "x7",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x11",
+              "0x7ffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x19",
+          "x9",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x11",
+              "0x7ffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x20",
+          "4"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x18",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x16",
+          "6"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x14",
+          "3"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x26"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x12",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x28"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x27"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x27",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x30"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x29"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x29",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x32"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x31"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x31",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x34"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x33"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x33",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x36"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x35"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x37"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x35",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x25",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x37"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x39"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x38",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x41"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x40",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x43"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x42",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x45"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x44"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x44",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x47"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x46"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x46",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x49"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x48"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x50"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x48",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x24",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x50"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x52"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x51"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x51",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x54"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x53"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x53",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x56"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x55"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x55",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x58"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x57"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x57",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x60"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x59"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x59",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x62"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x61"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x63"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x61",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x64"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x63"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x65"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x63",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x23",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x65"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x67"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x66"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x66",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x69"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x68"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x68",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x71"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x70"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x70",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x73"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x72"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x72",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x75"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x74"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x76"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x74",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x77"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x76"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x78"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x76",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x22",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x78"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x80"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x79"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x79",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x82"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x81"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x81",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x84"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x83"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x85"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x83",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x86"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x85"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x85",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x88"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x87"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x87",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x90"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x89"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x91"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x89",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x26"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x28"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x30"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x32"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x34"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x36"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x39"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x41"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x43"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x45"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x47"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x49"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x52"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x54"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x56"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x58"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[16]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x60"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[17]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x62"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[18]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x64"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[19]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x67"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[20]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x69"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[21]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x71"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[22]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x73"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[23]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x75"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[24]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x77"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[25]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x80"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[26]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x82"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[27]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x84"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[28]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x86"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[29]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x88"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[30]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x90"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[31]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x91"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_from_bytes",
+    "arguments": [
+      {
+        "datatype": "u8[32]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[5]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[31]"
+            ]
+          },
+          "44"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[30]"
+            ]
+          },
+          "36"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[29]"
+            ]
+          },
+          "28"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[28]"
+            ]
+          },
+          "20"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[27]"
+            ]
+          },
+          "12"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[26]"
+            ]
+          },
+          "4"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[25]"
+            ]
+          },
+          "47"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[24]"
+            ]
+          },
+          "39"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[23]"
+            ]
+          },
+          "31"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[22]"
+            ]
+          },
+          "23"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[21]"
+            ]
+          },
+          "15"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[20]"
+            ]
+          },
+          "7"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[19]"
+            ]
+          },
+          "50"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[18]"
+            ]
+          },
+          "42"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[17]"
+            ]
+          },
+          "34"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[16]"
+            ]
+          },
+          "26"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          "18"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          "10"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          "2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          "45"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          "37"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          "29"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          "21"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          "13"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          "5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x32"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x31",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x30",
+          "x33"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x29",
+          "x34"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x28",
+          "x35"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x27",
+          "x36"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x26",
+          "x37"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x38",
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x40"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x38",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x25",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x24",
+          "x41"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x23",
+          "x42"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x22",
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x21",
+          "x44"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x20",
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x46",
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x48"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x46",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x19",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x48"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x18",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x17",
+          "x50"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x16",
+          "x51"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x15",
+          "x52"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x14",
+          "x53"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x13",
+          "x54"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x55",
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x57"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x55",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x12",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x57"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x11",
+          "x58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x10",
+          "x59"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x9",
+          "x60"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x8",
+          "x61"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x63"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x7",
+          "x62"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x63",
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x65"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x63",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x6",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x65"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x67"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x5",
+          "x66"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x4",
+          "x67"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x69"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x3",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x2",
+          "x69"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x71"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x1",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x39"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x47"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x56"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x64"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x71"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_25519_carry_scmul_121666",
+    "arguments": [
+      {
+        "datatype": "u64[5]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[5]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u128",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1db42"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x2"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1db42"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x3"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1db42"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x4"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1db42"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x5"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1db42"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x5",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x5"
+            ]
+          },
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x8"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          },
+          "x4"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x8",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          },
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x11"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          },
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x11",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x11"
+            ]
+          },
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x14"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          },
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x14",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          },
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x17"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x15"
+            ]
+          },
+          "x1"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x17",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x17"
+            ]
+          },
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x18",
+          "0x13"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x7",
+          "x20"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x22"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x21",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x21",
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x22"
+            ]
+          },
+          "x10"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x25"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x24",
+              "51"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x24",
+          "0x7ffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x25"
+            ]
+          },
+          "x13"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x23"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x26"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x27"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x19"
+        ]
+      }
+    ]
+  }
+]

--- a/fiat-json/src/p224_32.json
+++ b/fiat-json/src/p224_32.json
@@ -1,0 +1,17661 @@
+[
+  {
+    "operation": "fiat_p224_addcarryx_u32",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_subborrowx_u32",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "i64",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "i64",
+            "name": [],
+            "operation": "-",
+            "arguments": [
+              {
+                "datatype": "i64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              },
+              {
+                "datatype": "i64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "i64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "i1",
+        "name": [
+          "x2"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "i1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_mulx_u32",
+    "arguments": [
+      {
+        "datatype": "u32",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      },
+      {
+        "datatype": "u32",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_cmovznz_u32",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u1",
+        "name": [
+          "x1"
+        ],
+        "operation": "!",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "!",
+            "arguments": [
+              "arg1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "-",
+                "arguments": [
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "0x0"
+                    ]
+                  },
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x1"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "|",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "arg3"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "~",
+                "arguments": [
+                  "x2"
+                ]
+              },
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_mul",
+    "arguments": [
+      {
+        "datatype": "u32[7]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[7]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[7]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8",
+          "x9"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x21",
+          "x18"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x19",
+          "x16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x17",
+          "x14"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x15",
+          "x12"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x13",
+          "x10"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          "x11",
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x33"
+            ]
+          },
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39",
+          "x40"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41",
+          "x42"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x43",
+          "x44"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x45",
+          "x46"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x44",
+          "x41"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x47",
+          "x48"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x46",
+          "x42",
+          "x39"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x49",
+          "x50"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x48",
+          "x40",
+          "x37"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x51"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x50"
+            ]
+          },
+          "x38"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x53"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x20",
+          "x35"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x54",
+          "x55"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x53",
+          "x22",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x56",
+          "x57"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x55",
+          "x24",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x58",
+          "x59"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x57",
+          "x26",
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x59",
+          "x28",
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x61",
+          "x30",
+          "x47"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x63",
+          "x32",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x65",
+          "x34",
+          "x51"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x72",
+          "x73"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x76",
+          "x77"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x78",
+          "x79"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x80",
+          "x81"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x82",
+          "x83"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x81",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x84",
+          "x85"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x83",
+          "x79",
+          "x76"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x86",
+          "x87"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x85",
+          "x77",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x88",
+          "x89"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x87",
+          "x75",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x90",
+          "x91"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x89",
+          "x73",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x91",
+          "x71",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x94"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x93"
+            ]
+          },
+          "x69"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x95",
+          "x96"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x54",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x97",
+          "x98"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x96",
+          "x56",
+          "x82"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x99",
+          "x100"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x98",
+          "x58",
+          "x84"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x101",
+          "x102"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x100",
+          "x60",
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x103",
+          "x104"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x102",
+          "x62",
+          "x88"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x105",
+          "x106"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x104",
+          "x64",
+          "x90"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x107",
+          "x108"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x106",
+          "x66",
+          "x92"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x109",
+          "x110"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x108",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x67"
+            ]
+          },
+          "x94"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x111",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x95",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x113",
+          "x114"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x111",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x115",
+          "x116"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x111",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x117",
+          "x118"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x111",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x119",
+          "x120"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x111",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x121",
+          "x122"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x120",
+          "x117"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x123",
+          "x124"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x122",
+          "x118",
+          "x115"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x125",
+          "x126"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x124",
+          "x116",
+          "x113"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x127"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x126"
+            ]
+          },
+          "x114"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x129"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x95",
+          "x111"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x130",
+          "x131"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x129",
+          "x97",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x132",
+          "x133"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x131",
+          "x99",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x134",
+          "x135"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x133",
+          "x101",
+          "x119"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x136",
+          "x137"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x135",
+          "x103",
+          "x121"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x138",
+          "x139"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x137",
+          "x105",
+          "x123"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x140",
+          "x141"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x139",
+          "x107",
+          "x125"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x142",
+          "x143"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x141",
+          "x109",
+          "x127"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x144"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x143"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x110"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x145",
+          "x146"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x147",
+          "x148"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x149",
+          "x150"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x151",
+          "x152"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x153",
+          "x154"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x155",
+          "x156"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x157",
+          "x158"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x159",
+          "x160"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x158",
+          "x155"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x161",
+          "x162"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x160",
+          "x156",
+          "x153"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x163",
+          "x164"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x162",
+          "x154",
+          "x151"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x165",
+          "x166"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x164",
+          "x152",
+          "x149"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x167",
+          "x168"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x166",
+          "x150",
+          "x147"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x169",
+          "x170"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x168",
+          "x148",
+          "x145"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x171"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x170"
+            ]
+          },
+          "x146"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x172",
+          "x173"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x130",
+          "x157"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x174",
+          "x175"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x173",
+          "x132",
+          "x159"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x176",
+          "x177"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x175",
+          "x134",
+          "x161"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x178",
+          "x179"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x177",
+          "x136",
+          "x163"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x180",
+          "x181"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x179",
+          "x138",
+          "x165"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x182",
+          "x183"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x181",
+          "x140",
+          "x167"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x184",
+          "x185"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x183",
+          "x142",
+          "x169"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x186",
+          "x187"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x185",
+          "x144",
+          "x171"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x188",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x172",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x190",
+          "x191"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x188",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x192",
+          "x193"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x188",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x194",
+          "x195"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x188",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x196",
+          "x197"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x188",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x198",
+          "x199"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x197",
+          "x194"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x200",
+          "x201"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x199",
+          "x195",
+          "x192"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x202",
+          "x203"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x201",
+          "x193",
+          "x190"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x204"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x203"
+            ]
+          },
+          "x191"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x206"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x172",
+          "x188"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x207",
+          "x208"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x206",
+          "x174",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x209",
+          "x210"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x208",
+          "x176",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x211",
+          "x212"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x210",
+          "x178",
+          "x196"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x213",
+          "x214"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x212",
+          "x180",
+          "x198"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x215",
+          "x216"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x214",
+          "x182",
+          "x200"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x217",
+          "x218"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x216",
+          "x184",
+          "x202"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x219",
+          "x220"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x218",
+          "x186",
+          "x204"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x221"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x220"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x187"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x222",
+          "x223"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x224",
+          "x225"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x226",
+          "x227"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x228",
+          "x229"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x230",
+          "x231"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x232",
+          "x233"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x234",
+          "x235"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x236",
+          "x237"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x235",
+          "x232"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x238",
+          "x239"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x237",
+          "x233",
+          "x230"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x240",
+          "x241"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x239",
+          "x231",
+          "x228"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x242",
+          "x243"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x241",
+          "x229",
+          "x226"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x244",
+          "x245"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x243",
+          "x227",
+          "x224"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x246",
+          "x247"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x245",
+          "x225",
+          "x222"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x248"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x247"
+            ]
+          },
+          "x223"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x249",
+          "x250"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x207",
+          "x234"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x251",
+          "x252"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x250",
+          "x209",
+          "x236"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x253",
+          "x254"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x252",
+          "x211",
+          "x238"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x255",
+          "x256"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x254",
+          "x213",
+          "x240"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x257",
+          "x258"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x256",
+          "x215",
+          "x242"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x259",
+          "x260"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x258",
+          "x217",
+          "x244"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x261",
+          "x262"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x260",
+          "x219",
+          "x246"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x263",
+          "x264"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x262",
+          "x221",
+          "x248"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x265",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x249",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x267",
+          "x268"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x265",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x269",
+          "x270"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x265",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x271",
+          "x272"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x265",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x273",
+          "x274"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x265",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x275",
+          "x276"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x274",
+          "x271"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x277",
+          "x278"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x276",
+          "x272",
+          "x269"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x279",
+          "x280"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x278",
+          "x270",
+          "x267"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x281"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x280"
+            ]
+          },
+          "x268"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x283"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x249",
+          "x265"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x284",
+          "x285"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x283",
+          "x251",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x286",
+          "x287"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x285",
+          "x253",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x288",
+          "x289"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x287",
+          "x255",
+          "x273"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x290",
+          "x291"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x289",
+          "x257",
+          "x275"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x292",
+          "x293"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x291",
+          "x259",
+          "x277"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x294",
+          "x295"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x293",
+          "x261",
+          "x279"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x296",
+          "x297"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x295",
+          "x263",
+          "x281"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x298"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x297"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x264"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x299",
+          "x300"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x301",
+          "x302"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x303",
+          "x304"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x305",
+          "x306"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x307",
+          "x308"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x309",
+          "x310"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x311",
+          "x312"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x313",
+          "x314"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x312",
+          "x309"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x315",
+          "x316"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x314",
+          "x310",
+          "x307"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x317",
+          "x318"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x316",
+          "x308",
+          "x305"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x319",
+          "x320"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x318",
+          "x306",
+          "x303"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x321",
+          "x322"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x320",
+          "x304",
+          "x301"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x323",
+          "x324"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x322",
+          "x302",
+          "x299"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x325"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x324"
+            ]
+          },
+          "x300"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x326",
+          "x327"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x284",
+          "x311"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x328",
+          "x329"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x327",
+          "x286",
+          "x313"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x330",
+          "x331"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x329",
+          "x288",
+          "x315"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x332",
+          "x333"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x331",
+          "x290",
+          "x317"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x334",
+          "x335"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x333",
+          "x292",
+          "x319"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x336",
+          "x337"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x335",
+          "x294",
+          "x321"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x338",
+          "x339"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x337",
+          "x296",
+          "x323"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x340",
+          "x341"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x339",
+          "x298",
+          "x325"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x342",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x326",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x344",
+          "x345"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x346",
+          "x347"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x348",
+          "x349"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x350",
+          "x351"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x352",
+          "x353"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x351",
+          "x348"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x354",
+          "x355"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x353",
+          "x349",
+          "x346"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x356",
+          "x357"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x355",
+          "x347",
+          "x344"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x358"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x357"
+            ]
+          },
+          "x345"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x360"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x326",
+          "x342"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x361",
+          "x362"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x360",
+          "x328",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x363",
+          "x364"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x362",
+          "x330",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x365",
+          "x366"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x364",
+          "x332",
+          "x350"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x367",
+          "x368"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x366",
+          "x334",
+          "x352"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x369",
+          "x370"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x368",
+          "x336",
+          "x354"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x371",
+          "x372"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x370",
+          "x338",
+          "x356"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x373",
+          "x374"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x372",
+          "x340",
+          "x358"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x375"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x374"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x341"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x376",
+          "x377"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x378",
+          "x379"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x380",
+          "x381"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x382",
+          "x383"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x384",
+          "x385"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x386",
+          "x387"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x388",
+          "x389"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x390",
+          "x391"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x389",
+          "x386"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x392",
+          "x393"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x391",
+          "x387",
+          "x384"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x394",
+          "x395"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x393",
+          "x385",
+          "x382"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x396",
+          "x397"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x395",
+          "x383",
+          "x380"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x398",
+          "x399"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x397",
+          "x381",
+          "x378"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x400",
+          "x401"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x399",
+          "x379",
+          "x376"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x402"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x401"
+            ]
+          },
+          "x377"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x403",
+          "x404"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x361",
+          "x388"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x405",
+          "x406"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x404",
+          "x363",
+          "x390"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x407",
+          "x408"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x406",
+          "x365",
+          "x392"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x409",
+          "x410"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x408",
+          "x367",
+          "x394"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x411",
+          "x412"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x410",
+          "x369",
+          "x396"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x413",
+          "x414"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x412",
+          "x371",
+          "x398"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x415",
+          "x416"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x414",
+          "x373",
+          "x400"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x417",
+          "x418"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x416",
+          "x375",
+          "x402"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x419",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x403",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x421",
+          "x422"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x419",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x423",
+          "x424"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x419",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x425",
+          "x426"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x419",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x427",
+          "x428"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x419",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x429",
+          "x430"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x428",
+          "x425"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x431",
+          "x432"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x430",
+          "x426",
+          "x423"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x433",
+          "x434"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x432",
+          "x424",
+          "x421"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x435"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x434"
+            ]
+          },
+          "x422"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x437"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x403",
+          "x419"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x438",
+          "x439"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x437",
+          "x405",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x440",
+          "x441"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x439",
+          "x407",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x442",
+          "x443"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x441",
+          "x409",
+          "x427"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x444",
+          "x445"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x443",
+          "x411",
+          "x429"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x446",
+          "x447"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x445",
+          "x413",
+          "x431"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x448",
+          "x449"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x447",
+          "x415",
+          "x433"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x450",
+          "x451"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x449",
+          "x417",
+          "x435"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x452"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x451"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x418"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x453",
+          "x454"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x455",
+          "x456"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x457",
+          "x458"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x459",
+          "x460"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x461",
+          "x462"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x463",
+          "x464"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x465",
+          "x466"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x467",
+          "x468"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x466",
+          "x463"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x469",
+          "x470"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x468",
+          "x464",
+          "x461"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x471",
+          "x472"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x470",
+          "x462",
+          "x459"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x473",
+          "x474"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x472",
+          "x460",
+          "x457"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x475",
+          "x476"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x474",
+          "x458",
+          "x455"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x477",
+          "x478"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x476",
+          "x456",
+          "x453"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x479"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x478"
+            ]
+          },
+          "x454"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x480",
+          "x481"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x438",
+          "x465"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x482",
+          "x483"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x481",
+          "x440",
+          "x467"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x484",
+          "x485"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x483",
+          "x442",
+          "x469"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x486",
+          "x487"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x485",
+          "x444",
+          "x471"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x488",
+          "x489"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x487",
+          "x446",
+          "x473"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x490",
+          "x491"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x489",
+          "x448",
+          "x475"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x492",
+          "x493"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x491",
+          "x450",
+          "x477"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x494",
+          "x495"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x493",
+          "x452",
+          "x479"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x496",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x480",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x498",
+          "x499"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x496",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x500",
+          "x501"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x496",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x502",
+          "x503"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x496",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x504",
+          "x505"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x496",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x506",
+          "x507"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x505",
+          "x502"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x508",
+          "x509"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x507",
+          "x503",
+          "x500"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x510",
+          "x511"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x509",
+          "x501",
+          "x498"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x512"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x511"
+            ]
+          },
+          "x499"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x514"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x480",
+          "x496"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x515",
+          "x516"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x514",
+          "x482",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x517",
+          "x518"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x516",
+          "x484",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x519",
+          "x520"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x518",
+          "x486",
+          "x504"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x521",
+          "x522"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x520",
+          "x488",
+          "x506"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x523",
+          "x524"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x522",
+          "x490",
+          "x508"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x525",
+          "x526"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x524",
+          "x492",
+          "x510"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x527",
+          "x528"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x526",
+          "x494",
+          "x512"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x529"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x528"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x495"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x530",
+          "x531"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x515",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x532",
+          "x533"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x531",
+          "x517",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x534",
+          "x535"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x533",
+          "x519",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x536",
+          "x537"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x535",
+          "x521",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x538",
+          "x539"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x537",
+          "x523",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x540",
+          "x541"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x539",
+          "x525",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x542",
+          "x543"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x541",
+          "x527",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x545"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x543",
+          "x529",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x546"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x545",
+          "x530",
+          "x515"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x547"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x545",
+          "x532",
+          "x517"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x548"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x545",
+          "x534",
+          "x519"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x549"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x545",
+          "x536",
+          "x521"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x550"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x545",
+          "x538",
+          "x523"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x551"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x545",
+          "x540",
+          "x525"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x552"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x545",
+          "x542",
+          "x527"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x546"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x547"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x548"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x549"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x550"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x551"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x552"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_square",
+    "arguments": [
+      {
+        "datatype": "u32[7]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[7]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8",
+          "x9"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x21",
+          "x18"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x19",
+          "x16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x17",
+          "x14"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x15",
+          "x12"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x13",
+          "x10"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          "x11",
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x33"
+            ]
+          },
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39",
+          "x40"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41",
+          "x42"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x43",
+          "x44"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x45",
+          "x46"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x44",
+          "x41"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x47",
+          "x48"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x46",
+          "x42",
+          "x39"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x49",
+          "x50"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x48",
+          "x40",
+          "x37"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x51"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x50"
+            ]
+          },
+          "x38"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x53"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x20",
+          "x35"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x54",
+          "x55"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x53",
+          "x22",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x56",
+          "x57"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x55",
+          "x24",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x58",
+          "x59"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x57",
+          "x26",
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x59",
+          "x28",
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x61",
+          "x30",
+          "x47"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x63",
+          "x32",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x65",
+          "x34",
+          "x51"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x72",
+          "x73"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x76",
+          "x77"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x78",
+          "x79"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x80",
+          "x81"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x82",
+          "x83"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x81",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x84",
+          "x85"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x83",
+          "x79",
+          "x76"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x86",
+          "x87"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x85",
+          "x77",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x88",
+          "x89"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x87",
+          "x75",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x90",
+          "x91"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x89",
+          "x73",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x91",
+          "x71",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x94"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x93"
+            ]
+          },
+          "x69"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x95",
+          "x96"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x54",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x97",
+          "x98"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x96",
+          "x56",
+          "x82"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x99",
+          "x100"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x98",
+          "x58",
+          "x84"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x101",
+          "x102"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x100",
+          "x60",
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x103",
+          "x104"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x102",
+          "x62",
+          "x88"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x105",
+          "x106"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x104",
+          "x64",
+          "x90"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x107",
+          "x108"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x106",
+          "x66",
+          "x92"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x109",
+          "x110"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x108",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x67"
+            ]
+          },
+          "x94"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x111",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x95",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x113",
+          "x114"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x111",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x115",
+          "x116"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x111",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x117",
+          "x118"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x111",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x119",
+          "x120"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x111",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x121",
+          "x122"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x120",
+          "x117"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x123",
+          "x124"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x122",
+          "x118",
+          "x115"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x125",
+          "x126"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x124",
+          "x116",
+          "x113"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x127"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x126"
+            ]
+          },
+          "x114"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x129"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x95",
+          "x111"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x130",
+          "x131"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x129",
+          "x97",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x132",
+          "x133"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x131",
+          "x99",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x134",
+          "x135"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x133",
+          "x101",
+          "x119"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x136",
+          "x137"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x135",
+          "x103",
+          "x121"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x138",
+          "x139"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x137",
+          "x105",
+          "x123"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x140",
+          "x141"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x139",
+          "x107",
+          "x125"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x142",
+          "x143"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x141",
+          "x109",
+          "x127"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x144"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x143"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x110"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x145",
+          "x146"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x147",
+          "x148"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x149",
+          "x150"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x151",
+          "x152"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x153",
+          "x154"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x155",
+          "x156"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x157",
+          "x158"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x159",
+          "x160"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x158",
+          "x155"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x161",
+          "x162"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x160",
+          "x156",
+          "x153"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x163",
+          "x164"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x162",
+          "x154",
+          "x151"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x165",
+          "x166"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x164",
+          "x152",
+          "x149"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x167",
+          "x168"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x166",
+          "x150",
+          "x147"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x169",
+          "x170"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x168",
+          "x148",
+          "x145"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x171"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x170"
+            ]
+          },
+          "x146"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x172",
+          "x173"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x130",
+          "x157"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x174",
+          "x175"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x173",
+          "x132",
+          "x159"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x176",
+          "x177"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x175",
+          "x134",
+          "x161"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x178",
+          "x179"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x177",
+          "x136",
+          "x163"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x180",
+          "x181"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x179",
+          "x138",
+          "x165"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x182",
+          "x183"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x181",
+          "x140",
+          "x167"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x184",
+          "x185"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x183",
+          "x142",
+          "x169"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x186",
+          "x187"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x185",
+          "x144",
+          "x171"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x188",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x172",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x190",
+          "x191"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x188",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x192",
+          "x193"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x188",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x194",
+          "x195"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x188",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x196",
+          "x197"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x188",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x198",
+          "x199"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x197",
+          "x194"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x200",
+          "x201"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x199",
+          "x195",
+          "x192"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x202",
+          "x203"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x201",
+          "x193",
+          "x190"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x204"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x203"
+            ]
+          },
+          "x191"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x206"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x172",
+          "x188"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x207",
+          "x208"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x206",
+          "x174",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x209",
+          "x210"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x208",
+          "x176",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x211",
+          "x212"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x210",
+          "x178",
+          "x196"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x213",
+          "x214"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x212",
+          "x180",
+          "x198"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x215",
+          "x216"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x214",
+          "x182",
+          "x200"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x217",
+          "x218"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x216",
+          "x184",
+          "x202"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x219",
+          "x220"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x218",
+          "x186",
+          "x204"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x221"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x220"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x187"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x222",
+          "x223"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x224",
+          "x225"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x226",
+          "x227"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x228",
+          "x229"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x230",
+          "x231"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x232",
+          "x233"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x234",
+          "x235"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x236",
+          "x237"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x235",
+          "x232"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x238",
+          "x239"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x237",
+          "x233",
+          "x230"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x240",
+          "x241"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x239",
+          "x231",
+          "x228"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x242",
+          "x243"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x241",
+          "x229",
+          "x226"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x244",
+          "x245"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x243",
+          "x227",
+          "x224"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x246",
+          "x247"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x245",
+          "x225",
+          "x222"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x248"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x247"
+            ]
+          },
+          "x223"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x249",
+          "x250"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x207",
+          "x234"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x251",
+          "x252"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x250",
+          "x209",
+          "x236"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x253",
+          "x254"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x252",
+          "x211",
+          "x238"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x255",
+          "x256"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x254",
+          "x213",
+          "x240"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x257",
+          "x258"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x256",
+          "x215",
+          "x242"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x259",
+          "x260"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x258",
+          "x217",
+          "x244"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x261",
+          "x262"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x260",
+          "x219",
+          "x246"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x263",
+          "x264"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x262",
+          "x221",
+          "x248"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x265",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x249",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x267",
+          "x268"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x265",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x269",
+          "x270"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x265",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x271",
+          "x272"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x265",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x273",
+          "x274"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x265",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x275",
+          "x276"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x274",
+          "x271"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x277",
+          "x278"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x276",
+          "x272",
+          "x269"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x279",
+          "x280"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x278",
+          "x270",
+          "x267"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x281"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x280"
+            ]
+          },
+          "x268"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x283"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x249",
+          "x265"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x284",
+          "x285"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x283",
+          "x251",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x286",
+          "x287"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x285",
+          "x253",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x288",
+          "x289"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x287",
+          "x255",
+          "x273"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x290",
+          "x291"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x289",
+          "x257",
+          "x275"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x292",
+          "x293"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x291",
+          "x259",
+          "x277"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x294",
+          "x295"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x293",
+          "x261",
+          "x279"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x296",
+          "x297"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x295",
+          "x263",
+          "x281"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x298"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x297"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x264"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x299",
+          "x300"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x301",
+          "x302"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x303",
+          "x304"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x305",
+          "x306"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x307",
+          "x308"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x309",
+          "x310"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x311",
+          "x312"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x313",
+          "x314"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x312",
+          "x309"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x315",
+          "x316"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x314",
+          "x310",
+          "x307"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x317",
+          "x318"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x316",
+          "x308",
+          "x305"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x319",
+          "x320"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x318",
+          "x306",
+          "x303"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x321",
+          "x322"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x320",
+          "x304",
+          "x301"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x323",
+          "x324"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x322",
+          "x302",
+          "x299"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x325"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x324"
+            ]
+          },
+          "x300"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x326",
+          "x327"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x284",
+          "x311"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x328",
+          "x329"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x327",
+          "x286",
+          "x313"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x330",
+          "x331"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x329",
+          "x288",
+          "x315"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x332",
+          "x333"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x331",
+          "x290",
+          "x317"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x334",
+          "x335"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x333",
+          "x292",
+          "x319"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x336",
+          "x337"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x335",
+          "x294",
+          "x321"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x338",
+          "x339"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x337",
+          "x296",
+          "x323"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x340",
+          "x341"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x339",
+          "x298",
+          "x325"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x342",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x326",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x344",
+          "x345"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x346",
+          "x347"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x348",
+          "x349"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x350",
+          "x351"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x352",
+          "x353"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x351",
+          "x348"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x354",
+          "x355"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x353",
+          "x349",
+          "x346"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x356",
+          "x357"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x355",
+          "x347",
+          "x344"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x358"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x357"
+            ]
+          },
+          "x345"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x360"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x326",
+          "x342"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x361",
+          "x362"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x360",
+          "x328",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x363",
+          "x364"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x362",
+          "x330",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x365",
+          "x366"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x364",
+          "x332",
+          "x350"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x367",
+          "x368"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x366",
+          "x334",
+          "x352"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x369",
+          "x370"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x368",
+          "x336",
+          "x354"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x371",
+          "x372"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x370",
+          "x338",
+          "x356"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x373",
+          "x374"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x372",
+          "x340",
+          "x358"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x375"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x374"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x341"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x376",
+          "x377"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x378",
+          "x379"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x380",
+          "x381"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x382",
+          "x383"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x384",
+          "x385"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x386",
+          "x387"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x388",
+          "x389"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x390",
+          "x391"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x389",
+          "x386"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x392",
+          "x393"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x391",
+          "x387",
+          "x384"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x394",
+          "x395"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x393",
+          "x385",
+          "x382"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x396",
+          "x397"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x395",
+          "x383",
+          "x380"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x398",
+          "x399"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x397",
+          "x381",
+          "x378"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x400",
+          "x401"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x399",
+          "x379",
+          "x376"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x402"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x401"
+            ]
+          },
+          "x377"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x403",
+          "x404"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x361",
+          "x388"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x405",
+          "x406"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x404",
+          "x363",
+          "x390"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x407",
+          "x408"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x406",
+          "x365",
+          "x392"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x409",
+          "x410"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x408",
+          "x367",
+          "x394"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x411",
+          "x412"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x410",
+          "x369",
+          "x396"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x413",
+          "x414"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x412",
+          "x371",
+          "x398"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x415",
+          "x416"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x414",
+          "x373",
+          "x400"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x417",
+          "x418"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x416",
+          "x375",
+          "x402"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x419",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x403",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x421",
+          "x422"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x419",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x423",
+          "x424"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x419",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x425",
+          "x426"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x419",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x427",
+          "x428"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x419",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x429",
+          "x430"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x428",
+          "x425"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x431",
+          "x432"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x430",
+          "x426",
+          "x423"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x433",
+          "x434"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x432",
+          "x424",
+          "x421"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x435"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x434"
+            ]
+          },
+          "x422"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x437"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x403",
+          "x419"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x438",
+          "x439"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x437",
+          "x405",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x440",
+          "x441"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x439",
+          "x407",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x442",
+          "x443"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x441",
+          "x409",
+          "x427"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x444",
+          "x445"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x443",
+          "x411",
+          "x429"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x446",
+          "x447"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x445",
+          "x413",
+          "x431"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x448",
+          "x449"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x447",
+          "x415",
+          "x433"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x450",
+          "x451"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x449",
+          "x417",
+          "x435"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x452"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x451"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x418"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x453",
+          "x454"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x455",
+          "x456"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x457",
+          "x458"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x459",
+          "x460"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x461",
+          "x462"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x463",
+          "x464"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x465",
+          "x466"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x467",
+          "x468"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x466",
+          "x463"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x469",
+          "x470"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x468",
+          "x464",
+          "x461"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x471",
+          "x472"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x470",
+          "x462",
+          "x459"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x473",
+          "x474"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x472",
+          "x460",
+          "x457"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x475",
+          "x476"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x474",
+          "x458",
+          "x455"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x477",
+          "x478"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x476",
+          "x456",
+          "x453"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x479"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x478"
+            ]
+          },
+          "x454"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x480",
+          "x481"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x438",
+          "x465"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x482",
+          "x483"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x481",
+          "x440",
+          "x467"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x484",
+          "x485"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x483",
+          "x442",
+          "x469"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x486",
+          "x487"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x485",
+          "x444",
+          "x471"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x488",
+          "x489"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x487",
+          "x446",
+          "x473"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x490",
+          "x491"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x489",
+          "x448",
+          "x475"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x492",
+          "x493"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x491",
+          "x450",
+          "x477"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x494",
+          "x495"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x493",
+          "x452",
+          "x479"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x496",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x480",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x498",
+          "x499"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x496",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x500",
+          "x501"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x496",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x502",
+          "x503"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x496",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x504",
+          "x505"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x496",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x506",
+          "x507"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x505",
+          "x502"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x508",
+          "x509"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x507",
+          "x503",
+          "x500"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x510",
+          "x511"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x509",
+          "x501",
+          "x498"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x512"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x511"
+            ]
+          },
+          "x499"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x514"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x480",
+          "x496"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x515",
+          "x516"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x514",
+          "x482",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x517",
+          "x518"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x516",
+          "x484",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x519",
+          "x520"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x518",
+          "x486",
+          "x504"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x521",
+          "x522"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x520",
+          "x488",
+          "x506"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x523",
+          "x524"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x522",
+          "x490",
+          "x508"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x525",
+          "x526"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x524",
+          "x492",
+          "x510"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x527",
+          "x528"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x526",
+          "x494",
+          "x512"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x529"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x528"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x495"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x530",
+          "x531"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x515",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x532",
+          "x533"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x531",
+          "x517",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x534",
+          "x535"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x533",
+          "x519",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x536",
+          "x537"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x535",
+          "x521",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x538",
+          "x539"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x537",
+          "x523",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x540",
+          "x541"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x539",
+          "x525",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x542",
+          "x543"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x541",
+          "x527",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x545"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x543",
+          "x529",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x546"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x545",
+          "x530",
+          "x515"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x547"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x545",
+          "x532",
+          "x517"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x548"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x545",
+          "x534",
+          "x519"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x549"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x545",
+          "x536",
+          "x521"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x550"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x545",
+          "x538",
+          "x523"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x551"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x545",
+          "x540",
+          "x525"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x552"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x545",
+          "x542",
+          "x527"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x546"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x547"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x548"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x549"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x550"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x551"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x552"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_add",
+    "arguments": [
+      {
+        "datatype": "u32[7]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[7]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[7]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x8",
+          "arg1[4]",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x10",
+          "arg1[5]",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x12",
+          "arg1[6]",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x1",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x16",
+          "x3",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x18",
+          "x5",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x20",
+          "x7",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x22",
+          "x9",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25",
+          "x26"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x24",
+          "x11",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27",
+          "x28"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x26",
+          "x13",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x30"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x28",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x30",
+          "x15",
+          "x1"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x30",
+          "x17",
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x30",
+          "x19",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x30",
+          "x21",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x30",
+          "x23",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x30",
+          "x25",
+          "x11"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x30",
+          "x27",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x31"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x32"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x33"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x34"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x35"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x36"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x37"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_sub",
+    "arguments": [
+      {
+        "datatype": "u32[7]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[7]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[7]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x8",
+          "arg1[4]",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x10",
+          "arg1[5]",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x12",
+          "arg1[6]",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x14",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "&",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x15"
+                    ]
+                  },
+                  "0x1"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x17",
+          "x3",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x19",
+          "x5",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x21",
+          "x7",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x9",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x11",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x13",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x22"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x24"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x26"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x28"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_opp",
+    "arguments": [
+      {
+        "datatype": "u32[7]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[7]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x8",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x10",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x12",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x14",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "&",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x15"
+                    ]
+                  },
+                  "0x1"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x17",
+          "x3",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x19",
+          "x5",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x21",
+          "x7",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x9",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x11",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x13",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x22"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x24"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x26"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x28"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_from_montgomery",
+    "arguments": [
+      {
+        "datatype": "u32[7]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[7]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4",
+          "x5"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6",
+          "x7"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8",
+          "x9"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x11",
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x13",
+          "x9",
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x15",
+          "x7",
+          "x4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x19"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x19"
+            ]
+          },
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x22",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x22",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x22",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x22",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x31",
+          "x28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34",
+          "x35"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x33",
+          "x29",
+          "x26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36",
+          "x37"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x35",
+          "x27",
+          "x24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38",
+          "x39"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x12",
+          "x30"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40",
+          "x41"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x39",
+          "x14",
+          "x32"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42",
+          "x43"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x41",
+          "x16",
+          "x34"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44",
+          "x45"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x43",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x17"
+                ]
+              },
+              "x5"
+            ]
+          },
+          "x36"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46",
+          "x47"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x45",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x37"
+                ]
+              },
+              "x25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x49"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x20",
+          "x22"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x50",
+          "x51"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x49"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x21"
+                ]
+              }
+            ]
+          },
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x52",
+          "x53"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x51",
+          "x10",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x54",
+          "x55"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x53",
+          "x38",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x56",
+          "x57"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x55",
+          "x40",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x58",
+          "x59"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x57",
+          "x42",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x59",
+          "x44",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x61",
+          "x46",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x64",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x50",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x64",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x64",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x64",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x72",
+          "x73"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x64",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x73",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x76",
+          "x77"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x75",
+          "x71",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x78",
+          "x79"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x77",
+          "x69",
+          "x66"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x81"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x50",
+          "x64"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x82",
+          "x83"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x81",
+          "x52",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x84",
+          "x85"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x83",
+          "x54",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x86",
+          "x87"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x85",
+          "x56",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x88",
+          "x89"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x87",
+          "x58",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x90",
+          "x91"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x89",
+          "x60",
+          "x76"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x91",
+          "x62",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x94",
+          "x95"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x93",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x63"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x47"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x79"
+                ]
+              },
+              "x67"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x96",
+          "x97"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x82",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x98",
+          "x99"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x97",
+          "x84",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x100",
+          "x101"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x99",
+          "x86",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x102",
+          "x103"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x101",
+          "x88",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x104",
+          "x105"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x103",
+          "x90",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x106",
+          "x107"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x105",
+          "x92",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x108",
+          "x109"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x107",
+          "x94",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x110",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x96",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x112",
+          "x113"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x110",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x114",
+          "x115"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x110",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x116",
+          "x117"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x110",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x118",
+          "x119"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x110",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x120",
+          "x121"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x119",
+          "x116"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x122",
+          "x123"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x121",
+          "x117",
+          "x114"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x124",
+          "x125"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x123",
+          "x115",
+          "x112"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x127"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x96",
+          "x110"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x128",
+          "x129"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x127",
+          "x98",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x130",
+          "x131"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x129",
+          "x100",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x132",
+          "x133"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x131",
+          "x102",
+          "x118"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x134",
+          "x135"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x133",
+          "x104",
+          "x120"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x136",
+          "x137"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x135",
+          "x106",
+          "x122"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x138",
+          "x139"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x137",
+          "x108",
+          "x124"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x140",
+          "x141"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x139",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x109"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x95"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x125"
+                ]
+              },
+              "x113"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x142",
+          "x143"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x128",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x144",
+          "x145"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x143",
+          "x130",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x146",
+          "x147"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x145",
+          "x132",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x148",
+          "x149"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x147",
+          "x134",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x150",
+          "x151"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x149",
+          "x136",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x152",
+          "x153"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x151",
+          "x138",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x154",
+          "x155"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x153",
+          "x140",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x156",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x142",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x158",
+          "x159"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x156",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x160",
+          "x161"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x156",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x162",
+          "x163"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x156",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x164",
+          "x165"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x156",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x166",
+          "x167"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x165",
+          "x162"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x168",
+          "x169"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x167",
+          "x163",
+          "x160"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x170",
+          "x171"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x169",
+          "x161",
+          "x158"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x173"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x142",
+          "x156"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x174",
+          "x175"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x173",
+          "x144",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x176",
+          "x177"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x175",
+          "x146",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x178",
+          "x179"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x177",
+          "x148",
+          "x164"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x180",
+          "x181"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x179",
+          "x150",
+          "x166"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x182",
+          "x183"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x181",
+          "x152",
+          "x168"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x184",
+          "x185"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x183",
+          "x154",
+          "x170"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x186",
+          "x187"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x185",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x155"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x141"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x171"
+                ]
+              },
+              "x159"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x188",
+          "x189"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x174",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x190",
+          "x191"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x189",
+          "x176",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x192",
+          "x193"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x191",
+          "x178",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x194",
+          "x195"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x193",
+          "x180",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x196",
+          "x197"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x195",
+          "x182",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x198",
+          "x199"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x197",
+          "x184",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x200",
+          "x201"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x199",
+          "x186",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x202",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x188",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x204",
+          "x205"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x202",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x206",
+          "x207"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x202",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x208",
+          "x209"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x202",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x210",
+          "x211"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x202",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x212",
+          "x213"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x211",
+          "x208"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x214",
+          "x215"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x213",
+          "x209",
+          "x206"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x216",
+          "x217"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x215",
+          "x207",
+          "x204"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x219"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x188",
+          "x202"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x220",
+          "x221"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x219",
+          "x190",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x222",
+          "x223"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x221",
+          "x192",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x224",
+          "x225"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x223",
+          "x194",
+          "x210"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x226",
+          "x227"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x225",
+          "x196",
+          "x212"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x228",
+          "x229"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x227",
+          "x198",
+          "x214"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x230",
+          "x231"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x229",
+          "x200",
+          "x216"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x232",
+          "x233"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x231",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x201"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x187"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x217"
+                ]
+              },
+              "x205"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x234",
+          "x235"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x220",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x236",
+          "x237"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x235",
+          "x222",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x238",
+          "x239"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x237",
+          "x224",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x240",
+          "x241"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x239",
+          "x226",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x242",
+          "x243"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x241",
+          "x228",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x244",
+          "x245"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x243",
+          "x230",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x246",
+          "x247"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x245",
+          "x232",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x248",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x234",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x250",
+          "x251"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x248",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x252",
+          "x253"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x248",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x254",
+          "x255"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x248",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x256",
+          "x257"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x248",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x258",
+          "x259"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x257",
+          "x254"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x260",
+          "x261"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x259",
+          "x255",
+          "x252"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x262",
+          "x263"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x261",
+          "x253",
+          "x250"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x265"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x234",
+          "x248"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x266",
+          "x267"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x265",
+          "x236",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x268",
+          "x269"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x267",
+          "x238",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x270",
+          "x271"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x269",
+          "x240",
+          "x256"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x272",
+          "x273"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x271",
+          "x242",
+          "x258"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x274",
+          "x275"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x273",
+          "x244",
+          "x260"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x276",
+          "x277"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x275",
+          "x246",
+          "x262"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x278",
+          "x279"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x277",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x247"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x233"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x263"
+                ]
+              },
+              "x251"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x280",
+          "x281"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x266",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x282",
+          "x283"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x281",
+          "x268",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x284",
+          "x285"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x283",
+          "x270",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x286",
+          "x287"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x285",
+          "x272",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x288",
+          "x289"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x287",
+          "x274",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x290",
+          "x291"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x289",
+          "x276",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x292",
+          "x293"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x291",
+          "x278",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x295"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x293",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x279"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x296"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x295",
+          "x280",
+          "x266"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x297"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x295",
+          "x282",
+          "x268"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x298"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x295",
+          "x284",
+          "x270"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x299"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x295",
+          "x286",
+          "x272"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x300"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x295",
+          "x288",
+          "x274"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x301"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x295",
+          "x290",
+          "x276"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x302"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x295",
+          "x292",
+          "x278"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x296"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x297"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x298"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x299"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x300"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x301"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x302"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_to_montgomery",
+    "arguments": [
+      {
+        "datatype": "u32[7]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[7]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8",
+          "x9"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x13",
+          "x10"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x15",
+          "x11",
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x18",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x18",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x18",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x18",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x27",
+          "x24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x25",
+          "x22"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          "x23",
+          "x20"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34",
+          "x35"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x12",
+          "x26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36",
+          "x37"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x35",
+          "x14",
+          "x28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38",
+          "x39"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x37",
+          "x16",
+          "x30"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40",
+          "x41"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x39",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x17"
+                ]
+              },
+              "x9"
+            ]
+          },
+          "x32"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42",
+          "x43"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x41",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x33"
+                ]
+              },
+              "x21"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44",
+          "x45"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46",
+          "x47"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x48",
+          "x49"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x50",
+          "x51"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x49",
+          "x46"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x52",
+          "x53"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x51",
+          "x47",
+          "x44"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x55"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x7",
+          "x18"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x56",
+          "x57"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x55"
+            ]
+          },
+          "x1"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x58",
+          "x59"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x36",
+          "x48"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x59",
+          "x38",
+          "x50"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x61",
+          "x40",
+          "x52"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x63",
+          "x42",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x53"
+                ]
+              },
+              "x45"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x66",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x56",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x66",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x66",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x72",
+          "x73"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x66",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x66",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x76",
+          "x77"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x75",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x78",
+          "x79"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x77",
+          "x73",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x80",
+          "x81"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x79",
+          "x71",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x82",
+          "x83"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x58",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x84",
+          "x85"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x83",
+          "x60",
+          "x76"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x86",
+          "x87"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x85",
+          "x62",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x88",
+          "x89"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x87",
+          "x64",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x90",
+          "x91"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x89",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x65"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x43"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x81"
+                ]
+              },
+              "x69"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x94",
+          "x95"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x96",
+          "x97"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x98",
+          "x99"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x97",
+          "x94"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x100",
+          "x101"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x99",
+          "x95",
+          "x92"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x103"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x56",
+          "x66"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x104",
+          "x105"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x103"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x57"
+                ]
+              }
+            ]
+          },
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x106",
+          "x107"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x105",
+          "x34",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x108",
+          "x109"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x107",
+          "x82",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x110",
+          "x111"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x109",
+          "x84",
+          "x96"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x112",
+          "x113"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x111",
+          "x86",
+          "x98"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x114",
+          "x115"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x113",
+          "x88",
+          "x100"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x116",
+          "x117"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x115",
+          "x90",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x101"
+                ]
+              },
+              "x93"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x118",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x104",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x120",
+          "x121"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x118",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x122",
+          "x123"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x118",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x124",
+          "x125"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x118",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x126",
+          "x127"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x118",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x128",
+          "x129"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x127",
+          "x124"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x130",
+          "x131"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x129",
+          "x125",
+          "x122"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x132",
+          "x133"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x131",
+          "x123",
+          "x120"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x135"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x104",
+          "x118"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x136",
+          "x137"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x135",
+          "x106",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x138",
+          "x139"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x137",
+          "x108",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x140",
+          "x141"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x139",
+          "x110",
+          "x126"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x142",
+          "x143"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x141",
+          "x112",
+          "x128"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x144",
+          "x145"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x143",
+          "x114",
+          "x130"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x146",
+          "x147"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x145",
+          "x116",
+          "x132"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x148",
+          "x149"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x147",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x117"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x91"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x133"
+                ]
+              },
+              "x121"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x150",
+          "x151"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x152",
+          "x153"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x154",
+          "x155"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x156",
+          "x157"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x155",
+          "x152"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x158",
+          "x159"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x157",
+          "x153",
+          "x150"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x160",
+          "x161"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x136",
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x162",
+          "x163"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x161",
+          "x138",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x164",
+          "x165"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x163",
+          "x140",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x166",
+          "x167"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x165",
+          "x142",
+          "x154"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x168",
+          "x169"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x167",
+          "x144",
+          "x156"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x170",
+          "x171"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x169",
+          "x146",
+          "x158"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x172",
+          "x173"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x171",
+          "x148",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x159"
+                ]
+              },
+              "x151"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x174",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x160",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x176",
+          "x177"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x174",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x178",
+          "x179"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x174",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x180",
+          "x181"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x174",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x182",
+          "x183"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x174",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x184",
+          "x185"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x183",
+          "x180"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x186",
+          "x187"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x185",
+          "x181",
+          "x178"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x188",
+          "x189"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x187",
+          "x179",
+          "x176"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x191"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x160",
+          "x174"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x192",
+          "x193"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x191",
+          "x162",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x194",
+          "x195"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x193",
+          "x164",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x196",
+          "x197"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x195",
+          "x166",
+          "x182"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x198",
+          "x199"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x197",
+          "x168",
+          "x184"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x200",
+          "x201"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x199",
+          "x170",
+          "x186"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x202",
+          "x203"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x201",
+          "x172",
+          "x188"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x204",
+          "x205"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x203",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x173"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x149"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x189"
+                ]
+              },
+              "x177"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x206",
+          "x207"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x208",
+          "x209"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x210",
+          "x211"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x212",
+          "x213"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x211",
+          "x208"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x214",
+          "x215"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x213",
+          "x209",
+          "x206"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x216",
+          "x217"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x192",
+          "x4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x218",
+          "x219"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x217",
+          "x194",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x220",
+          "x221"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x219",
+          "x196",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x222",
+          "x223"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x221",
+          "x198",
+          "x210"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x224",
+          "x225"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x223",
+          "x200",
+          "x212"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x226",
+          "x227"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x225",
+          "x202",
+          "x214"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x228",
+          "x229"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x227",
+          "x204",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x215"
+                ]
+              },
+              "x207"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x230",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x216",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x232",
+          "x233"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x230",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x234",
+          "x235"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x230",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x236",
+          "x237"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x230",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x238",
+          "x239"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x230",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x240",
+          "x241"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x239",
+          "x236"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x242",
+          "x243"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x241",
+          "x237",
+          "x234"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x244",
+          "x245"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x243",
+          "x235",
+          "x232"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x247"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x216",
+          "x230"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x248",
+          "x249"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x247",
+          "x218",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x250",
+          "x251"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x249",
+          "x220",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x252",
+          "x253"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x251",
+          "x222",
+          "x238"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x254",
+          "x255"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x253",
+          "x224",
+          "x240"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x256",
+          "x257"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x255",
+          "x226",
+          "x242"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x258",
+          "x259"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x257",
+          "x228",
+          "x244"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x260",
+          "x261"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x259",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x229"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x205"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x245"
+                ]
+              },
+              "x233"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x262",
+          "x263"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x264",
+          "x265"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x266",
+          "x267"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x268",
+          "x269"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x267",
+          "x264"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x270",
+          "x271"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x269",
+          "x265",
+          "x262"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x272",
+          "x273"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x248",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x274",
+          "x275"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x273",
+          "x250",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x276",
+          "x277"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x275",
+          "x252",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x278",
+          "x279"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x277",
+          "x254",
+          "x266"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x280",
+          "x281"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x279",
+          "x256",
+          "x268"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x282",
+          "x283"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x281",
+          "x258",
+          "x270"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x284",
+          "x285"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x283",
+          "x260",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x271"
+                ]
+              },
+              "x263"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x286",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x272",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x288",
+          "x289"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x286",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x290",
+          "x291"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x286",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x292",
+          "x293"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x286",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x294",
+          "x295"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x286",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x296",
+          "x297"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x295",
+          "x292"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x298",
+          "x299"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x297",
+          "x293",
+          "x290"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x300",
+          "x301"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x299",
+          "x291",
+          "x288"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x303"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x272",
+          "x286"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x304",
+          "x305"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x303",
+          "x274",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x306",
+          "x307"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x305",
+          "x276",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x308",
+          "x309"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x307",
+          "x278",
+          "x294"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x310",
+          "x311"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x309",
+          "x280",
+          "x296"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x312",
+          "x313"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x311",
+          "x282",
+          "x298"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x314",
+          "x315"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x313",
+          "x284",
+          "x300"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x316",
+          "x317"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x315",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x285"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x261"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x301"
+                ]
+              },
+              "x289"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x318",
+          "x319"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x320",
+          "x321"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x322",
+          "x323"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x324",
+          "x325"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x323",
+          "x320"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x326",
+          "x327"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x325",
+          "x321",
+          "x318"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x328",
+          "x329"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x304",
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x330",
+          "x331"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x329",
+          "x306",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x332",
+          "x333"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x331",
+          "x308",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x334",
+          "x335"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x333",
+          "x310",
+          "x322"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x336",
+          "x337"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x335",
+          "x312",
+          "x324"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x338",
+          "x339"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x337",
+          "x314",
+          "x326"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x340",
+          "x341"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x339",
+          "x316",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x327"
+                ]
+              },
+              "x319"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x342",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x328",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x344",
+          "x345"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x346",
+          "x347"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x348",
+          "x349"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x350",
+          "x351"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x352",
+          "x353"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x351",
+          "x348"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x354",
+          "x355"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x353",
+          "x349",
+          "x346"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x356",
+          "x357"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x355",
+          "x347",
+          "x344"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x359"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x328",
+          "x342"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x360",
+          "x361"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x359",
+          "x330",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x362",
+          "x363"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x361",
+          "x332",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x364",
+          "x365"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x363",
+          "x334",
+          "x350"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x366",
+          "x367"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x365",
+          "x336",
+          "x352"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x368",
+          "x369"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x367",
+          "x338",
+          "x354"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x370",
+          "x371"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x369",
+          "x340",
+          "x356"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x372",
+          "x373"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x371",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x341"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x317"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x357"
+                ]
+              },
+              "x345"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x374",
+          "x375"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x360",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x376",
+          "x377"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x375",
+          "x362",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x378",
+          "x379"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x377",
+          "x364",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x380",
+          "x381"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x379",
+          "x366",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x382",
+          "x383"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x381",
+          "x368",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x384",
+          "x385"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x383",
+          "x370",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x386",
+          "x387"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x385",
+          "x372",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x389"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x387",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x373"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x390"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x389",
+          "x374",
+          "x360"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x391"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x389",
+          "x376",
+          "x362"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x392"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x389",
+          "x378",
+          "x364"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x393"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x389",
+          "x380",
+          "x366"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x394"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x389",
+          "x382",
+          "x368"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x395"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x389",
+          "x384",
+          "x370"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x396"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x389",
+          "x386",
+          "x372"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x390"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x391"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x392"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x393"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x394"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x395"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x396"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_nonzero",
+    "arguments": [
+      {
+        "datatype": "u32[7]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "|",
+        "arguments": [
+          "arg1[0]",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "|",
+            "arguments": [
+              "arg1[1]",
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "|",
+                "arguments": [
+                  "arg1[2]",
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "|",
+                    "arguments": [
+                      "arg1[3]",
+                      {
+                        "datatype": "u32",
+                        "name": [],
+                        "operation": "|",
+                        "arguments": [
+                          "arg1[4]",
+                          {
+                            "datatype": "u32",
+                            "name": [],
+                            "operation": "|",
+                            "arguments": [
+                              "arg1[5]",
+                              "arg1[6]"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_selectznz",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[7]",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32[7]",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[7]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[0]",
+          "arg3[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[1]",
+          "arg3[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[2]",
+          "arg3[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[3]",
+          "arg3[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[4]",
+          "arg3[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[5]",
+          "arg3[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[6]",
+          "arg3[6]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_to_bytes",
+    "arguments": [
+      {
+        "datatype": "u32[7]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u8[28]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x8"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x7"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x7",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x10"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x9",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x12"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x11"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x13"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x11",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x14"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x6",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x16"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x15"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x15",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x18"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x17"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x19"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x17",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x20"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x5"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x5",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x22"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x21"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x21",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x24"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x23"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x25"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x23",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x26"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x4",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x28"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x27"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x27",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x30"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x29"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x31"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x29",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x32"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x3",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x34"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x33"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x33",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x36"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x35"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x37"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x35",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x38"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x2",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x40"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x39"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x39",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x42"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x41"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x43"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x41",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x44"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x45"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x1",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x46"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x45"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x47"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x45",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x48"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x47"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x49"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x47",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x10"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x12"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x13"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x14"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x19"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x22"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x24"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x25"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x26"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x28"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x30"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x31"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[16]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x32"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[17]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x34"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[18]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x36"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[19]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x37"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[20]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x38"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[21]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x40"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[22]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x42"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[23]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x43"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[24]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x44"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[25]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x46"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[26]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x48"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[27]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x49"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_from_bytes",
+    "arguments": [
+      {
+        "datatype": "u8[28]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[7]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[27]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[26]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[25]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[24]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[23]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[22]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[21]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x8"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[20]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[19]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[18]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[17]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x12"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[16]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x16"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[12]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x20"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x24"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x28"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x27",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x26",
+          "x29"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x25",
+          "x30"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x23",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x22",
+          "x32"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x21",
+          "x33"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x19",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x20"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x18",
+          "x35"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x17",
+          "x36"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x15",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x14",
+          "x38"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x13",
+          "x39"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x11",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x10",
+          "x41"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x43"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x9",
+          "x42"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x7",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x45"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x6",
+          "x44"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x5",
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x47"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x3",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x48"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x2",
+          "x47"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x49"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x1",
+          "x48"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x31"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x34"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x37"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x40"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x43"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x46"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x49"
+        ]
+      }
+    ]
+  }
+]

--- a/fiat-json/src/p224_64.json
+++ b/fiat-json/src/p224_64.json
@@ -1,0 +1,8910 @@
+[
+  {
+    "operation": "fiat_p224_addcarryx_u64",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u128",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              },
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "64"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_subborrowx_u64",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "i128",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "i128",
+            "name": [],
+            "operation": "-",
+            "arguments": [
+              {
+                "datatype": "i128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              },
+              {
+                "datatype": "i128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "i128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "i1",
+        "name": [
+          "x2"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "i1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "64"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_mulx_u64",
+    "arguments": [
+      {
+        "datatype": "u64",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u64",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u128",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "64"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_cmovznz_u64",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u1",
+        "name": [
+          "x1"
+        ],
+        "operation": "!",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "!",
+            "arguments": [
+              "arg1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "-",
+                "arguments": [
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "0x0"
+                    ]
+                  },
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x1"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "|",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "arg3"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "~",
+                "arguments": [
+                  "x2"
+                ]
+              },
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_mul",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[4]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x12",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x14",
+          "x10",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x16",
+          "x8",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          },
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x27",
+          "x24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x25",
+          "x22"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x31"
+            ]
+          },
+          "x23"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x34"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x11",
+          "x20"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35",
+          "x36"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x34",
+          "x13",
+          "x26"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x36",
+          "x15",
+          "x28"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39",
+          "x40"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x38",
+          "x17",
+          "x30"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41",
+          "x42"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x40",
+          "x19",
+          "x32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43",
+          "x44"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45",
+          "x46"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47",
+          "x48"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49",
+          "x50"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51",
+          "x52"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x50",
+          "x47"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53",
+          "x54"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x52",
+          "x48",
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55",
+          "x56"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x54",
+          "x46",
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x56"
+            ]
+          },
+          "x44"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58",
+          "x59"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x35",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x59",
+          "x37",
+          "x51"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x61",
+          "x39",
+          "x53"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x63",
+          "x41",
+          "x55"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x65",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          },
+          "x57"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x58",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x68",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72",
+          "x73"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x68",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x68",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x76",
+          "x77"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x75",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78",
+          "x79"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x77",
+          "x73",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x80"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x79"
+            ]
+          },
+          "x71"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x82"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x58",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83",
+          "x84"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x82",
+          "x60",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x85",
+          "x86"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x84",
+          "x62",
+          "x76"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87",
+          "x88"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x86",
+          "x64",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89",
+          "x90"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x88",
+          "x66",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x91"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x90"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x67"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x94",
+          "x95"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96",
+          "x97"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98",
+          "x99"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100",
+          "x101"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x99",
+          "x96"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102",
+          "x103"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x101",
+          "x97",
+          "x94"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x104",
+          "x105"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x103",
+          "x95",
+          "x92"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x106"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x105"
+            ]
+          },
+          "x93"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x107",
+          "x108"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x83",
+          "x98"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x109",
+          "x110"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x108",
+          "x85",
+          "x100"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x111",
+          "x112"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x110",
+          "x87",
+          "x102"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x113",
+          "x114"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x112",
+          "x89",
+          "x104"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x115",
+          "x116"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x114",
+          "x91",
+          "x106"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x117",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x107",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x119",
+          "x120"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x117",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x121",
+          "x122"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x117",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x123",
+          "x124"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x117",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x125",
+          "x126"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x124",
+          "x121"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x127",
+          "x128"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x126",
+          "x122",
+          "x119"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x129"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x128"
+            ]
+          },
+          "x120"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x131"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x107",
+          "x117"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x132",
+          "x133"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x131",
+          "x109",
+          "x123"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x134",
+          "x135"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x133",
+          "x111",
+          "x125"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x136",
+          "x137"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x135",
+          "x113",
+          "x127"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x138",
+          "x139"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x137",
+          "x115",
+          "x129"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x140"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x139"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x116"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x141",
+          "x142"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x143",
+          "x144"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x145",
+          "x146"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x147",
+          "x148"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x149",
+          "x150"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x148",
+          "x145"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x151",
+          "x152"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x150",
+          "x146",
+          "x143"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x153",
+          "x154"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x152",
+          "x144",
+          "x141"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x155"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x154"
+            ]
+          },
+          "x142"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x156",
+          "x157"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x132",
+          "x147"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x158",
+          "x159"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x157",
+          "x134",
+          "x149"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x160",
+          "x161"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x159",
+          "x136",
+          "x151"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x162",
+          "x163"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x161",
+          "x138",
+          "x153"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x164",
+          "x165"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x163",
+          "x140",
+          "x155"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x166",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x156",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x168",
+          "x169"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x166",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x170",
+          "x171"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x166",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x172",
+          "x173"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x166",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x174",
+          "x175"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x173",
+          "x170"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x176",
+          "x177"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x175",
+          "x171",
+          "x168"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x178"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x177"
+            ]
+          },
+          "x169"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x180"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x156",
+          "x166"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x181",
+          "x182"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x180",
+          "x158",
+          "x172"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x183",
+          "x184"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x182",
+          "x160",
+          "x174"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x185",
+          "x186"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x184",
+          "x162",
+          "x176"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x187",
+          "x188"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x186",
+          "x164",
+          "x178"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x189"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x188"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x165"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x190",
+          "x191"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x181",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x192",
+          "x193"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x191",
+          "x183",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x194",
+          "x195"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x193",
+          "x185",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x196",
+          "x197"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x195",
+          "x187",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x199"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x197",
+          "x189",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x200"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x199",
+          "x190",
+          "x181"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x201"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x199",
+          "x192",
+          "x183"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x202"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x199",
+          "x194",
+          "x185"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x203"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x199",
+          "x196",
+          "x187"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x200"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x201"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x202"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x203"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_square",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x12",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x14",
+          "x10",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x16",
+          "x8",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          },
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x27",
+          "x24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x25",
+          "x22"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x31"
+            ]
+          },
+          "x23"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x34"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x11",
+          "x20"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35",
+          "x36"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x34",
+          "x13",
+          "x26"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x36",
+          "x15",
+          "x28"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39",
+          "x40"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x38",
+          "x17",
+          "x30"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41",
+          "x42"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x40",
+          "x19",
+          "x32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43",
+          "x44"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45",
+          "x46"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47",
+          "x48"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49",
+          "x50"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51",
+          "x52"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x50",
+          "x47"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53",
+          "x54"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x52",
+          "x48",
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55",
+          "x56"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x54",
+          "x46",
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x56"
+            ]
+          },
+          "x44"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58",
+          "x59"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x35",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x59",
+          "x37",
+          "x51"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x61",
+          "x39",
+          "x53"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x63",
+          "x41",
+          "x55"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x65",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          },
+          "x57"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x58",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x68",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72",
+          "x73"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x68",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x68",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x76",
+          "x77"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x75",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78",
+          "x79"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x77",
+          "x73",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x80"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x79"
+            ]
+          },
+          "x71"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x82"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x58",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83",
+          "x84"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x82",
+          "x60",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x85",
+          "x86"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x84",
+          "x62",
+          "x76"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87",
+          "x88"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x86",
+          "x64",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89",
+          "x90"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x88",
+          "x66",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x91"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x90"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x67"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x94",
+          "x95"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96",
+          "x97"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98",
+          "x99"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100",
+          "x101"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x99",
+          "x96"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102",
+          "x103"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x101",
+          "x97",
+          "x94"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x104",
+          "x105"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x103",
+          "x95",
+          "x92"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x106"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x105"
+            ]
+          },
+          "x93"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x107",
+          "x108"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x83",
+          "x98"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x109",
+          "x110"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x108",
+          "x85",
+          "x100"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x111",
+          "x112"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x110",
+          "x87",
+          "x102"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x113",
+          "x114"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x112",
+          "x89",
+          "x104"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x115",
+          "x116"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x114",
+          "x91",
+          "x106"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x117",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x107",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x119",
+          "x120"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x117",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x121",
+          "x122"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x117",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x123",
+          "x124"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x117",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x125",
+          "x126"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x124",
+          "x121"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x127",
+          "x128"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x126",
+          "x122",
+          "x119"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x129"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x128"
+            ]
+          },
+          "x120"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x131"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x107",
+          "x117"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x132",
+          "x133"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x131",
+          "x109",
+          "x123"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x134",
+          "x135"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x133",
+          "x111",
+          "x125"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x136",
+          "x137"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x135",
+          "x113",
+          "x127"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x138",
+          "x139"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x137",
+          "x115",
+          "x129"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x140"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x139"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x116"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x141",
+          "x142"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x143",
+          "x144"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x145",
+          "x146"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x147",
+          "x148"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x149",
+          "x150"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x148",
+          "x145"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x151",
+          "x152"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x150",
+          "x146",
+          "x143"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x153",
+          "x154"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x152",
+          "x144",
+          "x141"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x155"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x154"
+            ]
+          },
+          "x142"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x156",
+          "x157"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x132",
+          "x147"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x158",
+          "x159"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x157",
+          "x134",
+          "x149"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x160",
+          "x161"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x159",
+          "x136",
+          "x151"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x162",
+          "x163"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x161",
+          "x138",
+          "x153"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x164",
+          "x165"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x163",
+          "x140",
+          "x155"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x166",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x156",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x168",
+          "x169"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x166",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x170",
+          "x171"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x166",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x172",
+          "x173"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x166",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x174",
+          "x175"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x173",
+          "x170"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x176",
+          "x177"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x175",
+          "x171",
+          "x168"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x178"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x177"
+            ]
+          },
+          "x169"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x180"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x156",
+          "x166"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x181",
+          "x182"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x180",
+          "x158",
+          "x172"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x183",
+          "x184"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x182",
+          "x160",
+          "x174"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x185",
+          "x186"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x184",
+          "x162",
+          "x176"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x187",
+          "x188"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x186",
+          "x164",
+          "x178"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x189"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x188"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x165"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x190",
+          "x191"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x181",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x192",
+          "x193"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x191",
+          "x183",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x194",
+          "x195"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x193",
+          "x185",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x196",
+          "x197"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x195",
+          "x187",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x199"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x197",
+          "x189",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x200"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x199",
+          "x190",
+          "x181"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x201"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x199",
+          "x192",
+          "x183"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x202"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x199",
+          "x194",
+          "x185"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x203"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x199",
+          "x196",
+          "x187"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x200"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x201"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x202"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x203"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_add",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[4]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x1",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x10",
+          "x3",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x12",
+          "x5",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x14",
+          "x7",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x18"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x16",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x18",
+          "x9",
+          "x1"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x18",
+          "x11",
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x18",
+          "x13",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x18",
+          "x15",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x19"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x21"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x22"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_sub",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[4]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x8",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "&",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x9"
+                    ]
+                  },
+                  "0x1"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x11",
+          "x3",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x9",
+              "0xffffffff00000000"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x13",
+          "x5",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x15",
+          "x7",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x9",
+              "0xffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x10"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x12"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x14"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_opp",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x8",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "&",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x9"
+                    ]
+                  },
+                  "0x1"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x11",
+          "x3",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x9",
+              "0xffffffff00000000"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x13",
+          "x5",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x15",
+          "x7",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x9",
+              "0xffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x10"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x12"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x14"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_from_montgomery",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4",
+          "x5"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6",
+          "x7"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8",
+          "x9"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x9",
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x11",
+          "x7",
+          "x4"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x15"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x15",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x17",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x10"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x19",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x12"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x16",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x18",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x20",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x22",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x28",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x28",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34",
+          "x35"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x28",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36",
+          "x37"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x35",
+          "x32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38",
+          "x39"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x37",
+          "x33",
+          "x30"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x41"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x22",
+          "x28"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42",
+          "x43"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x41",
+          "x24",
+          "x34"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44",
+          "x45"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x43",
+          "x26",
+          "x36"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46",
+          "x47"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x45",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x27"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x21"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x13"
+                        ]
+                      },
+                      "x5"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "x38"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48",
+          "x49"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x42",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50",
+          "x51"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x49",
+          "x44",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52",
+          "x53"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x51",
+          "x46",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x48",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56",
+          "x57"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x54",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58",
+          "x59"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x54",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x54",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x61",
+          "x58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x63",
+          "x59",
+          "x56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x67"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x48",
+          "x54"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x67",
+          "x50",
+          "x60"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x69",
+          "x52",
+          "x62"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72",
+          "x73"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x71",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x53"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x47"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x39"
+                        ]
+                      },
+                      "x31"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "x64"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x68",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x76",
+          "x77"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x75",
+          "x70",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78",
+          "x79"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x77",
+          "x72",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x80",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x74",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x82",
+          "x83"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x80",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84",
+          "x85"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x80",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x86",
+          "x87"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x80",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88",
+          "x89"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x87",
+          "x84"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90",
+          "x91"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x89",
+          "x85",
+          "x82"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x93"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x74",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x94",
+          "x95"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x93",
+          "x76",
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96",
+          "x97"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x95",
+          "x78",
+          "x88"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98",
+          "x99"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x97",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x79"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x73"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x65"
+                        ]
+                      },
+                      "x57"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "x90"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x99"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x91"
+                ]
+              },
+              "x83"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x101",
+          "x102"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x94",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x103",
+          "x104"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x102",
+          "x96",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x105",
+          "x106"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x104",
+          "x98",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x107",
+          "x108"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x106",
+          "x100",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x110"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x108",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x111"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x110",
+          "x101",
+          "x94"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x112"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x110",
+          "x103",
+          "x96"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x113"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x110",
+          "x105",
+          "x98"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x114"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x110",
+          "x107",
+          "x100"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x111"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x112"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x113"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x114"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_to_montgomery",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xfffffffe00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x12",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x14",
+          "x10",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x16",
+          "x8",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x19",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x19",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25",
+          "x26"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x19",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27",
+          "x28"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x26",
+          "x23"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29",
+          "x30"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x28",
+          "x24",
+          "x21"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x32"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x11",
+          "x19"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33",
+          "x34"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x32",
+          "x13",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35",
+          "x36"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x34",
+          "x15",
+          "x27"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x36",
+          "x17",
+          "x29"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39",
+          "x40"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41",
+          "x42"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xfffffffe00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43",
+          "x44"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45",
+          "x46"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47",
+          "x48"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x46",
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49",
+          "x50"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x48",
+          "x44",
+          "x41"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51",
+          "x52"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x50",
+          "x42",
+          "x39"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53",
+          "x54"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x33",
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55",
+          "x56"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x54",
+          "x35",
+          "x47"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57",
+          "x58"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x56",
+          "x37",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59",
+          "x60"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x58",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x38"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x18"
+                        ]
+                      },
+                      "x6"
+                    ]
+                  }
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x30"
+                    ]
+                  },
+                  "x22"
+                ]
+              }
+            ]
+          },
+          "x51"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x53",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x63",
+          "x64"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x61",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x65",
+          "x66"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x61",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x67",
+          "x68"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x61",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x69",
+          "x70"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x68",
+          "x65"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x71",
+          "x72"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x70",
+          "x66",
+          "x63"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x74"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x53",
+          "x61"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x75",
+          "x76"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x74",
+          "x55",
+          "x67"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x77",
+          "x78"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x76",
+          "x57",
+          "x69"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79",
+          "x80"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x78",
+          "x59",
+          "x71"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81",
+          "x82"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83",
+          "x84"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xfffffffe00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x85",
+          "x86"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87",
+          "x88"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89",
+          "x90"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x88",
+          "x85"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x91",
+          "x92"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x90",
+          "x86",
+          "x83"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x93",
+          "x94"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x92",
+          "x84",
+          "x81"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x95",
+          "x96"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x75",
+          "x87"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x97",
+          "x98"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x96",
+          "x77",
+          "x89"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x99",
+          "x100"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x98",
+          "x79",
+          "x91"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x101",
+          "x102"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x100",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x80"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x60"
+                        ]
+                      },
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "static_cast",
+                            "arguments": [
+                              "x52"
+                            ]
+                          },
+                          "x40"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x72"
+                    ]
+                  },
+                  "x64"
+                ]
+              }
+            ]
+          },
+          "x93"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x103",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x95",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x105",
+          "x106"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x103",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x107",
+          "x108"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x103",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x109",
+          "x110"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x103",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x111",
+          "x112"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x110",
+          "x107"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x113",
+          "x114"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x112",
+          "x108",
+          "x105"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x116"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x95",
+          "x103"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x117",
+          "x118"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x116",
+          "x97",
+          "x109"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x119",
+          "x120"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x118",
+          "x99",
+          "x111"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x121",
+          "x122"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x120",
+          "x101",
+          "x113"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x123",
+          "x124"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x125",
+          "x126"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xfffffffe00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x127",
+          "x128"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x129",
+          "x130"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x131",
+          "x132"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x130",
+          "x127"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x133",
+          "x134"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x132",
+          "x128",
+          "x125"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x135",
+          "x136"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x134",
+          "x126",
+          "x123"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x137",
+          "x138"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x117",
+          "x129"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x139",
+          "x140"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x138",
+          "x119",
+          "x131"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x141",
+          "x142"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x140",
+          "x121",
+          "x133"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x143",
+          "x144"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x142",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x122"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x102"
+                        ]
+                      },
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "static_cast",
+                            "arguments": [
+                              "x94"
+                            ]
+                          },
+                          "x82"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x114"
+                    ]
+                  },
+                  "x106"
+                ]
+              }
+            ]
+          },
+          "x135"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x145",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x137",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x147",
+          "x148"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x145",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x149",
+          "x150"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x145",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x151",
+          "x152"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x145",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x153",
+          "x154"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x152",
+          "x149"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x155",
+          "x156"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x154",
+          "x150",
+          "x147"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x158"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x137",
+          "x145"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x159",
+          "x160"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x158",
+          "x139",
+          "x151"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x161",
+          "x162"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x160",
+          "x141",
+          "x153"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x163",
+          "x164"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x162",
+          "x143",
+          "x155"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x165"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x164"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x144"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x136"
+                        ]
+                      },
+                      "x124"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x156"
+                ]
+              },
+              "x148"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x166",
+          "x167"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x159",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x168",
+          "x169"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x167",
+          "x161",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x170",
+          "x171"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x169",
+          "x163",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x172",
+          "x173"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x171",
+          "x165",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x175"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x173",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x176"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x175",
+          "x166",
+          "x159"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x177"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x175",
+          "x168",
+          "x161"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x178"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x175",
+          "x170",
+          "x163"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x179"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x175",
+          "x172",
+          "x165"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x176"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x177"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x178"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x179"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_nonzero",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "|",
+        "arguments": [
+          "arg1[0]",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "|",
+            "arguments": [
+              "arg1[1]",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "|",
+                "arguments": [
+                  "arg1[2]",
+                  "arg1[3]"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_selectznz",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[4]",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64[4]",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[0]",
+          "arg3[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[1]",
+          "arg3[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[2]",
+          "arg3[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[3]",
+          "arg3[3]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_to_bytes",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u8[28]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x5"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x4",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x7"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x6",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x9"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x8",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x11"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x10"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x10",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x13"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x12",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x15"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x14",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x17"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x18"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x16",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x19"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x3",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x21"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x20"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x20",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x23"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x22"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x22",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x25"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x24",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x27"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x26"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x26",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x29"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x28",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x31"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x30"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x32"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x30",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x33"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x2",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x35"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x34"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x34",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x37"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x36"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x36",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x39"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x38",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x41"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x40",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x43"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x42",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x45"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x44"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x46"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x44",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x47"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x1",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x49"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x48"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x48",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x51"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x50"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x52"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x50",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x11"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x13"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x15"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x17"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x19"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x21"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x23"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x25"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x27"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x29"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x31"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x32"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[16]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x33"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[17]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x35"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[18]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x37"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[19]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x39"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[20]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x41"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[21]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x43"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[22]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x45"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[23]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x46"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[24]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x47"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[25]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x49"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[26]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x51"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[27]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x52"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p224_from_bytes",
+    "arguments": [
+      {
+        "datatype": "u8[28]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[27]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[26]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[25]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[24]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[23]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[22]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[21]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[20]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[19]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[18]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[17]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x12"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[16]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x20"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x28"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x27",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x26",
+          "x29"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x25",
+          "x30"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x24",
+          "x31"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x23",
+          "x32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x22",
+          "x33"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x21",
+          "x34"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x19",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x20"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x18",
+          "x36"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x17",
+          "x37"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x16",
+          "x38"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x15",
+          "x39"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x14",
+          "x40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x13",
+          "x41"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x11",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x10",
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x9",
+          "x44"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x8",
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x7",
+          "x46"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x6",
+          "x47"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x5",
+          "x48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x3",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x2",
+          "x50"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x1",
+          "x51"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x35"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x42"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x49"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x52"
+        ]
+      }
+    ]
+  }
+]

--- a/fiat-json/src/p256_32.json
+++ b/fiat-json/src/p256_32.json
@@ -1,0 +1,21315 @@
+[
+  {
+    "operation": "fiat_p256_addcarryx_u32",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_subborrowx_u32",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "i64",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "i64",
+            "name": [],
+            "operation": "-",
+            "arguments": [
+              {
+                "datatype": "i64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              },
+              {
+                "datatype": "i64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "i64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "i1",
+        "name": [
+          "x2"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "i1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_mulx_u32",
+    "arguments": [
+      {
+        "datatype": "u32",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      },
+      {
+        "datatype": "u32",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_cmovznz_u32",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u1",
+        "name": [
+          "x1"
+        ],
+        "operation": "!",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "!",
+            "arguments": [
+              "arg1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "-",
+                "arguments": [
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "0x0"
+                    ]
+                  },
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x1"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "|",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "arg3"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "~",
+                "arguments": [
+                  "x2"
+                ]
+              },
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_mul",
+    "arguments": [
+      {
+        "datatype": "u32[8]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[8]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25",
+          "x26"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x24",
+          "x21"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27",
+          "x28"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x26",
+          "x22",
+          "x19"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29",
+          "x30"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x28",
+          "x20",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31",
+          "x32"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x30",
+          "x18",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33",
+          "x34"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x32",
+          "x16",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35",
+          "x36"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x34",
+          "x14",
+          "x11"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x36",
+          "x12",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          },
+          "x10"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40",
+          "x41"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x23",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42",
+          "x43"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x23",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44",
+          "x45"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x23",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46",
+          "x47"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x23",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x48",
+          "x49"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x47",
+          "x44"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x50",
+          "x51"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x49",
+          "x45",
+          "x42"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x52"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x51"
+            ]
+          },
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x54"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x23",
+          "x46"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x55",
+          "x56"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x54",
+          "x25",
+          "x48"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x57",
+          "x58"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x56",
+          "x27",
+          "x50"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x59",
+          "x60"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x58",
+          "x29",
+          "x52"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x61",
+          "x62"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x60",
+          "x31",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x63",
+          "x64"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x62",
+          "x33",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x65",
+          "x66"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x64",
+          "x35",
+          "x23"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x67",
+          "x68"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x66",
+          "x37",
+          "x40"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x69",
+          "x70"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x68",
+          "x39",
+          "x41"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x71",
+          "x72"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x73",
+          "x74"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x75",
+          "x76"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x77",
+          "x78"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x79",
+          "x80"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x81",
+          "x82"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x83",
+          "x84"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x85",
+          "x86"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x87",
+          "x88"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x86",
+          "x83"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x89",
+          "x90"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x88",
+          "x84",
+          "x81"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x91",
+          "x92"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x90",
+          "x82",
+          "x79"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x93",
+          "x94"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x92",
+          "x80",
+          "x77"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x95",
+          "x96"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x94",
+          "x78",
+          "x75"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x97",
+          "x98"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x96",
+          "x76",
+          "x73"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x99",
+          "x100"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x98",
+          "x74",
+          "x71"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x101"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x100"
+            ]
+          },
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x102",
+          "x103"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x55",
+          "x85"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x104",
+          "x105"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x103",
+          "x57",
+          "x87"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x106",
+          "x107"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x105",
+          "x59",
+          "x89"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x108",
+          "x109"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x107",
+          "x61",
+          "x91"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x110",
+          "x111"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x109",
+          "x63",
+          "x93"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x112",
+          "x113"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x111",
+          "x65",
+          "x95"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x114",
+          "x115"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x113",
+          "x67",
+          "x97"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x116",
+          "x117"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x115",
+          "x69",
+          "x99"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x118",
+          "x119"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x117",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x70"
+            ]
+          },
+          "x101"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x120",
+          "x121"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x102",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x122",
+          "x123"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x102",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x124",
+          "x125"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x102",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x126",
+          "x127"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x102",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x128",
+          "x129"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x127",
+          "x124"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x130",
+          "x131"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x129",
+          "x125",
+          "x122"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x132"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x131"
+            ]
+          },
+          "x123"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x134"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x102",
+          "x126"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x135",
+          "x136"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x134",
+          "x104",
+          "x128"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x137",
+          "x138"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x136",
+          "x106",
+          "x130"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x139",
+          "x140"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x138",
+          "x108",
+          "x132"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x141",
+          "x142"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x140",
+          "x110",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x143",
+          "x144"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x142",
+          "x112",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x145",
+          "x146"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x144",
+          "x114",
+          "x102"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x147",
+          "x148"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x146",
+          "x116",
+          "x120"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x149",
+          "x150"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x148",
+          "x118",
+          "x121"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x151"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x150"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x119"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x152",
+          "x153"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x154",
+          "x155"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x156",
+          "x157"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x158",
+          "x159"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x160",
+          "x161"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x162",
+          "x163"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x164",
+          "x165"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x166",
+          "x167"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x168",
+          "x169"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x167",
+          "x164"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x170",
+          "x171"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x169",
+          "x165",
+          "x162"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x172",
+          "x173"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x171",
+          "x163",
+          "x160"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x174",
+          "x175"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x173",
+          "x161",
+          "x158"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x176",
+          "x177"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x175",
+          "x159",
+          "x156"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x178",
+          "x179"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x177",
+          "x157",
+          "x154"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x180",
+          "x181"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x179",
+          "x155",
+          "x152"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x182"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x181"
+            ]
+          },
+          "x153"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x183",
+          "x184"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x135",
+          "x166"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x185",
+          "x186"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x184",
+          "x137",
+          "x168"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x187",
+          "x188"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x186",
+          "x139",
+          "x170"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x189",
+          "x190"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x188",
+          "x141",
+          "x172"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x191",
+          "x192"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x190",
+          "x143",
+          "x174"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x193",
+          "x194"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x192",
+          "x145",
+          "x176"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x195",
+          "x196"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x194",
+          "x147",
+          "x178"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x197",
+          "x198"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x196",
+          "x149",
+          "x180"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x199",
+          "x200"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x198",
+          "x151",
+          "x182"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x201",
+          "x202"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x183",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x203",
+          "x204"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x183",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x205",
+          "x206"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x183",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x207",
+          "x208"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x183",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x209",
+          "x210"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x208",
+          "x205"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x211",
+          "x212"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x210",
+          "x206",
+          "x203"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x213"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x212"
+            ]
+          },
+          "x204"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x215"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x183",
+          "x207"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x216",
+          "x217"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x215",
+          "x185",
+          "x209"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x218",
+          "x219"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x217",
+          "x187",
+          "x211"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x220",
+          "x221"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x219",
+          "x189",
+          "x213"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x222",
+          "x223"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x221",
+          "x191",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x224",
+          "x225"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x223",
+          "x193",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x226",
+          "x227"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x225",
+          "x195",
+          "x183"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x228",
+          "x229"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x227",
+          "x197",
+          "x201"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x230",
+          "x231"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x229",
+          "x199",
+          "x202"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x232"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x231"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x200"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x233",
+          "x234"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x235",
+          "x236"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x237",
+          "x238"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x239",
+          "x240"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x241",
+          "x242"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x243",
+          "x244"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x245",
+          "x246"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x247",
+          "x248"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x249",
+          "x250"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x248",
+          "x245"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x251",
+          "x252"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x250",
+          "x246",
+          "x243"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x253",
+          "x254"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x252",
+          "x244",
+          "x241"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x255",
+          "x256"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x254",
+          "x242",
+          "x239"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x257",
+          "x258"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x256",
+          "x240",
+          "x237"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x259",
+          "x260"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x258",
+          "x238",
+          "x235"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x261",
+          "x262"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x260",
+          "x236",
+          "x233"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x263"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x262"
+            ]
+          },
+          "x234"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x264",
+          "x265"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x216",
+          "x247"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x266",
+          "x267"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x265",
+          "x218",
+          "x249"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x268",
+          "x269"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x267",
+          "x220",
+          "x251"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x270",
+          "x271"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x269",
+          "x222",
+          "x253"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x272",
+          "x273"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x271",
+          "x224",
+          "x255"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x274",
+          "x275"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x273",
+          "x226",
+          "x257"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x276",
+          "x277"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x275",
+          "x228",
+          "x259"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x278",
+          "x279"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x277",
+          "x230",
+          "x261"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x280",
+          "x281"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x279",
+          "x232",
+          "x263"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x282",
+          "x283"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x264",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x284",
+          "x285"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x264",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x286",
+          "x287"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x264",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x288",
+          "x289"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x264",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x290",
+          "x291"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x289",
+          "x286"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x292",
+          "x293"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x291",
+          "x287",
+          "x284"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x294"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x293"
+            ]
+          },
+          "x285"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x296"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x264",
+          "x288"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x297",
+          "x298"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x296",
+          "x266",
+          "x290"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x299",
+          "x300"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x298",
+          "x268",
+          "x292"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x301",
+          "x302"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x300",
+          "x270",
+          "x294"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x303",
+          "x304"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x302",
+          "x272",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x305",
+          "x306"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x304",
+          "x274",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x307",
+          "x308"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x306",
+          "x276",
+          "x264"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x309",
+          "x310"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x308",
+          "x278",
+          "x282"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x311",
+          "x312"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x310",
+          "x280",
+          "x283"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x313"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x312"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x281"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x314",
+          "x315"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x316",
+          "x317"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x318",
+          "x319"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x320",
+          "x321"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x322",
+          "x323"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x324",
+          "x325"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x326",
+          "x327"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x328",
+          "x329"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x330",
+          "x331"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x329",
+          "x326"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x332",
+          "x333"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x331",
+          "x327",
+          "x324"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x334",
+          "x335"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x333",
+          "x325",
+          "x322"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x336",
+          "x337"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x335",
+          "x323",
+          "x320"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x338",
+          "x339"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x337",
+          "x321",
+          "x318"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x340",
+          "x341"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x339",
+          "x319",
+          "x316"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x342",
+          "x343"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x341",
+          "x317",
+          "x314"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x344"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x343"
+            ]
+          },
+          "x315"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x345",
+          "x346"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x297",
+          "x328"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x347",
+          "x348"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x346",
+          "x299",
+          "x330"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x349",
+          "x350"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x348",
+          "x301",
+          "x332"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x351",
+          "x352"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x350",
+          "x303",
+          "x334"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x353",
+          "x354"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x352",
+          "x305",
+          "x336"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x355",
+          "x356"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x354",
+          "x307",
+          "x338"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x357",
+          "x358"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x356",
+          "x309",
+          "x340"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x359",
+          "x360"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x358",
+          "x311",
+          "x342"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x361",
+          "x362"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x360",
+          "x313",
+          "x344"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x363",
+          "x364"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x345",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x365",
+          "x366"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x345",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x367",
+          "x368"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x345",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x369",
+          "x370"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x345",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x371",
+          "x372"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x370",
+          "x367"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x373",
+          "x374"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x372",
+          "x368",
+          "x365"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x375"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x374"
+            ]
+          },
+          "x366"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x377"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x345",
+          "x369"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x378",
+          "x379"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x377",
+          "x347",
+          "x371"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x380",
+          "x381"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x379",
+          "x349",
+          "x373"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x382",
+          "x383"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x381",
+          "x351",
+          "x375"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x384",
+          "x385"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x383",
+          "x353",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x386",
+          "x387"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x385",
+          "x355",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x388",
+          "x389"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x387",
+          "x357",
+          "x345"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x390",
+          "x391"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x389",
+          "x359",
+          "x363"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x392",
+          "x393"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x391",
+          "x361",
+          "x364"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x394"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x393"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x362"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x395",
+          "x396"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x397",
+          "x398"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x399",
+          "x400"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x401",
+          "x402"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x403",
+          "x404"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x405",
+          "x406"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x407",
+          "x408"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x409",
+          "x410"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x411",
+          "x412"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x410",
+          "x407"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x413",
+          "x414"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x412",
+          "x408",
+          "x405"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x415",
+          "x416"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x414",
+          "x406",
+          "x403"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x417",
+          "x418"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x416",
+          "x404",
+          "x401"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x419",
+          "x420"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x418",
+          "x402",
+          "x399"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x421",
+          "x422"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x420",
+          "x400",
+          "x397"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x423",
+          "x424"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x422",
+          "x398",
+          "x395"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x425"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x424"
+            ]
+          },
+          "x396"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x426",
+          "x427"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x378",
+          "x409"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x428",
+          "x429"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x427",
+          "x380",
+          "x411"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x430",
+          "x431"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x429",
+          "x382",
+          "x413"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x432",
+          "x433"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x431",
+          "x384",
+          "x415"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x434",
+          "x435"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x433",
+          "x386",
+          "x417"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x436",
+          "x437"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x435",
+          "x388",
+          "x419"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x438",
+          "x439"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x437",
+          "x390",
+          "x421"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x440",
+          "x441"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x439",
+          "x392",
+          "x423"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x442",
+          "x443"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x441",
+          "x394",
+          "x425"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x444",
+          "x445"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x426",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x446",
+          "x447"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x426",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x448",
+          "x449"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x426",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x450",
+          "x451"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x426",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x452",
+          "x453"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x451",
+          "x448"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x454",
+          "x455"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x453",
+          "x449",
+          "x446"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x456"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x455"
+            ]
+          },
+          "x447"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x458"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x426",
+          "x450"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x459",
+          "x460"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x458",
+          "x428",
+          "x452"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x461",
+          "x462"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x460",
+          "x430",
+          "x454"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x463",
+          "x464"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x462",
+          "x432",
+          "x456"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x465",
+          "x466"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x464",
+          "x434",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x467",
+          "x468"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x466",
+          "x436",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x469",
+          "x470"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x468",
+          "x438",
+          "x426"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x471",
+          "x472"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x470",
+          "x440",
+          "x444"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x473",
+          "x474"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x472",
+          "x442",
+          "x445"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x475"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x474"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x443"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x476",
+          "x477"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x478",
+          "x479"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x480",
+          "x481"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x482",
+          "x483"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x484",
+          "x485"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x486",
+          "x487"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x488",
+          "x489"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x490",
+          "x491"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x492",
+          "x493"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x491",
+          "x488"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x494",
+          "x495"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x493",
+          "x489",
+          "x486"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x496",
+          "x497"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x495",
+          "x487",
+          "x484"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x498",
+          "x499"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x497",
+          "x485",
+          "x482"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x500",
+          "x501"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x499",
+          "x483",
+          "x480"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x502",
+          "x503"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x501",
+          "x481",
+          "x478"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x504",
+          "x505"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x503",
+          "x479",
+          "x476"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x506"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x505"
+            ]
+          },
+          "x477"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x507",
+          "x508"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x459",
+          "x490"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x509",
+          "x510"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x508",
+          "x461",
+          "x492"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x511",
+          "x512"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x510",
+          "x463",
+          "x494"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x513",
+          "x514"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x512",
+          "x465",
+          "x496"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x515",
+          "x516"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x514",
+          "x467",
+          "x498"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x517",
+          "x518"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x516",
+          "x469",
+          "x500"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x519",
+          "x520"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x518",
+          "x471",
+          "x502"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x521",
+          "x522"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x520",
+          "x473",
+          "x504"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x523",
+          "x524"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x522",
+          "x475",
+          "x506"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x525",
+          "x526"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x507",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x527",
+          "x528"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x507",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x529",
+          "x530"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x507",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x531",
+          "x532"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x507",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x533",
+          "x534"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x532",
+          "x529"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x535",
+          "x536"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x534",
+          "x530",
+          "x527"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x537"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x536"
+            ]
+          },
+          "x528"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x539"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x507",
+          "x531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x540",
+          "x541"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x539",
+          "x509",
+          "x533"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x542",
+          "x543"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x541",
+          "x511",
+          "x535"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x544",
+          "x545"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x543",
+          "x513",
+          "x537"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x546",
+          "x547"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x545",
+          "x515",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x548",
+          "x549"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x547",
+          "x517",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x550",
+          "x551"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x549",
+          "x519",
+          "x507"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x552",
+          "x553"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x551",
+          "x521",
+          "x525"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x554",
+          "x555"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x553",
+          "x523",
+          "x526"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x556"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x555"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x524"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x557",
+          "x558"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x559",
+          "x560"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x561",
+          "x562"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x563",
+          "x564"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x565",
+          "x566"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x567",
+          "x568"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x569",
+          "x570"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x571",
+          "x572"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x573",
+          "x574"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x572",
+          "x569"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x575",
+          "x576"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x574",
+          "x570",
+          "x567"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x577",
+          "x578"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x576",
+          "x568",
+          "x565"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x579",
+          "x580"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x578",
+          "x566",
+          "x563"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x581",
+          "x582"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x580",
+          "x564",
+          "x561"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x583",
+          "x584"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x582",
+          "x562",
+          "x559"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x585",
+          "x586"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x584",
+          "x560",
+          "x557"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x587"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x586"
+            ]
+          },
+          "x558"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x588",
+          "x589"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x540",
+          "x571"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x590",
+          "x591"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x589",
+          "x542",
+          "x573"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x592",
+          "x593"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x591",
+          "x544",
+          "x575"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x594",
+          "x595"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x593",
+          "x546",
+          "x577"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x596",
+          "x597"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x595",
+          "x548",
+          "x579"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x598",
+          "x599"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x597",
+          "x550",
+          "x581"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x600",
+          "x601"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x599",
+          "x552",
+          "x583"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x602",
+          "x603"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x601",
+          "x554",
+          "x585"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x604",
+          "x605"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x603",
+          "x556",
+          "x587"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x606",
+          "x607"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x588",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x608",
+          "x609"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x588",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x610",
+          "x611"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x588",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x612",
+          "x613"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x588",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x614",
+          "x615"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x613",
+          "x610"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x616",
+          "x617"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x615",
+          "x611",
+          "x608"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x618"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x617"
+            ]
+          },
+          "x609"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x620"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x588",
+          "x612"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x621",
+          "x622"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x620",
+          "x590",
+          "x614"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x623",
+          "x624"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x622",
+          "x592",
+          "x616"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x625",
+          "x626"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x624",
+          "x594",
+          "x618"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x627",
+          "x628"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x626",
+          "x596",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x629",
+          "x630"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x628",
+          "x598",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x631",
+          "x632"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x630",
+          "x600",
+          "x588"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x633",
+          "x634"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x632",
+          "x602",
+          "x606"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x635",
+          "x636"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x634",
+          "x604",
+          "x607"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x637"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x636"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x605"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x638",
+          "x639"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x621",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x640",
+          "x641"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x639",
+          "x623",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x642",
+          "x643"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x641",
+          "x625",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x644",
+          "x645"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x643",
+          "x627",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x646",
+          "x647"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x645",
+          "x629",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x648",
+          "x649"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x647",
+          "x631",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x650",
+          "x651"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x649",
+          "x633",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x652",
+          "x653"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x651",
+          "x635",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x655"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x653",
+          "x637",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x656"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x655",
+          "x638",
+          "x621"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x657"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x655",
+          "x640",
+          "x623"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x658"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x655",
+          "x642",
+          "x625"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x659"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x655",
+          "x644",
+          "x627"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x660"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x655",
+          "x646",
+          "x629"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x661"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x655",
+          "x648",
+          "x631"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x662"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x655",
+          "x650",
+          "x633"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x663"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x655",
+          "x652",
+          "x635"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x656"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x657"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x658"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x659"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x660"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x661"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x662"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x663"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_square",
+    "arguments": [
+      {
+        "datatype": "u32[8]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25",
+          "x26"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x24",
+          "x21"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27",
+          "x28"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x26",
+          "x22",
+          "x19"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29",
+          "x30"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x28",
+          "x20",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31",
+          "x32"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x30",
+          "x18",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33",
+          "x34"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x32",
+          "x16",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35",
+          "x36"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x34",
+          "x14",
+          "x11"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x36",
+          "x12",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          },
+          "x10"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40",
+          "x41"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x23",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42",
+          "x43"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x23",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44",
+          "x45"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x23",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46",
+          "x47"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x23",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x48",
+          "x49"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x47",
+          "x44"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x50",
+          "x51"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x49",
+          "x45",
+          "x42"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x52"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x51"
+            ]
+          },
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x54"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x23",
+          "x46"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x55",
+          "x56"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x54",
+          "x25",
+          "x48"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x57",
+          "x58"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x56",
+          "x27",
+          "x50"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x59",
+          "x60"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x58",
+          "x29",
+          "x52"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x61",
+          "x62"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x60",
+          "x31",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x63",
+          "x64"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x62",
+          "x33",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x65",
+          "x66"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x64",
+          "x35",
+          "x23"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x67",
+          "x68"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x66",
+          "x37",
+          "x40"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x69",
+          "x70"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x68",
+          "x39",
+          "x41"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x71",
+          "x72"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x73",
+          "x74"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x75",
+          "x76"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x77",
+          "x78"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x79",
+          "x80"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x81",
+          "x82"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x83",
+          "x84"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x85",
+          "x86"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x87",
+          "x88"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x86",
+          "x83"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x89",
+          "x90"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x88",
+          "x84",
+          "x81"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x91",
+          "x92"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x90",
+          "x82",
+          "x79"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x93",
+          "x94"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x92",
+          "x80",
+          "x77"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x95",
+          "x96"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x94",
+          "x78",
+          "x75"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x97",
+          "x98"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x96",
+          "x76",
+          "x73"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x99",
+          "x100"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x98",
+          "x74",
+          "x71"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x101"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x100"
+            ]
+          },
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x102",
+          "x103"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x55",
+          "x85"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x104",
+          "x105"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x103",
+          "x57",
+          "x87"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x106",
+          "x107"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x105",
+          "x59",
+          "x89"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x108",
+          "x109"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x107",
+          "x61",
+          "x91"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x110",
+          "x111"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x109",
+          "x63",
+          "x93"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x112",
+          "x113"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x111",
+          "x65",
+          "x95"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x114",
+          "x115"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x113",
+          "x67",
+          "x97"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x116",
+          "x117"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x115",
+          "x69",
+          "x99"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x118",
+          "x119"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x117",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x70"
+            ]
+          },
+          "x101"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x120",
+          "x121"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x102",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x122",
+          "x123"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x102",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x124",
+          "x125"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x102",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x126",
+          "x127"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x102",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x128",
+          "x129"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x127",
+          "x124"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x130",
+          "x131"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x129",
+          "x125",
+          "x122"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x132"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x131"
+            ]
+          },
+          "x123"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x134"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x102",
+          "x126"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x135",
+          "x136"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x134",
+          "x104",
+          "x128"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x137",
+          "x138"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x136",
+          "x106",
+          "x130"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x139",
+          "x140"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x138",
+          "x108",
+          "x132"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x141",
+          "x142"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x140",
+          "x110",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x143",
+          "x144"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x142",
+          "x112",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x145",
+          "x146"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x144",
+          "x114",
+          "x102"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x147",
+          "x148"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x146",
+          "x116",
+          "x120"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x149",
+          "x150"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x148",
+          "x118",
+          "x121"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x151"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x150"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x119"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x152",
+          "x153"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x154",
+          "x155"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x156",
+          "x157"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x158",
+          "x159"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x160",
+          "x161"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x162",
+          "x163"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x164",
+          "x165"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x166",
+          "x167"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x168",
+          "x169"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x167",
+          "x164"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x170",
+          "x171"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x169",
+          "x165",
+          "x162"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x172",
+          "x173"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x171",
+          "x163",
+          "x160"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x174",
+          "x175"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x173",
+          "x161",
+          "x158"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x176",
+          "x177"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x175",
+          "x159",
+          "x156"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x178",
+          "x179"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x177",
+          "x157",
+          "x154"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x180",
+          "x181"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x179",
+          "x155",
+          "x152"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x182"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x181"
+            ]
+          },
+          "x153"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x183",
+          "x184"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x135",
+          "x166"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x185",
+          "x186"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x184",
+          "x137",
+          "x168"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x187",
+          "x188"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x186",
+          "x139",
+          "x170"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x189",
+          "x190"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x188",
+          "x141",
+          "x172"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x191",
+          "x192"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x190",
+          "x143",
+          "x174"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x193",
+          "x194"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x192",
+          "x145",
+          "x176"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x195",
+          "x196"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x194",
+          "x147",
+          "x178"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x197",
+          "x198"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x196",
+          "x149",
+          "x180"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x199",
+          "x200"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x198",
+          "x151",
+          "x182"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x201",
+          "x202"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x183",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x203",
+          "x204"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x183",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x205",
+          "x206"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x183",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x207",
+          "x208"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x183",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x209",
+          "x210"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x208",
+          "x205"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x211",
+          "x212"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x210",
+          "x206",
+          "x203"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x213"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x212"
+            ]
+          },
+          "x204"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x215"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x183",
+          "x207"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x216",
+          "x217"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x215",
+          "x185",
+          "x209"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x218",
+          "x219"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x217",
+          "x187",
+          "x211"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x220",
+          "x221"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x219",
+          "x189",
+          "x213"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x222",
+          "x223"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x221",
+          "x191",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x224",
+          "x225"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x223",
+          "x193",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x226",
+          "x227"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x225",
+          "x195",
+          "x183"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x228",
+          "x229"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x227",
+          "x197",
+          "x201"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x230",
+          "x231"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x229",
+          "x199",
+          "x202"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x232"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x231"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x200"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x233",
+          "x234"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x235",
+          "x236"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x237",
+          "x238"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x239",
+          "x240"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x241",
+          "x242"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x243",
+          "x244"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x245",
+          "x246"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x247",
+          "x248"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x249",
+          "x250"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x248",
+          "x245"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x251",
+          "x252"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x250",
+          "x246",
+          "x243"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x253",
+          "x254"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x252",
+          "x244",
+          "x241"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x255",
+          "x256"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x254",
+          "x242",
+          "x239"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x257",
+          "x258"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x256",
+          "x240",
+          "x237"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x259",
+          "x260"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x258",
+          "x238",
+          "x235"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x261",
+          "x262"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x260",
+          "x236",
+          "x233"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x263"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x262"
+            ]
+          },
+          "x234"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x264",
+          "x265"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x216",
+          "x247"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x266",
+          "x267"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x265",
+          "x218",
+          "x249"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x268",
+          "x269"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x267",
+          "x220",
+          "x251"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x270",
+          "x271"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x269",
+          "x222",
+          "x253"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x272",
+          "x273"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x271",
+          "x224",
+          "x255"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x274",
+          "x275"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x273",
+          "x226",
+          "x257"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x276",
+          "x277"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x275",
+          "x228",
+          "x259"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x278",
+          "x279"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x277",
+          "x230",
+          "x261"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x280",
+          "x281"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x279",
+          "x232",
+          "x263"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x282",
+          "x283"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x264",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x284",
+          "x285"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x264",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x286",
+          "x287"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x264",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x288",
+          "x289"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x264",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x290",
+          "x291"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x289",
+          "x286"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x292",
+          "x293"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x291",
+          "x287",
+          "x284"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x294"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x293"
+            ]
+          },
+          "x285"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x296"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x264",
+          "x288"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x297",
+          "x298"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x296",
+          "x266",
+          "x290"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x299",
+          "x300"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x298",
+          "x268",
+          "x292"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x301",
+          "x302"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x300",
+          "x270",
+          "x294"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x303",
+          "x304"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x302",
+          "x272",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x305",
+          "x306"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x304",
+          "x274",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x307",
+          "x308"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x306",
+          "x276",
+          "x264"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x309",
+          "x310"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x308",
+          "x278",
+          "x282"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x311",
+          "x312"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x310",
+          "x280",
+          "x283"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x313"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x312"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x281"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x314",
+          "x315"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x316",
+          "x317"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x318",
+          "x319"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x320",
+          "x321"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x322",
+          "x323"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x324",
+          "x325"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x326",
+          "x327"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x328",
+          "x329"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x330",
+          "x331"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x329",
+          "x326"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x332",
+          "x333"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x331",
+          "x327",
+          "x324"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x334",
+          "x335"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x333",
+          "x325",
+          "x322"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x336",
+          "x337"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x335",
+          "x323",
+          "x320"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x338",
+          "x339"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x337",
+          "x321",
+          "x318"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x340",
+          "x341"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x339",
+          "x319",
+          "x316"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x342",
+          "x343"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x341",
+          "x317",
+          "x314"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x344"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x343"
+            ]
+          },
+          "x315"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x345",
+          "x346"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x297",
+          "x328"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x347",
+          "x348"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x346",
+          "x299",
+          "x330"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x349",
+          "x350"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x348",
+          "x301",
+          "x332"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x351",
+          "x352"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x350",
+          "x303",
+          "x334"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x353",
+          "x354"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x352",
+          "x305",
+          "x336"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x355",
+          "x356"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x354",
+          "x307",
+          "x338"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x357",
+          "x358"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x356",
+          "x309",
+          "x340"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x359",
+          "x360"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x358",
+          "x311",
+          "x342"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x361",
+          "x362"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x360",
+          "x313",
+          "x344"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x363",
+          "x364"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x345",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x365",
+          "x366"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x345",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x367",
+          "x368"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x345",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x369",
+          "x370"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x345",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x371",
+          "x372"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x370",
+          "x367"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x373",
+          "x374"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x372",
+          "x368",
+          "x365"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x375"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x374"
+            ]
+          },
+          "x366"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x377"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x345",
+          "x369"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x378",
+          "x379"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x377",
+          "x347",
+          "x371"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x380",
+          "x381"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x379",
+          "x349",
+          "x373"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x382",
+          "x383"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x381",
+          "x351",
+          "x375"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x384",
+          "x385"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x383",
+          "x353",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x386",
+          "x387"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x385",
+          "x355",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x388",
+          "x389"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x387",
+          "x357",
+          "x345"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x390",
+          "x391"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x389",
+          "x359",
+          "x363"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x392",
+          "x393"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x391",
+          "x361",
+          "x364"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x394"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x393"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x362"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x395",
+          "x396"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x397",
+          "x398"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x399",
+          "x400"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x401",
+          "x402"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x403",
+          "x404"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x405",
+          "x406"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x407",
+          "x408"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x409",
+          "x410"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x411",
+          "x412"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x410",
+          "x407"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x413",
+          "x414"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x412",
+          "x408",
+          "x405"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x415",
+          "x416"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x414",
+          "x406",
+          "x403"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x417",
+          "x418"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x416",
+          "x404",
+          "x401"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x419",
+          "x420"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x418",
+          "x402",
+          "x399"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x421",
+          "x422"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x420",
+          "x400",
+          "x397"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x423",
+          "x424"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x422",
+          "x398",
+          "x395"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x425"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x424"
+            ]
+          },
+          "x396"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x426",
+          "x427"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x378",
+          "x409"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x428",
+          "x429"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x427",
+          "x380",
+          "x411"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x430",
+          "x431"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x429",
+          "x382",
+          "x413"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x432",
+          "x433"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x431",
+          "x384",
+          "x415"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x434",
+          "x435"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x433",
+          "x386",
+          "x417"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x436",
+          "x437"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x435",
+          "x388",
+          "x419"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x438",
+          "x439"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x437",
+          "x390",
+          "x421"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x440",
+          "x441"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x439",
+          "x392",
+          "x423"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x442",
+          "x443"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x441",
+          "x394",
+          "x425"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x444",
+          "x445"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x426",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x446",
+          "x447"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x426",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x448",
+          "x449"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x426",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x450",
+          "x451"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x426",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x452",
+          "x453"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x451",
+          "x448"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x454",
+          "x455"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x453",
+          "x449",
+          "x446"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x456"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x455"
+            ]
+          },
+          "x447"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x458"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x426",
+          "x450"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x459",
+          "x460"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x458",
+          "x428",
+          "x452"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x461",
+          "x462"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x460",
+          "x430",
+          "x454"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x463",
+          "x464"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x462",
+          "x432",
+          "x456"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x465",
+          "x466"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x464",
+          "x434",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x467",
+          "x468"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x466",
+          "x436",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x469",
+          "x470"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x468",
+          "x438",
+          "x426"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x471",
+          "x472"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x470",
+          "x440",
+          "x444"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x473",
+          "x474"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x472",
+          "x442",
+          "x445"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x475"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x474"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x443"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x476",
+          "x477"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x478",
+          "x479"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x480",
+          "x481"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x482",
+          "x483"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x484",
+          "x485"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x486",
+          "x487"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x488",
+          "x489"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x490",
+          "x491"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x492",
+          "x493"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x491",
+          "x488"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x494",
+          "x495"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x493",
+          "x489",
+          "x486"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x496",
+          "x497"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x495",
+          "x487",
+          "x484"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x498",
+          "x499"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x497",
+          "x485",
+          "x482"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x500",
+          "x501"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x499",
+          "x483",
+          "x480"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x502",
+          "x503"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x501",
+          "x481",
+          "x478"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x504",
+          "x505"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x503",
+          "x479",
+          "x476"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x506"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x505"
+            ]
+          },
+          "x477"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x507",
+          "x508"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x459",
+          "x490"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x509",
+          "x510"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x508",
+          "x461",
+          "x492"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x511",
+          "x512"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x510",
+          "x463",
+          "x494"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x513",
+          "x514"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x512",
+          "x465",
+          "x496"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x515",
+          "x516"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x514",
+          "x467",
+          "x498"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x517",
+          "x518"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x516",
+          "x469",
+          "x500"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x519",
+          "x520"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x518",
+          "x471",
+          "x502"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x521",
+          "x522"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x520",
+          "x473",
+          "x504"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x523",
+          "x524"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x522",
+          "x475",
+          "x506"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x525",
+          "x526"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x507",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x527",
+          "x528"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x507",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x529",
+          "x530"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x507",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x531",
+          "x532"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x507",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x533",
+          "x534"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x532",
+          "x529"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x535",
+          "x536"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x534",
+          "x530",
+          "x527"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x537"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x536"
+            ]
+          },
+          "x528"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x539"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x507",
+          "x531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x540",
+          "x541"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x539",
+          "x509",
+          "x533"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x542",
+          "x543"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x541",
+          "x511",
+          "x535"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x544",
+          "x545"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x543",
+          "x513",
+          "x537"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x546",
+          "x547"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x545",
+          "x515",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x548",
+          "x549"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x547",
+          "x517",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x550",
+          "x551"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x549",
+          "x519",
+          "x507"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x552",
+          "x553"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x551",
+          "x521",
+          "x525"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x554",
+          "x555"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x553",
+          "x523",
+          "x526"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x556"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x555"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x524"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x557",
+          "x558"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x559",
+          "x560"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x561",
+          "x562"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x563",
+          "x564"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x565",
+          "x566"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x567",
+          "x568"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x569",
+          "x570"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x571",
+          "x572"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x573",
+          "x574"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x572",
+          "x569"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x575",
+          "x576"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x574",
+          "x570",
+          "x567"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x577",
+          "x578"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x576",
+          "x568",
+          "x565"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x579",
+          "x580"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x578",
+          "x566",
+          "x563"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x581",
+          "x582"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x580",
+          "x564",
+          "x561"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x583",
+          "x584"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x582",
+          "x562",
+          "x559"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x585",
+          "x586"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x584",
+          "x560",
+          "x557"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x587"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x586"
+            ]
+          },
+          "x558"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x588",
+          "x589"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x540",
+          "x571"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x590",
+          "x591"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x589",
+          "x542",
+          "x573"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x592",
+          "x593"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x591",
+          "x544",
+          "x575"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x594",
+          "x595"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x593",
+          "x546",
+          "x577"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x596",
+          "x597"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x595",
+          "x548",
+          "x579"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x598",
+          "x599"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x597",
+          "x550",
+          "x581"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x600",
+          "x601"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x599",
+          "x552",
+          "x583"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x602",
+          "x603"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x601",
+          "x554",
+          "x585"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x604",
+          "x605"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x603",
+          "x556",
+          "x587"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x606",
+          "x607"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x588",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x608",
+          "x609"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x588",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x610",
+          "x611"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x588",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x612",
+          "x613"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x588",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x614",
+          "x615"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x613",
+          "x610"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x616",
+          "x617"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x615",
+          "x611",
+          "x608"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x618"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x617"
+            ]
+          },
+          "x609"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x620"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x588",
+          "x612"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x621",
+          "x622"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x620",
+          "x590",
+          "x614"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x623",
+          "x624"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x622",
+          "x592",
+          "x616"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x625",
+          "x626"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x624",
+          "x594",
+          "x618"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x627",
+          "x628"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x626",
+          "x596",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x629",
+          "x630"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x628",
+          "x598",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x631",
+          "x632"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x630",
+          "x600",
+          "x588"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x633",
+          "x634"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x632",
+          "x602",
+          "x606"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x635",
+          "x636"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x634",
+          "x604",
+          "x607"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x637"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x636"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x605"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x638",
+          "x639"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x621",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x640",
+          "x641"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x639",
+          "x623",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x642",
+          "x643"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x641",
+          "x625",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x644",
+          "x645"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x643",
+          "x627",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x646",
+          "x647"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x645",
+          "x629",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x648",
+          "x649"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x647",
+          "x631",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x650",
+          "x651"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x649",
+          "x633",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x652",
+          "x653"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x651",
+          "x635",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x655"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x653",
+          "x637",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x656"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x655",
+          "x638",
+          "x621"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x657"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x655",
+          "x640",
+          "x623"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x658"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x655",
+          "x642",
+          "x625"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x659"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x655",
+          "x644",
+          "x627"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x660"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x655",
+          "x646",
+          "x629"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x661"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x655",
+          "x648",
+          "x631"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x662"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x655",
+          "x650",
+          "x633"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x663"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x655",
+          "x652",
+          "x635"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x656"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x657"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x658"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x659"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x660"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x661"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x662"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x663"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_add",
+    "arguments": [
+      {
+        "datatype": "u32[8]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[8]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x8",
+          "arg1[4]",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x10",
+          "arg1[5]",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x12",
+          "arg1[6]",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x14",
+          "arg1[7]",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x18",
+          "x3",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x20",
+          "x5",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x22",
+          "x7",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25",
+          "x26"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x24",
+          "x9",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27",
+          "x28"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x26",
+          "x11",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29",
+          "x30"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x28",
+          "x13",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31",
+          "x32"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x30",
+          "x15",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x34"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x32",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x34",
+          "x17",
+          "x1"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x34",
+          "x19",
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x34",
+          "x21",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x34",
+          "x23",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x34",
+          "x25",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x34",
+          "x27",
+          "x11"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x34",
+          "x29",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x34",
+          "x31",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x35"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x36"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x37"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x38"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x39"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x40"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x41"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x42"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_sub",
+    "arguments": [
+      {
+        "datatype": "u32[8]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[8]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x8",
+          "arg1[4]",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x10",
+          "arg1[5]",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x12",
+          "arg1[6]",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x14",
+          "arg1[7]",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x16",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x19",
+          "x3",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x21",
+          "x5",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x7",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x9",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x11",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x13",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "&",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x17"
+                    ]
+                  },
+                  "0x1"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          "x15",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x22"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x24"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x26"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x28"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x30"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x32"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_opp",
+    "arguments": [
+      {
+        "datatype": "u32[8]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x8",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x10",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x12",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x14",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x16",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x19",
+          "x3",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x21",
+          "x5",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x7",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x9",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x11",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x13",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "&",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x17"
+                    ]
+                  },
+                  "0x1"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          "x15",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x22"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x24"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x26"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x28"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x30"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x32"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_from_montgomery",
+    "arguments": [
+      {
+        "datatype": "u32[8]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2",
+          "x3"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4",
+          "x5"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6",
+          "x7"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8",
+          "x9"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x9",
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x11",
+          "x7",
+          "x4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x15"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x15",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x10"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x17",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x12"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x19",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x13"
+                ]
+              },
+              "x5"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x16",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x18",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x20",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x22",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x22",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x22",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34",
+          "x35"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x22",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36",
+          "x37"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x35",
+          "x32"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38",
+          "x39"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x37",
+          "x33",
+          "x30"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x41"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x22",
+          "x34"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42",
+          "x43"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x41",
+          "x24",
+          "x36"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44",
+          "x45"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x43",
+          "x26",
+          "x38"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46",
+          "x47"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x45",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x27"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x21"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x39"
+                ]
+              },
+              "x31"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x48",
+          "x49"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x2",
+          "x22"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x50",
+          "x51"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x49",
+          "x3",
+          "x28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x52",
+          "x53"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x42",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x54",
+          "x55"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x53",
+          "x44",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x56",
+          "x57"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x55",
+          "x46",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x58",
+          "x59"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x52",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x52",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x52",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x52",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x65",
+          "x62"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x67",
+          "x63",
+          "x60"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x71"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x52",
+          "x64"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x72",
+          "x73"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x71",
+          "x54",
+          "x66"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x73",
+          "x56",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x76",
+          "x77"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x75",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x57"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x47"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x69"
+                ]
+              },
+              "x61"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x78",
+          "x79"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x77",
+          "x1",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x80",
+          "x81"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x79",
+          "x48",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x82",
+          "x83"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x81",
+          "x50",
+          "x52"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x84",
+          "x85"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x83",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x51"
+                ]
+              },
+              "x29"
+            ]
+          },
+          "x58"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x86",
+          "x87"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x72",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x88",
+          "x89"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x87",
+          "x74",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x90",
+          "x91"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x89",
+          "x76",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x91",
+          "x78",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x94",
+          "x95"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x93",
+          "x80",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x96",
+          "x97"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x95",
+          "x82",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x98",
+          "x99"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x97",
+          "x84",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x100",
+          "x101"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x99",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x85"
+                ]
+              },
+              "x59"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x102",
+          "x103"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x86",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x104",
+          "x105"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x86",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x106",
+          "x107"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x86",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x108",
+          "x109"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x86",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x110",
+          "x111"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x109",
+          "x106"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x112",
+          "x113"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x111",
+          "x107",
+          "x104"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x115"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x86",
+          "x108"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x116",
+          "x117"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x115",
+          "x88",
+          "x110"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x118",
+          "x119"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x117",
+          "x90",
+          "x112"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x120",
+          "x121"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x119",
+          "x92",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x113"
+                ]
+              },
+              "x105"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x122",
+          "x123"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x121",
+          "x94",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x124",
+          "x125"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x123",
+          "x96",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x126",
+          "x127"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x125",
+          "x98",
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x128",
+          "x129"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x127",
+          "x100",
+          "x102"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x130",
+          "x131"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x129",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x101"
+            ]
+          },
+          "x103"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x132",
+          "x133"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x116",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x134",
+          "x135"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x133",
+          "x118",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x136",
+          "x137"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x135",
+          "x120",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x138",
+          "x139"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x137",
+          "x122",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x140",
+          "x141"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x139",
+          "x124",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x142",
+          "x143"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x141",
+          "x126",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x144",
+          "x145"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x143",
+          "x128",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x146",
+          "x147"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x145",
+          "x130",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x148",
+          "x149"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x132",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x150",
+          "x151"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x132",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x152",
+          "x153"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x132",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x154",
+          "x155"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x132",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x156",
+          "x157"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x155",
+          "x152"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x158",
+          "x159"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x157",
+          "x153",
+          "x150"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x161"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x132",
+          "x154"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x162",
+          "x163"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x161",
+          "x134",
+          "x156"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x164",
+          "x165"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x163",
+          "x136",
+          "x158"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x166",
+          "x167"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x165",
+          "x138",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x159"
+                ]
+              },
+              "x151"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x168",
+          "x169"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x167",
+          "x140",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x170",
+          "x171"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x169",
+          "x142",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x172",
+          "x173"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x171",
+          "x144",
+          "x132"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x174",
+          "x175"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x173",
+          "x146",
+          "x148"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x176",
+          "x177"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x175",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x147"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x131"
+                ]
+              }
+            ]
+          },
+          "x149"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x178",
+          "x179"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x162",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x180",
+          "x181"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x179",
+          "x164",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x182",
+          "x183"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x181",
+          "x166",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x184",
+          "x185"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x183",
+          "x168",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x186",
+          "x187"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x185",
+          "x170",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x188",
+          "x189"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x187",
+          "x172",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x190",
+          "x191"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x189",
+          "x174",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x192",
+          "x193"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x191",
+          "x176",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x194",
+          "x195"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x178",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x196",
+          "x197"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x178",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x198",
+          "x199"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x178",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x200",
+          "x201"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x178",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x202",
+          "x203"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x201",
+          "x198"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x204",
+          "x205"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x203",
+          "x199",
+          "x196"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x207"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x178",
+          "x200"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x208",
+          "x209"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x207",
+          "x180",
+          "x202"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x210",
+          "x211"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x209",
+          "x182",
+          "x204"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x212",
+          "x213"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x211",
+          "x184",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x205"
+                ]
+              },
+              "x197"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x214",
+          "x215"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x213",
+          "x186",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x216",
+          "x217"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x215",
+          "x188",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x218",
+          "x219"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x217",
+          "x190",
+          "x178"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x220",
+          "x221"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x219",
+          "x192",
+          "x194"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x222",
+          "x223"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x221",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x193"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x177"
+                ]
+              }
+            ]
+          },
+          "x195"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x224",
+          "x225"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x208",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x226",
+          "x227"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x225",
+          "x210",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x228",
+          "x229"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x227",
+          "x212",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x230",
+          "x231"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x229",
+          "x214",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x232",
+          "x233"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x231",
+          "x216",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x234",
+          "x235"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x233",
+          "x218",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x236",
+          "x237"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x235",
+          "x220",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x238",
+          "x239"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x237",
+          "x222",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x240",
+          "x241"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x224",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x242",
+          "x243"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x224",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x244",
+          "x245"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x224",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x246",
+          "x247"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x224",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x248",
+          "x249"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x247",
+          "x244"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x250",
+          "x251"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x249",
+          "x245",
+          "x242"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x253"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x224",
+          "x246"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x254",
+          "x255"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x253",
+          "x226",
+          "x248"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x256",
+          "x257"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x255",
+          "x228",
+          "x250"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x258",
+          "x259"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x257",
+          "x230",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x251"
+                ]
+              },
+              "x243"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x260",
+          "x261"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x259",
+          "x232",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x262",
+          "x263"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x261",
+          "x234",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x264",
+          "x265"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x263",
+          "x236",
+          "x224"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x266",
+          "x267"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x265",
+          "x238",
+          "x240"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x268",
+          "x269"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x267",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x239"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x223"
+                ]
+              }
+            ]
+          },
+          "x241"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x270",
+          "x271"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x254",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x272",
+          "x273"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x271",
+          "x256",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x274",
+          "x275"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x273",
+          "x258",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x276",
+          "x277"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x275",
+          "x260",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x278",
+          "x279"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x277",
+          "x262",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x280",
+          "x281"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x279",
+          "x264",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x282",
+          "x283"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x281",
+          "x266",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x284",
+          "x285"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x283",
+          "x268",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x286",
+          "x287"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x270",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x288",
+          "x289"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x270",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x290",
+          "x291"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x270",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x292",
+          "x293"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x270",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x294",
+          "x295"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x293",
+          "x290"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x296",
+          "x297"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x295",
+          "x291",
+          "x288"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x299"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x270",
+          "x292"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x300",
+          "x301"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x299",
+          "x272",
+          "x294"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x302",
+          "x303"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x301",
+          "x274",
+          "x296"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x304",
+          "x305"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x303",
+          "x276",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x297"
+                ]
+              },
+              "x289"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x306",
+          "x307"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x305",
+          "x278",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x308",
+          "x309"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x307",
+          "x280",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x310",
+          "x311"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x309",
+          "x282",
+          "x270"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x312",
+          "x313"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x311",
+          "x284",
+          "x286"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x314",
+          "x315"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x313",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x285"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x269"
+                ]
+              }
+            ]
+          },
+          "x287"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x316",
+          "x317"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x300",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x318",
+          "x319"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x317",
+          "x302",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x320",
+          "x321"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x319",
+          "x304",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x322",
+          "x323"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x321",
+          "x306",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x324",
+          "x325"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x323",
+          "x308",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x326",
+          "x327"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x325",
+          "x310",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x328",
+          "x329"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x327",
+          "x312",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x330",
+          "x331"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x329",
+          "x314",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x333"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x331",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x315"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x334"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x333",
+          "x316",
+          "x300"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x335"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x333",
+          "x318",
+          "x302"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x336"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x333",
+          "x320",
+          "x304"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x337"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x333",
+          "x322",
+          "x306"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x338"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x333",
+          "x324",
+          "x308"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x339"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x333",
+          "x326",
+          "x310"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x340"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x333",
+          "x328",
+          "x312"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x341"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x333",
+          "x330",
+          "x314"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x334"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x335"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x336"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x337"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x338"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x339"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x340"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x341"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_to_montgomery",
+    "arguments": [
+      {
+        "datatype": "u32[8]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "0x4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "0xfffffffd"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "0xfffffffb"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "0x3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x20",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25",
+          "x26"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x24",
+          "x18",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27",
+          "x28"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x26",
+          "x16",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29",
+          "x30"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x28",
+          "x14",
+          "x11"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31",
+          "x32"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x30",
+          "x12",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33",
+          "x34"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x21",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35",
+          "x36"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x21",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x21",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39",
+          "x40"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x21",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41",
+          "x42"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x40",
+          "x37"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x43",
+          "x44"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x42",
+          "x38",
+          "x35"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x46"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x21",
+          "x39"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x47",
+          "x48"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x46",
+          "x22",
+          "x41"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x49",
+          "x50"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x48",
+          "x19",
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x51",
+          "x52"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x50",
+          "x23",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x44"
+                ]
+              },
+              "x36"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x53",
+          "x54"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x52",
+          "x25",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x55",
+          "x56"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x54",
+          "x27",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x57",
+          "x58"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x56",
+          "x29",
+          "x21"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x59",
+          "x60"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x58",
+          "x31",
+          "x33"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x61",
+          "x62"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x60",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x32"
+                ]
+              },
+              "x10"
+            ]
+          },
+          "x34"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x63",
+          "x64"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0x4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x65",
+          "x66"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xfffffffd"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x67",
+          "x68"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x69",
+          "x70"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x71",
+          "x72"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xfffffffb"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x73",
+          "x74"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x75",
+          "x76"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0x3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x77",
+          "x78"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x74",
+          "x71"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x79",
+          "x80"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x78",
+          "x72",
+          "x69"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x81",
+          "x82"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x80",
+          "x70",
+          "x67"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x83",
+          "x84"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x82",
+          "x68",
+          "x65"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x85",
+          "x86"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x84",
+          "x66",
+          "x63"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x87",
+          "x88"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x47",
+          "x75"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x89",
+          "x90"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x88",
+          "x49",
+          "x76"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x91",
+          "x92"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x90",
+          "x51",
+          "x73"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x93",
+          "x94"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x92",
+          "x53",
+          "x77"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x95",
+          "x96"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x94",
+          "x55",
+          "x79"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x97",
+          "x98"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x96",
+          "x57",
+          "x81"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x99",
+          "x100"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x98",
+          "x59",
+          "x83"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x101",
+          "x102"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x100",
+          "x61",
+          "x85"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x103",
+          "x104"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x87",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x105",
+          "x106"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x87",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x107",
+          "x108"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x87",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x109",
+          "x110"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x87",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x111",
+          "x112"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x110",
+          "x107"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x113",
+          "x114"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x112",
+          "x108",
+          "x105"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x116"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x87",
+          "x109"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x117",
+          "x118"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x116",
+          "x89",
+          "x111"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x119",
+          "x120"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x118",
+          "x91",
+          "x113"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x121",
+          "x122"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x120",
+          "x93",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x114"
+                ]
+              },
+              "x106"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x123",
+          "x124"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x122",
+          "x95",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x125",
+          "x126"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x124",
+          "x97",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x127",
+          "x128"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x126",
+          "x99",
+          "x87"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x129",
+          "x130"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x128",
+          "x101",
+          "x103"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x131",
+          "x132"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x130",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x102"
+                    ]
+                  },
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x62"
+                    ]
+                  }
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x86"
+                    ]
+                  },
+                  "x64"
+                ]
+              }
+            ]
+          },
+          "x104"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x133",
+          "x134"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0x4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x135",
+          "x136"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xfffffffd"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x137",
+          "x138"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x139",
+          "x140"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x141",
+          "x142"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xfffffffb"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x143",
+          "x144"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x145",
+          "x146"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0x3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x147",
+          "x148"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x144",
+          "x141"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x149",
+          "x150"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x148",
+          "x142",
+          "x139"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x151",
+          "x152"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x150",
+          "x140",
+          "x137"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x153",
+          "x154"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x152",
+          "x138",
+          "x135"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x155",
+          "x156"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x154",
+          "x136",
+          "x133"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x157",
+          "x158"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x117",
+          "x145"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x159",
+          "x160"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x158",
+          "x119",
+          "x146"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x161",
+          "x162"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x160",
+          "x121",
+          "x143"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x163",
+          "x164"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x162",
+          "x123",
+          "x147"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x165",
+          "x166"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x164",
+          "x125",
+          "x149"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x167",
+          "x168"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x166",
+          "x127",
+          "x151"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x169",
+          "x170"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x168",
+          "x129",
+          "x153"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x171",
+          "x172"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x170",
+          "x131",
+          "x155"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x173",
+          "x174"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x157",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x175",
+          "x176"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x157",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x177",
+          "x178"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x157",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x179",
+          "x180"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x157",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x181",
+          "x182"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x180",
+          "x177"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x183",
+          "x184"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x182",
+          "x178",
+          "x175"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x186"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x157",
+          "x179"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x187",
+          "x188"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x186",
+          "x159",
+          "x181"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x189",
+          "x190"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x188",
+          "x161",
+          "x183"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x191",
+          "x192"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x190",
+          "x163",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x184"
+                ]
+              },
+              "x176"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x193",
+          "x194"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x192",
+          "x165",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x195",
+          "x196"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x194",
+          "x167",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x197",
+          "x198"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x196",
+          "x169",
+          "x157"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x199",
+          "x200"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x198",
+          "x171",
+          "x173"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x201",
+          "x202"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x200",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x172"
+                    ]
+                  },
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x132"
+                    ]
+                  }
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x156"
+                    ]
+                  },
+                  "x134"
+                ]
+              }
+            ]
+          },
+          "x174"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x203",
+          "x204"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0x4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x205",
+          "x206"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xfffffffd"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x207",
+          "x208"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x209",
+          "x210"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x211",
+          "x212"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xfffffffb"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x213",
+          "x214"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x215",
+          "x216"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0x3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x217",
+          "x218"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x214",
+          "x211"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x219",
+          "x220"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x218",
+          "x212",
+          "x209"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x221",
+          "x222"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x220",
+          "x210",
+          "x207"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x223",
+          "x224"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x222",
+          "x208",
+          "x205"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x225",
+          "x226"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x224",
+          "x206",
+          "x203"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x227",
+          "x228"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x187",
+          "x215"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x229",
+          "x230"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x228",
+          "x189",
+          "x216"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x231",
+          "x232"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x230",
+          "x191",
+          "x213"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x233",
+          "x234"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x232",
+          "x193",
+          "x217"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x235",
+          "x236"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x234",
+          "x195",
+          "x219"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x237",
+          "x238"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x236",
+          "x197",
+          "x221"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x239",
+          "x240"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x238",
+          "x199",
+          "x223"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x241",
+          "x242"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x240",
+          "x201",
+          "x225"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x243",
+          "x244"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x227",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x245",
+          "x246"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x227",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x247",
+          "x248"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x227",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x249",
+          "x250"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x227",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x251",
+          "x252"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x250",
+          "x247"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x253",
+          "x254"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x252",
+          "x248",
+          "x245"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x256"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x227",
+          "x249"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x257",
+          "x258"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x256",
+          "x229",
+          "x251"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x259",
+          "x260"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x258",
+          "x231",
+          "x253"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x261",
+          "x262"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x260",
+          "x233",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x254"
+                ]
+              },
+              "x246"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x263",
+          "x264"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x262",
+          "x235",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x265",
+          "x266"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x264",
+          "x237",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x267",
+          "x268"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x266",
+          "x239",
+          "x227"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x269",
+          "x270"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x268",
+          "x241",
+          "x243"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x271",
+          "x272"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x270",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x242"
+                    ]
+                  },
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x202"
+                    ]
+                  }
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x226"
+                    ]
+                  },
+                  "x204"
+                ]
+              }
+            ]
+          },
+          "x244"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x273",
+          "x274"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0x4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x275",
+          "x276"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xfffffffd"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x277",
+          "x278"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x279",
+          "x280"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x281",
+          "x282"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xfffffffb"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x283",
+          "x284"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x285",
+          "x286"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0x3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x287",
+          "x288"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x284",
+          "x281"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x289",
+          "x290"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x288",
+          "x282",
+          "x279"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x291",
+          "x292"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x290",
+          "x280",
+          "x277"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x293",
+          "x294"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x292",
+          "x278",
+          "x275"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x295",
+          "x296"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x294",
+          "x276",
+          "x273"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x297",
+          "x298"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x257",
+          "x285"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x299",
+          "x300"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x298",
+          "x259",
+          "x286"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x301",
+          "x302"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x300",
+          "x261",
+          "x283"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x303",
+          "x304"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x302",
+          "x263",
+          "x287"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x305",
+          "x306"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x304",
+          "x265",
+          "x289"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x307",
+          "x308"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x306",
+          "x267",
+          "x291"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x309",
+          "x310"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x308",
+          "x269",
+          "x293"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x311",
+          "x312"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x310",
+          "x271",
+          "x295"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x313",
+          "x314"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x297",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x315",
+          "x316"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x297",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x317",
+          "x318"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x297",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x319",
+          "x320"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x297",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x321",
+          "x322"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x320",
+          "x317"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x323",
+          "x324"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x322",
+          "x318",
+          "x315"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x326"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x297",
+          "x319"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x327",
+          "x328"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x326",
+          "x299",
+          "x321"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x329",
+          "x330"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x328",
+          "x301",
+          "x323"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x331",
+          "x332"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x330",
+          "x303",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x324"
+                ]
+              },
+              "x316"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x333",
+          "x334"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x332",
+          "x305",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x335",
+          "x336"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x334",
+          "x307",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x337",
+          "x338"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x336",
+          "x309",
+          "x297"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x339",
+          "x340"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x338",
+          "x311",
+          "x313"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x341",
+          "x342"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x340",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x312"
+                    ]
+                  },
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x272"
+                    ]
+                  }
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x296"
+                    ]
+                  },
+                  "x274"
+                ]
+              }
+            ]
+          },
+          "x314"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x343",
+          "x344"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0x4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x345",
+          "x346"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0xfffffffd"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x347",
+          "x348"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x349",
+          "x350"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x351",
+          "x352"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0xfffffffb"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x353",
+          "x354"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x355",
+          "x356"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0x3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x357",
+          "x358"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x354",
+          "x351"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x359",
+          "x360"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x358",
+          "x352",
+          "x349"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x361",
+          "x362"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x360",
+          "x350",
+          "x347"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x363",
+          "x364"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x362",
+          "x348",
+          "x345"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x365",
+          "x366"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x364",
+          "x346",
+          "x343"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x367",
+          "x368"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x327",
+          "x355"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x369",
+          "x370"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x368",
+          "x329",
+          "x356"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x371",
+          "x372"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x370",
+          "x331",
+          "x353"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x373",
+          "x374"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x372",
+          "x333",
+          "x357"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x375",
+          "x376"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x374",
+          "x335",
+          "x359"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x377",
+          "x378"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x376",
+          "x337",
+          "x361"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x379",
+          "x380"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x378",
+          "x339",
+          "x363"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x381",
+          "x382"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x380",
+          "x341",
+          "x365"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x383",
+          "x384"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x367",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x385",
+          "x386"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x367",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x387",
+          "x388"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x367",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x389",
+          "x390"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x367",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x391",
+          "x392"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x390",
+          "x387"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x393",
+          "x394"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x392",
+          "x388",
+          "x385"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x396"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x367",
+          "x389"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x397",
+          "x398"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x396",
+          "x369",
+          "x391"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x399",
+          "x400"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x398",
+          "x371",
+          "x393"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x401",
+          "x402"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x400",
+          "x373",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x394"
+                ]
+              },
+              "x386"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x403",
+          "x404"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x402",
+          "x375",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x405",
+          "x406"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x404",
+          "x377",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x407",
+          "x408"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x406",
+          "x379",
+          "x367"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x409",
+          "x410"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x408",
+          "x381",
+          "x383"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x411",
+          "x412"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x410",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x382"
+                    ]
+                  },
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x342"
+                    ]
+                  }
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x366"
+                    ]
+                  },
+                  "x344"
+                ]
+              }
+            ]
+          },
+          "x384"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x413",
+          "x414"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0x4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x415",
+          "x416"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0xfffffffd"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x417",
+          "x418"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x419",
+          "x420"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x421",
+          "x422"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0xfffffffb"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x423",
+          "x424"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x425",
+          "x426"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0x3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x427",
+          "x428"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x424",
+          "x421"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x429",
+          "x430"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x428",
+          "x422",
+          "x419"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x431",
+          "x432"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x430",
+          "x420",
+          "x417"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x433",
+          "x434"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x432",
+          "x418",
+          "x415"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x435",
+          "x436"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x434",
+          "x416",
+          "x413"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x437",
+          "x438"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x397",
+          "x425"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x439",
+          "x440"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x438",
+          "x399",
+          "x426"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x441",
+          "x442"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x440",
+          "x401",
+          "x423"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x443",
+          "x444"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x442",
+          "x403",
+          "x427"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x445",
+          "x446"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x444",
+          "x405",
+          "x429"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x447",
+          "x448"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x446",
+          "x407",
+          "x431"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x449",
+          "x450"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x448",
+          "x409",
+          "x433"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x451",
+          "x452"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x450",
+          "x411",
+          "x435"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x453",
+          "x454"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x437",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x455",
+          "x456"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x437",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x457",
+          "x458"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x437",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x459",
+          "x460"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x437",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x461",
+          "x462"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x460",
+          "x457"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x463",
+          "x464"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x462",
+          "x458",
+          "x455"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x466"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x437",
+          "x459"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x467",
+          "x468"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x466",
+          "x439",
+          "x461"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x469",
+          "x470"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x468",
+          "x441",
+          "x463"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x471",
+          "x472"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x470",
+          "x443",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x464"
+                ]
+              },
+              "x456"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x473",
+          "x474"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x472",
+          "x445",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x475",
+          "x476"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x474",
+          "x447",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x477",
+          "x478"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x476",
+          "x449",
+          "x437"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x479",
+          "x480"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x478",
+          "x451",
+          "x453"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x481",
+          "x482"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x480",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x452"
+                    ]
+                  },
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x412"
+                    ]
+                  }
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x436"
+                    ]
+                  },
+                  "x414"
+                ]
+              }
+            ]
+          },
+          "x454"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x483",
+          "x484"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0x4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x485",
+          "x486"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0xfffffffd"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x487",
+          "x488"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x489",
+          "x490"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x491",
+          "x492"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0xfffffffb"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x493",
+          "x494"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x495",
+          "x496"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0x3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x497",
+          "x498"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x494",
+          "x491"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x499",
+          "x500"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x498",
+          "x492",
+          "x489"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x501",
+          "x502"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x500",
+          "x490",
+          "x487"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x503",
+          "x504"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x502",
+          "x488",
+          "x485"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x505",
+          "x506"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x504",
+          "x486",
+          "x483"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x507",
+          "x508"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x467",
+          "x495"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x509",
+          "x510"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x508",
+          "x469",
+          "x496"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x511",
+          "x512"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x510",
+          "x471",
+          "x493"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x513",
+          "x514"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x512",
+          "x473",
+          "x497"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x515",
+          "x516"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x514",
+          "x475",
+          "x499"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x517",
+          "x518"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x516",
+          "x477",
+          "x501"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x519",
+          "x520"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x518",
+          "x479",
+          "x503"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x521",
+          "x522"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x520",
+          "x481",
+          "x505"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x523",
+          "x524"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x507",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x525",
+          "x526"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x507",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x527",
+          "x528"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x507",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x529",
+          "x530"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x507",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x531",
+          "x532"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x530",
+          "x527"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x533",
+          "x534"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x532",
+          "x528",
+          "x525"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x536"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x507",
+          "x529"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x537",
+          "x538"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x536",
+          "x509",
+          "x531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x539",
+          "x540"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x538",
+          "x511",
+          "x533"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x541",
+          "x542"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x540",
+          "x513",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x534"
+                ]
+              },
+              "x526"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x543",
+          "x544"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x542",
+          "x515",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x545",
+          "x546"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x544",
+          "x517",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x547",
+          "x548"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x546",
+          "x519",
+          "x507"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x549",
+          "x550"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x548",
+          "x521",
+          "x523"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x551",
+          "x552"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x550",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x522"
+                    ]
+                  },
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x482"
+                    ]
+                  }
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x506"
+                    ]
+                  },
+                  "x484"
+                ]
+              }
+            ]
+          },
+          "x524"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x553",
+          "x554"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x537",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x555",
+          "x556"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x554",
+          "x539",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x557",
+          "x558"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x556",
+          "x541",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x559",
+          "x560"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x558",
+          "x543",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x561",
+          "x562"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x560",
+          "x545",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x563",
+          "x564"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x562",
+          "x547",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x565",
+          "x566"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x564",
+          "x549",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x567",
+          "x568"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x566",
+          "x551",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x570"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x568",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x552"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x571"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x570",
+          "x553",
+          "x537"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x572"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x570",
+          "x555",
+          "x539"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x573"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x570",
+          "x557",
+          "x541"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x574"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x570",
+          "x559",
+          "x543"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x575"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x570",
+          "x561",
+          "x545"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x576"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x570",
+          "x563",
+          "x547"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x577"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x570",
+          "x565",
+          "x549"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x578"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x570",
+          "x567",
+          "x551"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x571"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x572"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x573"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x574"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x575"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x576"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x577"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x578"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_nonzero",
+    "arguments": [
+      {
+        "datatype": "u32[8]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "|",
+        "arguments": [
+          "arg1[0]",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "|",
+            "arguments": [
+              "arg1[1]",
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "|",
+                "arguments": [
+                  "arg1[2]",
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "|",
+                    "arguments": [
+                      "arg1[3]",
+                      {
+                        "datatype": "u32",
+                        "name": [],
+                        "operation": "|",
+                        "arguments": [
+                          "arg1[4]",
+                          {
+                            "datatype": "u32",
+                            "name": [],
+                            "operation": "|",
+                            "arguments": [
+                              "arg1[5]",
+                              {
+                                "datatype": "u32",
+                                "name": [],
+                                "operation": "|",
+                                "arguments": [
+                                  "arg1[6]",
+                                  "arg1[7]"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_selectznz",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[8]",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32[8]",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[0]",
+          "arg3[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[1]",
+          "arg3[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[2]",
+          "arg3[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[3]",
+          "arg3[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[4]",
+          "arg3[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[5]",
+          "arg3[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[6]",
+          "arg3[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[7]",
+          "arg3[7]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_to_bytes",
+    "arguments": [
+      {
+        "datatype": "u32[8]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u8[32]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x9"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x8",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x11"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x10"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x10",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x13"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x14"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x12",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x15"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x7"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x7",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x17"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x16",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x19"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x20"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x18",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x21"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x6",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x23"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x22"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x22",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x25"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x26"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x24",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x27"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x5"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x5",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x29"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x28",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x31"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x30"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x32"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x30",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x33"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x4",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x35"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x34"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x34",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x37"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x36"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x38"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x36",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x39"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x3",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x41"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x40",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x43"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x44"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x42",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x45"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x2",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x47"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x46"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x48"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x46",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x49"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x48"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x50"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x48",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x51"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x52"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x1",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x53"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x52"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x54"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x52",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x55"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x54"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x56"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x54",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x11"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x13"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x14"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x15"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x17"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x19"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x21"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x23"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x25"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x26"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x27"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x29"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x31"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x32"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[16]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x33"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[17]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x35"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[18]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x37"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[19]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x38"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[20]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x39"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[21]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x41"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[22]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x43"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[23]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x44"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[24]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x45"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[25]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x47"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[26]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x49"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[27]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x50"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[28]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x51"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[29]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x53"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[30]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x55"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[31]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x56"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_from_bytes",
+    "arguments": [
+      {
+        "datatype": "u8[32]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[31]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[30]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[29]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[28]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[27]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[26]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[25]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x8"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[24]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[23]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[22]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[21]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x12"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[20]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[19]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[18]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[17]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x16"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[16]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x20"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[12]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x24"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x28"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x32"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x31",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x30",
+          "x33"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x29",
+          "x34"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x27",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x26",
+          "x36"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x25",
+          "x37"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x23",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x22",
+          "x39"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x21",
+          "x40"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x19",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x20"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x43"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x18",
+          "x42"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x17",
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x45"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x15",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x14",
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x47"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x13",
+          "x46"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x48"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x11",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x49"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x10",
+          "x48"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x50"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x9",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x51"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x7",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x52"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x6",
+          "x51"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x53"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x5",
+          "x52"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x54"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x3",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x55"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x2",
+          "x54"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x56"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x1",
+          "x55"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x35"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x38"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x41"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x44"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x47"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x50"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x53"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x56"
+        ]
+      }
+    ]
+  }
+]

--- a/fiat-json/src/p256_64.json
+++ b/fiat-json/src/p256_64.json
@@ -1,0 +1,8674 @@
+[
+  {
+    "operation": "fiat_p256_addcarryx_u64",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u128",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              },
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "64"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_subborrowx_u64",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "i128",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "i128",
+            "name": [],
+            "operation": "-",
+            "arguments": [
+              {
+                "datatype": "i128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              },
+              {
+                "datatype": "i128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "i128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "i1",
+        "name": [
+          "x2"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "i1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "64"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_mulx_u64",
+    "arguments": [
+      {
+        "datatype": "u64",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u64",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u128",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "64"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_cmovznz_u64",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u1",
+        "name": [
+          "x1"
+        ],
+        "operation": "!",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "!",
+            "arguments": [
+              "arg1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "-",
+                "arguments": [
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "0x0"
+                    ]
+                  },
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x1"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "|",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "arg3"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "~",
+                "arguments": [
+                  "x2"
+                ]
+              },
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_mul",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[4]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x12",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x14",
+          "x10",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x16",
+          "x8",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          },
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x25",
+          "x22"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x27"
+            ]
+          },
+          "x23"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x30"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x11",
+          "x24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31",
+          "x32"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x30",
+          "x13",
+          "x26"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33",
+          "x34"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x32",
+          "x15",
+          "x28"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35",
+          "x36"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x34",
+          "x17",
+          "x20"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x36",
+          "x19",
+          "x21"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39",
+          "x40"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41",
+          "x42"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43",
+          "x44"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45",
+          "x46"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47",
+          "x48"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x46",
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49",
+          "x50"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x48",
+          "x44",
+          "x41"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51",
+          "x52"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x50",
+          "x42",
+          "x39"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x52"
+            ]
+          },
+          "x40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54",
+          "x55"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x31",
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56",
+          "x57"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x55",
+          "x33",
+          "x47"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58",
+          "x59"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x57",
+          "x35",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x59",
+          "x37",
+          "x51"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x61",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          },
+          "x53"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x54",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x54",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x54",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x69",
+          "x66"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x71"
+            ]
+          },
+          "x67"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x74"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x54",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x75",
+          "x76"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x74",
+          "x56",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x77",
+          "x78"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x76",
+          "x58",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79",
+          "x80"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x78",
+          "x60",
+          "x64"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81",
+          "x82"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x80",
+          "x62",
+          "x65"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x82"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x63"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84",
+          "x85"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x86",
+          "x87"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88",
+          "x89"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90",
+          "x91"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x91",
+          "x88"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x94",
+          "x95"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x93",
+          "x89",
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96",
+          "x97"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x95",
+          "x87",
+          "x84"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x97"
+            ]
+          },
+          "x85"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x99",
+          "x100"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x75",
+          "x90"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x101",
+          "x102"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x100",
+          "x77",
+          "x92"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x103",
+          "x104"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x102",
+          "x79",
+          "x94"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x105",
+          "x106"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x104",
+          "x81",
+          "x96"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x107",
+          "x108"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x106",
+          "x83",
+          "x98"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x109",
+          "x110"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x99",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x111",
+          "x112"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x99",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x113",
+          "x114"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x99",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x115",
+          "x116"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x114",
+          "x111"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x117"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x116"
+            ]
+          },
+          "x112"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x119"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x99",
+          "x113"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x120",
+          "x121"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x119",
+          "x101",
+          "x115"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x122",
+          "x123"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x121",
+          "x103",
+          "x117"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x124",
+          "x125"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x123",
+          "x105",
+          "x109"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x126",
+          "x127"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x125",
+          "x107",
+          "x110"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x128"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x127"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x108"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x129",
+          "x130"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x131",
+          "x132"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x133",
+          "x134"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x135",
+          "x136"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x137",
+          "x138"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x136",
+          "x133"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x139",
+          "x140"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x138",
+          "x134",
+          "x131"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x141",
+          "x142"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x140",
+          "x132",
+          "x129"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x143"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x142"
+            ]
+          },
+          "x130"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x144",
+          "x145"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x120",
+          "x135"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x146",
+          "x147"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x145",
+          "x122",
+          "x137"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x148",
+          "x149"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x147",
+          "x124",
+          "x139"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x150",
+          "x151"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x149",
+          "x126",
+          "x141"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x152",
+          "x153"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x151",
+          "x128",
+          "x143"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x154",
+          "x155"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x144",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x156",
+          "x157"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x144",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x158",
+          "x159"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x144",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x160",
+          "x161"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x159",
+          "x156"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x162"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x161"
+            ]
+          },
+          "x157"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x164"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x144",
+          "x158"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x165",
+          "x166"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x164",
+          "x146",
+          "x160"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x167",
+          "x168"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x166",
+          "x148",
+          "x162"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x169",
+          "x170"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x168",
+          "x150",
+          "x154"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x171",
+          "x172"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x170",
+          "x152",
+          "x155"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x173"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x172"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x153"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x174",
+          "x175"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x165",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x176",
+          "x177"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x175",
+          "x167",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x178",
+          "x179"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x177",
+          "x169",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x180",
+          "x181"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x179",
+          "x171",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x183"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x181",
+          "x173",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x184"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x183",
+          "x174",
+          "x165"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x185"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x183",
+          "x176",
+          "x167"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x186"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x183",
+          "x178",
+          "x169"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x187"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x183",
+          "x180",
+          "x171"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x184"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x185"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x186"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x187"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_square",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x12",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x14",
+          "x10",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x16",
+          "x8",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          },
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x25",
+          "x22"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x27"
+            ]
+          },
+          "x23"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x30"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x11",
+          "x24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31",
+          "x32"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x30",
+          "x13",
+          "x26"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33",
+          "x34"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x32",
+          "x15",
+          "x28"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35",
+          "x36"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x34",
+          "x17",
+          "x20"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x36",
+          "x19",
+          "x21"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39",
+          "x40"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41",
+          "x42"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43",
+          "x44"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45",
+          "x46"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47",
+          "x48"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x46",
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49",
+          "x50"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x48",
+          "x44",
+          "x41"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51",
+          "x52"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x50",
+          "x42",
+          "x39"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x52"
+            ]
+          },
+          "x40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54",
+          "x55"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x31",
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56",
+          "x57"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x55",
+          "x33",
+          "x47"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58",
+          "x59"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x57",
+          "x35",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x59",
+          "x37",
+          "x51"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x61",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          },
+          "x53"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x54",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x54",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x54",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x69",
+          "x66"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x71"
+            ]
+          },
+          "x67"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x74"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x54",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x75",
+          "x76"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x74",
+          "x56",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x77",
+          "x78"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x76",
+          "x58",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79",
+          "x80"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x78",
+          "x60",
+          "x64"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81",
+          "x82"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x80",
+          "x62",
+          "x65"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x82"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x63"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84",
+          "x85"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x86",
+          "x87"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88",
+          "x89"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90",
+          "x91"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x91",
+          "x88"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x94",
+          "x95"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x93",
+          "x89",
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96",
+          "x97"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x95",
+          "x87",
+          "x84"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x97"
+            ]
+          },
+          "x85"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x99",
+          "x100"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x75",
+          "x90"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x101",
+          "x102"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x100",
+          "x77",
+          "x92"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x103",
+          "x104"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x102",
+          "x79",
+          "x94"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x105",
+          "x106"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x104",
+          "x81",
+          "x96"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x107",
+          "x108"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x106",
+          "x83",
+          "x98"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x109",
+          "x110"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x99",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x111",
+          "x112"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x99",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x113",
+          "x114"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x99",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x115",
+          "x116"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x114",
+          "x111"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x117"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x116"
+            ]
+          },
+          "x112"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x119"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x99",
+          "x113"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x120",
+          "x121"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x119",
+          "x101",
+          "x115"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x122",
+          "x123"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x121",
+          "x103",
+          "x117"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x124",
+          "x125"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x123",
+          "x105",
+          "x109"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x126",
+          "x127"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x125",
+          "x107",
+          "x110"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x128"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x127"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x108"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x129",
+          "x130"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x131",
+          "x132"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x133",
+          "x134"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x135",
+          "x136"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x137",
+          "x138"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x136",
+          "x133"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x139",
+          "x140"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x138",
+          "x134",
+          "x131"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x141",
+          "x142"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x140",
+          "x132",
+          "x129"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x143"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x142"
+            ]
+          },
+          "x130"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x144",
+          "x145"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x120",
+          "x135"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x146",
+          "x147"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x145",
+          "x122",
+          "x137"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x148",
+          "x149"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x147",
+          "x124",
+          "x139"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x150",
+          "x151"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x149",
+          "x126",
+          "x141"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x152",
+          "x153"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x151",
+          "x128",
+          "x143"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x154",
+          "x155"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x144",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x156",
+          "x157"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x144",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x158",
+          "x159"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x144",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x160",
+          "x161"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x159",
+          "x156"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x162"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x161"
+            ]
+          },
+          "x157"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x164"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x144",
+          "x158"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x165",
+          "x166"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x164",
+          "x146",
+          "x160"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x167",
+          "x168"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x166",
+          "x148",
+          "x162"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x169",
+          "x170"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x168",
+          "x150",
+          "x154"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x171",
+          "x172"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x170",
+          "x152",
+          "x155"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x173"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x172"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x153"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x174",
+          "x175"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x165",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x176",
+          "x177"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x175",
+          "x167",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x178",
+          "x179"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x177",
+          "x169",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x180",
+          "x181"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x179",
+          "x171",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x183"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x181",
+          "x173",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x184"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x183",
+          "x174",
+          "x165"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x185"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x183",
+          "x176",
+          "x167"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x186"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x183",
+          "x178",
+          "x169"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x187"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x183",
+          "x180",
+          "x171"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x184"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x185"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x186"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x187"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_add",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[4]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x10",
+          "x3",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x12",
+          "x5",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x14",
+          "x7",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x18"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x16",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x18",
+          "x9",
+          "x1"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x18",
+          "x11",
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x18",
+          "x13",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x18",
+          "x15",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x19"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x21"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x22"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_sub",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[4]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x8",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x11",
+          "x3",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x9",
+              "0xffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x13",
+          "x5",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x15",
+          "x7",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x9",
+              "0xffffffff00000001"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x10"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x12"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x14"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_opp",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x8",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x11",
+          "x3",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x9",
+              "0xffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x13",
+          "x5",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x15",
+          "x7",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x9",
+              "0xffffffff00000001"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x10"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x12"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x14"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_from_montgomery",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2",
+          "x3"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4",
+          "x5"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6",
+          "x7"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8",
+          "x9"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x7",
+          "x4"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x11"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x11",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x12",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x14",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x14",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x14",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x21",
+          "x18"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x14",
+          "x20"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x15"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x13"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x9"
+                        ]
+                      },
+                      "x5"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "x22"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x2",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x23"
+                ]
+              },
+              "x19"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x3",
+          "x16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x26",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34",
+          "x35"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x33",
+          "x28",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36",
+          "x37"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x35",
+          "x30",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38",
+          "x39"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x32",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40",
+          "x41"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x32",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42",
+          "x43"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x32",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44",
+          "x45"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x43",
+          "x40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x47"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x32",
+          "x42"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48",
+          "x49"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x47",
+          "x34",
+          "x44"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50",
+          "x51"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x49",
+          "x36",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x45"
+                ]
+              },
+              "x41"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52",
+          "x53"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x51",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x37"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x31"
+                    ]
+                  },
+                  "x17"
+                ]
+              }
+            ]
+          },
+          "x38"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54",
+          "x55"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x48",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56",
+          "x57"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x55",
+          "x50",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58",
+          "x59"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x57",
+          "x52",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x54",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x54",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x54",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x65",
+          "x62"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x69"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x54",
+          "x64"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x69",
+          "x56",
+          "x66"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72",
+          "x73"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x71",
+          "x58",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x67"
+                ]
+              },
+              "x63"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x73",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x59"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x53"
+                    ]
+                  },
+                  "x39"
+                ]
+              }
+            ]
+          },
+          "x60"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x76"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x75"
+            ]
+          },
+          "x61"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x77",
+          "x78"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x70",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79",
+          "x80"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x78",
+          "x72",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81",
+          "x82"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x80",
+          "x74",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83",
+          "x84"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x82",
+          "x76",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x86"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x84",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x86",
+          "x77",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x86",
+          "x79",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x86",
+          "x81",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x86",
+          "x83",
+          "x76"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x87"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x88"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x89"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x90"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_to_montgomery",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0x4fffffffd"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xfffffffbffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0x3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x12",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x14",
+          "x10",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x16",
+          "x8",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25",
+          "x26"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x24",
+          "x21"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x28"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x11",
+          "x23"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29",
+          "x30"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x28",
+          "x13",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31",
+          "x32"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x30",
+          "x15",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x26"
+                ]
+              },
+              "x22"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33",
+          "x34"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x32",
+          "x17",
+          "x19"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35",
+          "x36"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x34",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x18"
+                ]
+              },
+              "x6"
+            ]
+          },
+          "x20"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0x4fffffffd"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39",
+          "x40"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41",
+          "x42"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xfffffffbffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43",
+          "x44"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0x3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45",
+          "x46"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x44",
+          "x41"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47",
+          "x48"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x46",
+          "x42",
+          "x39"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49",
+          "x50"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x48",
+          "x40",
+          "x37"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51",
+          "x52"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x29",
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53",
+          "x54"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x52",
+          "x31",
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55",
+          "x56"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x54",
+          "x33",
+          "x47"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57",
+          "x58"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x56",
+          "x35",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59",
+          "x60"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x51",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61",
+          "x62"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x51",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x63",
+          "x64"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x51",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x65",
+          "x66"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x64",
+          "x61"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x68"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x51",
+          "x63"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x69",
+          "x70"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x68",
+          "x53",
+          "x65"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x71",
+          "x72"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x70",
+          "x55",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x66"
+                ]
+              },
+              "x62"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x73",
+          "x74"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x72",
+          "x57",
+          "x59"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x75",
+          "x76"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x74",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x58"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x36"
+                    ]
+                  }
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x50"
+                    ]
+                  },
+                  "x38"
+                ]
+              }
+            ]
+          },
+          "x60"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x77",
+          "x78"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0x4fffffffd"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79",
+          "x80"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81",
+          "x82"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xfffffffbffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83",
+          "x84"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0x3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x85",
+          "x86"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x84",
+          "x81"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87",
+          "x88"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x86",
+          "x82",
+          "x79"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89",
+          "x90"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x88",
+          "x80",
+          "x77"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x91",
+          "x92"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x69",
+          "x83"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x93",
+          "x94"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x92",
+          "x71",
+          "x85"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x95",
+          "x96"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x94",
+          "x73",
+          "x87"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x97",
+          "x98"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x96",
+          "x75",
+          "x89"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x99",
+          "x100"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x91",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x101",
+          "x102"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x91",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x103",
+          "x104"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x91",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x105",
+          "x106"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x104",
+          "x101"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x108"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x91",
+          "x103"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x109",
+          "x110"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x108",
+          "x93",
+          "x105"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x111",
+          "x112"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x110",
+          "x95",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x106"
+                ]
+              },
+              "x102"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x113",
+          "x114"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x112",
+          "x97",
+          "x99"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x115",
+          "x116"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x114",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x98"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x76"
+                    ]
+                  }
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x90"
+                    ]
+                  },
+                  "x78"
+                ]
+              }
+            ]
+          },
+          "x100"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x117",
+          "x118"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0x4fffffffd"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x119",
+          "x120"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x121",
+          "x122"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xfffffffbffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x123",
+          "x124"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0x3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x125",
+          "x126"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x124",
+          "x121"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x127",
+          "x128"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x126",
+          "x122",
+          "x119"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x129",
+          "x130"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x128",
+          "x120",
+          "x117"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x131",
+          "x132"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x109",
+          "x123"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x133",
+          "x134"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x132",
+          "x111",
+          "x125"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x135",
+          "x136"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x134",
+          "x113",
+          "x127"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x137",
+          "x138"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x136",
+          "x115",
+          "x129"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x139",
+          "x140"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x131",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x141",
+          "x142"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x131",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x143",
+          "x144"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x131",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x145",
+          "x146"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x144",
+          "x141"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x148"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x131",
+          "x143"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x149",
+          "x150"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x148",
+          "x133",
+          "x145"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x151",
+          "x152"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x150",
+          "x135",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x146"
+                ]
+              },
+              "x142"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x153",
+          "x154"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x152",
+          "x137",
+          "x139"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x155",
+          "x156"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x154",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x138"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x116"
+                    ]
+                  }
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x130"
+                    ]
+                  },
+                  "x118"
+                ]
+              }
+            ]
+          },
+          "x140"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x157",
+          "x158"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x149",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x159",
+          "x160"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x158",
+          "x151",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x161",
+          "x162"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x160",
+          "x153",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x163",
+          "x164"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x162",
+          "x155",
+          "0xffffffff00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x166"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x164",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x156"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x167"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x166",
+          "x157",
+          "x149"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x168"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x166",
+          "x159",
+          "x151"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x169"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x166",
+          "x161",
+          "x153"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x170"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x166",
+          "x163",
+          "x155"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x167"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x168"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x169"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x170"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_nonzero",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "|",
+        "arguments": [
+          "arg1[0]",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "|",
+            "arguments": [
+              "arg1[1]",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "|",
+                "arguments": [
+                  "arg1[2]",
+                  "arg1[3]"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_selectznz",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[4]",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64[4]",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[0]",
+          "arg3[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[1]",
+          "arg3[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[2]",
+          "arg3[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[3]",
+          "arg3[3]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_to_bytes",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u8[32]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x5"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x4",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x7"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x6",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x9"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x8",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x11"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x10"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x10",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x13"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x12",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x15"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x14",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x17"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x18"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x16",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x19"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x3",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x21"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x20"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x20",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x23"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x22"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x22",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x25"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x24",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x27"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x26"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x26",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x29"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x28",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x31"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x30"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x32"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x30",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x33"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x2",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x35"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x34"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x34",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x37"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x36"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x36",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x39"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x38",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x41"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x40",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x43"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x42",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x45"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x44"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x46"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x44",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x47"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x1",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x49"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x48"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x48",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x51"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x50"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x50",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x53"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x52"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x52",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x55"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x54"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x54",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x57"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x56"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x56",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x59"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x58"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x60"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x58",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x11"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x13"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x15"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x17"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x19"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x21"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x23"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x25"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x27"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x29"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x31"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x32"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[16]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x33"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[17]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x35"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[18]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x37"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[19]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x39"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[20]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x41"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[21]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x43"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[22]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x45"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[23]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x46"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[24]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x47"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[25]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x49"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[26]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x51"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[27]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x53"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[28]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x55"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[29]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x57"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[30]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x59"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[31]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x60"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p256_from_bytes",
+    "arguments": [
+      {
+        "datatype": "u8[32]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[31]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[30]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[29]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[28]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[27]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[26]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[25]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x8"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[24]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[23]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[22]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[21]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[20]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[19]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[18]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[17]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x16"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[16]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x24"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x32"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x31",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x30",
+          "x33"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x29",
+          "x34"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x28",
+          "x35"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x27",
+          "x36"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x26",
+          "x37"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x25",
+          "x38"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x23",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x22",
+          "x40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x21",
+          "x41"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x20",
+          "x42"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x19",
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x18",
+          "x44"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x17",
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x15",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x14",
+          "x47"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x13",
+          "x48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x12",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x11",
+          "x50"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x10",
+          "x51"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x9",
+          "x52"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x7",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x6",
+          "x54"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x5",
+          "x55"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x4",
+          "x56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x3",
+          "x57"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x2",
+          "x58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x1",
+          "x59"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x39"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x46"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x53"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x60"
+        ]
+      }
+    ]
+  }
+]

--- a/fiat-json/src/p384_32.json
+++ b/fiat-json/src/p384_32.json
@@ -1,0 +1,45310 @@
+[
+  {
+    "operation": "fiat_p384_addcarryx_u32",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_subborrowx_u32",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "i64",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "i64",
+            "name": [],
+            "operation": "-",
+            "arguments": [
+              {
+                "datatype": "i64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              },
+              {
+                "datatype": "i64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "i64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "i1",
+        "name": [
+          "x2"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "i1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_mulx_u32",
+    "arguments": [
+      {
+        "datatype": "u32",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      },
+      {
+        "datatype": "u32",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_cmovznz_u32",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u1",
+        "name": [
+          "x1"
+        ],
+        "operation": "!",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "!",
+            "arguments": [
+              "arg1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "-",
+                "arguments": [
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "0x0"
+                    ]
+                  },
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x1"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "|",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "arg3"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "~",
+                "arguments": [
+                  "x2"
+                ]
+              },
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_mul",
+    "arguments": [
+      {
+        "datatype": "u32[12]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[12]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[12]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg2[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg2[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg2[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg2[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25",
+          "x26"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27",
+          "x28"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29",
+          "x30"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31",
+          "x32"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33",
+          "x34"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35",
+          "x36"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x36",
+          "x33"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39",
+          "x40"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x38",
+          "x34",
+          "x31"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41",
+          "x42"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x40",
+          "x32",
+          "x29"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x43",
+          "x44"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x42",
+          "x30",
+          "x27"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x45",
+          "x46"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x44",
+          "x28",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x47",
+          "x48"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x46",
+          "x26",
+          "x23"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x49",
+          "x50"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x48",
+          "x24",
+          "x21"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x51",
+          "x52"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x50",
+          "x22",
+          "x19"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x53",
+          "x54"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x52",
+          "x20",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x55",
+          "x56"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x54",
+          "x18",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x57",
+          "x58"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x56",
+          "x16",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x59"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x58"
+            ]
+          },
+          "x14"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x72",
+          "x73"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x76",
+          "x77"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x78",
+          "x79"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x80",
+          "x81"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x77",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x82",
+          "x83"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x81",
+          "x75",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x84",
+          "x85"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x83",
+          "x73",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x86",
+          "x87"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x85",
+          "x71",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x88",
+          "x89"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x87",
+          "x69",
+          "x66"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x90",
+          "x91"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x89",
+          "x67",
+          "x64"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x91",
+          "x65",
+          "x62"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x94",
+          "x95"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x93",
+          "x63",
+          "x60"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x96"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x95"
+            ]
+          },
+          "x61"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x98"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x35",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x99",
+          "x100"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x98",
+          "x37",
+          "x79"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x101",
+          "x102"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x100",
+          "x39",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x103",
+          "x104"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x102",
+          "x41",
+          "x76"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x105",
+          "x106"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x104",
+          "x43",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x107",
+          "x108"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x106",
+          "x45",
+          "x82"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x109",
+          "x110"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x108",
+          "x47",
+          "x84"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x111",
+          "x112"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x110",
+          "x49",
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x113",
+          "x114"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x112",
+          "x51",
+          "x88"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x115",
+          "x116"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x114",
+          "x53",
+          "x90"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x117",
+          "x118"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x116",
+          "x55",
+          "x92"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x119",
+          "x120"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x118",
+          "x57",
+          "x94"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x121",
+          "x122"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x120",
+          "x59",
+          "x96"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x123",
+          "x124"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x125",
+          "x126"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x127",
+          "x128"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x129",
+          "x130"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x131",
+          "x132"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x133",
+          "x134"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x135",
+          "x136"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x137",
+          "x138"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x139",
+          "x140"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x141",
+          "x142"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x143",
+          "x144"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x145",
+          "x146"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x147",
+          "x148"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x146",
+          "x143"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x149",
+          "x150"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x148",
+          "x144",
+          "x141"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x151",
+          "x152"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x150",
+          "x142",
+          "x139"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x153",
+          "x154"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x152",
+          "x140",
+          "x137"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x155",
+          "x156"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x154",
+          "x138",
+          "x135"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x157",
+          "x158"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x156",
+          "x136",
+          "x133"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x159",
+          "x160"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x158",
+          "x134",
+          "x131"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x161",
+          "x162"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x160",
+          "x132",
+          "x129"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x163",
+          "x164"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x162",
+          "x130",
+          "x127"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x165",
+          "x166"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x164",
+          "x128",
+          "x125"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x167",
+          "x168"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x166",
+          "x126",
+          "x123"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x169"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x168"
+            ]
+          },
+          "x124"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x170",
+          "x171"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x99",
+          "x145"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x172",
+          "x173"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x171",
+          "x101",
+          "x147"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x174",
+          "x175"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x173",
+          "x103",
+          "x149"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x176",
+          "x177"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x175",
+          "x105",
+          "x151"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x178",
+          "x179"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x177",
+          "x107",
+          "x153"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x180",
+          "x181"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x179",
+          "x109",
+          "x155"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x182",
+          "x183"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x181",
+          "x111",
+          "x157"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x184",
+          "x185"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x183",
+          "x113",
+          "x159"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x186",
+          "x187"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x185",
+          "x115",
+          "x161"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x188",
+          "x189"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x187",
+          "x117",
+          "x163"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x190",
+          "x191"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x189",
+          "x119",
+          "x165"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x192",
+          "x193"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x191",
+          "x121",
+          "x167"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x194",
+          "x195"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x193",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x122"
+            ]
+          },
+          "x169"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x196",
+          "x197"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x170",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x198",
+          "x199"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x170",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x200",
+          "x201"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x170",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x202",
+          "x203"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x170",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x204",
+          "x205"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x170",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x206",
+          "x207"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x170",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x208",
+          "x209"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x170",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x210",
+          "x211"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x170",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x212",
+          "x213"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x170",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x214",
+          "x215"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x170",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x216",
+          "x217"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x213",
+          "x210"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x218",
+          "x219"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x217",
+          "x211",
+          "x208"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x220",
+          "x221"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x219",
+          "x209",
+          "x206"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x222",
+          "x223"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x221",
+          "x207",
+          "x204"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x224",
+          "x225"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x223",
+          "x205",
+          "x202"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x226",
+          "x227"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x225",
+          "x203",
+          "x200"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x228",
+          "x229"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x227",
+          "x201",
+          "x198"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x230",
+          "x231"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x229",
+          "x199",
+          "x196"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x232"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x231"
+            ]
+          },
+          "x197"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x234"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x170",
+          "x214"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x235",
+          "x236"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x234",
+          "x172",
+          "x215"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x237",
+          "x238"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x236",
+          "x174",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x239",
+          "x240"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x238",
+          "x176",
+          "x212"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x241",
+          "x242"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x240",
+          "x178",
+          "x216"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x243",
+          "x244"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x242",
+          "x180",
+          "x218"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x245",
+          "x246"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x244",
+          "x182",
+          "x220"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x247",
+          "x248"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x246",
+          "x184",
+          "x222"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x249",
+          "x250"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x248",
+          "x186",
+          "x224"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x251",
+          "x252"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x250",
+          "x188",
+          "x226"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x253",
+          "x254"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x252",
+          "x190",
+          "x228"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x255",
+          "x256"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x254",
+          "x192",
+          "x230"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x257",
+          "x258"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x256",
+          "x194",
+          "x232"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x259"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x258"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x195"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x260",
+          "x261"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x262",
+          "x263"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x264",
+          "x265"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x266",
+          "x267"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x268",
+          "x269"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x270",
+          "x271"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x272",
+          "x273"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x274",
+          "x275"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x276",
+          "x277"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x278",
+          "x279"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x280",
+          "x281"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x282",
+          "x283"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x284",
+          "x285"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x283",
+          "x280"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x286",
+          "x287"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x285",
+          "x281",
+          "x278"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x288",
+          "x289"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x287",
+          "x279",
+          "x276"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x290",
+          "x291"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x289",
+          "x277",
+          "x274"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x292",
+          "x293"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x291",
+          "x275",
+          "x272"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x294",
+          "x295"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x293",
+          "x273",
+          "x270"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x296",
+          "x297"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x295",
+          "x271",
+          "x268"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x298",
+          "x299"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x297",
+          "x269",
+          "x266"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x300",
+          "x301"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x299",
+          "x267",
+          "x264"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x302",
+          "x303"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x301",
+          "x265",
+          "x262"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x304",
+          "x305"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x303",
+          "x263",
+          "x260"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x306"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x305"
+            ]
+          },
+          "x261"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x307",
+          "x308"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x235",
+          "x282"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x309",
+          "x310"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x308",
+          "x237",
+          "x284"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x311",
+          "x312"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x310",
+          "x239",
+          "x286"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x313",
+          "x314"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x312",
+          "x241",
+          "x288"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x315",
+          "x316"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x314",
+          "x243",
+          "x290"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x317",
+          "x318"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x316",
+          "x245",
+          "x292"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x319",
+          "x320"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x318",
+          "x247",
+          "x294"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x321",
+          "x322"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x320",
+          "x249",
+          "x296"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x323",
+          "x324"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x322",
+          "x251",
+          "x298"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x325",
+          "x326"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x324",
+          "x253",
+          "x300"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x327",
+          "x328"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x326",
+          "x255",
+          "x302"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x329",
+          "x330"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x328",
+          "x257",
+          "x304"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x331",
+          "x332"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x330",
+          "x259",
+          "x306"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x333",
+          "x334"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x307",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x335",
+          "x336"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x307",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x337",
+          "x338"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x307",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x339",
+          "x340"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x307",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x341",
+          "x342"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x307",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x343",
+          "x344"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x307",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x345",
+          "x346"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x307",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x347",
+          "x348"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x307",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x349",
+          "x350"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x307",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x351",
+          "x352"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x307",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x353",
+          "x354"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x350",
+          "x347"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x355",
+          "x356"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x354",
+          "x348",
+          "x345"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x357",
+          "x358"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x356",
+          "x346",
+          "x343"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x359",
+          "x360"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x358",
+          "x344",
+          "x341"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x361",
+          "x362"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x360",
+          "x342",
+          "x339"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x363",
+          "x364"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x362",
+          "x340",
+          "x337"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x365",
+          "x366"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x364",
+          "x338",
+          "x335"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x367",
+          "x368"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x366",
+          "x336",
+          "x333"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x369"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x368"
+            ]
+          },
+          "x334"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x371"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x307",
+          "x351"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x372",
+          "x373"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x371",
+          "x309",
+          "x352"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x374",
+          "x375"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x373",
+          "x311",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x376",
+          "x377"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x375",
+          "x313",
+          "x349"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x378",
+          "x379"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x377",
+          "x315",
+          "x353"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x380",
+          "x381"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x379",
+          "x317",
+          "x355"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x382",
+          "x383"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x381",
+          "x319",
+          "x357"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x384",
+          "x385"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x383",
+          "x321",
+          "x359"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x386",
+          "x387"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x385",
+          "x323",
+          "x361"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x388",
+          "x389"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x387",
+          "x325",
+          "x363"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x390",
+          "x391"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x389",
+          "x327",
+          "x365"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x392",
+          "x393"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x391",
+          "x329",
+          "x367"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x394",
+          "x395"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x393",
+          "x331",
+          "x369"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x396"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x395"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x332"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x397",
+          "x398"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x399",
+          "x400"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x401",
+          "x402"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x403",
+          "x404"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x405",
+          "x406"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x407",
+          "x408"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x409",
+          "x410"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x411",
+          "x412"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x413",
+          "x414"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x415",
+          "x416"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x417",
+          "x418"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x419",
+          "x420"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x421",
+          "x422"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x420",
+          "x417"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x423",
+          "x424"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x422",
+          "x418",
+          "x415"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x425",
+          "x426"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x424",
+          "x416",
+          "x413"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x427",
+          "x428"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x426",
+          "x414",
+          "x411"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x429",
+          "x430"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x428",
+          "x412",
+          "x409"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x431",
+          "x432"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x430",
+          "x410",
+          "x407"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x433",
+          "x434"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x432",
+          "x408",
+          "x405"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x435",
+          "x436"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x434",
+          "x406",
+          "x403"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x437",
+          "x438"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x436",
+          "x404",
+          "x401"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x439",
+          "x440"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x438",
+          "x402",
+          "x399"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x441",
+          "x442"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x440",
+          "x400",
+          "x397"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x443"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x442"
+            ]
+          },
+          "x398"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x444",
+          "x445"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x372",
+          "x419"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x446",
+          "x447"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x445",
+          "x374",
+          "x421"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x448",
+          "x449"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x447",
+          "x376",
+          "x423"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x450",
+          "x451"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x449",
+          "x378",
+          "x425"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x452",
+          "x453"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x451",
+          "x380",
+          "x427"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x454",
+          "x455"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x453",
+          "x382",
+          "x429"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x456",
+          "x457"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x455",
+          "x384",
+          "x431"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x458",
+          "x459"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x457",
+          "x386",
+          "x433"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x460",
+          "x461"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x459",
+          "x388",
+          "x435"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x462",
+          "x463"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x461",
+          "x390",
+          "x437"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x464",
+          "x465"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x463",
+          "x392",
+          "x439"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x466",
+          "x467"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x465",
+          "x394",
+          "x441"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x468",
+          "x469"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x467",
+          "x396",
+          "x443"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x470",
+          "x471"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x444",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x472",
+          "x473"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x444",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x474",
+          "x475"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x444",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x476",
+          "x477"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x444",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x478",
+          "x479"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x444",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x480",
+          "x481"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x444",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x482",
+          "x483"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x444",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x484",
+          "x485"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x444",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x486",
+          "x487"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x444",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x488",
+          "x489"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x444",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x490",
+          "x491"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x487",
+          "x484"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x492",
+          "x493"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x491",
+          "x485",
+          "x482"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x494",
+          "x495"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x493",
+          "x483",
+          "x480"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x496",
+          "x497"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x495",
+          "x481",
+          "x478"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x498",
+          "x499"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x497",
+          "x479",
+          "x476"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x500",
+          "x501"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x499",
+          "x477",
+          "x474"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x502",
+          "x503"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x501",
+          "x475",
+          "x472"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x504",
+          "x505"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x503",
+          "x473",
+          "x470"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x506"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x505"
+            ]
+          },
+          "x471"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x508"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x444",
+          "x488"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x509",
+          "x510"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x508",
+          "x446",
+          "x489"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x511",
+          "x512"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x510",
+          "x448",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x513",
+          "x514"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x512",
+          "x450",
+          "x486"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x515",
+          "x516"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x514",
+          "x452",
+          "x490"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x517",
+          "x518"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x516",
+          "x454",
+          "x492"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x519",
+          "x520"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x518",
+          "x456",
+          "x494"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x521",
+          "x522"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x520",
+          "x458",
+          "x496"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x523",
+          "x524"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x522",
+          "x460",
+          "x498"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x525",
+          "x526"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x524",
+          "x462",
+          "x500"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x527",
+          "x528"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x526",
+          "x464",
+          "x502"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x529",
+          "x530"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x528",
+          "x466",
+          "x504"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x531",
+          "x532"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x530",
+          "x468",
+          "x506"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x533"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x532"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x469"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x534",
+          "x535"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x536",
+          "x537"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x538",
+          "x539"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x540",
+          "x541"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x542",
+          "x543"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x544",
+          "x545"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x546",
+          "x547"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x548",
+          "x549"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x550",
+          "x551"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x552",
+          "x553"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x554",
+          "x555"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x556",
+          "x557"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x558",
+          "x559"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x557",
+          "x554"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x560",
+          "x561"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x559",
+          "x555",
+          "x552"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x562",
+          "x563"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x561",
+          "x553",
+          "x550"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x564",
+          "x565"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x563",
+          "x551",
+          "x548"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x566",
+          "x567"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x565",
+          "x549",
+          "x546"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x568",
+          "x569"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x567",
+          "x547",
+          "x544"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x570",
+          "x571"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x569",
+          "x545",
+          "x542"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x572",
+          "x573"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x571",
+          "x543",
+          "x540"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x574",
+          "x575"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x573",
+          "x541",
+          "x538"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x576",
+          "x577"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x575",
+          "x539",
+          "x536"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x578",
+          "x579"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x577",
+          "x537",
+          "x534"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x580"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x579"
+            ]
+          },
+          "x535"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x581",
+          "x582"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x509",
+          "x556"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x583",
+          "x584"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x582",
+          "x511",
+          "x558"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x585",
+          "x586"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x584",
+          "x513",
+          "x560"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x587",
+          "x588"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x586",
+          "x515",
+          "x562"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x589",
+          "x590"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x588",
+          "x517",
+          "x564"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x591",
+          "x592"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x590",
+          "x519",
+          "x566"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x593",
+          "x594"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x592",
+          "x521",
+          "x568"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x595",
+          "x596"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x594",
+          "x523",
+          "x570"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x597",
+          "x598"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x596",
+          "x525",
+          "x572"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x599",
+          "x600"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x598",
+          "x527",
+          "x574"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x601",
+          "x602"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x600",
+          "x529",
+          "x576"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x603",
+          "x604"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x602",
+          "x531",
+          "x578"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x605",
+          "x606"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x604",
+          "x533",
+          "x580"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x607",
+          "x608"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x581",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x609",
+          "x610"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x581",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x611",
+          "x612"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x581",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x613",
+          "x614"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x581",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x615",
+          "x616"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x581",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x617",
+          "x618"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x581",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x619",
+          "x620"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x581",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x621",
+          "x622"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x581",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x623",
+          "x624"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x581",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x625",
+          "x626"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x581",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x627",
+          "x628"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x624",
+          "x621"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x629",
+          "x630"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x628",
+          "x622",
+          "x619"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x631",
+          "x632"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x630",
+          "x620",
+          "x617"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x633",
+          "x634"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x632",
+          "x618",
+          "x615"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x635",
+          "x636"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x634",
+          "x616",
+          "x613"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x637",
+          "x638"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x636",
+          "x614",
+          "x611"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x639",
+          "x640"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x638",
+          "x612",
+          "x609"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x641",
+          "x642"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x640",
+          "x610",
+          "x607"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x643"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x642"
+            ]
+          },
+          "x608"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x645"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x581",
+          "x625"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x646",
+          "x647"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x645",
+          "x583",
+          "x626"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x648",
+          "x649"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x647",
+          "x585",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x650",
+          "x651"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x649",
+          "x587",
+          "x623"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x652",
+          "x653"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x651",
+          "x589",
+          "x627"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x654",
+          "x655"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x653",
+          "x591",
+          "x629"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x656",
+          "x657"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x655",
+          "x593",
+          "x631"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x658",
+          "x659"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x657",
+          "x595",
+          "x633"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x660",
+          "x661"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x659",
+          "x597",
+          "x635"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x662",
+          "x663"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x661",
+          "x599",
+          "x637"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x664",
+          "x665"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x663",
+          "x601",
+          "x639"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x666",
+          "x667"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x665",
+          "x603",
+          "x641"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x668",
+          "x669"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x667",
+          "x605",
+          "x643"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x670"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x669"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x606"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x671",
+          "x672"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x673",
+          "x674"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x675",
+          "x676"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x677",
+          "x678"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x679",
+          "x680"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x681",
+          "x682"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x683",
+          "x684"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x685",
+          "x686"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x687",
+          "x688"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x689",
+          "x690"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x691",
+          "x692"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x693",
+          "x694"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x695",
+          "x696"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x694",
+          "x691"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x697",
+          "x698"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x696",
+          "x692",
+          "x689"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x699",
+          "x700"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x698",
+          "x690",
+          "x687"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x701",
+          "x702"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x700",
+          "x688",
+          "x685"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x703",
+          "x704"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x702",
+          "x686",
+          "x683"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x705",
+          "x706"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x704",
+          "x684",
+          "x681"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x707",
+          "x708"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x706",
+          "x682",
+          "x679"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x709",
+          "x710"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x708",
+          "x680",
+          "x677"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x711",
+          "x712"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x710",
+          "x678",
+          "x675"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x713",
+          "x714"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x712",
+          "x676",
+          "x673"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x715",
+          "x716"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x714",
+          "x674",
+          "x671"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x717"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x716"
+            ]
+          },
+          "x672"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x718",
+          "x719"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x646",
+          "x693"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x720",
+          "x721"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x719",
+          "x648",
+          "x695"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x722",
+          "x723"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x721",
+          "x650",
+          "x697"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x724",
+          "x725"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x723",
+          "x652",
+          "x699"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x726",
+          "x727"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x725",
+          "x654",
+          "x701"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x728",
+          "x729"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x727",
+          "x656",
+          "x703"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x730",
+          "x731"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x729",
+          "x658",
+          "x705"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x732",
+          "x733"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x731",
+          "x660",
+          "x707"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x734",
+          "x735"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x733",
+          "x662",
+          "x709"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x736",
+          "x737"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x735",
+          "x664",
+          "x711"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x738",
+          "x739"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x737",
+          "x666",
+          "x713"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x740",
+          "x741"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x739",
+          "x668",
+          "x715"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x742",
+          "x743"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x741",
+          "x670",
+          "x717"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x744",
+          "x745"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x718",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x746",
+          "x747"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x718",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x748",
+          "x749"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x718",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x750",
+          "x751"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x718",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x752",
+          "x753"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x718",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x754",
+          "x755"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x718",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x756",
+          "x757"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x718",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x758",
+          "x759"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x718",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x760",
+          "x761"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x718",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x762",
+          "x763"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x718",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x764",
+          "x765"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x761",
+          "x758"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x766",
+          "x767"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x765",
+          "x759",
+          "x756"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x768",
+          "x769"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x767",
+          "x757",
+          "x754"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x770",
+          "x771"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x769",
+          "x755",
+          "x752"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x772",
+          "x773"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x771",
+          "x753",
+          "x750"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x774",
+          "x775"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x773",
+          "x751",
+          "x748"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x776",
+          "x777"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x775",
+          "x749",
+          "x746"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x778",
+          "x779"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x777",
+          "x747",
+          "x744"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x780"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x779"
+            ]
+          },
+          "x745"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x782"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x718",
+          "x762"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x783",
+          "x784"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x782",
+          "x720",
+          "x763"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x785",
+          "x786"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x784",
+          "x722",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x787",
+          "x788"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x786",
+          "x724",
+          "x760"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x789",
+          "x790"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x788",
+          "x726",
+          "x764"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x791",
+          "x792"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x790",
+          "x728",
+          "x766"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x793",
+          "x794"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x792",
+          "x730",
+          "x768"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x795",
+          "x796"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x794",
+          "x732",
+          "x770"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x797",
+          "x798"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x796",
+          "x734",
+          "x772"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x799",
+          "x800"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x798",
+          "x736",
+          "x774"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x801",
+          "x802"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x800",
+          "x738",
+          "x776"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x803",
+          "x804"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x802",
+          "x740",
+          "x778"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x805",
+          "x806"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x804",
+          "x742",
+          "x780"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x807"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x806"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x743"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x808",
+          "x809"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x810",
+          "x811"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x812",
+          "x813"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x814",
+          "x815"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x816",
+          "x817"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x818",
+          "x819"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x820",
+          "x821"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x822",
+          "x823"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x824",
+          "x825"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x826",
+          "x827"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x828",
+          "x829"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x830",
+          "x831"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x832",
+          "x833"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x831",
+          "x828"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x834",
+          "x835"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x833",
+          "x829",
+          "x826"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x836",
+          "x837"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x835",
+          "x827",
+          "x824"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x838",
+          "x839"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x837",
+          "x825",
+          "x822"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x840",
+          "x841"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x839",
+          "x823",
+          "x820"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x842",
+          "x843"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x841",
+          "x821",
+          "x818"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x844",
+          "x845"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x843",
+          "x819",
+          "x816"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x846",
+          "x847"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x845",
+          "x817",
+          "x814"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x848",
+          "x849"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x847",
+          "x815",
+          "x812"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x850",
+          "x851"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x849",
+          "x813",
+          "x810"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x852",
+          "x853"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x851",
+          "x811",
+          "x808"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x854"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x853"
+            ]
+          },
+          "x809"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x855",
+          "x856"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x783",
+          "x830"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x857",
+          "x858"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x856",
+          "x785",
+          "x832"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x859",
+          "x860"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x858",
+          "x787",
+          "x834"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x861",
+          "x862"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x860",
+          "x789",
+          "x836"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x863",
+          "x864"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x862",
+          "x791",
+          "x838"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x865",
+          "x866"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x864",
+          "x793",
+          "x840"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x867",
+          "x868"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x866",
+          "x795",
+          "x842"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x869",
+          "x870"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x868",
+          "x797",
+          "x844"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x871",
+          "x872"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x870",
+          "x799",
+          "x846"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x873",
+          "x874"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x872",
+          "x801",
+          "x848"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x875",
+          "x876"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x874",
+          "x803",
+          "x850"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x877",
+          "x878"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x876",
+          "x805",
+          "x852"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x879",
+          "x880"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x878",
+          "x807",
+          "x854"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x881",
+          "x882"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x855",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x883",
+          "x884"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x855",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x885",
+          "x886"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x855",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x887",
+          "x888"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x855",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x889",
+          "x890"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x855",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x891",
+          "x892"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x855",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x893",
+          "x894"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x855",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x895",
+          "x896"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x855",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x897",
+          "x898"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x855",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x899",
+          "x900"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x855",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x901",
+          "x902"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x898",
+          "x895"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x903",
+          "x904"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x902",
+          "x896",
+          "x893"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x905",
+          "x906"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x904",
+          "x894",
+          "x891"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x907",
+          "x908"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x906",
+          "x892",
+          "x889"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x909",
+          "x910"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x908",
+          "x890",
+          "x887"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x911",
+          "x912"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x910",
+          "x888",
+          "x885"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x913",
+          "x914"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x912",
+          "x886",
+          "x883"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x915",
+          "x916"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x914",
+          "x884",
+          "x881"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x917"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x916"
+            ]
+          },
+          "x882"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x919"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x855",
+          "x899"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x920",
+          "x921"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x919",
+          "x857",
+          "x900"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x922",
+          "x923"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x921",
+          "x859",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x924",
+          "x925"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x923",
+          "x861",
+          "x897"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x926",
+          "x927"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x925",
+          "x863",
+          "x901"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x928",
+          "x929"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x927",
+          "x865",
+          "x903"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x930",
+          "x931"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x929",
+          "x867",
+          "x905"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x932",
+          "x933"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x931",
+          "x869",
+          "x907"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x934",
+          "x935"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x933",
+          "x871",
+          "x909"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x936",
+          "x937"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x935",
+          "x873",
+          "x911"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x938",
+          "x939"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x937",
+          "x875",
+          "x913"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x940",
+          "x941"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x939",
+          "x877",
+          "x915"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x942",
+          "x943"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x941",
+          "x879",
+          "x917"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x944"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x943"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x880"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x945",
+          "x946"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x947",
+          "x948"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x949",
+          "x950"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x951",
+          "x952"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x953",
+          "x954"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x955",
+          "x956"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x957",
+          "x958"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x959",
+          "x960"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x961",
+          "x962"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x963",
+          "x964"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x965",
+          "x966"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x967",
+          "x968"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x969",
+          "x970"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x968",
+          "x965"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x971",
+          "x972"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x970",
+          "x966",
+          "x963"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x973",
+          "x974"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x972",
+          "x964",
+          "x961"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x975",
+          "x976"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x974",
+          "x962",
+          "x959"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x977",
+          "x978"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x976",
+          "x960",
+          "x957"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x979",
+          "x980"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x978",
+          "x958",
+          "x955"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x981",
+          "x982"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x980",
+          "x956",
+          "x953"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x983",
+          "x984"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x982",
+          "x954",
+          "x951"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x985",
+          "x986"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x984",
+          "x952",
+          "x949"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x987",
+          "x988"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x986",
+          "x950",
+          "x947"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x989",
+          "x990"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x988",
+          "x948",
+          "x945"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x991"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x990"
+            ]
+          },
+          "x946"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x992",
+          "x993"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x920",
+          "x967"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x994",
+          "x995"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x993",
+          "x922",
+          "x969"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x996",
+          "x997"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x995",
+          "x924",
+          "x971"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x998",
+          "x999"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x997",
+          "x926",
+          "x973"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1000",
+          "x1001"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x999",
+          "x928",
+          "x975"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1002",
+          "x1003"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1001",
+          "x930",
+          "x977"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1004",
+          "x1005"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1003",
+          "x932",
+          "x979"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1006",
+          "x1007"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1005",
+          "x934",
+          "x981"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1008",
+          "x1009"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1007",
+          "x936",
+          "x983"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1010",
+          "x1011"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1009",
+          "x938",
+          "x985"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1012",
+          "x1013"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1011",
+          "x940",
+          "x987"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1014",
+          "x1015"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1013",
+          "x942",
+          "x989"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1016",
+          "x1017"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1015",
+          "x944",
+          "x991"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1018",
+          "x1019"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x992",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1020",
+          "x1021"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x992",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1022",
+          "x1023"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x992",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1024",
+          "x1025"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x992",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1026",
+          "x1027"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x992",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1028",
+          "x1029"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x992",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1030",
+          "x1031"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x992",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1032",
+          "x1033"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x992",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1034",
+          "x1035"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x992",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1036",
+          "x1037"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x992",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1038",
+          "x1039"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1035",
+          "x1032"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1040",
+          "x1041"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1039",
+          "x1033",
+          "x1030"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1042",
+          "x1043"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1041",
+          "x1031",
+          "x1028"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1044",
+          "x1045"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1043",
+          "x1029",
+          "x1026"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1046",
+          "x1047"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1045",
+          "x1027",
+          "x1024"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1048",
+          "x1049"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1047",
+          "x1025",
+          "x1022"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1050",
+          "x1051"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1049",
+          "x1023",
+          "x1020"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1052",
+          "x1053"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1051",
+          "x1021",
+          "x1018"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1054"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1053"
+            ]
+          },
+          "x1019"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x1056"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x992",
+          "x1036"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1057",
+          "x1058"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1056",
+          "x994",
+          "x1037"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1059",
+          "x1060"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1058",
+          "x996",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1061",
+          "x1062"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1060",
+          "x998",
+          "x1034"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1063",
+          "x1064"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1062",
+          "x1000",
+          "x1038"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1065",
+          "x1066"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1064",
+          "x1002",
+          "x1040"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1067",
+          "x1068"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1066",
+          "x1004",
+          "x1042"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1069",
+          "x1070"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1068",
+          "x1006",
+          "x1044"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1071",
+          "x1072"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1070",
+          "x1008",
+          "x1046"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1073",
+          "x1074"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1072",
+          "x1010",
+          "x1048"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1075",
+          "x1076"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1074",
+          "x1012",
+          "x1050"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1077",
+          "x1078"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1076",
+          "x1014",
+          "x1052"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1079",
+          "x1080"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1078",
+          "x1016",
+          "x1054"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1081"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1080"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1017"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1082",
+          "x1083"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1084",
+          "x1085"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1086",
+          "x1087"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1088",
+          "x1089"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1090",
+          "x1091"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1092",
+          "x1093"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1094",
+          "x1095"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1096",
+          "x1097"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1098",
+          "x1099"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1100",
+          "x1101"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1102",
+          "x1103"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1104",
+          "x1105"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1106",
+          "x1107"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1105",
+          "x1102"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1108",
+          "x1109"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1107",
+          "x1103",
+          "x1100"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1110",
+          "x1111"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1109",
+          "x1101",
+          "x1098"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1112",
+          "x1113"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1111",
+          "x1099",
+          "x1096"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1114",
+          "x1115"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1113",
+          "x1097",
+          "x1094"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1116",
+          "x1117"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1115",
+          "x1095",
+          "x1092"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1118",
+          "x1119"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1117",
+          "x1093",
+          "x1090"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1120",
+          "x1121"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1119",
+          "x1091",
+          "x1088"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1122",
+          "x1123"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1121",
+          "x1089",
+          "x1086"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1124",
+          "x1125"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1123",
+          "x1087",
+          "x1084"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1126",
+          "x1127"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1125",
+          "x1085",
+          "x1082"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1128"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1127"
+            ]
+          },
+          "x1083"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1129",
+          "x1130"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1057",
+          "x1104"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1131",
+          "x1132"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1130",
+          "x1059",
+          "x1106"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1133",
+          "x1134"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1132",
+          "x1061",
+          "x1108"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1135",
+          "x1136"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1134",
+          "x1063",
+          "x1110"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1137",
+          "x1138"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1136",
+          "x1065",
+          "x1112"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1139",
+          "x1140"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1138",
+          "x1067",
+          "x1114"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1141",
+          "x1142"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1140",
+          "x1069",
+          "x1116"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1143",
+          "x1144"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1142",
+          "x1071",
+          "x1118"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1145",
+          "x1146"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1144",
+          "x1073",
+          "x1120"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1147",
+          "x1148"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1146",
+          "x1075",
+          "x1122"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1149",
+          "x1150"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1148",
+          "x1077",
+          "x1124"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1151",
+          "x1152"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1150",
+          "x1079",
+          "x1126"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1153",
+          "x1154"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1152",
+          "x1081",
+          "x1128"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1155",
+          "x1156"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1129",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1157",
+          "x1158"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1129",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1159",
+          "x1160"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1129",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1161",
+          "x1162"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1129",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1163",
+          "x1164"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1129",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1165",
+          "x1166"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1129",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1167",
+          "x1168"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1129",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1169",
+          "x1170"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1129",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1171",
+          "x1172"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1129",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1173",
+          "x1174"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1129",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1175",
+          "x1176"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1172",
+          "x1169"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1177",
+          "x1178"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1176",
+          "x1170",
+          "x1167"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1179",
+          "x1180"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1178",
+          "x1168",
+          "x1165"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1181",
+          "x1182"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1180",
+          "x1166",
+          "x1163"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1183",
+          "x1184"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1182",
+          "x1164",
+          "x1161"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1185",
+          "x1186"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1184",
+          "x1162",
+          "x1159"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1187",
+          "x1188"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1186",
+          "x1160",
+          "x1157"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1189",
+          "x1190"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1188",
+          "x1158",
+          "x1155"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1191"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1190"
+            ]
+          },
+          "x1156"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x1193"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1129",
+          "x1173"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1194",
+          "x1195"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1193",
+          "x1131",
+          "x1174"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1196",
+          "x1197"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1195",
+          "x1133",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1198",
+          "x1199"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1197",
+          "x1135",
+          "x1171"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1200",
+          "x1201"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1199",
+          "x1137",
+          "x1175"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1202",
+          "x1203"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1201",
+          "x1139",
+          "x1177"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1204",
+          "x1205"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1203",
+          "x1141",
+          "x1179"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1206",
+          "x1207"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1205",
+          "x1143",
+          "x1181"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1208",
+          "x1209"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1207",
+          "x1145",
+          "x1183"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1210",
+          "x1211"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1209",
+          "x1147",
+          "x1185"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1212",
+          "x1213"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1211",
+          "x1149",
+          "x1187"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1214",
+          "x1215"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1213",
+          "x1151",
+          "x1189"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1216",
+          "x1217"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1215",
+          "x1153",
+          "x1191"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1218"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1217"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1154"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1219",
+          "x1220"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg2[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1221",
+          "x1222"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg2[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1223",
+          "x1224"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg2[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1225",
+          "x1226"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg2[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1227",
+          "x1228"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1229",
+          "x1230"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1231",
+          "x1232"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1233",
+          "x1234"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1235",
+          "x1236"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1237",
+          "x1238"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1239",
+          "x1240"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1241",
+          "x1242"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1243",
+          "x1244"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1242",
+          "x1239"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1245",
+          "x1246"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1244",
+          "x1240",
+          "x1237"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1247",
+          "x1248"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1246",
+          "x1238",
+          "x1235"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1249",
+          "x1250"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1248",
+          "x1236",
+          "x1233"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1251",
+          "x1252"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1250",
+          "x1234",
+          "x1231"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1253",
+          "x1254"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1252",
+          "x1232",
+          "x1229"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1255",
+          "x1256"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1254",
+          "x1230",
+          "x1227"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1257",
+          "x1258"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1256",
+          "x1228",
+          "x1225"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1259",
+          "x1260"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1258",
+          "x1226",
+          "x1223"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1261",
+          "x1262"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1260",
+          "x1224",
+          "x1221"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1263",
+          "x1264"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1262",
+          "x1222",
+          "x1219"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1265"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1264"
+            ]
+          },
+          "x1220"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1266",
+          "x1267"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1194",
+          "x1241"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1268",
+          "x1269"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1267",
+          "x1196",
+          "x1243"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1270",
+          "x1271"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1269",
+          "x1198",
+          "x1245"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1272",
+          "x1273"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1271",
+          "x1200",
+          "x1247"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1274",
+          "x1275"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1273",
+          "x1202",
+          "x1249"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1276",
+          "x1277"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1275",
+          "x1204",
+          "x1251"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1278",
+          "x1279"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1277",
+          "x1206",
+          "x1253"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1280",
+          "x1281"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1279",
+          "x1208",
+          "x1255"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1282",
+          "x1283"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1281",
+          "x1210",
+          "x1257"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1284",
+          "x1285"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1283",
+          "x1212",
+          "x1259"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1286",
+          "x1287"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1285",
+          "x1214",
+          "x1261"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1288",
+          "x1289"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1287",
+          "x1216",
+          "x1263"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1290",
+          "x1291"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1289",
+          "x1218",
+          "x1265"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1292",
+          "x1293"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1294",
+          "x1295"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1296",
+          "x1297"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1298",
+          "x1299"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1300",
+          "x1301"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1302",
+          "x1303"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1304",
+          "x1305"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1306",
+          "x1307"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1266",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1308",
+          "x1309"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1310",
+          "x1311"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1312",
+          "x1313"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1309",
+          "x1306"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1314",
+          "x1315"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1313",
+          "x1307",
+          "x1304"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1316",
+          "x1317"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1315",
+          "x1305",
+          "x1302"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1318",
+          "x1319"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1317",
+          "x1303",
+          "x1300"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1320",
+          "x1321"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1319",
+          "x1301",
+          "x1298"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1322",
+          "x1323"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1321",
+          "x1299",
+          "x1296"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1324",
+          "x1325"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1323",
+          "x1297",
+          "x1294"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1326",
+          "x1327"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1325",
+          "x1295",
+          "x1292"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1328"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1327"
+            ]
+          },
+          "x1293"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x1330"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1266",
+          "x1310"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1331",
+          "x1332"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1330",
+          "x1268",
+          "x1311"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1333",
+          "x1334"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1332",
+          "x1270",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1335",
+          "x1336"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1334",
+          "x1272",
+          "x1308"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1337",
+          "x1338"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1336",
+          "x1274",
+          "x1312"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1339",
+          "x1340"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1338",
+          "x1276",
+          "x1314"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1341",
+          "x1342"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1340",
+          "x1278",
+          "x1316"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1343",
+          "x1344"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1342",
+          "x1280",
+          "x1318"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1345",
+          "x1346"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1344",
+          "x1282",
+          "x1320"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1347",
+          "x1348"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1346",
+          "x1284",
+          "x1322"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1349",
+          "x1350"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1348",
+          "x1286",
+          "x1324"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1351",
+          "x1352"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1350",
+          "x1288",
+          "x1326"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1353",
+          "x1354"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1352",
+          "x1290",
+          "x1328"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1355"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1354"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1291"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1356",
+          "x1357"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg2[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1358",
+          "x1359"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg2[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1360",
+          "x1361"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg2[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1362",
+          "x1363"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg2[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1364",
+          "x1365"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1366",
+          "x1367"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1368",
+          "x1369"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1370",
+          "x1371"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1372",
+          "x1373"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1374",
+          "x1375"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1376",
+          "x1377"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1378",
+          "x1379"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1380",
+          "x1381"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1379",
+          "x1376"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1382",
+          "x1383"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1381",
+          "x1377",
+          "x1374"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1384",
+          "x1385"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1383",
+          "x1375",
+          "x1372"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1386",
+          "x1387"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1385",
+          "x1373",
+          "x1370"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1388",
+          "x1389"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1387",
+          "x1371",
+          "x1368"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1390",
+          "x1391"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1389",
+          "x1369",
+          "x1366"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1392",
+          "x1393"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1391",
+          "x1367",
+          "x1364"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1394",
+          "x1395"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1393",
+          "x1365",
+          "x1362"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1396",
+          "x1397"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1395",
+          "x1363",
+          "x1360"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1398",
+          "x1399"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1397",
+          "x1361",
+          "x1358"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1400",
+          "x1401"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1399",
+          "x1359",
+          "x1356"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1402"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1401"
+            ]
+          },
+          "x1357"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1403",
+          "x1404"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1331",
+          "x1378"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1405",
+          "x1406"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1404",
+          "x1333",
+          "x1380"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1407",
+          "x1408"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1406",
+          "x1335",
+          "x1382"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1409",
+          "x1410"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1408",
+          "x1337",
+          "x1384"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1411",
+          "x1412"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1410",
+          "x1339",
+          "x1386"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1413",
+          "x1414"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1412",
+          "x1341",
+          "x1388"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1415",
+          "x1416"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1414",
+          "x1343",
+          "x1390"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1417",
+          "x1418"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1416",
+          "x1345",
+          "x1392"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1419",
+          "x1420"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1418",
+          "x1347",
+          "x1394"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1421",
+          "x1422"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1420",
+          "x1349",
+          "x1396"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1423",
+          "x1424"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1422",
+          "x1351",
+          "x1398"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1425",
+          "x1426"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1424",
+          "x1353",
+          "x1400"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1427",
+          "x1428"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1426",
+          "x1355",
+          "x1402"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1429",
+          "x1430"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1403",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1431",
+          "x1432"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1403",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1433",
+          "x1434"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1403",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1435",
+          "x1436"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1403",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1437",
+          "x1438"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1403",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1439",
+          "x1440"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1403",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1441",
+          "x1442"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1403",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1443",
+          "x1444"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1403",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1445",
+          "x1446"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1403",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1447",
+          "x1448"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1403",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1449",
+          "x1450"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1446",
+          "x1443"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1451",
+          "x1452"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1450",
+          "x1444",
+          "x1441"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1453",
+          "x1454"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1452",
+          "x1442",
+          "x1439"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1455",
+          "x1456"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1454",
+          "x1440",
+          "x1437"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1457",
+          "x1458"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1456",
+          "x1438",
+          "x1435"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1459",
+          "x1460"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1458",
+          "x1436",
+          "x1433"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1461",
+          "x1462"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1460",
+          "x1434",
+          "x1431"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1463",
+          "x1464"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1462",
+          "x1432",
+          "x1429"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1465"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1464"
+            ]
+          },
+          "x1430"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x1467"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1403",
+          "x1447"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1468",
+          "x1469"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1467",
+          "x1405",
+          "x1448"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1470",
+          "x1471"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1469",
+          "x1407",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1472",
+          "x1473"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1471",
+          "x1409",
+          "x1445"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1474",
+          "x1475"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1473",
+          "x1411",
+          "x1449"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1476",
+          "x1477"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1475",
+          "x1413",
+          "x1451"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1478",
+          "x1479"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1477",
+          "x1415",
+          "x1453"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1480",
+          "x1481"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1479",
+          "x1417",
+          "x1455"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1482",
+          "x1483"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1481",
+          "x1419",
+          "x1457"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1484",
+          "x1485"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1483",
+          "x1421",
+          "x1459"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1486",
+          "x1487"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1485",
+          "x1423",
+          "x1461"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1488",
+          "x1489"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1487",
+          "x1425",
+          "x1463"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1490",
+          "x1491"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1489",
+          "x1427",
+          "x1465"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1492"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1491"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1428"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1493",
+          "x1494"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg2[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1495",
+          "x1496"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg2[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1497",
+          "x1498"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg2[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1499",
+          "x1500"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg2[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1501",
+          "x1502"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1503",
+          "x1504"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1505",
+          "x1506"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1507",
+          "x1508"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1509",
+          "x1510"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1511",
+          "x1512"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1513",
+          "x1514"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1515",
+          "x1516"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1517",
+          "x1518"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1516",
+          "x1513"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1519",
+          "x1520"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1518",
+          "x1514",
+          "x1511"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1521",
+          "x1522"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1520",
+          "x1512",
+          "x1509"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1523",
+          "x1524"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1522",
+          "x1510",
+          "x1507"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1525",
+          "x1526"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1524",
+          "x1508",
+          "x1505"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1527",
+          "x1528"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1526",
+          "x1506",
+          "x1503"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1529",
+          "x1530"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1528",
+          "x1504",
+          "x1501"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1531",
+          "x1532"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1530",
+          "x1502",
+          "x1499"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1533",
+          "x1534"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1532",
+          "x1500",
+          "x1497"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1535",
+          "x1536"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1534",
+          "x1498",
+          "x1495"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1537",
+          "x1538"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1536",
+          "x1496",
+          "x1493"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1539"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1538"
+            ]
+          },
+          "x1494"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1540",
+          "x1541"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1468",
+          "x1515"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1542",
+          "x1543"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1541",
+          "x1470",
+          "x1517"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1544",
+          "x1545"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1543",
+          "x1472",
+          "x1519"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1546",
+          "x1547"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1545",
+          "x1474",
+          "x1521"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1548",
+          "x1549"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1547",
+          "x1476",
+          "x1523"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1550",
+          "x1551"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1549",
+          "x1478",
+          "x1525"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1552",
+          "x1553"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1551",
+          "x1480",
+          "x1527"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1554",
+          "x1555"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1553",
+          "x1482",
+          "x1529"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1556",
+          "x1557"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1555",
+          "x1484",
+          "x1531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1558",
+          "x1559"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1557",
+          "x1486",
+          "x1533"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1560",
+          "x1561"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1559",
+          "x1488",
+          "x1535"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1562",
+          "x1563"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1561",
+          "x1490",
+          "x1537"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1564",
+          "x1565"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1563",
+          "x1492",
+          "x1539"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1566",
+          "x1567"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1540",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1568",
+          "x1569"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1540",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1570",
+          "x1571"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1540",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1572",
+          "x1573"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1540",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1574",
+          "x1575"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1540",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1576",
+          "x1577"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1540",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1578",
+          "x1579"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1540",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1580",
+          "x1581"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1540",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1582",
+          "x1583"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1540",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1584",
+          "x1585"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1540",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1586",
+          "x1587"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1583",
+          "x1580"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1588",
+          "x1589"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1587",
+          "x1581",
+          "x1578"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1590",
+          "x1591"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1589",
+          "x1579",
+          "x1576"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1592",
+          "x1593"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1591",
+          "x1577",
+          "x1574"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1594",
+          "x1595"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1593",
+          "x1575",
+          "x1572"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1596",
+          "x1597"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1595",
+          "x1573",
+          "x1570"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1598",
+          "x1599"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1597",
+          "x1571",
+          "x1568"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1600",
+          "x1601"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1599",
+          "x1569",
+          "x1566"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1602"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1601"
+            ]
+          },
+          "x1567"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x1604"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1540",
+          "x1584"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1605",
+          "x1606"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1604",
+          "x1542",
+          "x1585"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1607",
+          "x1608"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1606",
+          "x1544",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1609",
+          "x1610"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1608",
+          "x1546",
+          "x1582"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1611",
+          "x1612"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1610",
+          "x1548",
+          "x1586"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1613",
+          "x1614"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1612",
+          "x1550",
+          "x1588"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1615",
+          "x1616"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1614",
+          "x1552",
+          "x1590"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1617",
+          "x1618"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1616",
+          "x1554",
+          "x1592"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1619",
+          "x1620"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1618",
+          "x1556",
+          "x1594"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1621",
+          "x1622"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1620",
+          "x1558",
+          "x1596"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1623",
+          "x1624"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1622",
+          "x1560",
+          "x1598"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1625",
+          "x1626"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1624",
+          "x1562",
+          "x1600"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1627",
+          "x1628"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1626",
+          "x1564",
+          "x1602"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1629"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1628"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1565"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1630",
+          "x1631"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x1605",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1632",
+          "x1633"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1631",
+          "x1607",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1634",
+          "x1635"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1633",
+          "x1609",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1636",
+          "x1637"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1635",
+          "x1611",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1638",
+          "x1639"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1637",
+          "x1613",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1640",
+          "x1641"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1639",
+          "x1615",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1642",
+          "x1643"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1641",
+          "x1617",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1644",
+          "x1645"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1643",
+          "x1619",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1646",
+          "x1647"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1645",
+          "x1621",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1648",
+          "x1649"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1647",
+          "x1623",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1650",
+          "x1651"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1649",
+          "x1625",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1652",
+          "x1653"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1651",
+          "x1627",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x1655"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1653",
+          "x1629",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1656"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1630",
+          "x1605"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1657"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1632",
+          "x1607"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1658"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1634",
+          "x1609"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1659"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1636",
+          "x1611"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1660"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1638",
+          "x1613"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1661"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1640",
+          "x1615"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1662"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1642",
+          "x1617"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1663"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1644",
+          "x1619"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1664"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1646",
+          "x1621"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1665"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1648",
+          "x1623"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1666"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1650",
+          "x1625"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1667"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1652",
+          "x1627"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1656"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1657"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1658"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1659"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1660"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1661"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1662"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1663"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1664"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1665"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1666"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1667"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_square",
+    "arguments": [
+      {
+        "datatype": "u32[12]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[12]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25",
+          "x26"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27",
+          "x28"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29",
+          "x30"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31",
+          "x32"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33",
+          "x34"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35",
+          "x36"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x36",
+          "x33"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39",
+          "x40"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x38",
+          "x34",
+          "x31"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41",
+          "x42"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x40",
+          "x32",
+          "x29"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x43",
+          "x44"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x42",
+          "x30",
+          "x27"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x45",
+          "x46"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x44",
+          "x28",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x47",
+          "x48"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x46",
+          "x26",
+          "x23"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x49",
+          "x50"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x48",
+          "x24",
+          "x21"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x51",
+          "x52"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x50",
+          "x22",
+          "x19"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x53",
+          "x54"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x52",
+          "x20",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x55",
+          "x56"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x54",
+          "x18",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x57",
+          "x58"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x56",
+          "x16",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x59"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x58"
+            ]
+          },
+          "x14"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x72",
+          "x73"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x76",
+          "x77"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x78",
+          "x79"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x35",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x80",
+          "x81"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x77",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x82",
+          "x83"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x81",
+          "x75",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x84",
+          "x85"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x83",
+          "x73",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x86",
+          "x87"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x85",
+          "x71",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x88",
+          "x89"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x87",
+          "x69",
+          "x66"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x90",
+          "x91"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x89",
+          "x67",
+          "x64"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x91",
+          "x65",
+          "x62"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x94",
+          "x95"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x93",
+          "x63",
+          "x60"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x96"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x95"
+            ]
+          },
+          "x61"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x98"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x35",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x99",
+          "x100"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x98",
+          "x37",
+          "x79"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x101",
+          "x102"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x100",
+          "x39",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x103",
+          "x104"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x102",
+          "x41",
+          "x76"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x105",
+          "x106"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x104",
+          "x43",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x107",
+          "x108"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x106",
+          "x45",
+          "x82"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x109",
+          "x110"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x108",
+          "x47",
+          "x84"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x111",
+          "x112"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x110",
+          "x49",
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x113",
+          "x114"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x112",
+          "x51",
+          "x88"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x115",
+          "x116"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x114",
+          "x53",
+          "x90"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x117",
+          "x118"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x116",
+          "x55",
+          "x92"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x119",
+          "x120"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x118",
+          "x57",
+          "x94"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x121",
+          "x122"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x120",
+          "x59",
+          "x96"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x123",
+          "x124"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x125",
+          "x126"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x127",
+          "x128"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x129",
+          "x130"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x131",
+          "x132"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x133",
+          "x134"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x135",
+          "x136"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x137",
+          "x138"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x139",
+          "x140"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x141",
+          "x142"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x143",
+          "x144"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x145",
+          "x146"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x147",
+          "x148"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x146",
+          "x143"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x149",
+          "x150"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x148",
+          "x144",
+          "x141"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x151",
+          "x152"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x150",
+          "x142",
+          "x139"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x153",
+          "x154"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x152",
+          "x140",
+          "x137"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x155",
+          "x156"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x154",
+          "x138",
+          "x135"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x157",
+          "x158"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x156",
+          "x136",
+          "x133"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x159",
+          "x160"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x158",
+          "x134",
+          "x131"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x161",
+          "x162"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x160",
+          "x132",
+          "x129"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x163",
+          "x164"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x162",
+          "x130",
+          "x127"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x165",
+          "x166"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x164",
+          "x128",
+          "x125"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x167",
+          "x168"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x166",
+          "x126",
+          "x123"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x169"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x168"
+            ]
+          },
+          "x124"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x170",
+          "x171"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x99",
+          "x145"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x172",
+          "x173"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x171",
+          "x101",
+          "x147"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x174",
+          "x175"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x173",
+          "x103",
+          "x149"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x176",
+          "x177"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x175",
+          "x105",
+          "x151"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x178",
+          "x179"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x177",
+          "x107",
+          "x153"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x180",
+          "x181"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x179",
+          "x109",
+          "x155"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x182",
+          "x183"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x181",
+          "x111",
+          "x157"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x184",
+          "x185"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x183",
+          "x113",
+          "x159"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x186",
+          "x187"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x185",
+          "x115",
+          "x161"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x188",
+          "x189"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x187",
+          "x117",
+          "x163"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x190",
+          "x191"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x189",
+          "x119",
+          "x165"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x192",
+          "x193"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x191",
+          "x121",
+          "x167"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x194",
+          "x195"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x193",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x122"
+            ]
+          },
+          "x169"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x196",
+          "x197"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x170",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x198",
+          "x199"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x170",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x200",
+          "x201"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x170",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x202",
+          "x203"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x170",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x204",
+          "x205"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x170",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x206",
+          "x207"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x170",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x208",
+          "x209"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x170",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x210",
+          "x211"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x170",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x212",
+          "x213"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x170",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x214",
+          "x215"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x170",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x216",
+          "x217"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x213",
+          "x210"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x218",
+          "x219"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x217",
+          "x211",
+          "x208"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x220",
+          "x221"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x219",
+          "x209",
+          "x206"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x222",
+          "x223"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x221",
+          "x207",
+          "x204"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x224",
+          "x225"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x223",
+          "x205",
+          "x202"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x226",
+          "x227"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x225",
+          "x203",
+          "x200"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x228",
+          "x229"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x227",
+          "x201",
+          "x198"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x230",
+          "x231"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x229",
+          "x199",
+          "x196"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x232"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x231"
+            ]
+          },
+          "x197"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x234"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x170",
+          "x214"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x235",
+          "x236"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x234",
+          "x172",
+          "x215"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x237",
+          "x238"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x236",
+          "x174",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x239",
+          "x240"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x238",
+          "x176",
+          "x212"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x241",
+          "x242"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x240",
+          "x178",
+          "x216"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x243",
+          "x244"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x242",
+          "x180",
+          "x218"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x245",
+          "x246"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x244",
+          "x182",
+          "x220"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x247",
+          "x248"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x246",
+          "x184",
+          "x222"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x249",
+          "x250"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x248",
+          "x186",
+          "x224"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x251",
+          "x252"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x250",
+          "x188",
+          "x226"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x253",
+          "x254"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x252",
+          "x190",
+          "x228"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x255",
+          "x256"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x254",
+          "x192",
+          "x230"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x257",
+          "x258"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x256",
+          "x194",
+          "x232"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x259"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x258"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x195"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x260",
+          "x261"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x262",
+          "x263"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x264",
+          "x265"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x266",
+          "x267"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x268",
+          "x269"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x270",
+          "x271"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x272",
+          "x273"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x274",
+          "x275"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x276",
+          "x277"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x278",
+          "x279"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x280",
+          "x281"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x282",
+          "x283"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x284",
+          "x285"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x283",
+          "x280"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x286",
+          "x287"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x285",
+          "x281",
+          "x278"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x288",
+          "x289"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x287",
+          "x279",
+          "x276"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x290",
+          "x291"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x289",
+          "x277",
+          "x274"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x292",
+          "x293"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x291",
+          "x275",
+          "x272"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x294",
+          "x295"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x293",
+          "x273",
+          "x270"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x296",
+          "x297"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x295",
+          "x271",
+          "x268"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x298",
+          "x299"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x297",
+          "x269",
+          "x266"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x300",
+          "x301"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x299",
+          "x267",
+          "x264"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x302",
+          "x303"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x301",
+          "x265",
+          "x262"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x304",
+          "x305"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x303",
+          "x263",
+          "x260"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x306"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x305"
+            ]
+          },
+          "x261"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x307",
+          "x308"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x235",
+          "x282"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x309",
+          "x310"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x308",
+          "x237",
+          "x284"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x311",
+          "x312"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x310",
+          "x239",
+          "x286"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x313",
+          "x314"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x312",
+          "x241",
+          "x288"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x315",
+          "x316"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x314",
+          "x243",
+          "x290"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x317",
+          "x318"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x316",
+          "x245",
+          "x292"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x319",
+          "x320"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x318",
+          "x247",
+          "x294"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x321",
+          "x322"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x320",
+          "x249",
+          "x296"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x323",
+          "x324"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x322",
+          "x251",
+          "x298"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x325",
+          "x326"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x324",
+          "x253",
+          "x300"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x327",
+          "x328"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x326",
+          "x255",
+          "x302"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x329",
+          "x330"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x328",
+          "x257",
+          "x304"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x331",
+          "x332"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x330",
+          "x259",
+          "x306"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x333",
+          "x334"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x307",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x335",
+          "x336"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x307",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x337",
+          "x338"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x307",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x339",
+          "x340"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x307",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x341",
+          "x342"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x307",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x343",
+          "x344"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x307",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x345",
+          "x346"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x307",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x347",
+          "x348"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x307",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x349",
+          "x350"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x307",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x351",
+          "x352"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x307",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x353",
+          "x354"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x350",
+          "x347"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x355",
+          "x356"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x354",
+          "x348",
+          "x345"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x357",
+          "x358"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x356",
+          "x346",
+          "x343"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x359",
+          "x360"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x358",
+          "x344",
+          "x341"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x361",
+          "x362"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x360",
+          "x342",
+          "x339"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x363",
+          "x364"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x362",
+          "x340",
+          "x337"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x365",
+          "x366"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x364",
+          "x338",
+          "x335"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x367",
+          "x368"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x366",
+          "x336",
+          "x333"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x369"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x368"
+            ]
+          },
+          "x334"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x371"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x307",
+          "x351"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x372",
+          "x373"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x371",
+          "x309",
+          "x352"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x374",
+          "x375"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x373",
+          "x311",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x376",
+          "x377"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x375",
+          "x313",
+          "x349"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x378",
+          "x379"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x377",
+          "x315",
+          "x353"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x380",
+          "x381"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x379",
+          "x317",
+          "x355"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x382",
+          "x383"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x381",
+          "x319",
+          "x357"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x384",
+          "x385"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x383",
+          "x321",
+          "x359"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x386",
+          "x387"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x385",
+          "x323",
+          "x361"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x388",
+          "x389"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x387",
+          "x325",
+          "x363"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x390",
+          "x391"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x389",
+          "x327",
+          "x365"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x392",
+          "x393"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x391",
+          "x329",
+          "x367"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x394",
+          "x395"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x393",
+          "x331",
+          "x369"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x396"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x395"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x332"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x397",
+          "x398"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x399",
+          "x400"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x401",
+          "x402"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x403",
+          "x404"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x405",
+          "x406"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x407",
+          "x408"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x409",
+          "x410"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x411",
+          "x412"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x413",
+          "x414"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x415",
+          "x416"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x417",
+          "x418"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x419",
+          "x420"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x421",
+          "x422"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x420",
+          "x417"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x423",
+          "x424"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x422",
+          "x418",
+          "x415"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x425",
+          "x426"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x424",
+          "x416",
+          "x413"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x427",
+          "x428"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x426",
+          "x414",
+          "x411"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x429",
+          "x430"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x428",
+          "x412",
+          "x409"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x431",
+          "x432"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x430",
+          "x410",
+          "x407"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x433",
+          "x434"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x432",
+          "x408",
+          "x405"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x435",
+          "x436"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x434",
+          "x406",
+          "x403"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x437",
+          "x438"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x436",
+          "x404",
+          "x401"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x439",
+          "x440"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x438",
+          "x402",
+          "x399"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x441",
+          "x442"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x440",
+          "x400",
+          "x397"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x443"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x442"
+            ]
+          },
+          "x398"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x444",
+          "x445"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x372",
+          "x419"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x446",
+          "x447"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x445",
+          "x374",
+          "x421"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x448",
+          "x449"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x447",
+          "x376",
+          "x423"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x450",
+          "x451"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x449",
+          "x378",
+          "x425"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x452",
+          "x453"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x451",
+          "x380",
+          "x427"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x454",
+          "x455"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x453",
+          "x382",
+          "x429"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x456",
+          "x457"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x455",
+          "x384",
+          "x431"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x458",
+          "x459"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x457",
+          "x386",
+          "x433"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x460",
+          "x461"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x459",
+          "x388",
+          "x435"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x462",
+          "x463"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x461",
+          "x390",
+          "x437"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x464",
+          "x465"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x463",
+          "x392",
+          "x439"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x466",
+          "x467"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x465",
+          "x394",
+          "x441"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x468",
+          "x469"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x467",
+          "x396",
+          "x443"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x470",
+          "x471"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x444",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x472",
+          "x473"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x444",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x474",
+          "x475"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x444",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x476",
+          "x477"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x444",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x478",
+          "x479"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x444",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x480",
+          "x481"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x444",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x482",
+          "x483"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x444",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x484",
+          "x485"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x444",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x486",
+          "x487"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x444",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x488",
+          "x489"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x444",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x490",
+          "x491"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x487",
+          "x484"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x492",
+          "x493"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x491",
+          "x485",
+          "x482"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x494",
+          "x495"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x493",
+          "x483",
+          "x480"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x496",
+          "x497"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x495",
+          "x481",
+          "x478"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x498",
+          "x499"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x497",
+          "x479",
+          "x476"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x500",
+          "x501"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x499",
+          "x477",
+          "x474"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x502",
+          "x503"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x501",
+          "x475",
+          "x472"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x504",
+          "x505"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x503",
+          "x473",
+          "x470"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x506"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x505"
+            ]
+          },
+          "x471"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x508"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x444",
+          "x488"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x509",
+          "x510"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x508",
+          "x446",
+          "x489"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x511",
+          "x512"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x510",
+          "x448",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x513",
+          "x514"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x512",
+          "x450",
+          "x486"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x515",
+          "x516"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x514",
+          "x452",
+          "x490"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x517",
+          "x518"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x516",
+          "x454",
+          "x492"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x519",
+          "x520"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x518",
+          "x456",
+          "x494"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x521",
+          "x522"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x520",
+          "x458",
+          "x496"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x523",
+          "x524"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x522",
+          "x460",
+          "x498"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x525",
+          "x526"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x524",
+          "x462",
+          "x500"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x527",
+          "x528"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x526",
+          "x464",
+          "x502"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x529",
+          "x530"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x528",
+          "x466",
+          "x504"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x531",
+          "x532"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x530",
+          "x468",
+          "x506"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x533"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x532"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x469"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x534",
+          "x535"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x536",
+          "x537"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x538",
+          "x539"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x540",
+          "x541"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x542",
+          "x543"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x544",
+          "x545"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x546",
+          "x547"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x548",
+          "x549"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x550",
+          "x551"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x552",
+          "x553"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x554",
+          "x555"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x556",
+          "x557"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x558",
+          "x559"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x557",
+          "x554"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x560",
+          "x561"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x559",
+          "x555",
+          "x552"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x562",
+          "x563"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x561",
+          "x553",
+          "x550"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x564",
+          "x565"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x563",
+          "x551",
+          "x548"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x566",
+          "x567"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x565",
+          "x549",
+          "x546"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x568",
+          "x569"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x567",
+          "x547",
+          "x544"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x570",
+          "x571"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x569",
+          "x545",
+          "x542"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x572",
+          "x573"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x571",
+          "x543",
+          "x540"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x574",
+          "x575"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x573",
+          "x541",
+          "x538"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x576",
+          "x577"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x575",
+          "x539",
+          "x536"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x578",
+          "x579"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x577",
+          "x537",
+          "x534"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x580"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x579"
+            ]
+          },
+          "x535"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x581",
+          "x582"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x509",
+          "x556"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x583",
+          "x584"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x582",
+          "x511",
+          "x558"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x585",
+          "x586"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x584",
+          "x513",
+          "x560"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x587",
+          "x588"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x586",
+          "x515",
+          "x562"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x589",
+          "x590"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x588",
+          "x517",
+          "x564"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x591",
+          "x592"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x590",
+          "x519",
+          "x566"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x593",
+          "x594"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x592",
+          "x521",
+          "x568"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x595",
+          "x596"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x594",
+          "x523",
+          "x570"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x597",
+          "x598"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x596",
+          "x525",
+          "x572"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x599",
+          "x600"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x598",
+          "x527",
+          "x574"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x601",
+          "x602"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x600",
+          "x529",
+          "x576"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x603",
+          "x604"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x602",
+          "x531",
+          "x578"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x605",
+          "x606"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x604",
+          "x533",
+          "x580"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x607",
+          "x608"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x581",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x609",
+          "x610"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x581",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x611",
+          "x612"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x581",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x613",
+          "x614"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x581",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x615",
+          "x616"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x581",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x617",
+          "x618"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x581",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x619",
+          "x620"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x581",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x621",
+          "x622"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x581",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x623",
+          "x624"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x581",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x625",
+          "x626"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x581",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x627",
+          "x628"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x624",
+          "x621"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x629",
+          "x630"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x628",
+          "x622",
+          "x619"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x631",
+          "x632"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x630",
+          "x620",
+          "x617"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x633",
+          "x634"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x632",
+          "x618",
+          "x615"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x635",
+          "x636"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x634",
+          "x616",
+          "x613"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x637",
+          "x638"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x636",
+          "x614",
+          "x611"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x639",
+          "x640"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x638",
+          "x612",
+          "x609"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x641",
+          "x642"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x640",
+          "x610",
+          "x607"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x643"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x642"
+            ]
+          },
+          "x608"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x645"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x581",
+          "x625"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x646",
+          "x647"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x645",
+          "x583",
+          "x626"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x648",
+          "x649"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x647",
+          "x585",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x650",
+          "x651"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x649",
+          "x587",
+          "x623"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x652",
+          "x653"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x651",
+          "x589",
+          "x627"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x654",
+          "x655"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x653",
+          "x591",
+          "x629"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x656",
+          "x657"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x655",
+          "x593",
+          "x631"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x658",
+          "x659"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x657",
+          "x595",
+          "x633"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x660",
+          "x661"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x659",
+          "x597",
+          "x635"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x662",
+          "x663"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x661",
+          "x599",
+          "x637"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x664",
+          "x665"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x663",
+          "x601",
+          "x639"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x666",
+          "x667"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x665",
+          "x603",
+          "x641"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x668",
+          "x669"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x667",
+          "x605",
+          "x643"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x670"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x669"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x606"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x671",
+          "x672"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x673",
+          "x674"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x675",
+          "x676"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x677",
+          "x678"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x679",
+          "x680"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x681",
+          "x682"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x683",
+          "x684"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x685",
+          "x686"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x687",
+          "x688"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x689",
+          "x690"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x691",
+          "x692"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x693",
+          "x694"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x695",
+          "x696"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x694",
+          "x691"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x697",
+          "x698"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x696",
+          "x692",
+          "x689"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x699",
+          "x700"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x698",
+          "x690",
+          "x687"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x701",
+          "x702"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x700",
+          "x688",
+          "x685"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x703",
+          "x704"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x702",
+          "x686",
+          "x683"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x705",
+          "x706"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x704",
+          "x684",
+          "x681"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x707",
+          "x708"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x706",
+          "x682",
+          "x679"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x709",
+          "x710"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x708",
+          "x680",
+          "x677"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x711",
+          "x712"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x710",
+          "x678",
+          "x675"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x713",
+          "x714"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x712",
+          "x676",
+          "x673"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x715",
+          "x716"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x714",
+          "x674",
+          "x671"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x717"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x716"
+            ]
+          },
+          "x672"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x718",
+          "x719"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x646",
+          "x693"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x720",
+          "x721"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x719",
+          "x648",
+          "x695"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x722",
+          "x723"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x721",
+          "x650",
+          "x697"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x724",
+          "x725"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x723",
+          "x652",
+          "x699"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x726",
+          "x727"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x725",
+          "x654",
+          "x701"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x728",
+          "x729"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x727",
+          "x656",
+          "x703"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x730",
+          "x731"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x729",
+          "x658",
+          "x705"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x732",
+          "x733"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x731",
+          "x660",
+          "x707"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x734",
+          "x735"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x733",
+          "x662",
+          "x709"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x736",
+          "x737"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x735",
+          "x664",
+          "x711"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x738",
+          "x739"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x737",
+          "x666",
+          "x713"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x740",
+          "x741"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x739",
+          "x668",
+          "x715"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x742",
+          "x743"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x741",
+          "x670",
+          "x717"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x744",
+          "x745"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x718",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x746",
+          "x747"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x718",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x748",
+          "x749"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x718",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x750",
+          "x751"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x718",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x752",
+          "x753"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x718",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x754",
+          "x755"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x718",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x756",
+          "x757"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x718",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x758",
+          "x759"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x718",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x760",
+          "x761"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x718",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x762",
+          "x763"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x718",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x764",
+          "x765"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x761",
+          "x758"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x766",
+          "x767"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x765",
+          "x759",
+          "x756"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x768",
+          "x769"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x767",
+          "x757",
+          "x754"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x770",
+          "x771"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x769",
+          "x755",
+          "x752"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x772",
+          "x773"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x771",
+          "x753",
+          "x750"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x774",
+          "x775"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x773",
+          "x751",
+          "x748"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x776",
+          "x777"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x775",
+          "x749",
+          "x746"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x778",
+          "x779"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x777",
+          "x747",
+          "x744"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x780"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x779"
+            ]
+          },
+          "x745"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x782"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x718",
+          "x762"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x783",
+          "x784"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x782",
+          "x720",
+          "x763"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x785",
+          "x786"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x784",
+          "x722",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x787",
+          "x788"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x786",
+          "x724",
+          "x760"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x789",
+          "x790"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x788",
+          "x726",
+          "x764"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x791",
+          "x792"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x790",
+          "x728",
+          "x766"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x793",
+          "x794"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x792",
+          "x730",
+          "x768"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x795",
+          "x796"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x794",
+          "x732",
+          "x770"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x797",
+          "x798"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x796",
+          "x734",
+          "x772"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x799",
+          "x800"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x798",
+          "x736",
+          "x774"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x801",
+          "x802"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x800",
+          "x738",
+          "x776"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x803",
+          "x804"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x802",
+          "x740",
+          "x778"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x805",
+          "x806"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x804",
+          "x742",
+          "x780"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x807"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x806"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x743"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x808",
+          "x809"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x810",
+          "x811"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x812",
+          "x813"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x814",
+          "x815"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x816",
+          "x817"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x818",
+          "x819"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x820",
+          "x821"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x822",
+          "x823"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x824",
+          "x825"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x826",
+          "x827"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x828",
+          "x829"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x830",
+          "x831"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x832",
+          "x833"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x831",
+          "x828"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x834",
+          "x835"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x833",
+          "x829",
+          "x826"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x836",
+          "x837"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x835",
+          "x827",
+          "x824"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x838",
+          "x839"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x837",
+          "x825",
+          "x822"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x840",
+          "x841"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x839",
+          "x823",
+          "x820"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x842",
+          "x843"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x841",
+          "x821",
+          "x818"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x844",
+          "x845"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x843",
+          "x819",
+          "x816"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x846",
+          "x847"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x845",
+          "x817",
+          "x814"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x848",
+          "x849"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x847",
+          "x815",
+          "x812"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x850",
+          "x851"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x849",
+          "x813",
+          "x810"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x852",
+          "x853"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x851",
+          "x811",
+          "x808"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x854"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x853"
+            ]
+          },
+          "x809"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x855",
+          "x856"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x783",
+          "x830"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x857",
+          "x858"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x856",
+          "x785",
+          "x832"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x859",
+          "x860"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x858",
+          "x787",
+          "x834"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x861",
+          "x862"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x860",
+          "x789",
+          "x836"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x863",
+          "x864"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x862",
+          "x791",
+          "x838"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x865",
+          "x866"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x864",
+          "x793",
+          "x840"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x867",
+          "x868"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x866",
+          "x795",
+          "x842"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x869",
+          "x870"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x868",
+          "x797",
+          "x844"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x871",
+          "x872"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x870",
+          "x799",
+          "x846"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x873",
+          "x874"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x872",
+          "x801",
+          "x848"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x875",
+          "x876"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x874",
+          "x803",
+          "x850"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x877",
+          "x878"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x876",
+          "x805",
+          "x852"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x879",
+          "x880"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x878",
+          "x807",
+          "x854"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x881",
+          "x882"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x855",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x883",
+          "x884"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x855",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x885",
+          "x886"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x855",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x887",
+          "x888"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x855",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x889",
+          "x890"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x855",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x891",
+          "x892"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x855",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x893",
+          "x894"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x855",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x895",
+          "x896"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x855",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x897",
+          "x898"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x855",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x899",
+          "x900"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x855",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x901",
+          "x902"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x898",
+          "x895"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x903",
+          "x904"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x902",
+          "x896",
+          "x893"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x905",
+          "x906"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x904",
+          "x894",
+          "x891"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x907",
+          "x908"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x906",
+          "x892",
+          "x889"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x909",
+          "x910"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x908",
+          "x890",
+          "x887"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x911",
+          "x912"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x910",
+          "x888",
+          "x885"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x913",
+          "x914"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x912",
+          "x886",
+          "x883"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x915",
+          "x916"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x914",
+          "x884",
+          "x881"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x917"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x916"
+            ]
+          },
+          "x882"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x919"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x855",
+          "x899"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x920",
+          "x921"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x919",
+          "x857",
+          "x900"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x922",
+          "x923"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x921",
+          "x859",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x924",
+          "x925"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x923",
+          "x861",
+          "x897"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x926",
+          "x927"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x925",
+          "x863",
+          "x901"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x928",
+          "x929"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x927",
+          "x865",
+          "x903"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x930",
+          "x931"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x929",
+          "x867",
+          "x905"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x932",
+          "x933"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x931",
+          "x869",
+          "x907"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x934",
+          "x935"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x933",
+          "x871",
+          "x909"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x936",
+          "x937"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x935",
+          "x873",
+          "x911"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x938",
+          "x939"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x937",
+          "x875",
+          "x913"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x940",
+          "x941"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x939",
+          "x877",
+          "x915"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x942",
+          "x943"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x941",
+          "x879",
+          "x917"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x944"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x943"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x880"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x945",
+          "x946"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x947",
+          "x948"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x949",
+          "x950"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x951",
+          "x952"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x953",
+          "x954"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x955",
+          "x956"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x957",
+          "x958"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x959",
+          "x960"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x961",
+          "x962"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x963",
+          "x964"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x965",
+          "x966"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x967",
+          "x968"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x969",
+          "x970"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x968",
+          "x965"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x971",
+          "x972"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x970",
+          "x966",
+          "x963"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x973",
+          "x974"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x972",
+          "x964",
+          "x961"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x975",
+          "x976"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x974",
+          "x962",
+          "x959"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x977",
+          "x978"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x976",
+          "x960",
+          "x957"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x979",
+          "x980"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x978",
+          "x958",
+          "x955"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x981",
+          "x982"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x980",
+          "x956",
+          "x953"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x983",
+          "x984"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x982",
+          "x954",
+          "x951"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x985",
+          "x986"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x984",
+          "x952",
+          "x949"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x987",
+          "x988"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x986",
+          "x950",
+          "x947"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x989",
+          "x990"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x988",
+          "x948",
+          "x945"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x991"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x990"
+            ]
+          },
+          "x946"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x992",
+          "x993"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x920",
+          "x967"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x994",
+          "x995"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x993",
+          "x922",
+          "x969"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x996",
+          "x997"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x995",
+          "x924",
+          "x971"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x998",
+          "x999"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x997",
+          "x926",
+          "x973"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1000",
+          "x1001"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x999",
+          "x928",
+          "x975"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1002",
+          "x1003"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1001",
+          "x930",
+          "x977"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1004",
+          "x1005"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1003",
+          "x932",
+          "x979"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1006",
+          "x1007"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1005",
+          "x934",
+          "x981"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1008",
+          "x1009"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1007",
+          "x936",
+          "x983"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1010",
+          "x1011"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1009",
+          "x938",
+          "x985"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1012",
+          "x1013"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1011",
+          "x940",
+          "x987"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1014",
+          "x1015"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1013",
+          "x942",
+          "x989"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1016",
+          "x1017"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1015",
+          "x944",
+          "x991"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1018",
+          "x1019"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x992",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1020",
+          "x1021"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x992",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1022",
+          "x1023"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x992",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1024",
+          "x1025"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x992",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1026",
+          "x1027"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x992",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1028",
+          "x1029"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x992",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1030",
+          "x1031"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x992",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1032",
+          "x1033"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x992",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1034",
+          "x1035"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x992",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1036",
+          "x1037"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x992",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1038",
+          "x1039"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1035",
+          "x1032"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1040",
+          "x1041"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1039",
+          "x1033",
+          "x1030"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1042",
+          "x1043"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1041",
+          "x1031",
+          "x1028"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1044",
+          "x1045"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1043",
+          "x1029",
+          "x1026"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1046",
+          "x1047"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1045",
+          "x1027",
+          "x1024"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1048",
+          "x1049"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1047",
+          "x1025",
+          "x1022"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1050",
+          "x1051"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1049",
+          "x1023",
+          "x1020"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1052",
+          "x1053"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1051",
+          "x1021",
+          "x1018"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1054"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1053"
+            ]
+          },
+          "x1019"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x1056"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x992",
+          "x1036"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1057",
+          "x1058"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1056",
+          "x994",
+          "x1037"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1059",
+          "x1060"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1058",
+          "x996",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1061",
+          "x1062"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1060",
+          "x998",
+          "x1034"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1063",
+          "x1064"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1062",
+          "x1000",
+          "x1038"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1065",
+          "x1066"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1064",
+          "x1002",
+          "x1040"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1067",
+          "x1068"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1066",
+          "x1004",
+          "x1042"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1069",
+          "x1070"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1068",
+          "x1006",
+          "x1044"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1071",
+          "x1072"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1070",
+          "x1008",
+          "x1046"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1073",
+          "x1074"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1072",
+          "x1010",
+          "x1048"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1075",
+          "x1076"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1074",
+          "x1012",
+          "x1050"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1077",
+          "x1078"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1076",
+          "x1014",
+          "x1052"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1079",
+          "x1080"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1078",
+          "x1016",
+          "x1054"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1081"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1080"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1017"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1082",
+          "x1083"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1084",
+          "x1085"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1086",
+          "x1087"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1088",
+          "x1089"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1090",
+          "x1091"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1092",
+          "x1093"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1094",
+          "x1095"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1096",
+          "x1097"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1098",
+          "x1099"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1100",
+          "x1101"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1102",
+          "x1103"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1104",
+          "x1105"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1106",
+          "x1107"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1105",
+          "x1102"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1108",
+          "x1109"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1107",
+          "x1103",
+          "x1100"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1110",
+          "x1111"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1109",
+          "x1101",
+          "x1098"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1112",
+          "x1113"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1111",
+          "x1099",
+          "x1096"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1114",
+          "x1115"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1113",
+          "x1097",
+          "x1094"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1116",
+          "x1117"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1115",
+          "x1095",
+          "x1092"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1118",
+          "x1119"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1117",
+          "x1093",
+          "x1090"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1120",
+          "x1121"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1119",
+          "x1091",
+          "x1088"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1122",
+          "x1123"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1121",
+          "x1089",
+          "x1086"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1124",
+          "x1125"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1123",
+          "x1087",
+          "x1084"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1126",
+          "x1127"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1125",
+          "x1085",
+          "x1082"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1128"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1127"
+            ]
+          },
+          "x1083"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1129",
+          "x1130"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1057",
+          "x1104"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1131",
+          "x1132"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1130",
+          "x1059",
+          "x1106"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1133",
+          "x1134"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1132",
+          "x1061",
+          "x1108"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1135",
+          "x1136"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1134",
+          "x1063",
+          "x1110"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1137",
+          "x1138"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1136",
+          "x1065",
+          "x1112"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1139",
+          "x1140"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1138",
+          "x1067",
+          "x1114"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1141",
+          "x1142"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1140",
+          "x1069",
+          "x1116"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1143",
+          "x1144"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1142",
+          "x1071",
+          "x1118"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1145",
+          "x1146"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1144",
+          "x1073",
+          "x1120"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1147",
+          "x1148"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1146",
+          "x1075",
+          "x1122"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1149",
+          "x1150"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1148",
+          "x1077",
+          "x1124"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1151",
+          "x1152"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1150",
+          "x1079",
+          "x1126"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1153",
+          "x1154"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1152",
+          "x1081",
+          "x1128"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1155",
+          "x1156"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1129",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1157",
+          "x1158"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1129",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1159",
+          "x1160"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1129",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1161",
+          "x1162"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1129",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1163",
+          "x1164"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1129",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1165",
+          "x1166"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1129",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1167",
+          "x1168"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1129",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1169",
+          "x1170"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1129",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1171",
+          "x1172"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1129",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1173",
+          "x1174"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1129",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1175",
+          "x1176"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1172",
+          "x1169"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1177",
+          "x1178"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1176",
+          "x1170",
+          "x1167"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1179",
+          "x1180"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1178",
+          "x1168",
+          "x1165"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1181",
+          "x1182"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1180",
+          "x1166",
+          "x1163"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1183",
+          "x1184"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1182",
+          "x1164",
+          "x1161"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1185",
+          "x1186"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1184",
+          "x1162",
+          "x1159"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1187",
+          "x1188"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1186",
+          "x1160",
+          "x1157"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1189",
+          "x1190"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1188",
+          "x1158",
+          "x1155"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1191"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1190"
+            ]
+          },
+          "x1156"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x1193"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1129",
+          "x1173"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1194",
+          "x1195"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1193",
+          "x1131",
+          "x1174"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1196",
+          "x1197"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1195",
+          "x1133",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1198",
+          "x1199"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1197",
+          "x1135",
+          "x1171"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1200",
+          "x1201"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1199",
+          "x1137",
+          "x1175"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1202",
+          "x1203"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1201",
+          "x1139",
+          "x1177"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1204",
+          "x1205"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1203",
+          "x1141",
+          "x1179"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1206",
+          "x1207"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1205",
+          "x1143",
+          "x1181"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1208",
+          "x1209"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1207",
+          "x1145",
+          "x1183"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1210",
+          "x1211"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1209",
+          "x1147",
+          "x1185"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1212",
+          "x1213"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1211",
+          "x1149",
+          "x1187"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1214",
+          "x1215"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1213",
+          "x1151",
+          "x1189"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1216",
+          "x1217"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1215",
+          "x1153",
+          "x1191"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1218"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1217"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1154"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1219",
+          "x1220"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1221",
+          "x1222"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1223",
+          "x1224"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1225",
+          "x1226"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1227",
+          "x1228"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1229",
+          "x1230"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1231",
+          "x1232"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1233",
+          "x1234"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1235",
+          "x1236"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1237",
+          "x1238"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1239",
+          "x1240"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1241",
+          "x1242"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1243",
+          "x1244"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1242",
+          "x1239"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1245",
+          "x1246"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1244",
+          "x1240",
+          "x1237"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1247",
+          "x1248"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1246",
+          "x1238",
+          "x1235"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1249",
+          "x1250"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1248",
+          "x1236",
+          "x1233"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1251",
+          "x1252"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1250",
+          "x1234",
+          "x1231"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1253",
+          "x1254"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1252",
+          "x1232",
+          "x1229"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1255",
+          "x1256"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1254",
+          "x1230",
+          "x1227"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1257",
+          "x1258"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1256",
+          "x1228",
+          "x1225"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1259",
+          "x1260"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1258",
+          "x1226",
+          "x1223"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1261",
+          "x1262"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1260",
+          "x1224",
+          "x1221"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1263",
+          "x1264"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1262",
+          "x1222",
+          "x1219"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1265"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1264"
+            ]
+          },
+          "x1220"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1266",
+          "x1267"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1194",
+          "x1241"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1268",
+          "x1269"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1267",
+          "x1196",
+          "x1243"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1270",
+          "x1271"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1269",
+          "x1198",
+          "x1245"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1272",
+          "x1273"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1271",
+          "x1200",
+          "x1247"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1274",
+          "x1275"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1273",
+          "x1202",
+          "x1249"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1276",
+          "x1277"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1275",
+          "x1204",
+          "x1251"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1278",
+          "x1279"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1277",
+          "x1206",
+          "x1253"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1280",
+          "x1281"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1279",
+          "x1208",
+          "x1255"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1282",
+          "x1283"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1281",
+          "x1210",
+          "x1257"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1284",
+          "x1285"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1283",
+          "x1212",
+          "x1259"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1286",
+          "x1287"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1285",
+          "x1214",
+          "x1261"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1288",
+          "x1289"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1287",
+          "x1216",
+          "x1263"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1290",
+          "x1291"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1289",
+          "x1218",
+          "x1265"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1292",
+          "x1293"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1294",
+          "x1295"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1296",
+          "x1297"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1298",
+          "x1299"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1300",
+          "x1301"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1302",
+          "x1303"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1304",
+          "x1305"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1306",
+          "x1307"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1266",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1308",
+          "x1309"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1310",
+          "x1311"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1312",
+          "x1313"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1309",
+          "x1306"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1314",
+          "x1315"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1313",
+          "x1307",
+          "x1304"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1316",
+          "x1317"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1315",
+          "x1305",
+          "x1302"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1318",
+          "x1319"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1317",
+          "x1303",
+          "x1300"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1320",
+          "x1321"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1319",
+          "x1301",
+          "x1298"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1322",
+          "x1323"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1321",
+          "x1299",
+          "x1296"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1324",
+          "x1325"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1323",
+          "x1297",
+          "x1294"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1326",
+          "x1327"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1325",
+          "x1295",
+          "x1292"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1328"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1327"
+            ]
+          },
+          "x1293"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x1330"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1266",
+          "x1310"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1331",
+          "x1332"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1330",
+          "x1268",
+          "x1311"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1333",
+          "x1334"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1332",
+          "x1270",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1335",
+          "x1336"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1334",
+          "x1272",
+          "x1308"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1337",
+          "x1338"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1336",
+          "x1274",
+          "x1312"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1339",
+          "x1340"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1338",
+          "x1276",
+          "x1314"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1341",
+          "x1342"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1340",
+          "x1278",
+          "x1316"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1343",
+          "x1344"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1342",
+          "x1280",
+          "x1318"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1345",
+          "x1346"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1344",
+          "x1282",
+          "x1320"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1347",
+          "x1348"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1346",
+          "x1284",
+          "x1322"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1349",
+          "x1350"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1348",
+          "x1286",
+          "x1324"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1351",
+          "x1352"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1350",
+          "x1288",
+          "x1326"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1353",
+          "x1354"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1352",
+          "x1290",
+          "x1328"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1355"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1354"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1291"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1356",
+          "x1357"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1358",
+          "x1359"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1360",
+          "x1361"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1362",
+          "x1363"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1364",
+          "x1365"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1366",
+          "x1367"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1368",
+          "x1369"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1370",
+          "x1371"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1372",
+          "x1373"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1374",
+          "x1375"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1376",
+          "x1377"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1378",
+          "x1379"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1380",
+          "x1381"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1379",
+          "x1376"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1382",
+          "x1383"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1381",
+          "x1377",
+          "x1374"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1384",
+          "x1385"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1383",
+          "x1375",
+          "x1372"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1386",
+          "x1387"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1385",
+          "x1373",
+          "x1370"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1388",
+          "x1389"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1387",
+          "x1371",
+          "x1368"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1390",
+          "x1391"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1389",
+          "x1369",
+          "x1366"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1392",
+          "x1393"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1391",
+          "x1367",
+          "x1364"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1394",
+          "x1395"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1393",
+          "x1365",
+          "x1362"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1396",
+          "x1397"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1395",
+          "x1363",
+          "x1360"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1398",
+          "x1399"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1397",
+          "x1361",
+          "x1358"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1400",
+          "x1401"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1399",
+          "x1359",
+          "x1356"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1402"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1401"
+            ]
+          },
+          "x1357"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1403",
+          "x1404"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1331",
+          "x1378"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1405",
+          "x1406"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1404",
+          "x1333",
+          "x1380"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1407",
+          "x1408"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1406",
+          "x1335",
+          "x1382"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1409",
+          "x1410"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1408",
+          "x1337",
+          "x1384"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1411",
+          "x1412"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1410",
+          "x1339",
+          "x1386"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1413",
+          "x1414"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1412",
+          "x1341",
+          "x1388"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1415",
+          "x1416"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1414",
+          "x1343",
+          "x1390"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1417",
+          "x1418"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1416",
+          "x1345",
+          "x1392"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1419",
+          "x1420"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1418",
+          "x1347",
+          "x1394"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1421",
+          "x1422"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1420",
+          "x1349",
+          "x1396"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1423",
+          "x1424"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1422",
+          "x1351",
+          "x1398"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1425",
+          "x1426"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1424",
+          "x1353",
+          "x1400"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1427",
+          "x1428"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1426",
+          "x1355",
+          "x1402"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1429",
+          "x1430"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1403",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1431",
+          "x1432"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1403",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1433",
+          "x1434"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1403",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1435",
+          "x1436"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1403",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1437",
+          "x1438"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1403",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1439",
+          "x1440"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1403",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1441",
+          "x1442"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1403",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1443",
+          "x1444"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1403",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1445",
+          "x1446"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1403",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1447",
+          "x1448"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1403",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1449",
+          "x1450"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1446",
+          "x1443"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1451",
+          "x1452"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1450",
+          "x1444",
+          "x1441"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1453",
+          "x1454"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1452",
+          "x1442",
+          "x1439"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1455",
+          "x1456"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1454",
+          "x1440",
+          "x1437"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1457",
+          "x1458"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1456",
+          "x1438",
+          "x1435"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1459",
+          "x1460"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1458",
+          "x1436",
+          "x1433"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1461",
+          "x1462"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1460",
+          "x1434",
+          "x1431"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1463",
+          "x1464"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1462",
+          "x1432",
+          "x1429"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1465"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1464"
+            ]
+          },
+          "x1430"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x1467"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1403",
+          "x1447"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1468",
+          "x1469"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1467",
+          "x1405",
+          "x1448"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1470",
+          "x1471"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1469",
+          "x1407",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1472",
+          "x1473"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1471",
+          "x1409",
+          "x1445"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1474",
+          "x1475"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1473",
+          "x1411",
+          "x1449"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1476",
+          "x1477"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1475",
+          "x1413",
+          "x1451"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1478",
+          "x1479"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1477",
+          "x1415",
+          "x1453"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1480",
+          "x1481"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1479",
+          "x1417",
+          "x1455"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1482",
+          "x1483"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1481",
+          "x1419",
+          "x1457"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1484",
+          "x1485"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1483",
+          "x1421",
+          "x1459"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1486",
+          "x1487"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1485",
+          "x1423",
+          "x1461"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1488",
+          "x1489"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1487",
+          "x1425",
+          "x1463"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1490",
+          "x1491"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1489",
+          "x1427",
+          "x1465"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1492"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1491"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1428"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1493",
+          "x1494"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1495",
+          "x1496"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1497",
+          "x1498"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1499",
+          "x1500"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1501",
+          "x1502"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1503",
+          "x1504"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1505",
+          "x1506"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1507",
+          "x1508"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1509",
+          "x1510"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1511",
+          "x1512"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1513",
+          "x1514"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1515",
+          "x1516"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1517",
+          "x1518"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1516",
+          "x1513"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1519",
+          "x1520"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1518",
+          "x1514",
+          "x1511"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1521",
+          "x1522"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1520",
+          "x1512",
+          "x1509"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1523",
+          "x1524"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1522",
+          "x1510",
+          "x1507"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1525",
+          "x1526"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1524",
+          "x1508",
+          "x1505"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1527",
+          "x1528"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1526",
+          "x1506",
+          "x1503"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1529",
+          "x1530"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1528",
+          "x1504",
+          "x1501"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1531",
+          "x1532"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1530",
+          "x1502",
+          "x1499"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1533",
+          "x1534"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1532",
+          "x1500",
+          "x1497"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1535",
+          "x1536"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1534",
+          "x1498",
+          "x1495"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1537",
+          "x1538"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1536",
+          "x1496",
+          "x1493"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1539"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1538"
+            ]
+          },
+          "x1494"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1540",
+          "x1541"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1468",
+          "x1515"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1542",
+          "x1543"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1541",
+          "x1470",
+          "x1517"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1544",
+          "x1545"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1543",
+          "x1472",
+          "x1519"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1546",
+          "x1547"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1545",
+          "x1474",
+          "x1521"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1548",
+          "x1549"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1547",
+          "x1476",
+          "x1523"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1550",
+          "x1551"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1549",
+          "x1478",
+          "x1525"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1552",
+          "x1553"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1551",
+          "x1480",
+          "x1527"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1554",
+          "x1555"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1553",
+          "x1482",
+          "x1529"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1556",
+          "x1557"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1555",
+          "x1484",
+          "x1531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1558",
+          "x1559"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1557",
+          "x1486",
+          "x1533"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1560",
+          "x1561"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1559",
+          "x1488",
+          "x1535"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1562",
+          "x1563"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1561",
+          "x1490",
+          "x1537"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1564",
+          "x1565"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1563",
+          "x1492",
+          "x1539"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1566",
+          "x1567"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1540",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1568",
+          "x1569"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1540",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1570",
+          "x1571"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1540",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1572",
+          "x1573"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1540",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1574",
+          "x1575"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1540",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1576",
+          "x1577"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1540",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1578",
+          "x1579"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1540",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1580",
+          "x1581"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1540",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1582",
+          "x1583"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1540",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1584",
+          "x1585"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1540",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1586",
+          "x1587"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1583",
+          "x1580"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1588",
+          "x1589"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1587",
+          "x1581",
+          "x1578"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1590",
+          "x1591"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1589",
+          "x1579",
+          "x1576"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1592",
+          "x1593"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1591",
+          "x1577",
+          "x1574"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1594",
+          "x1595"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1593",
+          "x1575",
+          "x1572"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1596",
+          "x1597"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1595",
+          "x1573",
+          "x1570"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1598",
+          "x1599"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1597",
+          "x1571",
+          "x1568"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1600",
+          "x1601"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1599",
+          "x1569",
+          "x1566"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1602"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1601"
+            ]
+          },
+          "x1567"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x1604"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1540",
+          "x1584"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1605",
+          "x1606"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1604",
+          "x1542",
+          "x1585"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1607",
+          "x1608"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1606",
+          "x1544",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1609",
+          "x1610"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1608",
+          "x1546",
+          "x1582"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1611",
+          "x1612"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1610",
+          "x1548",
+          "x1586"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1613",
+          "x1614"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1612",
+          "x1550",
+          "x1588"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1615",
+          "x1616"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1614",
+          "x1552",
+          "x1590"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1617",
+          "x1618"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1616",
+          "x1554",
+          "x1592"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1619",
+          "x1620"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1618",
+          "x1556",
+          "x1594"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1621",
+          "x1622"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1620",
+          "x1558",
+          "x1596"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1623",
+          "x1624"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1622",
+          "x1560",
+          "x1598"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1625",
+          "x1626"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1624",
+          "x1562",
+          "x1600"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1627",
+          "x1628"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1626",
+          "x1564",
+          "x1602"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1629"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1628"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1565"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1630",
+          "x1631"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x1605",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1632",
+          "x1633"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1631",
+          "x1607",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1634",
+          "x1635"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1633",
+          "x1609",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1636",
+          "x1637"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1635",
+          "x1611",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1638",
+          "x1639"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1637",
+          "x1613",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1640",
+          "x1641"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1639",
+          "x1615",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1642",
+          "x1643"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1641",
+          "x1617",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1644",
+          "x1645"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1643",
+          "x1619",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1646",
+          "x1647"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1645",
+          "x1621",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1648",
+          "x1649"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1647",
+          "x1623",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1650",
+          "x1651"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1649",
+          "x1625",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1652",
+          "x1653"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1651",
+          "x1627",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x1655"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1653",
+          "x1629",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1656"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1630",
+          "x1605"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1657"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1632",
+          "x1607"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1658"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1634",
+          "x1609"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1659"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1636",
+          "x1611"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1660"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1638",
+          "x1613"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1661"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1640",
+          "x1615"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1662"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1642",
+          "x1617"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1663"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1644",
+          "x1619"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1664"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1646",
+          "x1621"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1665"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1648",
+          "x1623"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1666"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1650",
+          "x1625"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1667"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1655",
+          "x1652",
+          "x1627"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1656"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1657"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1658"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1659"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1660"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1661"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1662"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1663"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1664"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1665"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1666"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1667"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_add",
+    "arguments": [
+      {
+        "datatype": "u32[12]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[12]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[12]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x8",
+          "arg1[4]",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x10",
+          "arg1[5]",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x12",
+          "arg1[6]",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x14",
+          "arg1[7]",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x16",
+          "arg1[8]",
+          "arg2[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x18",
+          "arg1[9]",
+          "arg2[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x20",
+          "arg1[10]",
+          "arg2[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x22",
+          "arg1[11]",
+          "arg2[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25",
+          "x26"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27",
+          "x28"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x26",
+          "x3",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29",
+          "x30"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x28",
+          "x5",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31",
+          "x32"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x30",
+          "x7",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33",
+          "x34"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x32",
+          "x9",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35",
+          "x36"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x34",
+          "x11",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x36",
+          "x13",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39",
+          "x40"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x38",
+          "x15",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41",
+          "x42"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x40",
+          "x17",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x43",
+          "x44"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x42",
+          "x19",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x45",
+          "x46"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x44",
+          "x21",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x47",
+          "x48"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x46",
+          "x23",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x50"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x48",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x51"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x50",
+          "x25",
+          "x1"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x52"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x50",
+          "x27",
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x53"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x50",
+          "x29",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x54"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x50",
+          "x31",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x55"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x50",
+          "x33",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x56"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x50",
+          "x35",
+          "x11"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x57"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x50",
+          "x37",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x58"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x50",
+          "x39",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x59"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x50",
+          "x41",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x60"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x50",
+          "x43",
+          "x19"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x61"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x50",
+          "x45",
+          "x21"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x62"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x50",
+          "x47",
+          "x23"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x51"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x52"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x53"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x54"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x55"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x56"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x57"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x58"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x59"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x60"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x61"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x62"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_sub",
+    "arguments": [
+      {
+        "datatype": "u32[12]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[12]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[12]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x8",
+          "arg1[4]",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x10",
+          "arg1[5]",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x12",
+          "arg1[6]",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x14",
+          "arg1[7]",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x16",
+          "arg1[8]",
+          "arg2[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x18",
+          "arg1[9]",
+          "arg2[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x20",
+          "arg1[10]",
+          "arg2[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x22",
+          "arg1[11]",
+          "arg2[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x24",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x3",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x5",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          "x7",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34",
+          "x35"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x33",
+          "x9",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x25",
+              "0xfffffffe"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36",
+          "x37"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x35",
+          "x11",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38",
+          "x39"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x37",
+          "x13",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40",
+          "x41"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x39",
+          "x15",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42",
+          "x43"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x41",
+          "x17",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44",
+          "x45"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x43",
+          "x19",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46",
+          "x47"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x45",
+          "x21",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x48",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x47",
+          "x23",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x26"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x28"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x30"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x32"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x34"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x36"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x38"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x40"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x42"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x44"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x46"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x48"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_opp",
+    "arguments": [
+      {
+        "datatype": "u32[12]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[12]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x8",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x10",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x12",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x14",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x16",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x18",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x20",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x22",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x24",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x3",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x5",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          "x7",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34",
+          "x35"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x33",
+          "x9",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x25",
+              "0xfffffffe"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36",
+          "x37"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x35",
+          "x11",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38",
+          "x39"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x37",
+          "x13",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40",
+          "x41"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x39",
+          "x15",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42",
+          "x43"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x41",
+          "x17",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44",
+          "x45"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x43",
+          "x19",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46",
+          "x47"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x45",
+          "x21",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x48",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x47",
+          "x23",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x26"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x28"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x30"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x32"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x34"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x36"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x38"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x40"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x42"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x44"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x46"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x48"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_from_montgomery",
+    "arguments": [
+      {
+        "datatype": "u32[12]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[12]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2",
+          "x3"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4",
+          "x5"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6",
+          "x7"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8",
+          "x9"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x19",
+          "x16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x17",
+          "x14"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x15",
+          "x12"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x13",
+          "x10"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x11",
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          "x9",
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34",
+          "x35"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x33",
+          "x7",
+          "x4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36",
+          "x37"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x35",
+          "x5",
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x39"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "x20"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40",
+          "x41"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x39"
+                ]
+              },
+              "x21"
+            ]
+          },
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42",
+          "x43"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44",
+          "x45"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46",
+          "x47"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x48",
+          "x49"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x50",
+          "x51"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x52",
+          "x53"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x54",
+          "x55"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x56",
+          "x57"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x58",
+          "x59"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x59",
+          "x56"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x63",
+          "x57",
+          "x54"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x65",
+          "x55",
+          "x52"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x67",
+          "x53",
+          "x50"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x69",
+          "x51",
+          "x48"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x72",
+          "x73"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x71",
+          "x49",
+          "x46"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x73",
+          "x47",
+          "x44"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x76",
+          "x77"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x75",
+          "x45",
+          "x42"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x79"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x40",
+          "x60"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x80",
+          "x81"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x79",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x41"
+            ]
+          },
+          "x61"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x82",
+          "x83"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x81",
+          "x18",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x84",
+          "x85"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x83",
+          "x22",
+          "x58"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x86",
+          "x87"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x85",
+          "x24",
+          "x62"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x88",
+          "x89"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x87",
+          "x26",
+          "x64"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x90",
+          "x91"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x89",
+          "x28",
+          "x66"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x91",
+          "x30",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x94",
+          "x95"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x93",
+          "x32",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x96",
+          "x97"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x95",
+          "x34",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x98",
+          "x99"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x97",
+          "x36",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x100",
+          "x101"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x99",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x37"
+                ]
+              },
+              "x3"
+            ]
+          },
+          "x76"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x102",
+          "x103"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x101",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x77"
+                ]
+              },
+              "x43"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x104",
+          "x105"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x80",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x106",
+          "x107"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x105",
+          "x82",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x108",
+          "x109"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x107",
+          "x84",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x110",
+          "x111"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x109",
+          "x86",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x112",
+          "x113"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x111",
+          "x88",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x114",
+          "x115"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x113",
+          "x90",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x116",
+          "x117"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x115",
+          "x92",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x118",
+          "x119"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x117",
+          "x94",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x120",
+          "x121"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x119",
+          "x96",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x122",
+          "x123"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x121",
+          "x98",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x124",
+          "x125"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x123",
+          "x100",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x126",
+          "x127"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x125",
+          "x102",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x128",
+          "x129"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x104",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x130",
+          "x131"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x104",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x132",
+          "x133"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x104",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x134",
+          "x135"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x104",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x136",
+          "x137"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x104",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x138",
+          "x139"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x104",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x140",
+          "x141"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x104",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x142",
+          "x143"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x104",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x144",
+          "x145"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x104",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x146",
+          "x147"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x104",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x148",
+          "x149"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x145",
+          "x142"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x150",
+          "x151"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x149",
+          "x143",
+          "x140"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x152",
+          "x153"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x151",
+          "x141",
+          "x138"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x154",
+          "x155"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x153",
+          "x139",
+          "x136"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x156",
+          "x157"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x155",
+          "x137",
+          "x134"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x158",
+          "x159"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x157",
+          "x135",
+          "x132"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x160",
+          "x161"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x159",
+          "x133",
+          "x130"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x162",
+          "x163"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x161",
+          "x131",
+          "x128"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x165"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x104",
+          "x146"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x166",
+          "x167"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x165",
+          "x106",
+          "x147"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x168",
+          "x169"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x167",
+          "x108",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x170",
+          "x171"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x169",
+          "x110",
+          "x144"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x172",
+          "x173"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x171",
+          "x112",
+          "x148"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x174",
+          "x175"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x173",
+          "x114",
+          "x150"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x176",
+          "x177"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x175",
+          "x116",
+          "x152"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x178",
+          "x179"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x177",
+          "x118",
+          "x154"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x180",
+          "x181"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x179",
+          "x120",
+          "x156"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x182",
+          "x183"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x181",
+          "x122",
+          "x158"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x184",
+          "x185"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x183",
+          "x124",
+          "x160"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x186",
+          "x187"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x185",
+          "x126",
+          "x162"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x188",
+          "x189"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x187",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x127"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x103"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x163"
+                ]
+              },
+              "x129"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x190",
+          "x191"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x166",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x192",
+          "x193"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x191",
+          "x168",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x194",
+          "x195"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x193",
+          "x170",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x196",
+          "x197"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x195",
+          "x172",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x198",
+          "x199"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x197",
+          "x174",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x200",
+          "x201"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x199",
+          "x176",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x202",
+          "x203"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x201",
+          "x178",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x204",
+          "x205"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x203",
+          "x180",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x206",
+          "x207"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x205",
+          "x182",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x208",
+          "x209"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x207",
+          "x184",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x210",
+          "x211"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x209",
+          "x186",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x212",
+          "x213"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x211",
+          "x188",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x214",
+          "x215"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x190",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x216",
+          "x217"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x190",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x218",
+          "x219"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x190",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x220",
+          "x221"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x190",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x222",
+          "x223"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x190",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x224",
+          "x225"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x190",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x226",
+          "x227"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x190",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x228",
+          "x229"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x190",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x230",
+          "x231"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x190",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x232",
+          "x233"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x190",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x234",
+          "x235"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x231",
+          "x228"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x236",
+          "x237"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x235",
+          "x229",
+          "x226"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x238",
+          "x239"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x237",
+          "x227",
+          "x224"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x240",
+          "x241"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x239",
+          "x225",
+          "x222"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x242",
+          "x243"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x241",
+          "x223",
+          "x220"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x244",
+          "x245"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x243",
+          "x221",
+          "x218"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x246",
+          "x247"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x245",
+          "x219",
+          "x216"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x248",
+          "x249"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x247",
+          "x217",
+          "x214"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x251"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x190",
+          "x232"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x252",
+          "x253"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x251",
+          "x192",
+          "x233"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x254",
+          "x255"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x253",
+          "x194",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x256",
+          "x257"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x255",
+          "x196",
+          "x230"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x258",
+          "x259"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x257",
+          "x198",
+          "x234"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x260",
+          "x261"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x259",
+          "x200",
+          "x236"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x262",
+          "x263"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x261",
+          "x202",
+          "x238"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x264",
+          "x265"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x263",
+          "x204",
+          "x240"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x266",
+          "x267"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x265",
+          "x206",
+          "x242"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x268",
+          "x269"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x267",
+          "x208",
+          "x244"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x270",
+          "x271"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x269",
+          "x210",
+          "x246"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x272",
+          "x273"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x271",
+          "x212",
+          "x248"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x274",
+          "x275"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x273",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x213"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x189"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x249"
+                ]
+              },
+              "x215"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x276",
+          "x277"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x252",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x278",
+          "x279"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x277",
+          "x254",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x280",
+          "x281"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x279",
+          "x256",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x282",
+          "x283"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x281",
+          "x258",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x284",
+          "x285"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x283",
+          "x260",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x286",
+          "x287"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x285",
+          "x262",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x288",
+          "x289"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x287",
+          "x264",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x290",
+          "x291"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x289",
+          "x266",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x292",
+          "x293"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x291",
+          "x268",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x294",
+          "x295"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x293",
+          "x270",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x296",
+          "x297"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x295",
+          "x272",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x298",
+          "x299"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x297",
+          "x274",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x300",
+          "x301"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x276",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x302",
+          "x303"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x276",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x304",
+          "x305"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x276",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x306",
+          "x307"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x276",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x308",
+          "x309"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x276",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x310",
+          "x311"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x276",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x312",
+          "x313"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x276",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x314",
+          "x315"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x276",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x316",
+          "x317"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x276",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x318",
+          "x319"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x276",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x320",
+          "x321"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x317",
+          "x314"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x322",
+          "x323"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x321",
+          "x315",
+          "x312"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x324",
+          "x325"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x323",
+          "x313",
+          "x310"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x326",
+          "x327"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x325",
+          "x311",
+          "x308"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x328",
+          "x329"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x327",
+          "x309",
+          "x306"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x330",
+          "x331"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x329",
+          "x307",
+          "x304"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x332",
+          "x333"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x331",
+          "x305",
+          "x302"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x334",
+          "x335"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x333",
+          "x303",
+          "x300"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x337"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x276",
+          "x318"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x338",
+          "x339"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x337",
+          "x278",
+          "x319"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x340",
+          "x341"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x339",
+          "x280",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x342",
+          "x343"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x341",
+          "x282",
+          "x316"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x344",
+          "x345"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x343",
+          "x284",
+          "x320"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x346",
+          "x347"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x345",
+          "x286",
+          "x322"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x348",
+          "x349"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x347",
+          "x288",
+          "x324"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x350",
+          "x351"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x349",
+          "x290",
+          "x326"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x352",
+          "x353"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x351",
+          "x292",
+          "x328"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x354",
+          "x355"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x353",
+          "x294",
+          "x330"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x356",
+          "x357"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x355",
+          "x296",
+          "x332"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x358",
+          "x359"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x357",
+          "x298",
+          "x334"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x360",
+          "x361"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x359",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x299"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x275"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x335"
+                ]
+              },
+              "x301"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x362",
+          "x363"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x338",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x364",
+          "x365"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x363",
+          "x340",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x366",
+          "x367"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x365",
+          "x342",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x368",
+          "x369"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x367",
+          "x344",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x370",
+          "x371"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x369",
+          "x346",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x372",
+          "x373"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x371",
+          "x348",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x374",
+          "x375"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x373",
+          "x350",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x376",
+          "x377"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x375",
+          "x352",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x378",
+          "x379"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x377",
+          "x354",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x380",
+          "x381"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x379",
+          "x356",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x382",
+          "x383"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x381",
+          "x358",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x384",
+          "x385"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x383",
+          "x360",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x386",
+          "x387"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x362",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x388",
+          "x389"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x362",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x390",
+          "x391"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x362",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x392",
+          "x393"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x362",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x394",
+          "x395"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x362",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x396",
+          "x397"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x362",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x398",
+          "x399"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x362",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x400",
+          "x401"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x362",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x402",
+          "x403"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x362",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x404",
+          "x405"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x362",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x406",
+          "x407"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x403",
+          "x400"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x408",
+          "x409"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x407",
+          "x401",
+          "x398"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x410",
+          "x411"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x409",
+          "x399",
+          "x396"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x412",
+          "x413"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x411",
+          "x397",
+          "x394"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x414",
+          "x415"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x413",
+          "x395",
+          "x392"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x416",
+          "x417"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x415",
+          "x393",
+          "x390"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x418",
+          "x419"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x417",
+          "x391",
+          "x388"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x420",
+          "x421"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x419",
+          "x389",
+          "x386"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x423"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x362",
+          "x404"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x424",
+          "x425"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x423",
+          "x364",
+          "x405"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x426",
+          "x427"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x425",
+          "x366",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x428",
+          "x429"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x427",
+          "x368",
+          "x402"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x430",
+          "x431"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x429",
+          "x370",
+          "x406"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x432",
+          "x433"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x431",
+          "x372",
+          "x408"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x434",
+          "x435"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x433",
+          "x374",
+          "x410"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x436",
+          "x437"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x435",
+          "x376",
+          "x412"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x438",
+          "x439"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x437",
+          "x378",
+          "x414"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x440",
+          "x441"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x439",
+          "x380",
+          "x416"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x442",
+          "x443"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x441",
+          "x382",
+          "x418"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x444",
+          "x445"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x443",
+          "x384",
+          "x420"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x446",
+          "x447"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x445",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x385"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x361"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x421"
+                ]
+              },
+              "x387"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x448",
+          "x449"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x424",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x450",
+          "x451"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x449",
+          "x426",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x452",
+          "x453"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x451",
+          "x428",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x454",
+          "x455"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x453",
+          "x430",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x456",
+          "x457"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x455",
+          "x432",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x458",
+          "x459"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x457",
+          "x434",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x460",
+          "x461"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x459",
+          "x436",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x462",
+          "x463"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x461",
+          "x438",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x464",
+          "x465"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x463",
+          "x440",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x466",
+          "x467"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x465",
+          "x442",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x468",
+          "x469"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x467",
+          "x444",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x470",
+          "x471"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x469",
+          "x446",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x472",
+          "x473"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x448",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x474",
+          "x475"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x448",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x476",
+          "x477"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x448",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x478",
+          "x479"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x448",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x480",
+          "x481"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x448",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x482",
+          "x483"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x448",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x484",
+          "x485"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x448",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x486",
+          "x487"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x448",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x488",
+          "x489"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x448",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x490",
+          "x491"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x448",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x492",
+          "x493"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x489",
+          "x486"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x494",
+          "x495"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x493",
+          "x487",
+          "x484"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x496",
+          "x497"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x495",
+          "x485",
+          "x482"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x498",
+          "x499"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x497",
+          "x483",
+          "x480"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x500",
+          "x501"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x499",
+          "x481",
+          "x478"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x502",
+          "x503"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x501",
+          "x479",
+          "x476"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x504",
+          "x505"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x503",
+          "x477",
+          "x474"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x506",
+          "x507"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x505",
+          "x475",
+          "x472"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x509"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x448",
+          "x490"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x510",
+          "x511"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x509",
+          "x450",
+          "x491"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x512",
+          "x513"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x511",
+          "x452",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x514",
+          "x515"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x513",
+          "x454",
+          "x488"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x516",
+          "x517"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x515",
+          "x456",
+          "x492"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x518",
+          "x519"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x517",
+          "x458",
+          "x494"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x520",
+          "x521"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x519",
+          "x460",
+          "x496"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x522",
+          "x523"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x521",
+          "x462",
+          "x498"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x524",
+          "x525"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x523",
+          "x464",
+          "x500"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x526",
+          "x527"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x525",
+          "x466",
+          "x502"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x528",
+          "x529"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x527",
+          "x468",
+          "x504"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x530",
+          "x531"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x529",
+          "x470",
+          "x506"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x532",
+          "x533"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x531",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x471"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x447"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x507"
+                ]
+              },
+              "x473"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x534",
+          "x535"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x510",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x536",
+          "x537"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x535",
+          "x512",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x538",
+          "x539"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x537",
+          "x514",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x540",
+          "x541"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x539",
+          "x516",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x542",
+          "x543"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x541",
+          "x518",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x544",
+          "x545"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x543",
+          "x520",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x546",
+          "x547"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x545",
+          "x522",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x548",
+          "x549"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x547",
+          "x524",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x550",
+          "x551"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x549",
+          "x526",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x552",
+          "x553"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x551",
+          "x528",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x554",
+          "x555"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x553",
+          "x530",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x556",
+          "x557"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x555",
+          "x532",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x558",
+          "x559"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x534",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x560",
+          "x561"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x534",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x562",
+          "x563"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x534",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x564",
+          "x565"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x534",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x566",
+          "x567"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x534",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x568",
+          "x569"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x534",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x570",
+          "x571"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x534",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x572",
+          "x573"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x534",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x574",
+          "x575"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x534",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x576",
+          "x577"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x534",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x578",
+          "x579"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x575",
+          "x572"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x580",
+          "x581"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x579",
+          "x573",
+          "x570"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x582",
+          "x583"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x581",
+          "x571",
+          "x568"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x584",
+          "x585"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x583",
+          "x569",
+          "x566"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x586",
+          "x587"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x585",
+          "x567",
+          "x564"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x588",
+          "x589"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x587",
+          "x565",
+          "x562"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x590",
+          "x591"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x589",
+          "x563",
+          "x560"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x592",
+          "x593"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x591",
+          "x561",
+          "x558"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x595"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x534",
+          "x576"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x596",
+          "x597"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x595",
+          "x536",
+          "x577"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x598",
+          "x599"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x597",
+          "x538",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x600",
+          "x601"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x599",
+          "x540",
+          "x574"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x602",
+          "x603"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x601",
+          "x542",
+          "x578"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x604",
+          "x605"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x603",
+          "x544",
+          "x580"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x606",
+          "x607"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x605",
+          "x546",
+          "x582"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x608",
+          "x609"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x607",
+          "x548",
+          "x584"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x610",
+          "x611"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x609",
+          "x550",
+          "x586"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x612",
+          "x613"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x611",
+          "x552",
+          "x588"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x614",
+          "x615"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x613",
+          "x554",
+          "x590"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x616",
+          "x617"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x615",
+          "x556",
+          "x592"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x618",
+          "x619"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x617",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x557"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x533"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x593"
+                ]
+              },
+              "x559"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x620",
+          "x621"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x596",
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x622",
+          "x623"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x621",
+          "x598",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x624",
+          "x625"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x623",
+          "x600",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x626",
+          "x627"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x625",
+          "x602",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x628",
+          "x629"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x627",
+          "x604",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x630",
+          "x631"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x629",
+          "x606",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x632",
+          "x633"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x631",
+          "x608",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x634",
+          "x635"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x633",
+          "x610",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x636",
+          "x637"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x635",
+          "x612",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x638",
+          "x639"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x637",
+          "x614",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x640",
+          "x641"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x639",
+          "x616",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x642",
+          "x643"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x641",
+          "x618",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x644",
+          "x645"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x620",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x646",
+          "x647"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x620",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x648",
+          "x649"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x620",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x650",
+          "x651"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x620",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x652",
+          "x653"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x620",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x654",
+          "x655"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x620",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x656",
+          "x657"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x620",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x658",
+          "x659"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x620",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x660",
+          "x661"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x620",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x662",
+          "x663"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x620",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x664",
+          "x665"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x661",
+          "x658"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x666",
+          "x667"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x665",
+          "x659",
+          "x656"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x668",
+          "x669"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x667",
+          "x657",
+          "x654"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x670",
+          "x671"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x669",
+          "x655",
+          "x652"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x672",
+          "x673"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x671",
+          "x653",
+          "x650"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x674",
+          "x675"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x673",
+          "x651",
+          "x648"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x676",
+          "x677"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x675",
+          "x649",
+          "x646"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x678",
+          "x679"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x677",
+          "x647",
+          "x644"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x681"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x620",
+          "x662"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x682",
+          "x683"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x681",
+          "x622",
+          "x663"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x684",
+          "x685"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x683",
+          "x624",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x686",
+          "x687"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x685",
+          "x626",
+          "x660"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x688",
+          "x689"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x687",
+          "x628",
+          "x664"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x690",
+          "x691"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x689",
+          "x630",
+          "x666"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x692",
+          "x693"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x691",
+          "x632",
+          "x668"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x694",
+          "x695"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x693",
+          "x634",
+          "x670"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x696",
+          "x697"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x695",
+          "x636",
+          "x672"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x698",
+          "x699"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x697",
+          "x638",
+          "x674"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x700",
+          "x701"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x699",
+          "x640",
+          "x676"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x702",
+          "x703"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x701",
+          "x642",
+          "x678"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x704",
+          "x705"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x703",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x643"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x619"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x679"
+                ]
+              },
+              "x645"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x706",
+          "x707"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x682",
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x708",
+          "x709"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x707",
+          "x684",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x710",
+          "x711"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x709",
+          "x686",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x712",
+          "x713"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x711",
+          "x688",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x714",
+          "x715"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x713",
+          "x690",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x716",
+          "x717"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x715",
+          "x692",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x718",
+          "x719"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x717",
+          "x694",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x720",
+          "x721"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x719",
+          "x696",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x722",
+          "x723"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x721",
+          "x698",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x724",
+          "x725"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x723",
+          "x700",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x726",
+          "x727"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x725",
+          "x702",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x728",
+          "x729"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x727",
+          "x704",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x730",
+          "x731"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x706",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x732",
+          "x733"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x706",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x734",
+          "x735"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x706",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x736",
+          "x737"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x706",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x738",
+          "x739"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x706",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x740",
+          "x741"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x706",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x742",
+          "x743"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x706",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x744",
+          "x745"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x706",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x746",
+          "x747"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x706",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x748",
+          "x749"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x706",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x750",
+          "x751"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x747",
+          "x744"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x752",
+          "x753"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x751",
+          "x745",
+          "x742"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x754",
+          "x755"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x753",
+          "x743",
+          "x740"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x756",
+          "x757"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x755",
+          "x741",
+          "x738"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x758",
+          "x759"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x757",
+          "x739",
+          "x736"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x760",
+          "x761"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x759",
+          "x737",
+          "x734"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x762",
+          "x763"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x761",
+          "x735",
+          "x732"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x764",
+          "x765"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x763",
+          "x733",
+          "x730"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x767"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x706",
+          "x748"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x768",
+          "x769"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x767",
+          "x708",
+          "x749"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x770",
+          "x771"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x769",
+          "x710",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x772",
+          "x773"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x771",
+          "x712",
+          "x746"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x774",
+          "x775"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x773",
+          "x714",
+          "x750"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x776",
+          "x777"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x775",
+          "x716",
+          "x752"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x778",
+          "x779"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x777",
+          "x718",
+          "x754"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x780",
+          "x781"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x779",
+          "x720",
+          "x756"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x782",
+          "x783"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x781",
+          "x722",
+          "x758"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x784",
+          "x785"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x783",
+          "x724",
+          "x760"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x786",
+          "x787"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x785",
+          "x726",
+          "x762"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x788",
+          "x789"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x787",
+          "x728",
+          "x764"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x790",
+          "x791"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x789",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x729"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x705"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x765"
+                ]
+              },
+              "x731"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x792",
+          "x793"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x768",
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x794",
+          "x795"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x793",
+          "x770",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x796",
+          "x797"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x795",
+          "x772",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x798",
+          "x799"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x797",
+          "x774",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x800",
+          "x801"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x799",
+          "x776",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x802",
+          "x803"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x801",
+          "x778",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x804",
+          "x805"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x803",
+          "x780",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x806",
+          "x807"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x805",
+          "x782",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x808",
+          "x809"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x807",
+          "x784",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x810",
+          "x811"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x809",
+          "x786",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x812",
+          "x813"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x811",
+          "x788",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x814",
+          "x815"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x813",
+          "x790",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x816",
+          "x817"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x792",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x818",
+          "x819"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x792",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x820",
+          "x821"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x792",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x822",
+          "x823"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x792",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x824",
+          "x825"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x792",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x826",
+          "x827"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x792",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x828",
+          "x829"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x792",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x830",
+          "x831"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x792",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x832",
+          "x833"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x792",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x834",
+          "x835"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x792",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x836",
+          "x837"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x833",
+          "x830"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x838",
+          "x839"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x837",
+          "x831",
+          "x828"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x840",
+          "x841"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x839",
+          "x829",
+          "x826"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x842",
+          "x843"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x841",
+          "x827",
+          "x824"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x844",
+          "x845"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x843",
+          "x825",
+          "x822"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x846",
+          "x847"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x845",
+          "x823",
+          "x820"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x848",
+          "x849"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x847",
+          "x821",
+          "x818"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x850",
+          "x851"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x849",
+          "x819",
+          "x816"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x853"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x792",
+          "x834"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x854",
+          "x855"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x853",
+          "x794",
+          "x835"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x856",
+          "x857"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x855",
+          "x796",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x858",
+          "x859"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x857",
+          "x798",
+          "x832"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x860",
+          "x861"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x859",
+          "x800",
+          "x836"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x862",
+          "x863"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x861",
+          "x802",
+          "x838"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x864",
+          "x865"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x863",
+          "x804",
+          "x840"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x866",
+          "x867"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x865",
+          "x806",
+          "x842"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x868",
+          "x869"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x867",
+          "x808",
+          "x844"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x870",
+          "x871"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x869",
+          "x810",
+          "x846"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x872",
+          "x873"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x871",
+          "x812",
+          "x848"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x874",
+          "x875"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x873",
+          "x814",
+          "x850"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x876",
+          "x877"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x875",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x815"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x791"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x851"
+                ]
+              },
+              "x817"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x878",
+          "x879"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x854",
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x880",
+          "x881"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x879",
+          "x856",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x882",
+          "x883"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x881",
+          "x858",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x884",
+          "x885"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x883",
+          "x860",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x886",
+          "x887"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x885",
+          "x862",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x888",
+          "x889"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x887",
+          "x864",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x890",
+          "x891"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x889",
+          "x866",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x892",
+          "x893"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x891",
+          "x868",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x894",
+          "x895"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x893",
+          "x870",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x896",
+          "x897"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x895",
+          "x872",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x898",
+          "x899"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x897",
+          "x874",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x900",
+          "x901"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x899",
+          "x876",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x902",
+          "x903"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x878",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x904",
+          "x905"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x878",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x906",
+          "x907"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x878",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x908",
+          "x909"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x878",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x910",
+          "x911"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x878",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x912",
+          "x913"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x878",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x914",
+          "x915"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x878",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x916",
+          "x917"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x878",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x918",
+          "x919"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x878",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x920",
+          "x921"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x878",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x922",
+          "x923"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x919",
+          "x916"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x924",
+          "x925"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x923",
+          "x917",
+          "x914"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x926",
+          "x927"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x925",
+          "x915",
+          "x912"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x928",
+          "x929"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x927",
+          "x913",
+          "x910"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x930",
+          "x931"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x929",
+          "x911",
+          "x908"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x932",
+          "x933"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x931",
+          "x909",
+          "x906"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x934",
+          "x935"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x933",
+          "x907",
+          "x904"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x936",
+          "x937"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x935",
+          "x905",
+          "x902"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x939"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x878",
+          "x920"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x940",
+          "x941"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x939",
+          "x880",
+          "x921"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x942",
+          "x943"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x941",
+          "x882",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x944",
+          "x945"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x943",
+          "x884",
+          "x918"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x946",
+          "x947"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x945",
+          "x886",
+          "x922"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x948",
+          "x949"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x947",
+          "x888",
+          "x924"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x950",
+          "x951"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x949",
+          "x890",
+          "x926"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x952",
+          "x953"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x951",
+          "x892",
+          "x928"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x954",
+          "x955"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x953",
+          "x894",
+          "x930"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x956",
+          "x957"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x955",
+          "x896",
+          "x932"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x958",
+          "x959"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x957",
+          "x898",
+          "x934"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x960",
+          "x961"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x959",
+          "x900",
+          "x936"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x962",
+          "x963"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x961",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x901"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x877"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x937"
+                ]
+              },
+              "x903"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x964",
+          "x965"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x940",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x966",
+          "x967"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x965",
+          "x942",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x968",
+          "x969"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x967",
+          "x944",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x970",
+          "x971"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x969",
+          "x946",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x972",
+          "x973"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x971",
+          "x948",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x974",
+          "x975"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x973",
+          "x950",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x976",
+          "x977"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x975",
+          "x952",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x978",
+          "x979"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x977",
+          "x954",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x980",
+          "x981"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x979",
+          "x956",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x982",
+          "x983"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x981",
+          "x958",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x984",
+          "x985"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x983",
+          "x960",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x986",
+          "x987"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x985",
+          "x962",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x989"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x987",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x963"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x990"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x989",
+          "x964",
+          "x940"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x991"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x989",
+          "x966",
+          "x942"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x992"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x989",
+          "x968",
+          "x944"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x993"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x989",
+          "x970",
+          "x946"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x994"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x989",
+          "x972",
+          "x948"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x995"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x989",
+          "x974",
+          "x950"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x996"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x989",
+          "x976",
+          "x952"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x997"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x989",
+          "x978",
+          "x954"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x998"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x989",
+          "x980",
+          "x956"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x999"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x989",
+          "x982",
+          "x958"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1000"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x989",
+          "x984",
+          "x960"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1001"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x989",
+          "x986",
+          "x962"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x990"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x991"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x992"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x993"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x994"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x995"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x996"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x997"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x998"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x999"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1000"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1001"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_to_montgomery",
+    "arguments": [
+      {
+        "datatype": "u32[12]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[12]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x14"
+                ]
+              }
+            ]
+          },
+          "x12"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25",
+          "x26"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27",
+          "x28"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29",
+          "x30"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31",
+          "x32"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33",
+          "x34"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35",
+          "x36"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39",
+          "x40"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41",
+          "x42"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x12",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x43",
+          "x44"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x40",
+          "x37"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x45",
+          "x46"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x44",
+          "x38",
+          "x35"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x47",
+          "x48"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x46",
+          "x36",
+          "x33"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x49",
+          "x50"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x48",
+          "x34",
+          "x31"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x51",
+          "x52"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x50",
+          "x32",
+          "x29"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x53",
+          "x54"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x52",
+          "x30",
+          "x27"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x55",
+          "x56"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x54",
+          "x28",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x57",
+          "x58"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x56",
+          "x26",
+          "x23"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x60"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x12",
+          "x41"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x61",
+          "x62"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x60",
+          "x19",
+          "x42"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x63",
+          "x64"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x17",
+          "x39"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x65",
+          "x66"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x64",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x18"
+                ]
+              }
+            ]
+          },
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x67",
+          "x68"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x66",
+          "x15",
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x69",
+          "x70"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x68",
+          "x16",
+          "x47"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x71",
+          "x72"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x70",
+          "x13",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x73",
+          "x74"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x72",
+          "x21",
+          "x51"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x75",
+          "x76"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x74",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x22"
+            ]
+          },
+          "x53"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x77",
+          "x78"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x76",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x55"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x79",
+          "x80"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x78",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x57"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x81",
+          "x82"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x80",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x58"
+                ]
+              },
+              "x24"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x83",
+          "x84"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x85",
+          "x86"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x87",
+          "x88"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x89",
+          "x90"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x91",
+          "x92"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x84"
+                ]
+              }
+            ]
+          },
+          "x1"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x93",
+          "x94"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x61",
+          "x1"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x95",
+          "x96"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x94",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x62"
+                ]
+              },
+              "x20"
+            ]
+          },
+          "x89"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x97",
+          "x98"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x96",
+          "x63",
+          "x90"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x99",
+          "x100"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x98",
+          "x65",
+          "x87"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x101",
+          "x102"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x100",
+          "x67",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x88"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x103",
+          "x104"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x102",
+          "x69",
+          "x85"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x105",
+          "x106"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x104",
+          "x71",
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x107",
+          "x108"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x106",
+          "x73",
+          "x83"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x109",
+          "x110"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x108",
+          "x75",
+          "x91"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x111",
+          "x112"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x110",
+          "x77",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x92"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x113",
+          "x114"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x112",
+          "x79",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x115",
+          "x116"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x114",
+          "x81",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x117",
+          "x118"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x93",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x119",
+          "x120"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x93",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x121",
+          "x122"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x93",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x123",
+          "x124"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x93",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x125",
+          "x126"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x93",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x127",
+          "x128"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x93",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x129",
+          "x130"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x93",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x131",
+          "x132"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x93",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x133",
+          "x134"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x93",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x135",
+          "x136"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x93",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x137",
+          "x138"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x134",
+          "x131"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x139",
+          "x140"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x138",
+          "x132",
+          "x129"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x141",
+          "x142"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x140",
+          "x130",
+          "x127"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x143",
+          "x144"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x142",
+          "x128",
+          "x125"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x145",
+          "x146"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x144",
+          "x126",
+          "x123"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x147",
+          "x148"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x146",
+          "x124",
+          "x121"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x149",
+          "x150"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x148",
+          "x122",
+          "x119"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x151",
+          "x152"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x150",
+          "x120",
+          "x117"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x154"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x93",
+          "x135"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x155",
+          "x156"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x154",
+          "x95",
+          "x136"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x157",
+          "x158"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x156",
+          "x97",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x159",
+          "x160"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x158",
+          "x99",
+          "x133"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x161",
+          "x162"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x160",
+          "x101",
+          "x137"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x163",
+          "x164"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x162",
+          "x103",
+          "x139"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x165",
+          "x166"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x164",
+          "x105",
+          "x141"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x167",
+          "x168"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x166",
+          "x107",
+          "x143"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x169",
+          "x170"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x168",
+          "x109",
+          "x145"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x171",
+          "x172"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x170",
+          "x111",
+          "x147"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x173",
+          "x174"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x172",
+          "x113",
+          "x149"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x175",
+          "x176"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x174",
+          "x115",
+          "x151"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x177",
+          "x178"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x176",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x116"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x82"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x152"
+                ]
+              },
+              "x118"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x179",
+          "x180"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x181",
+          "x182"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x183",
+          "x184"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x185",
+          "x186"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x187",
+          "x188"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x180"
+                ]
+              }
+            ]
+          },
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x189",
+          "x190"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x155",
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x191",
+          "x192"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x190",
+          "x157",
+          "x185"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x193",
+          "x194"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x192",
+          "x159",
+          "x186"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x195",
+          "x196"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x194",
+          "x161",
+          "x183"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x197",
+          "x198"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x196",
+          "x163",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x184"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x199",
+          "x200"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x198",
+          "x165",
+          "x181"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x201",
+          "x202"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x200",
+          "x167",
+          "x182"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x203",
+          "x204"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x202",
+          "x169",
+          "x179"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x205",
+          "x206"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x204",
+          "x171",
+          "x187"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x207",
+          "x208"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x206",
+          "x173",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x188"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x209",
+          "x210"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x208",
+          "x175",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x211",
+          "x212"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x210",
+          "x177",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x213",
+          "x214"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x189",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x215",
+          "x216"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x189",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x217",
+          "x218"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x189",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x219",
+          "x220"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x189",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x221",
+          "x222"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x189",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x223",
+          "x224"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x189",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x225",
+          "x226"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x189",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x227",
+          "x228"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x189",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x229",
+          "x230"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x189",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x231",
+          "x232"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x189",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x233",
+          "x234"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x230",
+          "x227"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x235",
+          "x236"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x234",
+          "x228",
+          "x225"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x237",
+          "x238"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x236",
+          "x226",
+          "x223"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x239",
+          "x240"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x238",
+          "x224",
+          "x221"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x241",
+          "x242"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x240",
+          "x222",
+          "x219"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x243",
+          "x244"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x242",
+          "x220",
+          "x217"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x245",
+          "x246"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x244",
+          "x218",
+          "x215"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x247",
+          "x248"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x246",
+          "x216",
+          "x213"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x250"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x189",
+          "x231"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x251",
+          "x252"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x250",
+          "x191",
+          "x232"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x253",
+          "x254"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x252",
+          "x193",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x255",
+          "x256"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x254",
+          "x195",
+          "x229"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x257",
+          "x258"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x256",
+          "x197",
+          "x233"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x259",
+          "x260"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x258",
+          "x199",
+          "x235"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x261",
+          "x262"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x260",
+          "x201",
+          "x237"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x263",
+          "x264"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x262",
+          "x203",
+          "x239"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x265",
+          "x266"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x264",
+          "x205",
+          "x241"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x267",
+          "x268"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x266",
+          "x207",
+          "x243"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x269",
+          "x270"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x268",
+          "x209",
+          "x245"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x271",
+          "x272"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x270",
+          "x211",
+          "x247"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x273",
+          "x274"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x272",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x212"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x178"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x248"
+                ]
+              },
+              "x214"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x275",
+          "x276"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x277",
+          "x278"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x279",
+          "x280"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x281",
+          "x282"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x283",
+          "x284"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x276"
+                ]
+              }
+            ]
+          },
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x285",
+          "x286"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x251",
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x287",
+          "x288"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x286",
+          "x253",
+          "x281"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x289",
+          "x290"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x288",
+          "x255",
+          "x282"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x291",
+          "x292"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x290",
+          "x257",
+          "x279"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x293",
+          "x294"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x292",
+          "x259",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x280"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x295",
+          "x296"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x294",
+          "x261",
+          "x277"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x297",
+          "x298"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x296",
+          "x263",
+          "x278"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x299",
+          "x300"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x298",
+          "x265",
+          "x275"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x301",
+          "x302"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x300",
+          "x267",
+          "x283"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x303",
+          "x304"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x302",
+          "x269",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x284"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x305",
+          "x306"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x304",
+          "x271",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x307",
+          "x308"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x306",
+          "x273",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x309",
+          "x310"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x285",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x311",
+          "x312"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x285",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x313",
+          "x314"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x285",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x315",
+          "x316"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x285",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x317",
+          "x318"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x285",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x319",
+          "x320"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x285",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x321",
+          "x322"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x285",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x323",
+          "x324"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x285",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x325",
+          "x326"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x285",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x327",
+          "x328"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x285",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x329",
+          "x330"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x326",
+          "x323"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x331",
+          "x332"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x330",
+          "x324",
+          "x321"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x333",
+          "x334"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x332",
+          "x322",
+          "x319"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x335",
+          "x336"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x334",
+          "x320",
+          "x317"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x337",
+          "x338"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x336",
+          "x318",
+          "x315"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x339",
+          "x340"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x338",
+          "x316",
+          "x313"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x341",
+          "x342"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x340",
+          "x314",
+          "x311"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x343",
+          "x344"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x342",
+          "x312",
+          "x309"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x346"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x285",
+          "x327"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x347",
+          "x348"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x346",
+          "x287",
+          "x328"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x349",
+          "x350"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x348",
+          "x289",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x351",
+          "x352"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x350",
+          "x291",
+          "x325"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x353",
+          "x354"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x352",
+          "x293",
+          "x329"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x355",
+          "x356"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x354",
+          "x295",
+          "x331"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x357",
+          "x358"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x356",
+          "x297",
+          "x333"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x359",
+          "x360"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x358",
+          "x299",
+          "x335"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x361",
+          "x362"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x360",
+          "x301",
+          "x337"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x363",
+          "x364"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x362",
+          "x303",
+          "x339"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x365",
+          "x366"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x364",
+          "x305",
+          "x341"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x367",
+          "x368"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x366",
+          "x307",
+          "x343"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x369",
+          "x370"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x368",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x308"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x274"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x344"
+                ]
+              },
+              "x310"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x371",
+          "x372"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x373",
+          "x374"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x375",
+          "x376"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x377",
+          "x378"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x379",
+          "x380"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x372"
+                ]
+              }
+            ]
+          },
+          "x4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x381",
+          "x382"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x347",
+          "x4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x383",
+          "x384"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x382",
+          "x349",
+          "x377"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x385",
+          "x386"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x384",
+          "x351",
+          "x378"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x387",
+          "x388"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x386",
+          "x353",
+          "x375"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x389",
+          "x390"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x388",
+          "x355",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x376"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x391",
+          "x392"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x390",
+          "x357",
+          "x373"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x393",
+          "x394"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x392",
+          "x359",
+          "x374"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x395",
+          "x396"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x394",
+          "x361",
+          "x371"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x397",
+          "x398"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x396",
+          "x363",
+          "x379"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x399",
+          "x400"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x398",
+          "x365",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x380"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x401",
+          "x402"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x400",
+          "x367",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x403",
+          "x404"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x402",
+          "x369",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x405",
+          "x406"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x381",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x407",
+          "x408"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x381",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x409",
+          "x410"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x381",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x411",
+          "x412"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x381",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x413",
+          "x414"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x381",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x415",
+          "x416"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x381",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x417",
+          "x418"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x381",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x419",
+          "x420"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x381",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x421",
+          "x422"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x381",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x423",
+          "x424"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x381",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x425",
+          "x426"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x422",
+          "x419"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x427",
+          "x428"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x426",
+          "x420",
+          "x417"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x429",
+          "x430"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x428",
+          "x418",
+          "x415"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x431",
+          "x432"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x430",
+          "x416",
+          "x413"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x433",
+          "x434"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x432",
+          "x414",
+          "x411"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x435",
+          "x436"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x434",
+          "x412",
+          "x409"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x437",
+          "x438"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x436",
+          "x410",
+          "x407"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x439",
+          "x440"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x438",
+          "x408",
+          "x405"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x442"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x381",
+          "x423"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x443",
+          "x444"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x442",
+          "x383",
+          "x424"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x445",
+          "x446"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x444",
+          "x385",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x447",
+          "x448"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x446",
+          "x387",
+          "x421"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x449",
+          "x450"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x448",
+          "x389",
+          "x425"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x451",
+          "x452"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x450",
+          "x391",
+          "x427"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x453",
+          "x454"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x452",
+          "x393",
+          "x429"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x455",
+          "x456"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x454",
+          "x395",
+          "x431"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x457",
+          "x458"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x456",
+          "x397",
+          "x433"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x459",
+          "x460"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x458",
+          "x399",
+          "x435"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x461",
+          "x462"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x460",
+          "x401",
+          "x437"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x463",
+          "x464"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x462",
+          "x403",
+          "x439"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x465",
+          "x466"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x464",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x404"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x370"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x440"
+                ]
+              },
+              "x406"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x467",
+          "x468"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x469",
+          "x470"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x471",
+          "x472"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x473",
+          "x474"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x475",
+          "x476"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x468"
+                ]
+              }
+            ]
+          },
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x477",
+          "x478"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x443",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x479",
+          "x480"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x478",
+          "x445",
+          "x473"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x481",
+          "x482"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x480",
+          "x447",
+          "x474"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x483",
+          "x484"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x482",
+          "x449",
+          "x471"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x485",
+          "x486"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x484",
+          "x451",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x472"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x487",
+          "x488"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x486",
+          "x453",
+          "x469"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x489",
+          "x490"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x488",
+          "x455",
+          "x470"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x491",
+          "x492"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x490",
+          "x457",
+          "x467"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x493",
+          "x494"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x492",
+          "x459",
+          "x475"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x495",
+          "x496"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x494",
+          "x461",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x476"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x497",
+          "x498"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x496",
+          "x463",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x499",
+          "x500"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x498",
+          "x465",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x501",
+          "x502"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x477",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x503",
+          "x504"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x477",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x505",
+          "x506"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x477",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x507",
+          "x508"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x477",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x509",
+          "x510"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x477",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x511",
+          "x512"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x477",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x513",
+          "x514"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x477",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x515",
+          "x516"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x477",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x517",
+          "x518"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x477",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x519",
+          "x520"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x477",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x521",
+          "x522"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x518",
+          "x515"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x523",
+          "x524"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x522",
+          "x516",
+          "x513"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x525",
+          "x526"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x524",
+          "x514",
+          "x511"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x527",
+          "x528"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x526",
+          "x512",
+          "x509"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x529",
+          "x530"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x528",
+          "x510",
+          "x507"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x531",
+          "x532"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x530",
+          "x508",
+          "x505"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x533",
+          "x534"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x532",
+          "x506",
+          "x503"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x535",
+          "x536"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x534",
+          "x504",
+          "x501"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x538"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x477",
+          "x519"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x539",
+          "x540"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x538",
+          "x479",
+          "x520"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x541",
+          "x542"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x540",
+          "x481",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x543",
+          "x544"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x542",
+          "x483",
+          "x517"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x545",
+          "x546"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x544",
+          "x485",
+          "x521"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x547",
+          "x548"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x546",
+          "x487",
+          "x523"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x549",
+          "x550"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x548",
+          "x489",
+          "x525"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x551",
+          "x552"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x550",
+          "x491",
+          "x527"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x553",
+          "x554"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x552",
+          "x493",
+          "x529"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x555",
+          "x556"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x554",
+          "x495",
+          "x531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x557",
+          "x558"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x556",
+          "x497",
+          "x533"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x559",
+          "x560"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x558",
+          "x499",
+          "x535"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x561",
+          "x562"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x560",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x500"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x466"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x536"
+                ]
+              },
+              "x502"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x563",
+          "x564"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x565",
+          "x566"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x567",
+          "x568"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x569",
+          "x570"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x571",
+          "x572"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x564"
+                ]
+              }
+            ]
+          },
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x573",
+          "x574"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x539",
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x575",
+          "x576"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x574",
+          "x541",
+          "x569"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x577",
+          "x578"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x576",
+          "x543",
+          "x570"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x579",
+          "x580"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x578",
+          "x545",
+          "x567"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x581",
+          "x582"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x580",
+          "x547",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x568"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x583",
+          "x584"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x582",
+          "x549",
+          "x565"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x585",
+          "x586"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x584",
+          "x551",
+          "x566"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x587",
+          "x588"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x586",
+          "x553",
+          "x563"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x589",
+          "x590"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x588",
+          "x555",
+          "x571"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x591",
+          "x592"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x590",
+          "x557",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x572"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x593",
+          "x594"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x592",
+          "x559",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x595",
+          "x596"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x594",
+          "x561",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x597",
+          "x598"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x573",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x599",
+          "x600"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x573",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x601",
+          "x602"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x573",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x603",
+          "x604"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x573",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x605",
+          "x606"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x573",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x607",
+          "x608"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x573",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x609",
+          "x610"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x573",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x611",
+          "x612"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x573",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x613",
+          "x614"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x573",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x615",
+          "x616"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x573",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x617",
+          "x618"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x614",
+          "x611"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x619",
+          "x620"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x618",
+          "x612",
+          "x609"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x621",
+          "x622"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x620",
+          "x610",
+          "x607"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x623",
+          "x624"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x622",
+          "x608",
+          "x605"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x625",
+          "x626"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x624",
+          "x606",
+          "x603"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x627",
+          "x628"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x626",
+          "x604",
+          "x601"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x629",
+          "x630"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x628",
+          "x602",
+          "x599"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x631",
+          "x632"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x630",
+          "x600",
+          "x597"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x634"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x573",
+          "x615"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x635",
+          "x636"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x634",
+          "x575",
+          "x616"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x637",
+          "x638"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x636",
+          "x577",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x639",
+          "x640"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x638",
+          "x579",
+          "x613"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x641",
+          "x642"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x640",
+          "x581",
+          "x617"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x643",
+          "x644"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x642",
+          "x583",
+          "x619"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x645",
+          "x646"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x644",
+          "x585",
+          "x621"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x647",
+          "x648"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x646",
+          "x587",
+          "x623"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x649",
+          "x650"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x648",
+          "x589",
+          "x625"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x651",
+          "x652"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x650",
+          "x591",
+          "x627"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x653",
+          "x654"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x652",
+          "x593",
+          "x629"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x655",
+          "x656"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x654",
+          "x595",
+          "x631"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x657",
+          "x658"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x656",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x596"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x562"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x632"
+                ]
+              },
+              "x598"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x659",
+          "x660"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x661",
+          "x662"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x663",
+          "x664"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x665",
+          "x666"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x667",
+          "x668"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x660"
+                ]
+              }
+            ]
+          },
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x669",
+          "x670"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x635",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x671",
+          "x672"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x670",
+          "x637",
+          "x665"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x673",
+          "x674"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x672",
+          "x639",
+          "x666"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x675",
+          "x676"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x674",
+          "x641",
+          "x663"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x677",
+          "x678"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x676",
+          "x643",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x664"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x679",
+          "x680"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x678",
+          "x645",
+          "x661"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x681",
+          "x682"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x680",
+          "x647",
+          "x662"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x683",
+          "x684"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x682",
+          "x649",
+          "x659"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x685",
+          "x686"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x684",
+          "x651",
+          "x667"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x687",
+          "x688"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x686",
+          "x653",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x668"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x689",
+          "x690"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x688",
+          "x655",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x691",
+          "x692"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x690",
+          "x657",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x693",
+          "x694"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x669",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x695",
+          "x696"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x669",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x697",
+          "x698"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x669",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x699",
+          "x700"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x669",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x701",
+          "x702"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x669",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x703",
+          "x704"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x669",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x705",
+          "x706"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x669",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x707",
+          "x708"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x669",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x709",
+          "x710"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x669",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x711",
+          "x712"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x669",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x713",
+          "x714"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x710",
+          "x707"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x715",
+          "x716"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x714",
+          "x708",
+          "x705"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x717",
+          "x718"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x716",
+          "x706",
+          "x703"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x719",
+          "x720"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x718",
+          "x704",
+          "x701"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x721",
+          "x722"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x720",
+          "x702",
+          "x699"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x723",
+          "x724"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x722",
+          "x700",
+          "x697"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x725",
+          "x726"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x724",
+          "x698",
+          "x695"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x727",
+          "x728"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x726",
+          "x696",
+          "x693"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x730"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x669",
+          "x711"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x731",
+          "x732"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x730",
+          "x671",
+          "x712"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x733",
+          "x734"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x732",
+          "x673",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x735",
+          "x736"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x734",
+          "x675",
+          "x709"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x737",
+          "x738"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x736",
+          "x677",
+          "x713"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x739",
+          "x740"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x738",
+          "x679",
+          "x715"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x741",
+          "x742"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x740",
+          "x681",
+          "x717"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x743",
+          "x744"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x742",
+          "x683",
+          "x719"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x745",
+          "x746"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x744",
+          "x685",
+          "x721"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x747",
+          "x748"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x746",
+          "x687",
+          "x723"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x749",
+          "x750"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x748",
+          "x689",
+          "x725"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x751",
+          "x752"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x750",
+          "x691",
+          "x727"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x753",
+          "x754"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x752",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x692"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x658"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x728"
+                ]
+              },
+              "x694"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x755",
+          "x756"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x757",
+          "x758"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x759",
+          "x760"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x761",
+          "x762"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x763",
+          "x764"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x756"
+                ]
+              }
+            ]
+          },
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x765",
+          "x766"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x731",
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x767",
+          "x768"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x766",
+          "x733",
+          "x761"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x769",
+          "x770"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x768",
+          "x735",
+          "x762"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x771",
+          "x772"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x770",
+          "x737",
+          "x759"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x773",
+          "x774"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x772",
+          "x739",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x760"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x775",
+          "x776"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x774",
+          "x741",
+          "x757"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x777",
+          "x778"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x776",
+          "x743",
+          "x758"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x779",
+          "x780"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x778",
+          "x745",
+          "x755"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x781",
+          "x782"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x780",
+          "x747",
+          "x763"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x783",
+          "x784"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x782",
+          "x749",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x764"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x785",
+          "x786"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x784",
+          "x751",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x787",
+          "x788"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x786",
+          "x753",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x789",
+          "x790"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x765",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x791",
+          "x792"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x765",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x793",
+          "x794"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x765",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x795",
+          "x796"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x765",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x797",
+          "x798"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x765",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x799",
+          "x800"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x765",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x801",
+          "x802"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x765",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x803",
+          "x804"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x765",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x805",
+          "x806"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x765",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x807",
+          "x808"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x765",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x809",
+          "x810"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x806",
+          "x803"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x811",
+          "x812"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x810",
+          "x804",
+          "x801"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x813",
+          "x814"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x812",
+          "x802",
+          "x799"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x815",
+          "x816"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x814",
+          "x800",
+          "x797"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x817",
+          "x818"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x816",
+          "x798",
+          "x795"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x819",
+          "x820"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x818",
+          "x796",
+          "x793"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x821",
+          "x822"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x820",
+          "x794",
+          "x791"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x823",
+          "x824"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x822",
+          "x792",
+          "x789"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x826"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x765",
+          "x807"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x827",
+          "x828"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x826",
+          "x767",
+          "x808"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x829",
+          "x830"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x828",
+          "x769",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x831",
+          "x832"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x830",
+          "x771",
+          "x805"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x833",
+          "x834"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x832",
+          "x773",
+          "x809"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x835",
+          "x836"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x834",
+          "x775",
+          "x811"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x837",
+          "x838"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x836",
+          "x777",
+          "x813"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x839",
+          "x840"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x838",
+          "x779",
+          "x815"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x841",
+          "x842"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x840",
+          "x781",
+          "x817"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x843",
+          "x844"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x842",
+          "x783",
+          "x819"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x845",
+          "x846"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x844",
+          "x785",
+          "x821"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x847",
+          "x848"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x846",
+          "x787",
+          "x823"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x849",
+          "x850"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x848",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x788"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x754"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x824"
+                ]
+              },
+              "x790"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x851",
+          "x852"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x853",
+          "x854"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x855",
+          "x856"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x857",
+          "x858"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x859",
+          "x860"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x852"
+                ]
+              }
+            ]
+          },
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x861",
+          "x862"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x827",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x863",
+          "x864"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x862",
+          "x829",
+          "x857"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x865",
+          "x866"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x864",
+          "x831",
+          "x858"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x867",
+          "x868"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x866",
+          "x833",
+          "x855"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x869",
+          "x870"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x868",
+          "x835",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x856"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x871",
+          "x872"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x870",
+          "x837",
+          "x853"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x873",
+          "x874"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x872",
+          "x839",
+          "x854"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x875",
+          "x876"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x874",
+          "x841",
+          "x851"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x877",
+          "x878"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x876",
+          "x843",
+          "x859"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x879",
+          "x880"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x878",
+          "x845",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x860"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x881",
+          "x882"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x880",
+          "x847",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x883",
+          "x884"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x882",
+          "x849",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x885",
+          "x886"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x861",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x887",
+          "x888"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x861",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x889",
+          "x890"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x861",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x891",
+          "x892"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x861",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x893",
+          "x894"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x861",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x895",
+          "x896"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x861",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x897",
+          "x898"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x861",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x899",
+          "x900"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x861",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x901",
+          "x902"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x861",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x903",
+          "x904"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x861",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x905",
+          "x906"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x902",
+          "x899"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x907",
+          "x908"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x906",
+          "x900",
+          "x897"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x909",
+          "x910"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x908",
+          "x898",
+          "x895"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x911",
+          "x912"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x910",
+          "x896",
+          "x893"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x913",
+          "x914"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x912",
+          "x894",
+          "x891"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x915",
+          "x916"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x914",
+          "x892",
+          "x889"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x917",
+          "x918"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x916",
+          "x890",
+          "x887"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x919",
+          "x920"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x918",
+          "x888",
+          "x885"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x922"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x861",
+          "x903"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x923",
+          "x924"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x922",
+          "x863",
+          "x904"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x925",
+          "x926"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x924",
+          "x865",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x927",
+          "x928"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x926",
+          "x867",
+          "x901"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x929",
+          "x930"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x928",
+          "x869",
+          "x905"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x931",
+          "x932"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x930",
+          "x871",
+          "x907"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x933",
+          "x934"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x932",
+          "x873",
+          "x909"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x935",
+          "x936"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x934",
+          "x875",
+          "x911"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x937",
+          "x938"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x936",
+          "x877",
+          "x913"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x939",
+          "x940"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x938",
+          "x879",
+          "x915"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x941",
+          "x942"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x940",
+          "x881",
+          "x917"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x943",
+          "x944"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x942",
+          "x883",
+          "x919"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x945",
+          "x946"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x944",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x884"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x850"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x920"
+                ]
+              },
+              "x886"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x947",
+          "x948"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x949",
+          "x950"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x951",
+          "x952"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x953",
+          "x954"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x10",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x955",
+          "x956"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x948"
+                ]
+              }
+            ]
+          },
+          "x10"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x957",
+          "x958"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x923",
+          "x10"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x959",
+          "x960"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x958",
+          "x925",
+          "x953"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x961",
+          "x962"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x960",
+          "x927",
+          "x954"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x963",
+          "x964"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x962",
+          "x929",
+          "x951"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x965",
+          "x966"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x964",
+          "x931",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x952"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x967",
+          "x968"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x966",
+          "x933",
+          "x949"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x969",
+          "x970"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x968",
+          "x935",
+          "x950"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x971",
+          "x972"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x970",
+          "x937",
+          "x947"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x973",
+          "x974"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x972",
+          "x939",
+          "x955"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x975",
+          "x976"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x974",
+          "x941",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x956"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x977",
+          "x978"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x976",
+          "x943",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x979",
+          "x980"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x978",
+          "x945",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x981",
+          "x982"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x957",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x983",
+          "x984"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x957",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x985",
+          "x986"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x957",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x987",
+          "x988"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x957",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x989",
+          "x990"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x957",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x991",
+          "x992"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x957",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x993",
+          "x994"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x957",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x995",
+          "x996"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x957",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x997",
+          "x998"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x957",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x999",
+          "x1000"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x957",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1001",
+          "x1002"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x998",
+          "x995"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1003",
+          "x1004"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1002",
+          "x996",
+          "x993"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1005",
+          "x1006"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1004",
+          "x994",
+          "x991"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1007",
+          "x1008"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1006",
+          "x992",
+          "x989"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1009",
+          "x1010"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1008",
+          "x990",
+          "x987"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1011",
+          "x1012"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1010",
+          "x988",
+          "x985"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1013",
+          "x1014"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1012",
+          "x986",
+          "x983"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1015",
+          "x1016"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1014",
+          "x984",
+          "x981"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x1018"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x957",
+          "x999"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1019",
+          "x1020"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1018",
+          "x959",
+          "x1000"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1021",
+          "x1022"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1020",
+          "x961",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1023",
+          "x1024"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1022",
+          "x963",
+          "x997"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1025",
+          "x1026"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1024",
+          "x965",
+          "x1001"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1027",
+          "x1028"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1026",
+          "x967",
+          "x1003"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1029",
+          "x1030"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1028",
+          "x969",
+          "x1005"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1031",
+          "x1032"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1030",
+          "x971",
+          "x1007"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1033",
+          "x1034"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1032",
+          "x973",
+          "x1009"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1035",
+          "x1036"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1034",
+          "x975",
+          "x1011"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1037",
+          "x1038"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1036",
+          "x977",
+          "x1013"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1039",
+          "x1040"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1038",
+          "x979",
+          "x1015"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1041",
+          "x1042"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1040",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x980"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x946"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x1016"
+                ]
+              },
+              "x982"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1043",
+          "x1044"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1045",
+          "x1046"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1047",
+          "x1048"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1049",
+          "x1050"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1051",
+          "x1052"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x1044"
+                ]
+              }
+            ]
+          },
+          "x11"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1053",
+          "x1054"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1019",
+          "x11"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1055",
+          "x1056"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1054",
+          "x1021",
+          "x1049"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1057",
+          "x1058"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1056",
+          "x1023",
+          "x1050"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1059",
+          "x1060"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1058",
+          "x1025",
+          "x1047"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1061",
+          "x1062"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1060",
+          "x1027",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x1048"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1063",
+          "x1064"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1062",
+          "x1029",
+          "x1045"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1065",
+          "x1066"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1064",
+          "x1031",
+          "x1046"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1067",
+          "x1068"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1066",
+          "x1033",
+          "x1043"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1069",
+          "x1070"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1068",
+          "x1035",
+          "x1051"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1071",
+          "x1072"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1070",
+          "x1037",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1052"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1073",
+          "x1074"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1072",
+          "x1039",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1075",
+          "x1076"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1074",
+          "x1041",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1077",
+          "x1078"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1053",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1079",
+          "x1080"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1053",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1081",
+          "x1082"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1053",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1083",
+          "x1084"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1053",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1085",
+          "x1086"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1053",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1087",
+          "x1088"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1053",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1089",
+          "x1090"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1053",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1091",
+          "x1092"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1053",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1093",
+          "x1094"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1053",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1095",
+          "x1096"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1053",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1097",
+          "x1098"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1094",
+          "x1091"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1099",
+          "x1100"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1098",
+          "x1092",
+          "x1089"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1101",
+          "x1102"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1100",
+          "x1090",
+          "x1087"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1103",
+          "x1104"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1102",
+          "x1088",
+          "x1085"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1105",
+          "x1106"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1104",
+          "x1086",
+          "x1083"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1107",
+          "x1108"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1106",
+          "x1084",
+          "x1081"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1109",
+          "x1110"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1108",
+          "x1082",
+          "x1079"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1111",
+          "x1112"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1110",
+          "x1080",
+          "x1077"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x1114"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1053",
+          "x1095"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1115",
+          "x1116"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1114",
+          "x1055",
+          "x1096"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1117",
+          "x1118"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1116",
+          "x1057",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1119",
+          "x1120"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1118",
+          "x1059",
+          "x1093"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1121",
+          "x1122"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1120",
+          "x1061",
+          "x1097"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1123",
+          "x1124"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1122",
+          "x1063",
+          "x1099"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1125",
+          "x1126"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1124",
+          "x1065",
+          "x1101"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1127",
+          "x1128"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1126",
+          "x1067",
+          "x1103"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1129",
+          "x1130"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1128",
+          "x1069",
+          "x1105"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1131",
+          "x1132"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1130",
+          "x1071",
+          "x1107"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1133",
+          "x1134"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1132",
+          "x1073",
+          "x1109"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1135",
+          "x1136"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1134",
+          "x1075",
+          "x1111"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1137",
+          "x1138"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x1136",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x1076"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x1042"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x1112"
+                ]
+              },
+              "x1078"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1139",
+          "x1140"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x1115",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1141",
+          "x1142"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1140",
+          "x1117",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1143",
+          "x1144"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1142",
+          "x1119",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1145",
+          "x1146"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1144",
+          "x1121",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1147",
+          "x1148"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1146",
+          "x1123",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1149",
+          "x1150"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1148",
+          "x1125",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1151",
+          "x1152"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1150",
+          "x1127",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1153",
+          "x1154"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1152",
+          "x1129",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1155",
+          "x1156"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1154",
+          "x1131",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1157",
+          "x1158"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1156",
+          "x1133",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1159",
+          "x1160"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1158",
+          "x1135",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1161",
+          "x1162"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1160",
+          "x1137",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x1164"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x1162",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1138"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1165"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1164",
+          "x1139",
+          "x1115"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1166"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1164",
+          "x1141",
+          "x1117"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1167"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1164",
+          "x1143",
+          "x1119"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1168"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1164",
+          "x1145",
+          "x1121"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1169"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1164",
+          "x1147",
+          "x1123"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1170"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1164",
+          "x1149",
+          "x1125"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1171"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1164",
+          "x1151",
+          "x1127"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1172"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1164",
+          "x1153",
+          "x1129"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1173"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1164",
+          "x1155",
+          "x1131"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1174"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1164",
+          "x1157",
+          "x1133"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1175"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1164",
+          "x1159",
+          "x1135"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x1176"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x1164",
+          "x1161",
+          "x1137"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1165"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1166"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1167"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1168"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1169"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1170"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1171"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1172"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1173"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1174"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1175"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1176"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_nonzero",
+    "arguments": [
+      {
+        "datatype": "u32[12]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "|",
+        "arguments": [
+          "arg1[0]",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "|",
+            "arguments": [
+              "arg1[1]",
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "|",
+                "arguments": [
+                  "arg1[2]",
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "|",
+                    "arguments": [
+                      "arg1[3]",
+                      {
+                        "datatype": "u32",
+                        "name": [],
+                        "operation": "|",
+                        "arguments": [
+                          "arg1[4]",
+                          {
+                            "datatype": "u32",
+                            "name": [],
+                            "operation": "|",
+                            "arguments": [
+                              "arg1[5]",
+                              {
+                                "datatype": "u32",
+                                "name": [],
+                                "operation": "|",
+                                "arguments": [
+                                  "arg1[6]",
+                                  {
+                                    "datatype": "u32",
+                                    "name": [],
+                                    "operation": "|",
+                                    "arguments": [
+                                      "arg1[7]",
+                                      {
+                                        "datatype": "u32",
+                                        "name": [],
+                                        "operation": "|",
+                                        "arguments": [
+                                          "arg1[8]",
+                                          {
+                                            "datatype": "u32",
+                                            "name": [],
+                                            "operation": "|",
+                                            "arguments": [
+                                              "arg1[9]",
+                                              {
+                                                "datatype": "u32",
+                                                "name": [],
+                                                "operation": "|",
+                                                "arguments": [
+                                                  "arg1[10]",
+                                                  "arg1[11]"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_selectznz",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[12]",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32[12]",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[12]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[0]",
+          "arg3[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[1]",
+          "arg3[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[2]",
+          "arg3[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[3]",
+          "arg3[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[4]",
+          "arg3[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[5]",
+          "arg3[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[6]",
+          "arg3[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[7]",
+          "arg3[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[8]",
+          "arg3[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[9]",
+          "arg3[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[10]",
+          "arg3[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[11]",
+          "arg3[11]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x10"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x11"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x12"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_to_bytes",
+    "arguments": [
+      {
+        "datatype": "u32[12]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u8[48]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x13"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x12",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x15"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x14",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x17"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x18"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x16",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x19"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x11"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x11",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x21"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x20"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x20",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x23"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x22"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x24"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x22",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x25"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x10"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x10",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x27"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x26"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x26",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x29"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x30"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x28",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x31"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x9",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x33"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x32"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x32",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x35"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x34"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x36"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x34",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x37"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x8",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x39"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x38",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x41"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x42"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x40",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x43"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x7"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x7",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x45"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x44"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x44",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x47"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x46"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x48"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x46",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x49"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x50"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x6",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x51"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x50"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x52"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x50",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x53"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x52"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x54"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x52",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x55"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x5"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x56"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x5",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x57"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x56"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x58"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x56",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x59"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x58"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x60"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x58",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x61"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x62"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x4",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x63"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x62"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x64"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x62",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x65"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x64"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x66"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x64",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x67"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x68"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x3",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x69"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x68"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x70"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x68",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x71"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x70"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x72"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x70",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x73"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x74"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x2",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x75"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x74"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x76"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x74",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x77"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x76"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x78"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x76",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x79"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x80"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x1",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x81"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x80"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x82"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x80",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x83"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x82"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x84"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x82",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x13"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x15"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x17"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x19"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x21"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x23"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x24"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x25"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x27"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x29"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x30"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x31"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x33"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x35"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x36"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[16]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x37"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[17]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x39"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[18]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x41"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[19]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x42"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[20]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x43"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[21]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x45"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[22]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x47"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[23]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x48"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[24]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x49"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[25]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x51"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[26]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x53"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[27]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x54"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[28]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x55"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[29]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x57"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[30]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x59"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[31]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x60"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[32]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x61"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[33]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x63"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[34]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x65"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[35]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x66"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[36]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x67"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[37]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x69"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[38]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x71"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[39]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x72"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[40]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x73"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[41]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x75"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[42]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x77"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[43]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x78"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[44]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x79"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[45]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x81"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[46]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x83"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[47]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x84"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_from_bytes",
+    "arguments": [
+      {
+        "datatype": "u8[48]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[12]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[47]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[46]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[45]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[44]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[43]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[42]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[41]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x8"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[40]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[39]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[38]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[37]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x12"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[36]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[35]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[34]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[33]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x16"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[32]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[31]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[30]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[29]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x20"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[28]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[27]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[26]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[25]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x24"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[24]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[23]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[22]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[21]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x28"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[20]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[19]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[18]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[17]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x32"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[16]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x36"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[12]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x40"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x43"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x44"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x45"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x47"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x48"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x49"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x47",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x48"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x50"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x46",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x51"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x45",
+          "x50"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x52"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x43",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x44"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x53"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x42",
+          "x52"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x54"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x41",
+          "x53"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x55"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x39",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x56"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x38",
+          "x55"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x57"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x37",
+          "x56"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x58"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x35",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x36"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x59"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x34",
+          "x58"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x60"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x33",
+          "x59"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x61"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x31",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x62"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x30",
+          "x61"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x63"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x29",
+          "x62"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x64"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x27",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x65"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x26",
+          "x64"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x66"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x25",
+          "x65"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x67"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x23",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x68"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x22",
+          "x67"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x69"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x21",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x70"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x19",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x20"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x71"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x18",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x72"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x17",
+          "x71"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x73"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x15",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x74"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x14",
+          "x73"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x75"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x13",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x76"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x11",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x77"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x10",
+          "x76"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x78"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x9",
+          "x77"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x79"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x7",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x80"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x6",
+          "x79"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x81"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x5",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x82"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x3",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x83"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x2",
+          "x82"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x84"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x1",
+          "x83"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x51"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x54"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x57"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x60"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x63"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x66"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x69"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x72"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x75"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x78"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x81"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x84"
+        ]
+      }
+    ]
+  }
+]

--- a/fiat-json/src/p384_64.json
+++ b/fiat-json/src/p384_64.json
@@ -1,0 +1,17119 @@
+[
+  {
+    "operation": "fiat_p384_addcarryx_u64",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u128",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              },
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "64"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_subborrowx_u64",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "i128",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "i128",
+            "name": [],
+            "operation": "-",
+            "arguments": [
+              {
+                "datatype": "i128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              },
+              {
+                "datatype": "i128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "i128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "i1",
+        "name": [
+          "x2"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "i1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "64"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_mulx_u64",
+    "arguments": [
+      {
+        "datatype": "u64",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u64",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u128",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "64"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_cmovznz_u64",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u1",
+        "name": [
+          "x1"
+        ],
+        "operation": "!",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "!",
+            "arguments": [
+              "arg1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "-",
+                "arguments": [
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "0x0"
+                    ]
+                  },
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x1"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "|",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "arg3"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "~",
+                "arguments": [
+                  "x2"
+                ]
+              },
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_mul",
+    "arguments": [
+      {
+        "datatype": "u64[6]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[6]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[6]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x18",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x20",
+          "x16",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x22",
+          "x14",
+          "x11"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25",
+          "x26"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x24",
+          "x12",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27",
+          "x28"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x26",
+          "x10",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          },
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x17",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x30",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34",
+          "x35"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x30",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36",
+          "x37"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x30",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38",
+          "x39"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x30",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40",
+          "x41"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x30",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42",
+          "x43"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x30",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44",
+          "x45"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x43",
+          "x40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46",
+          "x47"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x45",
+          "x41",
+          "x38"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48",
+          "x49"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x47",
+          "x39",
+          "x36"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50",
+          "x51"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x49",
+          "x37",
+          "x34"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52",
+          "x53"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x51",
+          "x35",
+          "x32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x53"
+            ]
+          },
+          "x33"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x56"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x17",
+          "x42"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57",
+          "x58"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x56",
+          "x19",
+          "x44"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59",
+          "x60"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x58",
+          "x21",
+          "x46"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61",
+          "x62"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x60",
+          "x23",
+          "x48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x63",
+          "x64"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x62",
+          "x25",
+          "x50"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x65",
+          "x66"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x64",
+          "x27",
+          "x52"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x67",
+          "x68"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x66",
+          "x29",
+          "x54"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x69",
+          "x70"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x71",
+          "x72"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x73",
+          "x74"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x75",
+          "x76"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x77",
+          "x78"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79",
+          "x80"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81",
+          "x82"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x80",
+          "x77"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83",
+          "x84"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x82",
+          "x78",
+          "x75"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x85",
+          "x86"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x84",
+          "x76",
+          "x73"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87",
+          "x88"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x86",
+          "x74",
+          "x71"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89",
+          "x90"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x88",
+          "x72",
+          "x69"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x91"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x90"
+            ]
+          },
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x57",
+          "x79"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x94",
+          "x95"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x93",
+          "x59",
+          "x81"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96",
+          "x97"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x95",
+          "x61",
+          "x83"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98",
+          "x99"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x97",
+          "x63",
+          "x85"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100",
+          "x101"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x99",
+          "x65",
+          "x87"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102",
+          "x103"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x101",
+          "x67",
+          "x89"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x104",
+          "x105"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x103",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x68"
+            ]
+          },
+          "x91"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x106",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x92",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x108",
+          "x109"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x106",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x110",
+          "x111"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x106",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x112",
+          "x113"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x106",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x114",
+          "x115"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x106",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x116",
+          "x117"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x106",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x118",
+          "x119"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x106",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x120",
+          "x121"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x119",
+          "x116"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x122",
+          "x123"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x121",
+          "x117",
+          "x114"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x124",
+          "x125"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x123",
+          "x115",
+          "x112"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x126",
+          "x127"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x125",
+          "x113",
+          "x110"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x128",
+          "x129"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x127",
+          "x111",
+          "x108"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x130"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x129"
+            ]
+          },
+          "x109"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x132"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x92",
+          "x118"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x133",
+          "x134"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x132",
+          "x94",
+          "x120"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x135",
+          "x136"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x134",
+          "x96",
+          "x122"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x137",
+          "x138"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x136",
+          "x98",
+          "x124"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x139",
+          "x140"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x138",
+          "x100",
+          "x126"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x141",
+          "x142"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x140",
+          "x102",
+          "x128"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x143",
+          "x144"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x142",
+          "x104",
+          "x130"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x145"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x144"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x105"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x146",
+          "x147"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x148",
+          "x149"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x150",
+          "x151"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x152",
+          "x153"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x154",
+          "x155"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x156",
+          "x157"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x158",
+          "x159"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x157",
+          "x154"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x160",
+          "x161"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x159",
+          "x155",
+          "x152"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x162",
+          "x163"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x161",
+          "x153",
+          "x150"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x164",
+          "x165"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x163",
+          "x151",
+          "x148"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x166",
+          "x167"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x165",
+          "x149",
+          "x146"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x168"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x167"
+            ]
+          },
+          "x147"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x169",
+          "x170"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x133",
+          "x156"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x171",
+          "x172"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x170",
+          "x135",
+          "x158"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x173",
+          "x174"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x172",
+          "x137",
+          "x160"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x175",
+          "x176"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x174",
+          "x139",
+          "x162"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x177",
+          "x178"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x176",
+          "x141",
+          "x164"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x179",
+          "x180"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x178",
+          "x143",
+          "x166"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x181",
+          "x182"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x180",
+          "x145",
+          "x168"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x183",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x169",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x185",
+          "x186"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x183",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x187",
+          "x188"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x183",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x189",
+          "x190"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x183",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x191",
+          "x192"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x183",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x193",
+          "x194"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x183",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x195",
+          "x196"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x183",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x197",
+          "x198"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x196",
+          "x193"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x199",
+          "x200"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x198",
+          "x194",
+          "x191"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x201",
+          "x202"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x200",
+          "x192",
+          "x189"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x203",
+          "x204"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x202",
+          "x190",
+          "x187"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x205",
+          "x206"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x204",
+          "x188",
+          "x185"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x207"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x206"
+            ]
+          },
+          "x186"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x209"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x169",
+          "x195"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x210",
+          "x211"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x209",
+          "x171",
+          "x197"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x212",
+          "x213"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x211",
+          "x173",
+          "x199"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x214",
+          "x215"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x213",
+          "x175",
+          "x201"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x216",
+          "x217"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x215",
+          "x177",
+          "x203"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x218",
+          "x219"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x217",
+          "x179",
+          "x205"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x220",
+          "x221"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x219",
+          "x181",
+          "x207"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x222"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x221"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x182"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x223",
+          "x224"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x225",
+          "x226"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x227",
+          "x228"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x229",
+          "x230"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x231",
+          "x232"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x233",
+          "x234"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x235",
+          "x236"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x234",
+          "x231"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x237",
+          "x238"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x236",
+          "x232",
+          "x229"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x239",
+          "x240"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x238",
+          "x230",
+          "x227"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x241",
+          "x242"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x240",
+          "x228",
+          "x225"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x243",
+          "x244"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x242",
+          "x226",
+          "x223"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x245"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x244"
+            ]
+          },
+          "x224"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x246",
+          "x247"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x210",
+          "x233"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x248",
+          "x249"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x247",
+          "x212",
+          "x235"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x250",
+          "x251"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x249",
+          "x214",
+          "x237"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x252",
+          "x253"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x251",
+          "x216",
+          "x239"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x254",
+          "x255"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x253",
+          "x218",
+          "x241"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x256",
+          "x257"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x255",
+          "x220",
+          "x243"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x258",
+          "x259"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x257",
+          "x222",
+          "x245"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x260",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x246",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x262",
+          "x263"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x260",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x264",
+          "x265"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x260",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x266",
+          "x267"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x260",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x268",
+          "x269"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x260",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x270",
+          "x271"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x260",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x272",
+          "x273"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x260",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x274",
+          "x275"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x273",
+          "x270"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x276",
+          "x277"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x275",
+          "x271",
+          "x268"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x278",
+          "x279"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x277",
+          "x269",
+          "x266"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x280",
+          "x281"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x279",
+          "x267",
+          "x264"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x282",
+          "x283"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x281",
+          "x265",
+          "x262"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x284"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x283"
+            ]
+          },
+          "x263"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x286"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x246",
+          "x272"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x287",
+          "x288"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x286",
+          "x248",
+          "x274"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x289",
+          "x290"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x288",
+          "x250",
+          "x276"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x291",
+          "x292"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x290",
+          "x252",
+          "x278"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x293",
+          "x294"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x292",
+          "x254",
+          "x280"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x295",
+          "x296"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x294",
+          "x256",
+          "x282"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x297",
+          "x298"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x296",
+          "x258",
+          "x284"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x299"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x298"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x259"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x300",
+          "x301"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x302",
+          "x303"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x304",
+          "x305"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x306",
+          "x307"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x308",
+          "x309"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x310",
+          "x311"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x312",
+          "x313"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x311",
+          "x308"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x314",
+          "x315"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x313",
+          "x309",
+          "x306"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x316",
+          "x317"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x315",
+          "x307",
+          "x304"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x318",
+          "x319"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x317",
+          "x305",
+          "x302"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x320",
+          "x321"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x319",
+          "x303",
+          "x300"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x322"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x321"
+            ]
+          },
+          "x301"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x323",
+          "x324"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x287",
+          "x310"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x325",
+          "x326"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x324",
+          "x289",
+          "x312"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x327",
+          "x328"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x326",
+          "x291",
+          "x314"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x329",
+          "x330"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x328",
+          "x293",
+          "x316"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x331",
+          "x332"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x330",
+          "x295",
+          "x318"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x333",
+          "x334"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x332",
+          "x297",
+          "x320"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x335",
+          "x336"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x334",
+          "x299",
+          "x322"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x337",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x323",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x339",
+          "x340"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x337",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x341",
+          "x342"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x337",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x343",
+          "x344"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x337",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x345",
+          "x346"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x337",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x347",
+          "x348"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x337",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x349",
+          "x350"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x337",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x351",
+          "x352"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x350",
+          "x347"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x353",
+          "x354"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x352",
+          "x348",
+          "x345"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x355",
+          "x356"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x354",
+          "x346",
+          "x343"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x357",
+          "x358"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x356",
+          "x344",
+          "x341"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x359",
+          "x360"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x358",
+          "x342",
+          "x339"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x361"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x360"
+            ]
+          },
+          "x340"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x363"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x323",
+          "x349"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x364",
+          "x365"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x363",
+          "x325",
+          "x351"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x366",
+          "x367"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x365",
+          "x327",
+          "x353"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x368",
+          "x369"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x367",
+          "x329",
+          "x355"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x370",
+          "x371"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x369",
+          "x331",
+          "x357"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x372",
+          "x373"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x371",
+          "x333",
+          "x359"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x374",
+          "x375"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x373",
+          "x335",
+          "x361"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x376"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x375"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x336"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x377",
+          "x378"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x379",
+          "x380"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x381",
+          "x382"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x383",
+          "x384"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x385",
+          "x386"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x387",
+          "x388"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x389",
+          "x390"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x388",
+          "x385"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x391",
+          "x392"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x390",
+          "x386",
+          "x383"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x393",
+          "x394"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x392",
+          "x384",
+          "x381"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x395",
+          "x396"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x394",
+          "x382",
+          "x379"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x397",
+          "x398"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x396",
+          "x380",
+          "x377"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x399"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x398"
+            ]
+          },
+          "x378"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x400",
+          "x401"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x364",
+          "x387"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x402",
+          "x403"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x401",
+          "x366",
+          "x389"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x404",
+          "x405"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x403",
+          "x368",
+          "x391"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x406",
+          "x407"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x405",
+          "x370",
+          "x393"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x408",
+          "x409"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x407",
+          "x372",
+          "x395"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x410",
+          "x411"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x409",
+          "x374",
+          "x397"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x412",
+          "x413"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x411",
+          "x376",
+          "x399"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x414",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x400",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x416",
+          "x417"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x414",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x418",
+          "x419"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x414",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x420",
+          "x421"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x414",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x422",
+          "x423"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x414",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x424",
+          "x425"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x414",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x426",
+          "x427"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x414",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x428",
+          "x429"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x427",
+          "x424"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x430",
+          "x431"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x429",
+          "x425",
+          "x422"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x432",
+          "x433"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x431",
+          "x423",
+          "x420"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x434",
+          "x435"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x433",
+          "x421",
+          "x418"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x436",
+          "x437"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x435",
+          "x419",
+          "x416"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x438"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x437"
+            ]
+          },
+          "x417"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x440"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x400",
+          "x426"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x441",
+          "x442"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x440",
+          "x402",
+          "x428"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x443",
+          "x444"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x442",
+          "x404",
+          "x430"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x445",
+          "x446"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x444",
+          "x406",
+          "x432"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x447",
+          "x448"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x446",
+          "x408",
+          "x434"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x449",
+          "x450"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x448",
+          "x410",
+          "x436"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x451",
+          "x452"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x450",
+          "x412",
+          "x438"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x453"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x452"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x413"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x454",
+          "x455"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x441",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x456",
+          "x457"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x455",
+          "x443",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x458",
+          "x459"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x457",
+          "x445",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x460",
+          "x461"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x459",
+          "x447",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x462",
+          "x463"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x461",
+          "x449",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x464",
+          "x465"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x463",
+          "x451",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x467"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x465",
+          "x453",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x468"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x467",
+          "x454",
+          "x441"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x469"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x467",
+          "x456",
+          "x443"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x470"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x467",
+          "x458",
+          "x445"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x471"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x467",
+          "x460",
+          "x447"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x472"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x467",
+          "x462",
+          "x449"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x473"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x467",
+          "x464",
+          "x451"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x468"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x469"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x470"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x471"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x472"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x473"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_square",
+    "arguments": [
+      {
+        "datatype": "u64[6]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[6]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x18",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x20",
+          "x16",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x22",
+          "x14",
+          "x11"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25",
+          "x26"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x24",
+          "x12",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27",
+          "x28"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x26",
+          "x10",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          },
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x17",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x30",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34",
+          "x35"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x30",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36",
+          "x37"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x30",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38",
+          "x39"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x30",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40",
+          "x41"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x30",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42",
+          "x43"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x30",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44",
+          "x45"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x43",
+          "x40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46",
+          "x47"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x45",
+          "x41",
+          "x38"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48",
+          "x49"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x47",
+          "x39",
+          "x36"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50",
+          "x51"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x49",
+          "x37",
+          "x34"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52",
+          "x53"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x51",
+          "x35",
+          "x32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x53"
+            ]
+          },
+          "x33"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x56"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x17",
+          "x42"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57",
+          "x58"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x56",
+          "x19",
+          "x44"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59",
+          "x60"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x58",
+          "x21",
+          "x46"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61",
+          "x62"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x60",
+          "x23",
+          "x48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x63",
+          "x64"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x62",
+          "x25",
+          "x50"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x65",
+          "x66"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x64",
+          "x27",
+          "x52"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x67",
+          "x68"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x66",
+          "x29",
+          "x54"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x69",
+          "x70"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x71",
+          "x72"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x73",
+          "x74"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x75",
+          "x76"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x77",
+          "x78"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79",
+          "x80"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81",
+          "x82"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x80",
+          "x77"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83",
+          "x84"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x82",
+          "x78",
+          "x75"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x85",
+          "x86"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x84",
+          "x76",
+          "x73"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87",
+          "x88"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x86",
+          "x74",
+          "x71"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89",
+          "x90"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x88",
+          "x72",
+          "x69"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x91"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x90"
+            ]
+          },
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x57",
+          "x79"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x94",
+          "x95"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x93",
+          "x59",
+          "x81"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96",
+          "x97"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x95",
+          "x61",
+          "x83"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98",
+          "x99"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x97",
+          "x63",
+          "x85"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100",
+          "x101"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x99",
+          "x65",
+          "x87"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102",
+          "x103"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x101",
+          "x67",
+          "x89"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x104",
+          "x105"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x103",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x68"
+            ]
+          },
+          "x91"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x106",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x92",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x108",
+          "x109"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x106",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x110",
+          "x111"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x106",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x112",
+          "x113"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x106",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x114",
+          "x115"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x106",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x116",
+          "x117"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x106",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x118",
+          "x119"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x106",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x120",
+          "x121"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x119",
+          "x116"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x122",
+          "x123"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x121",
+          "x117",
+          "x114"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x124",
+          "x125"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x123",
+          "x115",
+          "x112"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x126",
+          "x127"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x125",
+          "x113",
+          "x110"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x128",
+          "x129"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x127",
+          "x111",
+          "x108"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x130"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x129"
+            ]
+          },
+          "x109"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x132"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x92",
+          "x118"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x133",
+          "x134"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x132",
+          "x94",
+          "x120"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x135",
+          "x136"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x134",
+          "x96",
+          "x122"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x137",
+          "x138"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x136",
+          "x98",
+          "x124"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x139",
+          "x140"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x138",
+          "x100",
+          "x126"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x141",
+          "x142"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x140",
+          "x102",
+          "x128"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x143",
+          "x144"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x142",
+          "x104",
+          "x130"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x145"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x144"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x105"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x146",
+          "x147"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x148",
+          "x149"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x150",
+          "x151"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x152",
+          "x153"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x154",
+          "x155"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x156",
+          "x157"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x158",
+          "x159"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x157",
+          "x154"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x160",
+          "x161"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x159",
+          "x155",
+          "x152"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x162",
+          "x163"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x161",
+          "x153",
+          "x150"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x164",
+          "x165"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x163",
+          "x151",
+          "x148"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x166",
+          "x167"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x165",
+          "x149",
+          "x146"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x168"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x167"
+            ]
+          },
+          "x147"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x169",
+          "x170"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x133",
+          "x156"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x171",
+          "x172"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x170",
+          "x135",
+          "x158"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x173",
+          "x174"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x172",
+          "x137",
+          "x160"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x175",
+          "x176"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x174",
+          "x139",
+          "x162"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x177",
+          "x178"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x176",
+          "x141",
+          "x164"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x179",
+          "x180"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x178",
+          "x143",
+          "x166"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x181",
+          "x182"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x180",
+          "x145",
+          "x168"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x183",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x169",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x185",
+          "x186"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x183",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x187",
+          "x188"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x183",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x189",
+          "x190"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x183",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x191",
+          "x192"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x183",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x193",
+          "x194"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x183",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x195",
+          "x196"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x183",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x197",
+          "x198"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x196",
+          "x193"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x199",
+          "x200"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x198",
+          "x194",
+          "x191"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x201",
+          "x202"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x200",
+          "x192",
+          "x189"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x203",
+          "x204"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x202",
+          "x190",
+          "x187"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x205",
+          "x206"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x204",
+          "x188",
+          "x185"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x207"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x206"
+            ]
+          },
+          "x186"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x209"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x169",
+          "x195"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x210",
+          "x211"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x209",
+          "x171",
+          "x197"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x212",
+          "x213"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x211",
+          "x173",
+          "x199"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x214",
+          "x215"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x213",
+          "x175",
+          "x201"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x216",
+          "x217"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x215",
+          "x177",
+          "x203"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x218",
+          "x219"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x217",
+          "x179",
+          "x205"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x220",
+          "x221"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x219",
+          "x181",
+          "x207"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x222"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x221"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x182"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x223",
+          "x224"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x225",
+          "x226"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x227",
+          "x228"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x229",
+          "x230"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x231",
+          "x232"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x233",
+          "x234"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x235",
+          "x236"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x234",
+          "x231"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x237",
+          "x238"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x236",
+          "x232",
+          "x229"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x239",
+          "x240"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x238",
+          "x230",
+          "x227"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x241",
+          "x242"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x240",
+          "x228",
+          "x225"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x243",
+          "x244"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x242",
+          "x226",
+          "x223"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x245"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x244"
+            ]
+          },
+          "x224"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x246",
+          "x247"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x210",
+          "x233"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x248",
+          "x249"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x247",
+          "x212",
+          "x235"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x250",
+          "x251"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x249",
+          "x214",
+          "x237"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x252",
+          "x253"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x251",
+          "x216",
+          "x239"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x254",
+          "x255"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x253",
+          "x218",
+          "x241"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x256",
+          "x257"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x255",
+          "x220",
+          "x243"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x258",
+          "x259"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x257",
+          "x222",
+          "x245"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x260",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x246",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x262",
+          "x263"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x260",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x264",
+          "x265"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x260",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x266",
+          "x267"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x260",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x268",
+          "x269"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x260",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x270",
+          "x271"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x260",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x272",
+          "x273"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x260",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x274",
+          "x275"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x273",
+          "x270"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x276",
+          "x277"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x275",
+          "x271",
+          "x268"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x278",
+          "x279"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x277",
+          "x269",
+          "x266"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x280",
+          "x281"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x279",
+          "x267",
+          "x264"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x282",
+          "x283"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x281",
+          "x265",
+          "x262"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x284"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x283"
+            ]
+          },
+          "x263"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x286"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x246",
+          "x272"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x287",
+          "x288"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x286",
+          "x248",
+          "x274"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x289",
+          "x290"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x288",
+          "x250",
+          "x276"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x291",
+          "x292"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x290",
+          "x252",
+          "x278"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x293",
+          "x294"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x292",
+          "x254",
+          "x280"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x295",
+          "x296"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x294",
+          "x256",
+          "x282"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x297",
+          "x298"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x296",
+          "x258",
+          "x284"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x299"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x298"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x259"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x300",
+          "x301"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x302",
+          "x303"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x304",
+          "x305"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x306",
+          "x307"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x308",
+          "x309"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x310",
+          "x311"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x312",
+          "x313"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x311",
+          "x308"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x314",
+          "x315"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x313",
+          "x309",
+          "x306"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x316",
+          "x317"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x315",
+          "x307",
+          "x304"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x318",
+          "x319"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x317",
+          "x305",
+          "x302"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x320",
+          "x321"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x319",
+          "x303",
+          "x300"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x322"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x321"
+            ]
+          },
+          "x301"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x323",
+          "x324"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x287",
+          "x310"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x325",
+          "x326"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x324",
+          "x289",
+          "x312"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x327",
+          "x328"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x326",
+          "x291",
+          "x314"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x329",
+          "x330"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x328",
+          "x293",
+          "x316"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x331",
+          "x332"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x330",
+          "x295",
+          "x318"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x333",
+          "x334"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x332",
+          "x297",
+          "x320"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x335",
+          "x336"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x334",
+          "x299",
+          "x322"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x337",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x323",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x339",
+          "x340"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x337",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x341",
+          "x342"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x337",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x343",
+          "x344"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x337",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x345",
+          "x346"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x337",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x347",
+          "x348"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x337",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x349",
+          "x350"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x337",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x351",
+          "x352"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x350",
+          "x347"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x353",
+          "x354"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x352",
+          "x348",
+          "x345"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x355",
+          "x356"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x354",
+          "x346",
+          "x343"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x357",
+          "x358"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x356",
+          "x344",
+          "x341"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x359",
+          "x360"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x358",
+          "x342",
+          "x339"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x361"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x360"
+            ]
+          },
+          "x340"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x363"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x323",
+          "x349"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x364",
+          "x365"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x363",
+          "x325",
+          "x351"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x366",
+          "x367"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x365",
+          "x327",
+          "x353"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x368",
+          "x369"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x367",
+          "x329",
+          "x355"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x370",
+          "x371"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x369",
+          "x331",
+          "x357"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x372",
+          "x373"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x371",
+          "x333",
+          "x359"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x374",
+          "x375"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x373",
+          "x335",
+          "x361"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x376"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x375"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x336"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x377",
+          "x378"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x379",
+          "x380"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x381",
+          "x382"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x383",
+          "x384"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x385",
+          "x386"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x387",
+          "x388"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x389",
+          "x390"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x388",
+          "x385"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x391",
+          "x392"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x390",
+          "x386",
+          "x383"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x393",
+          "x394"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x392",
+          "x384",
+          "x381"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x395",
+          "x396"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x394",
+          "x382",
+          "x379"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x397",
+          "x398"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x396",
+          "x380",
+          "x377"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x399"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x398"
+            ]
+          },
+          "x378"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x400",
+          "x401"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x364",
+          "x387"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x402",
+          "x403"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x401",
+          "x366",
+          "x389"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x404",
+          "x405"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x403",
+          "x368",
+          "x391"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x406",
+          "x407"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x405",
+          "x370",
+          "x393"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x408",
+          "x409"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x407",
+          "x372",
+          "x395"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x410",
+          "x411"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x409",
+          "x374",
+          "x397"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x412",
+          "x413"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x411",
+          "x376",
+          "x399"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x414",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x400",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x416",
+          "x417"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x414",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x418",
+          "x419"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x414",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x420",
+          "x421"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x414",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x422",
+          "x423"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x414",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x424",
+          "x425"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x414",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x426",
+          "x427"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x414",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x428",
+          "x429"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x427",
+          "x424"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x430",
+          "x431"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x429",
+          "x425",
+          "x422"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x432",
+          "x433"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x431",
+          "x423",
+          "x420"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x434",
+          "x435"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x433",
+          "x421",
+          "x418"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x436",
+          "x437"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x435",
+          "x419",
+          "x416"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x438"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x437"
+            ]
+          },
+          "x417"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x440"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x400",
+          "x426"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x441",
+          "x442"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x440",
+          "x402",
+          "x428"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x443",
+          "x444"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x442",
+          "x404",
+          "x430"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x445",
+          "x446"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x444",
+          "x406",
+          "x432"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x447",
+          "x448"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x446",
+          "x408",
+          "x434"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x449",
+          "x450"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x448",
+          "x410",
+          "x436"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x451",
+          "x452"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x450",
+          "x412",
+          "x438"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x453"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x452"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x413"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x454",
+          "x455"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x441",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x456",
+          "x457"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x455",
+          "x443",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x458",
+          "x459"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x457",
+          "x445",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x460",
+          "x461"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x459",
+          "x447",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x462",
+          "x463"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x461",
+          "x449",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x464",
+          "x465"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x463",
+          "x451",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x467"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x465",
+          "x453",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x468"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x467",
+          "x454",
+          "x441"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x469"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x467",
+          "x456",
+          "x443"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x470"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x467",
+          "x458",
+          "x445"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x471"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x467",
+          "x460",
+          "x447"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x472"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x467",
+          "x462",
+          "x449"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x473"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x467",
+          "x464",
+          "x451"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x468"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x469"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x470"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x471"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x472"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x473"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_add",
+    "arguments": [
+      {
+        "datatype": "u64[6]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[6]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[6]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x8",
+          "arg1[4]",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x10",
+          "arg1[5]",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x14",
+          "x3",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x16",
+          "x5",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x18",
+          "x7",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x20",
+          "x9",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x22",
+          "x11",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x26"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x24",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x26",
+          "x13",
+          "x1"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x26",
+          "x15",
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x26",
+          "x17",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x26",
+          "x19",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x26",
+          "x21",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x26",
+          "x23",
+          "x11"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x27"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x28"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x29"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x30"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x31"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x32"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_sub",
+    "arguments": [
+      {
+        "datatype": "u64[6]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[6]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[6]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x8",
+          "arg1[4]",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x10",
+          "arg1[5]",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x12",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x13",
+              "0xffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x15",
+          "x3",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x13",
+              "0xffffffff00000000"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x17",
+          "x5",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x13",
+              "0xfffffffffffffffe"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x19",
+          "x7",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x21",
+          "x9",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x11",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x14"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x22"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x24"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_opp",
+    "arguments": [
+      {
+        "datatype": "u64[6]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[6]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x8",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x10",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x12",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x13",
+              "0xffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x15",
+          "x3",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x13",
+              "0xffffffff00000000"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x17",
+          "x5",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x13",
+              "0xfffffffffffffffe"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x19",
+          "x7",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x21",
+          "x9",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x11",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x14"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x22"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x24"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_from_montgomery",
+    "arguments": [
+      {
+        "datatype": "u64[6]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[6]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4",
+          "x5"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6",
+          "x7"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8",
+          "x9"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x15",
+          "x12"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x17",
+          "x13",
+          "x10"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x19",
+          "x11",
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x21",
+          "x9",
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x7",
+          "x4"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "x14"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x18"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x20"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34",
+          "x35"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x33",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x22"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36",
+          "x37"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x35",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38",
+          "x39"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x37",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x25"
+                ]
+              },
+              "x5"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40",
+          "x41"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x28",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42",
+          "x43"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x41",
+          "x30",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44",
+          "x45"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x43",
+          "x32",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46",
+          "x47"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x45",
+          "x34",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48",
+          "x49"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x47",
+          "x36",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50",
+          "x51"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x49",
+          "x38",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54",
+          "x55"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x52",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56",
+          "x57"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x52",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58",
+          "x59"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x52",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x52",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x52",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x52",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x65",
+          "x62"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x67",
+          "x63",
+          "x60"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x69",
+          "x61",
+          "x58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72",
+          "x73"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x71",
+          "x59",
+          "x56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x73",
+          "x57",
+          "x54"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x77"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x40",
+          "x64"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78",
+          "x79"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x77",
+          "x42",
+          "x66"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x80",
+          "x81"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x79",
+          "x44",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x82",
+          "x83"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x81",
+          "x46",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84",
+          "x85"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x83",
+          "x48",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x86",
+          "x87"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x85",
+          "x50",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88",
+          "x89"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x87",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x51"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x39"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x75"
+                ]
+              },
+              "x55"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90",
+          "x91"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x78",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x91",
+          "x80",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x94",
+          "x95"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x93",
+          "x82",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96",
+          "x97"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x95",
+          "x84",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98",
+          "x99"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x97",
+          "x86",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100",
+          "x101"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x99",
+          "x88",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x90",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x104",
+          "x105"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x102",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x106",
+          "x107"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x102",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x108",
+          "x109"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x102",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x110",
+          "x111"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x102",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x112",
+          "x113"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x102",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x114",
+          "x115"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x102",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x116",
+          "x117"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x115",
+          "x112"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x118",
+          "x119"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x117",
+          "x113",
+          "x110"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x120",
+          "x121"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x119",
+          "x111",
+          "x108"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x122",
+          "x123"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x121",
+          "x109",
+          "x106"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x124",
+          "x125"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x123",
+          "x107",
+          "x104"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x127"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x90",
+          "x114"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x128",
+          "x129"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x127",
+          "x92",
+          "x116"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x130",
+          "x131"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x129",
+          "x94",
+          "x118"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x132",
+          "x133"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x131",
+          "x96",
+          "x120"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x134",
+          "x135"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x133",
+          "x98",
+          "x122"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x136",
+          "x137"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x135",
+          "x100",
+          "x124"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x138",
+          "x139"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x137",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x101"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x89"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x125"
+                ]
+              },
+              "x105"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x140",
+          "x141"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x128",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x142",
+          "x143"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x141",
+          "x130",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x144",
+          "x145"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x143",
+          "x132",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x146",
+          "x147"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x145",
+          "x134",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x148",
+          "x149"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x147",
+          "x136",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x150",
+          "x151"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x149",
+          "x138",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x152",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x140",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x154",
+          "x155"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x152",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x156",
+          "x157"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x152",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x158",
+          "x159"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x152",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x160",
+          "x161"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x152",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x162",
+          "x163"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x152",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x164",
+          "x165"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x152",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x166",
+          "x167"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x165",
+          "x162"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x168",
+          "x169"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x167",
+          "x163",
+          "x160"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x170",
+          "x171"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x169",
+          "x161",
+          "x158"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x172",
+          "x173"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x171",
+          "x159",
+          "x156"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x174",
+          "x175"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x173",
+          "x157",
+          "x154"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x177"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x140",
+          "x164"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x178",
+          "x179"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x177",
+          "x142",
+          "x166"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x180",
+          "x181"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x179",
+          "x144",
+          "x168"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x182",
+          "x183"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x181",
+          "x146",
+          "x170"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x184",
+          "x185"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x183",
+          "x148",
+          "x172"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x186",
+          "x187"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x185",
+          "x150",
+          "x174"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x188",
+          "x189"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x187",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x151"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x139"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x175"
+                ]
+              },
+              "x155"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x190",
+          "x191"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x178",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x192",
+          "x193"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x191",
+          "x180",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x194",
+          "x195"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x193",
+          "x182",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x196",
+          "x197"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x195",
+          "x184",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x198",
+          "x199"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x197",
+          "x186",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x200",
+          "x201"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x199",
+          "x188",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x202",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x190",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x204",
+          "x205"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x202",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x206",
+          "x207"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x202",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x208",
+          "x209"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x202",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x210",
+          "x211"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x202",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x212",
+          "x213"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x202",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x214",
+          "x215"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x202",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x216",
+          "x217"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x215",
+          "x212"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x218",
+          "x219"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x217",
+          "x213",
+          "x210"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x220",
+          "x221"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x219",
+          "x211",
+          "x208"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x222",
+          "x223"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x221",
+          "x209",
+          "x206"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x224",
+          "x225"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x223",
+          "x207",
+          "x204"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x227"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x190",
+          "x214"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x228",
+          "x229"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x227",
+          "x192",
+          "x216"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x230",
+          "x231"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x229",
+          "x194",
+          "x218"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x232",
+          "x233"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x231",
+          "x196",
+          "x220"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x234",
+          "x235"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x233",
+          "x198",
+          "x222"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x236",
+          "x237"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x235",
+          "x200",
+          "x224"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x238",
+          "x239"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x237",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x201"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x189"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x225"
+                ]
+              },
+              "x205"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x240",
+          "x241"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x228",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x242",
+          "x243"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x241",
+          "x230",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x244",
+          "x245"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x243",
+          "x232",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x246",
+          "x247"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x245",
+          "x234",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x248",
+          "x249"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x247",
+          "x236",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x250",
+          "x251"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x249",
+          "x238",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x252",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x240",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x254",
+          "x255"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x252",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x256",
+          "x257"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x252",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x258",
+          "x259"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x252",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x260",
+          "x261"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x252",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x262",
+          "x263"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x252",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x264",
+          "x265"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x252",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x266",
+          "x267"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x265",
+          "x262"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x268",
+          "x269"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x267",
+          "x263",
+          "x260"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x270",
+          "x271"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x269",
+          "x261",
+          "x258"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x272",
+          "x273"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x271",
+          "x259",
+          "x256"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x274",
+          "x275"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x273",
+          "x257",
+          "x254"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x277"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x240",
+          "x264"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x278",
+          "x279"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x277",
+          "x242",
+          "x266"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x280",
+          "x281"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x279",
+          "x244",
+          "x268"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x282",
+          "x283"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x281",
+          "x246",
+          "x270"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x284",
+          "x285"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x283",
+          "x248",
+          "x272"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x286",
+          "x287"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x285",
+          "x250",
+          "x274"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x288",
+          "x289"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x287",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x251"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x239"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x275"
+                ]
+              },
+              "x255"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x290",
+          "x291"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x278",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x292",
+          "x293"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x291",
+          "x280",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x294",
+          "x295"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x293",
+          "x282",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x296",
+          "x297"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x295",
+          "x284",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x298",
+          "x299"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x297",
+          "x286",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x300",
+          "x301"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x299",
+          "x288",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x303"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x301",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x289"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x304"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x303",
+          "x290",
+          "x278"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x305"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x303",
+          "x292",
+          "x280"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x306"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x303",
+          "x294",
+          "x282"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x307"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x303",
+          "x296",
+          "x284"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x308"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x303",
+          "x298",
+          "x286"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x309"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x303",
+          "x300",
+          "x288"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x304"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x305"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x306"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x307"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x308"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x309"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_to_montgomery",
+    "arguments": [
+      {
+        "datatype": "u64[6]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[6]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0x200000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0xfffffffe00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0x200000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0xfffffffe00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x14",
+          "x11"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x16",
+          "x12",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x18",
+          "x10",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x20",
+          "x8",
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x13",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25",
+          "x26"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x23",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27",
+          "x28"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x23",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29",
+          "x30"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x23",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31",
+          "x32"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x23",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33",
+          "x34"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x23",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35",
+          "x36"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x23",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x36",
+          "x33"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39",
+          "x40"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x38",
+          "x34",
+          "x31"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41",
+          "x42"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x40",
+          "x32",
+          "x29"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43",
+          "x44"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x42",
+          "x30",
+          "x27"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45",
+          "x46"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x44",
+          "x28",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x48"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x13",
+          "x35"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49",
+          "x50"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x48",
+          "x15",
+          "x37"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51",
+          "x52"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x50",
+          "x17",
+          "x39"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53",
+          "x54"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x52",
+          "x19",
+          "x41"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55",
+          "x56"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x54",
+          "x21",
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57",
+          "x58"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x56",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x22"
+            ]
+          },
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59",
+          "x60"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x58",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x46"
+                ]
+              },
+              "x26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61",
+          "x62"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0x200000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x63",
+          "x64"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xfffffffe00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x65",
+          "x66"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0x200000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x67",
+          "x68"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xfffffffe00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x69",
+          "x70"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x68",
+          "x65"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x71",
+          "x72"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x70",
+          "x66",
+          "x63"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x73",
+          "x74"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x72",
+          "x64",
+          "x61"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x75",
+          "x76"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x74",
+          "x62",
+          "x1"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x77",
+          "x78"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x49",
+          "x67"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79",
+          "x80"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x78",
+          "x51",
+          "x69"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81",
+          "x82"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x80",
+          "x53",
+          "x71"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83",
+          "x84"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x82",
+          "x55",
+          "x73"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x85",
+          "x86"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x84",
+          "x57",
+          "x75"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87",
+          "x88"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x86",
+          "x59",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x76"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x77",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x91",
+          "x92"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x89",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x93",
+          "x94"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x89",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x95",
+          "x96"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x89",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x97",
+          "x98"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x89",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x99",
+          "x100"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x89",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x101",
+          "x102"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x89",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x103",
+          "x104"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x102",
+          "x99"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x105",
+          "x106"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x104",
+          "x100",
+          "x97"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x107",
+          "x108"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x106",
+          "x98",
+          "x95"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x109",
+          "x110"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x108",
+          "x96",
+          "x93"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x111",
+          "x112"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x110",
+          "x94",
+          "x91"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x114"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x77",
+          "x101"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x115",
+          "x116"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x114",
+          "x79",
+          "x103"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x117",
+          "x118"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x116",
+          "x81",
+          "x105"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x119",
+          "x120"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x118",
+          "x83",
+          "x107"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x121",
+          "x122"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x120",
+          "x85",
+          "x109"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x123",
+          "x124"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x122",
+          "x87",
+          "x111"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x125",
+          "x126"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x124",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x88"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x60"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x112"
+                ]
+              },
+              "x92"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x127",
+          "x128"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0x200000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x129",
+          "x130"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xfffffffe00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x131",
+          "x132"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0x200000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x133",
+          "x134"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xfffffffe00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x135",
+          "x136"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x134",
+          "x131"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x137",
+          "x138"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x136",
+          "x132",
+          "x129"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x139",
+          "x140"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x138",
+          "x130",
+          "x127"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x141",
+          "x142"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x140",
+          "x128",
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x143",
+          "x144"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x115",
+          "x133"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x145",
+          "x146"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x144",
+          "x117",
+          "x135"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x147",
+          "x148"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x146",
+          "x119",
+          "x137"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x149",
+          "x150"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x148",
+          "x121",
+          "x139"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x151",
+          "x152"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x150",
+          "x123",
+          "x141"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x153",
+          "x154"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x152",
+          "x125",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x142"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x155",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x143",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x157",
+          "x158"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x155",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x159",
+          "x160"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x155",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x161",
+          "x162"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x155",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x163",
+          "x164"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x155",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x165",
+          "x166"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x155",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x167",
+          "x168"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x155",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x169",
+          "x170"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x168",
+          "x165"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x171",
+          "x172"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x170",
+          "x166",
+          "x163"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x173",
+          "x174"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x172",
+          "x164",
+          "x161"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x175",
+          "x176"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x174",
+          "x162",
+          "x159"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x177",
+          "x178"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x176",
+          "x160",
+          "x157"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x180"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x143",
+          "x167"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x181",
+          "x182"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x180",
+          "x145",
+          "x169"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x183",
+          "x184"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x182",
+          "x147",
+          "x171"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x185",
+          "x186"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x184",
+          "x149",
+          "x173"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x187",
+          "x188"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x186",
+          "x151",
+          "x175"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x189",
+          "x190"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x188",
+          "x153",
+          "x177"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x191",
+          "x192"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x190",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x154"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x126"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x178"
+                ]
+              },
+              "x158"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x193",
+          "x194"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0x200000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x195",
+          "x196"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xfffffffe00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x197",
+          "x198"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0x200000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x199",
+          "x200"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xfffffffe00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x201",
+          "x202"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x200",
+          "x197"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x203",
+          "x204"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x202",
+          "x198",
+          "x195"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x205",
+          "x206"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x204",
+          "x196",
+          "x193"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x207",
+          "x208"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x206",
+          "x194",
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x209",
+          "x210"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x181",
+          "x199"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x211",
+          "x212"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x210",
+          "x183",
+          "x201"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x213",
+          "x214"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x212",
+          "x185",
+          "x203"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x215",
+          "x216"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x214",
+          "x187",
+          "x205"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x217",
+          "x218"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x216",
+          "x189",
+          "x207"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x219",
+          "x220"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x218",
+          "x191",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x208"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x221",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x209",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x223",
+          "x224"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x221",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x225",
+          "x226"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x221",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x227",
+          "x228"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x221",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x229",
+          "x230"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x221",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x231",
+          "x232"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x221",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x233",
+          "x234"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x221",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x235",
+          "x236"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x234",
+          "x231"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x237",
+          "x238"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x236",
+          "x232",
+          "x229"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x239",
+          "x240"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x238",
+          "x230",
+          "x227"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x241",
+          "x242"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x240",
+          "x228",
+          "x225"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x243",
+          "x244"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x242",
+          "x226",
+          "x223"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x246"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x209",
+          "x233"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x247",
+          "x248"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x246",
+          "x211",
+          "x235"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x249",
+          "x250"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x248",
+          "x213",
+          "x237"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x251",
+          "x252"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x250",
+          "x215",
+          "x239"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x253",
+          "x254"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x252",
+          "x217",
+          "x241"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x255",
+          "x256"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x254",
+          "x219",
+          "x243"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x257",
+          "x258"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x256",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x220"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x192"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x244"
+                ]
+              },
+              "x224"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x259",
+          "x260"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0x200000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x261",
+          "x262"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xfffffffe00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x263",
+          "x264"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0x200000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x265",
+          "x266"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xfffffffe00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x267",
+          "x268"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x266",
+          "x263"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x269",
+          "x270"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x268",
+          "x264",
+          "x261"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x271",
+          "x272"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x270",
+          "x262",
+          "x259"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x273",
+          "x274"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x272",
+          "x260",
+          "x4"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x275",
+          "x276"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x247",
+          "x265"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x277",
+          "x278"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x276",
+          "x249",
+          "x267"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x279",
+          "x280"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x278",
+          "x251",
+          "x269"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x281",
+          "x282"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x280",
+          "x253",
+          "x271"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x283",
+          "x284"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x282",
+          "x255",
+          "x273"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x285",
+          "x286"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x284",
+          "x257",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x274"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x287",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x275",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x289",
+          "x290"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x287",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x291",
+          "x292"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x287",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x293",
+          "x294"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x287",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x295",
+          "x296"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x287",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x297",
+          "x298"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x287",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x299",
+          "x300"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x287",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x301",
+          "x302"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x300",
+          "x297"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x303",
+          "x304"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x302",
+          "x298",
+          "x295"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x305",
+          "x306"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x304",
+          "x296",
+          "x293"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x307",
+          "x308"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x306",
+          "x294",
+          "x291"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x309",
+          "x310"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x308",
+          "x292",
+          "x289"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x312"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x275",
+          "x299"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x313",
+          "x314"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x312",
+          "x277",
+          "x301"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x315",
+          "x316"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x314",
+          "x279",
+          "x303"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x317",
+          "x318"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x316",
+          "x281",
+          "x305"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x319",
+          "x320"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x318",
+          "x283",
+          "x307"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x321",
+          "x322"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x320",
+          "x285",
+          "x309"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x323",
+          "x324"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x322",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x286"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x258"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x310"
+                ]
+              },
+              "x290"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x325",
+          "x326"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0x200000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x327",
+          "x328"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0xfffffffe00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x329",
+          "x330"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0x200000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x331",
+          "x332"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0xfffffffe00000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x333",
+          "x334"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x332",
+          "x329"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x335",
+          "x336"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x334",
+          "x330",
+          "x327"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x337",
+          "x338"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x336",
+          "x328",
+          "x325"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x339",
+          "x340"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x338",
+          "x326",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x341",
+          "x342"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x313",
+          "x331"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x343",
+          "x344"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x342",
+          "x315",
+          "x333"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x345",
+          "x346"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x344",
+          "x317",
+          "x335"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x347",
+          "x348"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x346",
+          "x319",
+          "x337"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x349",
+          "x350"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x348",
+          "x321",
+          "x339"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x351",
+          "x352"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x350",
+          "x323",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x340"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x353",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x341",
+          "0x100000001"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x355",
+          "x356"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x353",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x357",
+          "x358"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x353",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x359",
+          "x360"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x353",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x361",
+          "x362"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x353",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x363",
+          "x364"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x353",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x365",
+          "x366"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x353",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x367",
+          "x368"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x366",
+          "x363"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x369",
+          "x370"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x368",
+          "x364",
+          "x361"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x371",
+          "x372"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x370",
+          "x362",
+          "x359"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x373",
+          "x374"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x372",
+          "x360",
+          "x357"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x375",
+          "x376"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x374",
+          "x358",
+          "x355"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x378"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x341",
+          "x365"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x379",
+          "x380"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x378",
+          "x343",
+          "x367"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x381",
+          "x382"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x380",
+          "x345",
+          "x369"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x383",
+          "x384"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x382",
+          "x347",
+          "x371"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x385",
+          "x386"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x384",
+          "x349",
+          "x373"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x387",
+          "x388"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x386",
+          "x351",
+          "x375"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x389",
+          "x390"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x388",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x352"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x324"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x376"
+                ]
+              },
+              "x356"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x391",
+          "x392"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x379",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x393",
+          "x394"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x392",
+          "x381",
+          "0xffffffff00000000"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x395",
+          "x396"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x394",
+          "x383",
+          "0xfffffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x397",
+          "x398"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x396",
+          "x385",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x399",
+          "x400"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x398",
+          "x387",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x401",
+          "x402"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x400",
+          "x389",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x404"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x402",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x390"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x405"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x404",
+          "x391",
+          "x379"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x406"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x404",
+          "x393",
+          "x381"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x407"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x404",
+          "x395",
+          "x383"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x408"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x404",
+          "x397",
+          "x385"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x409"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x404",
+          "x399",
+          "x387"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x410"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x404",
+          "x401",
+          "x389"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x405"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x406"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x407"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x408"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x409"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x410"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_nonzero",
+    "arguments": [
+      {
+        "datatype": "u64[6]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "|",
+        "arguments": [
+          "arg1[0]",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "|",
+            "arguments": [
+              "arg1[1]",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "|",
+                "arguments": [
+                  "arg1[2]",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "|",
+                    "arguments": [
+                      "arg1[3]",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "|",
+                        "arguments": [
+                          "arg1[4]",
+                          "arg1[5]"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_selectznz",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[6]",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64[6]",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[6]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[0]",
+          "arg3[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[1]",
+          "arg3[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[2]",
+          "arg3[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[3]",
+          "arg3[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[4]",
+          "arg3[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[5]",
+          "arg3[5]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_to_bytes",
+    "arguments": [
+      {
+        "datatype": "u64[6]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u8[48]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x7"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x6",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x9"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x8",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x11"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x10"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x10",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x13"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x12",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x15"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x14",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x17"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x16",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x19"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x20"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x18",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x21"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x5"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x5",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x23"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x22"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x22",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x25"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x24",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x27"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x26"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x26",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x29"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x28",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x31"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x30"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x30",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x33"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x32"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x34"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x32",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x35"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x4",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x37"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x36"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x36",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x39"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x38",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x41"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x40",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x43"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x42",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x45"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x44"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x44",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x47"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x46"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x48"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x46",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x49"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x3",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x51"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x50"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x50",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x53"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x52"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x52",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x55"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x54"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x54",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x57"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x56"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x56",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x59"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x58"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x58",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x61"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x60"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x62"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x60",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x63"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x2",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x65"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x64"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x64",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x67"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x66"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x66",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x69"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x68"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x68",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x71"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x70"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x70",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x73"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x72"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x72",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x75"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x74"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x76"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x74",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x77"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x1",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x79"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x78"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x80"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x78",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x81"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x80"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x82"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x80",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x83"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x82"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x82",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x85"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x84"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x86"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x84",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x87"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x86"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x86",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x89"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x88"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x90"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x88",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x11"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x13"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x15"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x17"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x19"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x21"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x23"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x25"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x27"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x29"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x31"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x33"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x34"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[16]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x35"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[17]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x37"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[18]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x39"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[19]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x41"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[20]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x43"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[21]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x45"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[22]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x47"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[23]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x48"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[24]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x49"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[25]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x51"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[26]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x53"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[27]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x55"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[28]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x57"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[29]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x59"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[30]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x61"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[31]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x62"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[32]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x63"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[33]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x65"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[34]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x67"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[35]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x69"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[36]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x71"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[37]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x73"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[38]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x75"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[39]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x76"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[40]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x77"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[41]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x79"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[42]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x81"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[43]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x83"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[44]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x85"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[45]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x87"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[46]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x89"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[47]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x90"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p384_from_bytes",
+    "arguments": [
+      {
+        "datatype": "u8[48]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[6]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[47]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[46]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[45]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[44]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[43]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[42]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[41]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x8"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[40]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[39]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[38]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[37]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[36]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[35]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[34]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[33]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x16"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[32]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[31]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[30]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[29]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[28]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[27]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[26]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[25]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x24"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[24]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[23]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[22]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[21]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[20]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[19]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[18]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[17]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x32"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[16]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x40"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x48"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x47",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x48"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x46",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x45",
+          "x50"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x44",
+          "x51"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x43",
+          "x52"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x42",
+          "x53"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x41",
+          "x54"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x39",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x38",
+          "x56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x37",
+          "x57"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x36",
+          "x58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x35",
+          "x59"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x34",
+          "x60"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x33",
+          "x61"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x63"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x31",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x30",
+          "x63"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x65"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x29",
+          "x64"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x28",
+          "x65"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x67"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x27",
+          "x66"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x26",
+          "x67"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x69"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x25",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x23",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x71"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x22",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x21",
+          "x71"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x73"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x20",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x19",
+          "x73"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x75"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x18",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x76"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x17",
+          "x75"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x77"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x15",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x14",
+          "x77"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x13",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x80"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x12",
+          "x79"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x11",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x82"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x10",
+          "x81"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x9",
+          "x82"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x7",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x85"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x6",
+          "x84"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x86"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x5",
+          "x85"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x4",
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x3",
+          "x87"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x2",
+          "x88"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x1",
+          "x89"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x55"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x62"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x69"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x76"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x83"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x90"
+        ]
+      }
+    ]
+  }
+]

--- a/fiat-json/src/p434_64.json
+++ b/fiat-json/src/p434_64.json
@@ -1,0 +1,21635 @@
+[
+  {
+    "operation": "fiat_p434_addcarryx_u64",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u128",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              },
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "64"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p434_subborrowx_u64",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "i128",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "i128",
+            "name": [],
+            "operation": "-",
+            "arguments": [
+              {
+                "datatype": "i128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              },
+              {
+                "datatype": "i128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "i128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "i1",
+        "name": [
+          "x2"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "i1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "64"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p434_mulx_u64",
+    "arguments": [
+      {
+        "datatype": "u64",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u64",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u128",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "64"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p434_cmovznz_u64",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u1",
+        "name": [
+          "x1"
+        ],
+        "operation": "!",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "!",
+            "arguments": [
+              "arg1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "-",
+                "arguments": [
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "0x0"
+                    ]
+                  },
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x1"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "|",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "arg3"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "~",
+                "arguments": [
+                  "x2"
+                ]
+              },
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p434_mul",
+    "arguments": [
+      {
+        "datatype": "u64[7]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[7]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[7]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8",
+          "x9"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x21",
+          "x18"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x19",
+          "x16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x17",
+          "x14"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x15",
+          "x12"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x13",
+          "x10"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          "x11",
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x33"
+            ]
+          },
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35",
+          "x36"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39",
+          "x40"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41",
+          "x42"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43",
+          "x44"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45",
+          "x46"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47",
+          "x48"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49",
+          "x50"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x48",
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51",
+          "x52"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x50",
+          "x46",
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53",
+          "x54"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x52",
+          "x44",
+          "x41"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55",
+          "x56"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x54",
+          "x42",
+          "x39"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57",
+          "x58"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x56",
+          "x40",
+          "x37"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59",
+          "x60"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x58",
+          "x38",
+          "x35"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x60"
+            ]
+          },
+          "x36"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x63"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x20",
+          "x47"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x63",
+          "x22",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x65",
+          "x24",
+          "x51"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x67",
+          "x26",
+          "x53"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x69",
+          "x28",
+          "x55"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72",
+          "x73"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x71",
+          "x30",
+          "x57"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x73",
+          "x32",
+          "x59"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x76",
+          "x77"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x75",
+          "x34",
+          "x61"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78",
+          "x79"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x80",
+          "x81"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x82",
+          "x83"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84",
+          "x85"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x86",
+          "x87"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88",
+          "x89"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90",
+          "x91"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x91",
+          "x88"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x94",
+          "x95"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x93",
+          "x89",
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96",
+          "x97"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x95",
+          "x87",
+          "x84"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98",
+          "x99"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x97",
+          "x85",
+          "x82"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100",
+          "x101"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x99",
+          "x83",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102",
+          "x103"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x101",
+          "x81",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x104"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x103"
+            ]
+          },
+          "x79"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x105",
+          "x106"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x64",
+          "x90"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x107",
+          "x108"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x106",
+          "x66",
+          "x92"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x109",
+          "x110"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x108",
+          "x68",
+          "x94"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x111",
+          "x112"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x110",
+          "x70",
+          "x96"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x113",
+          "x114"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x112",
+          "x72",
+          "x98"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x115",
+          "x116"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x114",
+          "x74",
+          "x100"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x117",
+          "x118"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x116",
+          "x76",
+          "x102"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x119",
+          "x120"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x118",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x77"
+            ]
+          },
+          "x104"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x121",
+          "x122"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x105",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x123",
+          "x124"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x105",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x125",
+          "x126"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x105",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x127",
+          "x128"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x105",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x129",
+          "x130"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x105",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x131",
+          "x132"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x105",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x133",
+          "x134"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x105",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x135",
+          "x136"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x134",
+          "x131"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x137",
+          "x138"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x136",
+          "x132",
+          "x129"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x139",
+          "x140"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x138",
+          "x130",
+          "x127"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x141",
+          "x142"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x140",
+          "x128",
+          "x125"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x143",
+          "x144"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x142",
+          "x126",
+          "x123"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x145",
+          "x146"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x144",
+          "x124",
+          "x121"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x147"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x146"
+            ]
+          },
+          "x122"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x149"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x105",
+          "x133"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x150",
+          "x151"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x149",
+          "x107",
+          "x135"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x152",
+          "x153"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x151",
+          "x109",
+          "x137"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x154",
+          "x155"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x153",
+          "x111",
+          "x139"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x156",
+          "x157"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x155",
+          "x113",
+          "x141"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x158",
+          "x159"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x157",
+          "x115",
+          "x143"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x160",
+          "x161"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x159",
+          "x117",
+          "x145"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x162",
+          "x163"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x161",
+          "x119",
+          "x147"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x164"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x163"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x120"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x165",
+          "x166"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x167",
+          "x168"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x169",
+          "x170"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x171",
+          "x172"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x173",
+          "x174"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x175",
+          "x176"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x177",
+          "x178"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x179",
+          "x180"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x178",
+          "x175"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x181",
+          "x182"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x180",
+          "x176",
+          "x173"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x183",
+          "x184"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x182",
+          "x174",
+          "x171"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x185",
+          "x186"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x184",
+          "x172",
+          "x169"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x187",
+          "x188"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x186",
+          "x170",
+          "x167"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x189",
+          "x190"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x188",
+          "x168",
+          "x165"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x191"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x190"
+            ]
+          },
+          "x166"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x192",
+          "x193"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x150",
+          "x177"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x194",
+          "x195"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x193",
+          "x152",
+          "x179"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x196",
+          "x197"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x195",
+          "x154",
+          "x181"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x198",
+          "x199"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x197",
+          "x156",
+          "x183"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x200",
+          "x201"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x199",
+          "x158",
+          "x185"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x202",
+          "x203"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x201",
+          "x160",
+          "x187"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x204",
+          "x205"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x203",
+          "x162",
+          "x189"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x206",
+          "x207"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x205",
+          "x164",
+          "x191"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x208",
+          "x209"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x192",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x210",
+          "x211"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x192",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x212",
+          "x213"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x192",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x214",
+          "x215"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x192",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x216",
+          "x217"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x192",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x218",
+          "x219"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x192",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x220",
+          "x221"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x192",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x222",
+          "x223"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x221",
+          "x218"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x224",
+          "x225"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x223",
+          "x219",
+          "x216"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x226",
+          "x227"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x225",
+          "x217",
+          "x214"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x228",
+          "x229"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x227",
+          "x215",
+          "x212"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x230",
+          "x231"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x229",
+          "x213",
+          "x210"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x232",
+          "x233"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x231",
+          "x211",
+          "x208"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x234"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x233"
+            ]
+          },
+          "x209"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x236"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x192",
+          "x220"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x237",
+          "x238"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x236",
+          "x194",
+          "x222"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x239",
+          "x240"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x238",
+          "x196",
+          "x224"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x241",
+          "x242"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x240",
+          "x198",
+          "x226"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x243",
+          "x244"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x242",
+          "x200",
+          "x228"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x245",
+          "x246"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x244",
+          "x202",
+          "x230"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x247",
+          "x248"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x246",
+          "x204",
+          "x232"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x249",
+          "x250"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x248",
+          "x206",
+          "x234"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x251"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x250"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x207"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x252",
+          "x253"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x254",
+          "x255"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x256",
+          "x257"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x258",
+          "x259"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x260",
+          "x261"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x262",
+          "x263"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x264",
+          "x265"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x266",
+          "x267"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x265",
+          "x262"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x268",
+          "x269"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x267",
+          "x263",
+          "x260"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x270",
+          "x271"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x269",
+          "x261",
+          "x258"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x272",
+          "x273"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x271",
+          "x259",
+          "x256"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x274",
+          "x275"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x273",
+          "x257",
+          "x254"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x276",
+          "x277"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x275",
+          "x255",
+          "x252"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x278"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x277"
+            ]
+          },
+          "x253"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x279",
+          "x280"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x237",
+          "x264"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x281",
+          "x282"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x280",
+          "x239",
+          "x266"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x283",
+          "x284"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x282",
+          "x241",
+          "x268"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x285",
+          "x286"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x284",
+          "x243",
+          "x270"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x287",
+          "x288"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x286",
+          "x245",
+          "x272"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x289",
+          "x290"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x288",
+          "x247",
+          "x274"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x291",
+          "x292"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x290",
+          "x249",
+          "x276"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x293",
+          "x294"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x292",
+          "x251",
+          "x278"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x295",
+          "x296"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x279",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x297",
+          "x298"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x279",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x299",
+          "x300"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x279",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x301",
+          "x302"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x279",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x303",
+          "x304"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x279",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x305",
+          "x306"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x279",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x307",
+          "x308"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x279",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x309",
+          "x310"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x308",
+          "x305"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x311",
+          "x312"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x310",
+          "x306",
+          "x303"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x313",
+          "x314"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x312",
+          "x304",
+          "x301"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x315",
+          "x316"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x314",
+          "x302",
+          "x299"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x317",
+          "x318"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x316",
+          "x300",
+          "x297"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x319",
+          "x320"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x318",
+          "x298",
+          "x295"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x321"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x320"
+            ]
+          },
+          "x296"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x323"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x279",
+          "x307"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x324",
+          "x325"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x323",
+          "x281",
+          "x309"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x326",
+          "x327"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x325",
+          "x283",
+          "x311"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x328",
+          "x329"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x327",
+          "x285",
+          "x313"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x330",
+          "x331"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x329",
+          "x287",
+          "x315"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x332",
+          "x333"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x331",
+          "x289",
+          "x317"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x334",
+          "x335"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x333",
+          "x291",
+          "x319"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x336",
+          "x337"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x335",
+          "x293",
+          "x321"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x338"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x337"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x294"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x339",
+          "x340"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x341",
+          "x342"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x343",
+          "x344"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x345",
+          "x346"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x347",
+          "x348"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x349",
+          "x350"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x351",
+          "x352"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x353",
+          "x354"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x352",
+          "x349"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x355",
+          "x356"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x354",
+          "x350",
+          "x347"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x357",
+          "x358"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x356",
+          "x348",
+          "x345"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x359",
+          "x360"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x358",
+          "x346",
+          "x343"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x361",
+          "x362"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x360",
+          "x344",
+          "x341"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x363",
+          "x364"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x362",
+          "x342",
+          "x339"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x365"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x364"
+            ]
+          },
+          "x340"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x366",
+          "x367"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x324",
+          "x351"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x368",
+          "x369"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x367",
+          "x326",
+          "x353"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x370",
+          "x371"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x369",
+          "x328",
+          "x355"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x372",
+          "x373"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x371",
+          "x330",
+          "x357"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x374",
+          "x375"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x373",
+          "x332",
+          "x359"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x376",
+          "x377"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x375",
+          "x334",
+          "x361"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x378",
+          "x379"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x377",
+          "x336",
+          "x363"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x380",
+          "x381"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x379",
+          "x338",
+          "x365"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x382",
+          "x383"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x366",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x384",
+          "x385"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x366",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x386",
+          "x387"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x366",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x388",
+          "x389"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x366",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x390",
+          "x391"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x366",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x392",
+          "x393"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x366",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x394",
+          "x395"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x366",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x396",
+          "x397"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x395",
+          "x392"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x398",
+          "x399"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x397",
+          "x393",
+          "x390"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x400",
+          "x401"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x399",
+          "x391",
+          "x388"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x402",
+          "x403"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x401",
+          "x389",
+          "x386"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x404",
+          "x405"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x403",
+          "x387",
+          "x384"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x406",
+          "x407"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x405",
+          "x385",
+          "x382"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x408"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x407"
+            ]
+          },
+          "x383"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x410"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x366",
+          "x394"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x411",
+          "x412"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x410",
+          "x368",
+          "x396"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x413",
+          "x414"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x412",
+          "x370",
+          "x398"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x415",
+          "x416"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x414",
+          "x372",
+          "x400"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x417",
+          "x418"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x416",
+          "x374",
+          "x402"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x419",
+          "x420"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x418",
+          "x376",
+          "x404"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x421",
+          "x422"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x420",
+          "x378",
+          "x406"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x423",
+          "x424"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x422",
+          "x380",
+          "x408"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x425"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x424"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x381"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x426",
+          "x427"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x428",
+          "x429"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x430",
+          "x431"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x432",
+          "x433"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x434",
+          "x435"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x436",
+          "x437"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x438",
+          "x439"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x440",
+          "x441"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x439",
+          "x436"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x442",
+          "x443"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x441",
+          "x437",
+          "x434"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x444",
+          "x445"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x443",
+          "x435",
+          "x432"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x446",
+          "x447"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x445",
+          "x433",
+          "x430"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x448",
+          "x449"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x447",
+          "x431",
+          "x428"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x450",
+          "x451"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x449",
+          "x429",
+          "x426"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x452"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x451"
+            ]
+          },
+          "x427"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x453",
+          "x454"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x411",
+          "x438"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x455",
+          "x456"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x454",
+          "x413",
+          "x440"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x457",
+          "x458"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x456",
+          "x415",
+          "x442"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x459",
+          "x460"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x458",
+          "x417",
+          "x444"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x461",
+          "x462"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x460",
+          "x419",
+          "x446"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x463",
+          "x464"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x462",
+          "x421",
+          "x448"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x465",
+          "x466"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x464",
+          "x423",
+          "x450"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x467",
+          "x468"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x466",
+          "x425",
+          "x452"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x469",
+          "x470"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x453",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x471",
+          "x472"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x453",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x473",
+          "x474"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x453",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x475",
+          "x476"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x453",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x477",
+          "x478"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x453",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x479",
+          "x480"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x453",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x481",
+          "x482"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x453",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x483",
+          "x484"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x482",
+          "x479"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x485",
+          "x486"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x484",
+          "x480",
+          "x477"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x487",
+          "x488"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x486",
+          "x478",
+          "x475"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x489",
+          "x490"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x488",
+          "x476",
+          "x473"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x491",
+          "x492"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x490",
+          "x474",
+          "x471"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x493",
+          "x494"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x492",
+          "x472",
+          "x469"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x495"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x494"
+            ]
+          },
+          "x470"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x497"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x453",
+          "x481"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x498",
+          "x499"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x497",
+          "x455",
+          "x483"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x500",
+          "x501"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x499",
+          "x457",
+          "x485"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x502",
+          "x503"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x501",
+          "x459",
+          "x487"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x504",
+          "x505"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x503",
+          "x461",
+          "x489"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x506",
+          "x507"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x505",
+          "x463",
+          "x491"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x508",
+          "x509"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x507",
+          "x465",
+          "x493"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x510",
+          "x511"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x509",
+          "x467",
+          "x495"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x512"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x511"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x468"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x513",
+          "x514"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x515",
+          "x516"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x517",
+          "x518"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x519",
+          "x520"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x521",
+          "x522"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x523",
+          "x524"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x525",
+          "x526"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x527",
+          "x528"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x526",
+          "x523"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x529",
+          "x530"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x528",
+          "x524",
+          "x521"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x531",
+          "x532"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x530",
+          "x522",
+          "x519"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x533",
+          "x534"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x532",
+          "x520",
+          "x517"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x535",
+          "x536"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x534",
+          "x518",
+          "x515"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x537",
+          "x538"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x536",
+          "x516",
+          "x513"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x539"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x538"
+            ]
+          },
+          "x514"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x540",
+          "x541"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x498",
+          "x525"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x542",
+          "x543"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x541",
+          "x500",
+          "x527"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x544",
+          "x545"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x543",
+          "x502",
+          "x529"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x546",
+          "x547"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x545",
+          "x504",
+          "x531"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x548",
+          "x549"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x547",
+          "x506",
+          "x533"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x550",
+          "x551"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x549",
+          "x508",
+          "x535"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x552",
+          "x553"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x551",
+          "x510",
+          "x537"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x554",
+          "x555"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x553",
+          "x512",
+          "x539"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x556",
+          "x557"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x540",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x558",
+          "x559"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x540",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x560",
+          "x561"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x540",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x562",
+          "x563"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x540",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x564",
+          "x565"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x540",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x566",
+          "x567"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x540",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x568",
+          "x569"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x540",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x570",
+          "x571"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x569",
+          "x566"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x572",
+          "x573"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x571",
+          "x567",
+          "x564"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x574",
+          "x575"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x573",
+          "x565",
+          "x562"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x576",
+          "x577"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x575",
+          "x563",
+          "x560"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x578",
+          "x579"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x577",
+          "x561",
+          "x558"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x580",
+          "x581"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x579",
+          "x559",
+          "x556"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x582"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x581"
+            ]
+          },
+          "x557"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x584"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x540",
+          "x568"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x585",
+          "x586"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x584",
+          "x542",
+          "x570"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x587",
+          "x588"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x586",
+          "x544",
+          "x572"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x589",
+          "x590"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x588",
+          "x546",
+          "x574"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x591",
+          "x592"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x590",
+          "x548",
+          "x576"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x593",
+          "x594"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x592",
+          "x550",
+          "x578"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x595",
+          "x596"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x594",
+          "x552",
+          "x580"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x597",
+          "x598"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x596",
+          "x554",
+          "x582"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x599"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x598"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x555"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x600",
+          "x601"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x585",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x602",
+          "x603"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x601",
+          "x587",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x604",
+          "x605"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x603",
+          "x589",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x606",
+          "x607"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x605",
+          "x591",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x608",
+          "x609"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x607",
+          "x593",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x610",
+          "x611"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x609",
+          "x595",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x612",
+          "x613"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x611",
+          "x597",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x615"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x613",
+          "x599",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x616"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x615",
+          "x600",
+          "x585"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x617"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x615",
+          "x602",
+          "x587"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x618"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x615",
+          "x604",
+          "x589"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x619"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x615",
+          "x606",
+          "x591"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x620"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x615",
+          "x608",
+          "x593"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x621"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x615",
+          "x610",
+          "x595"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x622"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x615",
+          "x612",
+          "x597"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x616"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x617"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x618"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x619"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x620"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x621"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x622"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p434_square",
+    "arguments": [
+      {
+        "datatype": "u64[7]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[7]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8",
+          "x9"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x21",
+          "x18"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x19",
+          "x16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x17",
+          "x14"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x15",
+          "x12"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x13",
+          "x10"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          "x11",
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x33"
+            ]
+          },
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35",
+          "x36"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39",
+          "x40"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41",
+          "x42"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43",
+          "x44"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45",
+          "x46"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47",
+          "x48"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49",
+          "x50"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x48",
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51",
+          "x52"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x50",
+          "x46",
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53",
+          "x54"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x52",
+          "x44",
+          "x41"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55",
+          "x56"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x54",
+          "x42",
+          "x39"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57",
+          "x58"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x56",
+          "x40",
+          "x37"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59",
+          "x60"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x58",
+          "x38",
+          "x35"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x60"
+            ]
+          },
+          "x36"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x63"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x20",
+          "x47"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x63",
+          "x22",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x65",
+          "x24",
+          "x51"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x67",
+          "x26",
+          "x53"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x69",
+          "x28",
+          "x55"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72",
+          "x73"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x71",
+          "x30",
+          "x57"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x73",
+          "x32",
+          "x59"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x76",
+          "x77"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x75",
+          "x34",
+          "x61"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78",
+          "x79"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x80",
+          "x81"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x82",
+          "x83"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84",
+          "x85"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x86",
+          "x87"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88",
+          "x89"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90",
+          "x91"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x91",
+          "x88"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x94",
+          "x95"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x93",
+          "x89",
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96",
+          "x97"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x95",
+          "x87",
+          "x84"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98",
+          "x99"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x97",
+          "x85",
+          "x82"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100",
+          "x101"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x99",
+          "x83",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102",
+          "x103"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x101",
+          "x81",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x104"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x103"
+            ]
+          },
+          "x79"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x105",
+          "x106"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x64",
+          "x90"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x107",
+          "x108"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x106",
+          "x66",
+          "x92"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x109",
+          "x110"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x108",
+          "x68",
+          "x94"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x111",
+          "x112"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x110",
+          "x70",
+          "x96"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x113",
+          "x114"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x112",
+          "x72",
+          "x98"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x115",
+          "x116"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x114",
+          "x74",
+          "x100"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x117",
+          "x118"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x116",
+          "x76",
+          "x102"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x119",
+          "x120"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x118",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x77"
+            ]
+          },
+          "x104"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x121",
+          "x122"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x105",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x123",
+          "x124"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x105",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x125",
+          "x126"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x105",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x127",
+          "x128"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x105",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x129",
+          "x130"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x105",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x131",
+          "x132"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x105",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x133",
+          "x134"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x105",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x135",
+          "x136"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x134",
+          "x131"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x137",
+          "x138"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x136",
+          "x132",
+          "x129"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x139",
+          "x140"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x138",
+          "x130",
+          "x127"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x141",
+          "x142"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x140",
+          "x128",
+          "x125"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x143",
+          "x144"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x142",
+          "x126",
+          "x123"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x145",
+          "x146"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x144",
+          "x124",
+          "x121"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x147"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x146"
+            ]
+          },
+          "x122"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x149"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x105",
+          "x133"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x150",
+          "x151"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x149",
+          "x107",
+          "x135"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x152",
+          "x153"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x151",
+          "x109",
+          "x137"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x154",
+          "x155"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x153",
+          "x111",
+          "x139"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x156",
+          "x157"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x155",
+          "x113",
+          "x141"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x158",
+          "x159"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x157",
+          "x115",
+          "x143"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x160",
+          "x161"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x159",
+          "x117",
+          "x145"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x162",
+          "x163"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x161",
+          "x119",
+          "x147"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x164"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x163"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x120"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x165",
+          "x166"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x167",
+          "x168"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x169",
+          "x170"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x171",
+          "x172"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x173",
+          "x174"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x175",
+          "x176"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x177",
+          "x178"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x179",
+          "x180"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x178",
+          "x175"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x181",
+          "x182"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x180",
+          "x176",
+          "x173"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x183",
+          "x184"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x182",
+          "x174",
+          "x171"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x185",
+          "x186"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x184",
+          "x172",
+          "x169"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x187",
+          "x188"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x186",
+          "x170",
+          "x167"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x189",
+          "x190"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x188",
+          "x168",
+          "x165"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x191"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x190"
+            ]
+          },
+          "x166"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x192",
+          "x193"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x150",
+          "x177"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x194",
+          "x195"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x193",
+          "x152",
+          "x179"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x196",
+          "x197"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x195",
+          "x154",
+          "x181"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x198",
+          "x199"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x197",
+          "x156",
+          "x183"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x200",
+          "x201"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x199",
+          "x158",
+          "x185"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x202",
+          "x203"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x201",
+          "x160",
+          "x187"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x204",
+          "x205"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x203",
+          "x162",
+          "x189"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x206",
+          "x207"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x205",
+          "x164",
+          "x191"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x208",
+          "x209"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x192",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x210",
+          "x211"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x192",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x212",
+          "x213"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x192",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x214",
+          "x215"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x192",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x216",
+          "x217"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x192",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x218",
+          "x219"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x192",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x220",
+          "x221"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x192",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x222",
+          "x223"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x221",
+          "x218"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x224",
+          "x225"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x223",
+          "x219",
+          "x216"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x226",
+          "x227"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x225",
+          "x217",
+          "x214"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x228",
+          "x229"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x227",
+          "x215",
+          "x212"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x230",
+          "x231"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x229",
+          "x213",
+          "x210"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x232",
+          "x233"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x231",
+          "x211",
+          "x208"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x234"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x233"
+            ]
+          },
+          "x209"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x236"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x192",
+          "x220"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x237",
+          "x238"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x236",
+          "x194",
+          "x222"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x239",
+          "x240"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x238",
+          "x196",
+          "x224"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x241",
+          "x242"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x240",
+          "x198",
+          "x226"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x243",
+          "x244"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x242",
+          "x200",
+          "x228"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x245",
+          "x246"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x244",
+          "x202",
+          "x230"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x247",
+          "x248"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x246",
+          "x204",
+          "x232"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x249",
+          "x250"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x248",
+          "x206",
+          "x234"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x251"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x250"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x207"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x252",
+          "x253"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x254",
+          "x255"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x256",
+          "x257"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x258",
+          "x259"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x260",
+          "x261"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x262",
+          "x263"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x264",
+          "x265"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x266",
+          "x267"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x265",
+          "x262"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x268",
+          "x269"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x267",
+          "x263",
+          "x260"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x270",
+          "x271"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x269",
+          "x261",
+          "x258"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x272",
+          "x273"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x271",
+          "x259",
+          "x256"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x274",
+          "x275"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x273",
+          "x257",
+          "x254"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x276",
+          "x277"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x275",
+          "x255",
+          "x252"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x278"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x277"
+            ]
+          },
+          "x253"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x279",
+          "x280"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x237",
+          "x264"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x281",
+          "x282"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x280",
+          "x239",
+          "x266"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x283",
+          "x284"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x282",
+          "x241",
+          "x268"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x285",
+          "x286"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x284",
+          "x243",
+          "x270"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x287",
+          "x288"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x286",
+          "x245",
+          "x272"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x289",
+          "x290"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x288",
+          "x247",
+          "x274"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x291",
+          "x292"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x290",
+          "x249",
+          "x276"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x293",
+          "x294"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x292",
+          "x251",
+          "x278"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x295",
+          "x296"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x279",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x297",
+          "x298"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x279",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x299",
+          "x300"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x279",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x301",
+          "x302"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x279",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x303",
+          "x304"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x279",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x305",
+          "x306"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x279",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x307",
+          "x308"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x279",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x309",
+          "x310"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x308",
+          "x305"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x311",
+          "x312"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x310",
+          "x306",
+          "x303"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x313",
+          "x314"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x312",
+          "x304",
+          "x301"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x315",
+          "x316"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x314",
+          "x302",
+          "x299"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x317",
+          "x318"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x316",
+          "x300",
+          "x297"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x319",
+          "x320"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x318",
+          "x298",
+          "x295"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x321"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x320"
+            ]
+          },
+          "x296"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x323"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x279",
+          "x307"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x324",
+          "x325"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x323",
+          "x281",
+          "x309"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x326",
+          "x327"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x325",
+          "x283",
+          "x311"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x328",
+          "x329"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x327",
+          "x285",
+          "x313"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x330",
+          "x331"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x329",
+          "x287",
+          "x315"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x332",
+          "x333"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x331",
+          "x289",
+          "x317"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x334",
+          "x335"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x333",
+          "x291",
+          "x319"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x336",
+          "x337"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x335",
+          "x293",
+          "x321"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x338"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x337"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x294"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x339",
+          "x340"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x341",
+          "x342"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x343",
+          "x344"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x345",
+          "x346"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x347",
+          "x348"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x349",
+          "x350"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x351",
+          "x352"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x353",
+          "x354"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x352",
+          "x349"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x355",
+          "x356"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x354",
+          "x350",
+          "x347"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x357",
+          "x358"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x356",
+          "x348",
+          "x345"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x359",
+          "x360"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x358",
+          "x346",
+          "x343"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x361",
+          "x362"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x360",
+          "x344",
+          "x341"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x363",
+          "x364"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x362",
+          "x342",
+          "x339"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x365"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x364"
+            ]
+          },
+          "x340"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x366",
+          "x367"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x324",
+          "x351"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x368",
+          "x369"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x367",
+          "x326",
+          "x353"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x370",
+          "x371"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x369",
+          "x328",
+          "x355"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x372",
+          "x373"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x371",
+          "x330",
+          "x357"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x374",
+          "x375"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x373",
+          "x332",
+          "x359"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x376",
+          "x377"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x375",
+          "x334",
+          "x361"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x378",
+          "x379"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x377",
+          "x336",
+          "x363"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x380",
+          "x381"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x379",
+          "x338",
+          "x365"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x382",
+          "x383"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x366",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x384",
+          "x385"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x366",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x386",
+          "x387"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x366",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x388",
+          "x389"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x366",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x390",
+          "x391"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x366",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x392",
+          "x393"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x366",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x394",
+          "x395"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x366",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x396",
+          "x397"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x395",
+          "x392"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x398",
+          "x399"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x397",
+          "x393",
+          "x390"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x400",
+          "x401"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x399",
+          "x391",
+          "x388"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x402",
+          "x403"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x401",
+          "x389",
+          "x386"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x404",
+          "x405"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x403",
+          "x387",
+          "x384"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x406",
+          "x407"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x405",
+          "x385",
+          "x382"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x408"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x407"
+            ]
+          },
+          "x383"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x410"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x366",
+          "x394"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x411",
+          "x412"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x410",
+          "x368",
+          "x396"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x413",
+          "x414"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x412",
+          "x370",
+          "x398"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x415",
+          "x416"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x414",
+          "x372",
+          "x400"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x417",
+          "x418"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x416",
+          "x374",
+          "x402"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x419",
+          "x420"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x418",
+          "x376",
+          "x404"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x421",
+          "x422"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x420",
+          "x378",
+          "x406"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x423",
+          "x424"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x422",
+          "x380",
+          "x408"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x425"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x424"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x381"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x426",
+          "x427"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x428",
+          "x429"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x430",
+          "x431"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x432",
+          "x433"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x434",
+          "x435"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x436",
+          "x437"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x438",
+          "x439"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x440",
+          "x441"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x439",
+          "x436"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x442",
+          "x443"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x441",
+          "x437",
+          "x434"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x444",
+          "x445"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x443",
+          "x435",
+          "x432"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x446",
+          "x447"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x445",
+          "x433",
+          "x430"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x448",
+          "x449"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x447",
+          "x431",
+          "x428"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x450",
+          "x451"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x449",
+          "x429",
+          "x426"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x452"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x451"
+            ]
+          },
+          "x427"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x453",
+          "x454"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x411",
+          "x438"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x455",
+          "x456"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x454",
+          "x413",
+          "x440"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x457",
+          "x458"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x456",
+          "x415",
+          "x442"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x459",
+          "x460"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x458",
+          "x417",
+          "x444"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x461",
+          "x462"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x460",
+          "x419",
+          "x446"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x463",
+          "x464"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x462",
+          "x421",
+          "x448"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x465",
+          "x466"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x464",
+          "x423",
+          "x450"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x467",
+          "x468"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x466",
+          "x425",
+          "x452"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x469",
+          "x470"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x453",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x471",
+          "x472"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x453",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x473",
+          "x474"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x453",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x475",
+          "x476"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x453",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x477",
+          "x478"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x453",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x479",
+          "x480"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x453",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x481",
+          "x482"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x453",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x483",
+          "x484"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x482",
+          "x479"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x485",
+          "x486"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x484",
+          "x480",
+          "x477"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x487",
+          "x488"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x486",
+          "x478",
+          "x475"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x489",
+          "x490"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x488",
+          "x476",
+          "x473"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x491",
+          "x492"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x490",
+          "x474",
+          "x471"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x493",
+          "x494"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x492",
+          "x472",
+          "x469"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x495"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x494"
+            ]
+          },
+          "x470"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x497"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x453",
+          "x481"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x498",
+          "x499"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x497",
+          "x455",
+          "x483"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x500",
+          "x501"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x499",
+          "x457",
+          "x485"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x502",
+          "x503"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x501",
+          "x459",
+          "x487"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x504",
+          "x505"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x503",
+          "x461",
+          "x489"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x506",
+          "x507"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x505",
+          "x463",
+          "x491"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x508",
+          "x509"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x507",
+          "x465",
+          "x493"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x510",
+          "x511"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x509",
+          "x467",
+          "x495"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x512"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x511"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x468"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x513",
+          "x514"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x515",
+          "x516"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x517",
+          "x518"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x519",
+          "x520"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x521",
+          "x522"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x523",
+          "x524"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x525",
+          "x526"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x527",
+          "x528"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x526",
+          "x523"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x529",
+          "x530"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x528",
+          "x524",
+          "x521"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x531",
+          "x532"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x530",
+          "x522",
+          "x519"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x533",
+          "x534"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x532",
+          "x520",
+          "x517"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x535",
+          "x536"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x534",
+          "x518",
+          "x515"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x537",
+          "x538"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x536",
+          "x516",
+          "x513"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x539"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x538"
+            ]
+          },
+          "x514"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x540",
+          "x541"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x498",
+          "x525"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x542",
+          "x543"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x541",
+          "x500",
+          "x527"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x544",
+          "x545"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x543",
+          "x502",
+          "x529"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x546",
+          "x547"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x545",
+          "x504",
+          "x531"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x548",
+          "x549"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x547",
+          "x506",
+          "x533"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x550",
+          "x551"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x549",
+          "x508",
+          "x535"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x552",
+          "x553"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x551",
+          "x510",
+          "x537"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x554",
+          "x555"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x553",
+          "x512",
+          "x539"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x556",
+          "x557"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x540",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x558",
+          "x559"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x540",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x560",
+          "x561"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x540",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x562",
+          "x563"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x540",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x564",
+          "x565"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x540",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x566",
+          "x567"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x540",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x568",
+          "x569"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x540",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x570",
+          "x571"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x569",
+          "x566"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x572",
+          "x573"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x571",
+          "x567",
+          "x564"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x574",
+          "x575"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x573",
+          "x565",
+          "x562"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x576",
+          "x577"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x575",
+          "x563",
+          "x560"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x578",
+          "x579"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x577",
+          "x561",
+          "x558"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x580",
+          "x581"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x579",
+          "x559",
+          "x556"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x582"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x581"
+            ]
+          },
+          "x557"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x584"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x540",
+          "x568"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x585",
+          "x586"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x584",
+          "x542",
+          "x570"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x587",
+          "x588"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x586",
+          "x544",
+          "x572"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x589",
+          "x590"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x588",
+          "x546",
+          "x574"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x591",
+          "x592"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x590",
+          "x548",
+          "x576"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x593",
+          "x594"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x592",
+          "x550",
+          "x578"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x595",
+          "x596"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x594",
+          "x552",
+          "x580"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x597",
+          "x598"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x596",
+          "x554",
+          "x582"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x599"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x598"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x555"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x600",
+          "x601"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x585",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x602",
+          "x603"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x601",
+          "x587",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x604",
+          "x605"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x603",
+          "x589",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x606",
+          "x607"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x605",
+          "x591",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x608",
+          "x609"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x607",
+          "x593",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x610",
+          "x611"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x609",
+          "x595",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x612",
+          "x613"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x611",
+          "x597",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x615"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x613",
+          "x599",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x616"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x615",
+          "x600",
+          "x585"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x617"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x615",
+          "x602",
+          "x587"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x618"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x615",
+          "x604",
+          "x589"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x619"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x615",
+          "x606",
+          "x591"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x620"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x615",
+          "x608",
+          "x593"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x621"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x615",
+          "x610",
+          "x595"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x622"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x615",
+          "x612",
+          "x597"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x616"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x617"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x618"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x619"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x620"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x621"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x622"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p434_add",
+    "arguments": [
+      {
+        "datatype": "u64[7]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[7]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[7]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x8",
+          "arg1[4]",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x10",
+          "arg1[5]",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x12",
+          "arg1[6]",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x16",
+          "x3",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x18",
+          "x5",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x20",
+          "x7",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x22",
+          "x9",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25",
+          "x26"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x24",
+          "x11",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27",
+          "x28"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x26",
+          "x13",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x30"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x28",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x30",
+          "x15",
+          "x1"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x30",
+          "x17",
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x30",
+          "x19",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x30",
+          "x21",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x30",
+          "x23",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x30",
+          "x25",
+          "x11"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x30",
+          "x27",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x31"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x32"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x33"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x34"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x35"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x36"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x37"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p434_sub",
+    "arguments": [
+      {
+        "datatype": "u64[7]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[7]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[7]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x8",
+          "arg1[4]",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x10",
+          "arg1[5]",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x12",
+          "arg1[6]",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x14",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x17",
+          "x3",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x19",
+          "x5",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x21",
+          "x7",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x15",
+              "0xfdc1767ae2ffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x9",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x15",
+              "0x7bc65c783158aea3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x11",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x15",
+              "0x6cfc5fd681c52056"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x13",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x15",
+              "0x2341f27177344"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x22"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x24"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x26"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x28"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p434_opp",
+    "arguments": [
+      {
+        "datatype": "u64[7]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[7]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x8",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x10",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x12",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x14",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x17",
+          "x3",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x19",
+          "x5",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x21",
+          "x7",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x15",
+              "0xfdc1767ae2ffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x9",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x15",
+              "0x7bc65c783158aea3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x11",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x15",
+              "0x6cfc5fd681c52056"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x13",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x15",
+              "0x2341f27177344"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x22"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x24"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x26"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x28"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p434_from_montgomery",
+    "arguments": [
+      {
+        "datatype": "u64[7]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[7]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2",
+          "x3"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4",
+          "x5"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6",
+          "x7"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8",
+          "x9"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x15",
+          "x12"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x17",
+          "x13",
+          "x10"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x19",
+          "x11",
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x21",
+          "x9",
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x7",
+          "x4"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x5",
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "x14"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x18"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34",
+          "x35"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x33",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x20"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36",
+          "x37"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x35",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x22"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38",
+          "x39"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x37",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40",
+          "x41"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x39",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x26"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42",
+          "x43"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x30",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44",
+          "x45"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x43",
+          "x32",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46",
+          "x47"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x45",
+          "x34",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48",
+          "x49"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x47",
+          "x36",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50",
+          "x51"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x49",
+          "x38",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52",
+          "x53"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x51",
+          "x40",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54",
+          "x55"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x42",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56",
+          "x57"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x42",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58",
+          "x59"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x42",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x42",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x42",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x42",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x42",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x67",
+          "x64"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x69",
+          "x65",
+          "x62"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72",
+          "x73"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x71",
+          "x63",
+          "x60"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x73",
+          "x61",
+          "x58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x76",
+          "x77"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x75",
+          "x59",
+          "x56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78",
+          "x79"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x77",
+          "x57",
+          "x54"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x81"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x42",
+          "x66"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x82",
+          "x83"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x81",
+          "x44",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84",
+          "x85"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x83",
+          "x46",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x86",
+          "x87"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x85",
+          "x48",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88",
+          "x89"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x87",
+          "x50",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90",
+          "x91"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x89",
+          "x52",
+          "x76"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x91",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x53"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x41"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x27"
+                        ]
+                      },
+                      "x3"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x94",
+          "x95"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x82",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96",
+          "x97"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x95",
+          "x84",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98",
+          "x99"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x97",
+          "x86",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100",
+          "x101"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x99",
+          "x88",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102",
+          "x103"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x101",
+          "x90",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x104",
+          "x105"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x103",
+          "x92",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x106",
+          "x107"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x94",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x108",
+          "x109"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x94",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x110",
+          "x111"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x94",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x112",
+          "x113"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x94",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x114",
+          "x115"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x94",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x116",
+          "x117"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x94",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x118",
+          "x119"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x94",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x120",
+          "x121"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x119",
+          "x116"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x122",
+          "x123"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x121",
+          "x117",
+          "x114"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x124",
+          "x125"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x123",
+          "x115",
+          "x112"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x126",
+          "x127"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x125",
+          "x113",
+          "x110"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x128",
+          "x129"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x127",
+          "x111",
+          "x108"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x130",
+          "x131"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x129",
+          "x109",
+          "x106"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x133"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x94",
+          "x118"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x134",
+          "x135"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x133",
+          "x96",
+          "x120"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x136",
+          "x137"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x135",
+          "x98",
+          "x122"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x138",
+          "x139"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x137",
+          "x100",
+          "x124"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x140",
+          "x141"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x139",
+          "x102",
+          "x126"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x142",
+          "x143"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x141",
+          "x104",
+          "x128"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x144",
+          "x145"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x143",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x105"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x93"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x79"
+                        ]
+                      },
+                      "x55"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "x130"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x146",
+          "x147"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x134",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x148",
+          "x149"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x147",
+          "x136",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x150",
+          "x151"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x149",
+          "x138",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x152",
+          "x153"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x151",
+          "x140",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x154",
+          "x155"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x153",
+          "x142",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x156",
+          "x157"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x155",
+          "x144",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x158",
+          "x159"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x146",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x160",
+          "x161"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x146",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x162",
+          "x163"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x146",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x164",
+          "x165"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x146",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x166",
+          "x167"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x146",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x168",
+          "x169"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x146",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x170",
+          "x171"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x146",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x172",
+          "x173"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x171",
+          "x168"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x174",
+          "x175"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x173",
+          "x169",
+          "x166"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x176",
+          "x177"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x175",
+          "x167",
+          "x164"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x178",
+          "x179"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x177",
+          "x165",
+          "x162"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x180",
+          "x181"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x179",
+          "x163",
+          "x160"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x182",
+          "x183"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x181",
+          "x161",
+          "x158"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x185"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x146",
+          "x170"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x186",
+          "x187"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x185",
+          "x148",
+          "x172"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x188",
+          "x189"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x187",
+          "x150",
+          "x174"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x190",
+          "x191"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x189",
+          "x152",
+          "x176"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x192",
+          "x193"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x191",
+          "x154",
+          "x178"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x194",
+          "x195"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x193",
+          "x156",
+          "x180"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x196",
+          "x197"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x195",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x157"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x145"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x131"
+                        ]
+                      },
+                      "x107"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "x182"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x198",
+          "x199"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x186",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x200",
+          "x201"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x199",
+          "x188",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x202",
+          "x203"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x201",
+          "x190",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x204",
+          "x205"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x203",
+          "x192",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x206",
+          "x207"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x205",
+          "x194",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x208",
+          "x209"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x207",
+          "x196",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x210",
+          "x211"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x198",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x212",
+          "x213"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x198",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x214",
+          "x215"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x198",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x216",
+          "x217"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x198",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x218",
+          "x219"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x198",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x220",
+          "x221"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x198",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x222",
+          "x223"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x198",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x224",
+          "x225"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x223",
+          "x220"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x226",
+          "x227"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x225",
+          "x221",
+          "x218"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x228",
+          "x229"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x227",
+          "x219",
+          "x216"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x230",
+          "x231"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x229",
+          "x217",
+          "x214"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x232",
+          "x233"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x231",
+          "x215",
+          "x212"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x234",
+          "x235"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x233",
+          "x213",
+          "x210"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x237"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x198",
+          "x222"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x238",
+          "x239"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x237",
+          "x200",
+          "x224"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x240",
+          "x241"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x239",
+          "x202",
+          "x226"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x242",
+          "x243"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x241",
+          "x204",
+          "x228"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x244",
+          "x245"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x243",
+          "x206",
+          "x230"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x246",
+          "x247"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x245",
+          "x208",
+          "x232"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x248",
+          "x249"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x247",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x209"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x197"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x183"
+                        ]
+                      },
+                      "x159"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "x234"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x250",
+          "x251"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x238",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x252",
+          "x253"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x251",
+          "x240",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x254",
+          "x255"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x253",
+          "x242",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x256",
+          "x257"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x255",
+          "x244",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x258",
+          "x259"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x257",
+          "x246",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x260",
+          "x261"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x259",
+          "x248",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x262",
+          "x263"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x250",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x264",
+          "x265"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x250",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x266",
+          "x267"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x250",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x268",
+          "x269"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x250",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x270",
+          "x271"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x250",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x272",
+          "x273"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x250",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x274",
+          "x275"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x250",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x276",
+          "x277"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x275",
+          "x272"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x278",
+          "x279"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x277",
+          "x273",
+          "x270"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x280",
+          "x281"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x279",
+          "x271",
+          "x268"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x282",
+          "x283"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x281",
+          "x269",
+          "x266"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x284",
+          "x285"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x283",
+          "x267",
+          "x264"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x286",
+          "x287"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x285",
+          "x265",
+          "x262"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x289"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x250",
+          "x274"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x290",
+          "x291"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x289",
+          "x252",
+          "x276"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x292",
+          "x293"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x291",
+          "x254",
+          "x278"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x294",
+          "x295"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x293",
+          "x256",
+          "x280"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x296",
+          "x297"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x295",
+          "x258",
+          "x282"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x298",
+          "x299"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x297",
+          "x260",
+          "x284"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x300",
+          "x301"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x299",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x261"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x249"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x235"
+                        ]
+                      },
+                      "x211"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "x286"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x302",
+          "x303"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x290",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x304",
+          "x305"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x303",
+          "x292",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x306",
+          "x307"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x305",
+          "x294",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x308",
+          "x309"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x307",
+          "x296",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x310",
+          "x311"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x309",
+          "x298",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x312",
+          "x313"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x311",
+          "x300",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x314",
+          "x315"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x302",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x316",
+          "x317"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x302",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x318",
+          "x319"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x302",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x320",
+          "x321"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x302",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x322",
+          "x323"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x302",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x324",
+          "x325"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x302",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x326",
+          "x327"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x302",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x328",
+          "x329"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x327",
+          "x324"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x330",
+          "x331"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x329",
+          "x325",
+          "x322"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x332",
+          "x333"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x331",
+          "x323",
+          "x320"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x334",
+          "x335"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x333",
+          "x321",
+          "x318"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x336",
+          "x337"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x335",
+          "x319",
+          "x316"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x338",
+          "x339"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x337",
+          "x317",
+          "x314"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x341"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x302",
+          "x326"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x342",
+          "x343"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x341",
+          "x304",
+          "x328"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x344",
+          "x345"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x343",
+          "x306",
+          "x330"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x346",
+          "x347"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x345",
+          "x308",
+          "x332"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x348",
+          "x349"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x347",
+          "x310",
+          "x334"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x350",
+          "x351"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x349",
+          "x312",
+          "x336"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x352",
+          "x353"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x351",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x313"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x301"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x287"
+                        ]
+                      },
+                      "x263"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "x338"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x354"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x353"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x339"
+                ]
+              },
+              "x315"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x355",
+          "x356"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x342",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x357",
+          "x358"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x356",
+          "x344",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x359",
+          "x360"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x358",
+          "x346",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x361",
+          "x362"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x360",
+          "x348",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x363",
+          "x364"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x362",
+          "x350",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x365",
+          "x366"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x364",
+          "x352",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x367",
+          "x368"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x366",
+          "x354",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x370"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x368",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x371"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x370",
+          "x355",
+          "x342"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x372"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x370",
+          "x357",
+          "x344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x373"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x370",
+          "x359",
+          "x346"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x374"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x370",
+          "x361",
+          "x348"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x375"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x370",
+          "x363",
+          "x350"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x376"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x370",
+          "x365",
+          "x352"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x377"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x370",
+          "x367",
+          "x354"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x371"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x372"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x373"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x374"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x375"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x376"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x377"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p434_to_montgomery",
+    "arguments": [
+      {
+        "datatype": "u64[7]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[7]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8",
+          "x9"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0x25a89bcdd12a"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0x69e16a61c7686d9a"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0xabcd92bf2dde347e"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0x175cc6af8d6c7c0b"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0xab27973f8311688d"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0xacec7367768798c2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0x28e55b65dcd69b30"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x21",
+          "x18"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x19",
+          "x16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x17",
+          "x14"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x15",
+          "x12"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x13",
+          "x10"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          "x11",
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34",
+          "x35"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36",
+          "x37"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38",
+          "x39"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40",
+          "x41"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42",
+          "x43"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44",
+          "x45"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46",
+          "x47"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48",
+          "x49"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x47",
+          "x44"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50",
+          "x51"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x49",
+          "x45",
+          "x42"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52",
+          "x53"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x51",
+          "x43",
+          "x40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54",
+          "x55"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x53",
+          "x41",
+          "x38"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56",
+          "x57"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x55",
+          "x39",
+          "x36"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58",
+          "x59"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x57",
+          "x37",
+          "x34"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x61"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x20",
+          "x46"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x61",
+          "x22",
+          "x48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x63",
+          "x24",
+          "x50"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x65",
+          "x26",
+          "x52"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x67",
+          "x28",
+          "x54"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x69",
+          "x30",
+          "x56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72",
+          "x73"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x71",
+          "x32",
+          "x58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0x25a89bcdd12a"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x76",
+          "x77"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0x69e16a61c7686d9a"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78",
+          "x79"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xabcd92bf2dde347e"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x80",
+          "x81"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0x175cc6af8d6c7c0b"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x82",
+          "x83"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xab27973f8311688d"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84",
+          "x85"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xacec7367768798c2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x86",
+          "x87"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0x28e55b65dcd69b30"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88",
+          "x89"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x87",
+          "x84"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90",
+          "x91"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x89",
+          "x85",
+          "x82"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x91",
+          "x83",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x94",
+          "x95"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x93",
+          "x81",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96",
+          "x97"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x95",
+          "x79",
+          "x76"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98",
+          "x99"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x97",
+          "x77",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100",
+          "x101"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x62",
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102",
+          "x103"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x101",
+          "x64",
+          "x88"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x104",
+          "x105"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x103",
+          "x66",
+          "x90"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x106",
+          "x107"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x105",
+          "x68",
+          "x92"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x108",
+          "x109"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x107",
+          "x70",
+          "x94"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x110",
+          "x111"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x109",
+          "x72",
+          "x96"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x112",
+          "x113"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x111",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x73"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x33"
+                        ]
+                      },
+                      "x9"
+                    ]
+                  }
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x59"
+                    ]
+                  },
+                  "x35"
+                ]
+              }
+            ]
+          },
+          "x98"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x114",
+          "x115"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x100",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x116",
+          "x117"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x100",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x118",
+          "x119"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x100",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x120",
+          "x121"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x100",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x122",
+          "x123"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x100",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x124",
+          "x125"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x100",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x126",
+          "x127"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x100",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x128",
+          "x129"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x127",
+          "x124"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x130",
+          "x131"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x129",
+          "x125",
+          "x122"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x132",
+          "x133"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x131",
+          "x123",
+          "x120"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x134",
+          "x135"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x133",
+          "x121",
+          "x118"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x136",
+          "x137"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x135",
+          "x119",
+          "x116"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x138",
+          "x139"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x137",
+          "x117",
+          "x114"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x141"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x100",
+          "x126"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x142",
+          "x143"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x141",
+          "x102",
+          "x128"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x144",
+          "x145"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x143",
+          "x104",
+          "x130"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x146",
+          "x147"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x145",
+          "x106",
+          "x132"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x148",
+          "x149"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x147",
+          "x108",
+          "x134"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x150",
+          "x151"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x149",
+          "x110",
+          "x136"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x152",
+          "x153"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x151",
+          "x112",
+          "x138"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x154",
+          "x155"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0x25a89bcdd12a"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x156",
+          "x157"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0x69e16a61c7686d9a"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x158",
+          "x159"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xabcd92bf2dde347e"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x160",
+          "x161"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0x175cc6af8d6c7c0b"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x162",
+          "x163"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xab27973f8311688d"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x164",
+          "x165"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xacec7367768798c2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x166",
+          "x167"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0x28e55b65dcd69b30"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x168",
+          "x169"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x167",
+          "x164"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x170",
+          "x171"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x169",
+          "x165",
+          "x162"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x172",
+          "x173"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x171",
+          "x163",
+          "x160"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x174",
+          "x175"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x173",
+          "x161",
+          "x158"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x176",
+          "x177"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x175",
+          "x159",
+          "x156"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x178",
+          "x179"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x177",
+          "x157",
+          "x154"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x180",
+          "x181"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x142",
+          "x166"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x182",
+          "x183"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x181",
+          "x144",
+          "x168"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x184",
+          "x185"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x183",
+          "x146",
+          "x170"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x186",
+          "x187"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x185",
+          "x148",
+          "x172"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x188",
+          "x189"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x187",
+          "x150",
+          "x174"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x190",
+          "x191"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x189",
+          "x152",
+          "x176"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x192",
+          "x193"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x191",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x153"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x113"
+                        ]
+                      },
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "static_cast",
+                            "arguments": [
+                              "x99"
+                            ]
+                          },
+                          "x75"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x139"
+                    ]
+                  },
+                  "x115"
+                ]
+              }
+            ]
+          },
+          "x178"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x194",
+          "x195"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x180",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x196",
+          "x197"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x180",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x198",
+          "x199"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x180",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x200",
+          "x201"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x180",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x202",
+          "x203"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x180",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x204",
+          "x205"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x180",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x206",
+          "x207"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x180",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x208",
+          "x209"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x207",
+          "x204"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x210",
+          "x211"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x209",
+          "x205",
+          "x202"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x212",
+          "x213"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x211",
+          "x203",
+          "x200"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x214",
+          "x215"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x213",
+          "x201",
+          "x198"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x216",
+          "x217"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x215",
+          "x199",
+          "x196"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x218",
+          "x219"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x217",
+          "x197",
+          "x194"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x221"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x180",
+          "x206"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x222",
+          "x223"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x221",
+          "x182",
+          "x208"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x224",
+          "x225"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x223",
+          "x184",
+          "x210"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x226",
+          "x227"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x225",
+          "x186",
+          "x212"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x228",
+          "x229"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x227",
+          "x188",
+          "x214"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x230",
+          "x231"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x229",
+          "x190",
+          "x216"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x232",
+          "x233"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x231",
+          "x192",
+          "x218"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x234",
+          "x235"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0x25a89bcdd12a"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x236",
+          "x237"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0x69e16a61c7686d9a"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x238",
+          "x239"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xabcd92bf2dde347e"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x240",
+          "x241"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0x175cc6af8d6c7c0b"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x242",
+          "x243"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xab27973f8311688d"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x244",
+          "x245"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xacec7367768798c2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x246",
+          "x247"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0x28e55b65dcd69b30"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x248",
+          "x249"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x247",
+          "x244"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x250",
+          "x251"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x249",
+          "x245",
+          "x242"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x252",
+          "x253"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x251",
+          "x243",
+          "x240"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x254",
+          "x255"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x253",
+          "x241",
+          "x238"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x256",
+          "x257"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x255",
+          "x239",
+          "x236"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x258",
+          "x259"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x257",
+          "x237",
+          "x234"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x260",
+          "x261"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x222",
+          "x246"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x262",
+          "x263"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x261",
+          "x224",
+          "x248"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x264",
+          "x265"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x263",
+          "x226",
+          "x250"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x266",
+          "x267"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x265",
+          "x228",
+          "x252"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x268",
+          "x269"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x267",
+          "x230",
+          "x254"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x270",
+          "x271"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x269",
+          "x232",
+          "x256"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x272",
+          "x273"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x271",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x233"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x193"
+                        ]
+                      },
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "static_cast",
+                            "arguments": [
+                              "x179"
+                            ]
+                          },
+                          "x155"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x219"
+                    ]
+                  },
+                  "x195"
+                ]
+              }
+            ]
+          },
+          "x258"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x274",
+          "x275"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x260",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x276",
+          "x277"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x260",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x278",
+          "x279"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x260",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x280",
+          "x281"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x260",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x282",
+          "x283"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x260",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x284",
+          "x285"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x260",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x286",
+          "x287"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x260",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x288",
+          "x289"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x287",
+          "x284"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x290",
+          "x291"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x289",
+          "x285",
+          "x282"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x292",
+          "x293"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x291",
+          "x283",
+          "x280"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x294",
+          "x295"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x293",
+          "x281",
+          "x278"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x296",
+          "x297"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x295",
+          "x279",
+          "x276"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x298",
+          "x299"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x297",
+          "x277",
+          "x274"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x301"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x260",
+          "x286"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x302",
+          "x303"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x301",
+          "x262",
+          "x288"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x304",
+          "x305"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x303",
+          "x264",
+          "x290"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x306",
+          "x307"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x305",
+          "x266",
+          "x292"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x308",
+          "x309"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x307",
+          "x268",
+          "x294"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x310",
+          "x311"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x309",
+          "x270",
+          "x296"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x312",
+          "x313"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x311",
+          "x272",
+          "x298"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x314",
+          "x315"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0x25a89bcdd12a"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x316",
+          "x317"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0x69e16a61c7686d9a"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x318",
+          "x319"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xabcd92bf2dde347e"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x320",
+          "x321"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0x175cc6af8d6c7c0b"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x322",
+          "x323"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xab27973f8311688d"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x324",
+          "x325"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xacec7367768798c2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x326",
+          "x327"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0x28e55b65dcd69b30"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x328",
+          "x329"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x327",
+          "x324"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x330",
+          "x331"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x329",
+          "x325",
+          "x322"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x332",
+          "x333"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x331",
+          "x323",
+          "x320"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x334",
+          "x335"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x333",
+          "x321",
+          "x318"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x336",
+          "x337"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x335",
+          "x319",
+          "x316"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x338",
+          "x339"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x337",
+          "x317",
+          "x314"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x340",
+          "x341"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x302",
+          "x326"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x342",
+          "x343"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x341",
+          "x304",
+          "x328"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x344",
+          "x345"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x343",
+          "x306",
+          "x330"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x346",
+          "x347"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x345",
+          "x308",
+          "x332"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x348",
+          "x349"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x347",
+          "x310",
+          "x334"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x350",
+          "x351"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x349",
+          "x312",
+          "x336"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x352",
+          "x353"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x351",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x313"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x273"
+                        ]
+                      },
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "static_cast",
+                            "arguments": [
+                              "x259"
+                            ]
+                          },
+                          "x235"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x299"
+                    ]
+                  },
+                  "x275"
+                ]
+              }
+            ]
+          },
+          "x338"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x354",
+          "x355"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x340",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x356",
+          "x357"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x340",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x358",
+          "x359"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x340",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x360",
+          "x361"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x340",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x362",
+          "x363"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x340",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x364",
+          "x365"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x340",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x366",
+          "x367"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x340",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x368",
+          "x369"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x367",
+          "x364"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x370",
+          "x371"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x369",
+          "x365",
+          "x362"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x372",
+          "x373"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x371",
+          "x363",
+          "x360"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x374",
+          "x375"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x373",
+          "x361",
+          "x358"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x376",
+          "x377"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x375",
+          "x359",
+          "x356"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x378",
+          "x379"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x377",
+          "x357",
+          "x354"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x381"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x340",
+          "x366"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x382",
+          "x383"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x381",
+          "x342",
+          "x368"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x384",
+          "x385"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x383",
+          "x344",
+          "x370"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x386",
+          "x387"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x385",
+          "x346",
+          "x372"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x388",
+          "x389"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x387",
+          "x348",
+          "x374"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x390",
+          "x391"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x389",
+          "x350",
+          "x376"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x392",
+          "x393"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x391",
+          "x352",
+          "x378"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x394",
+          "x395"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0x25a89bcdd12a"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x396",
+          "x397"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0x69e16a61c7686d9a"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x398",
+          "x399"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0xabcd92bf2dde347e"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x400",
+          "x401"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0x175cc6af8d6c7c0b"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x402",
+          "x403"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0xab27973f8311688d"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x404",
+          "x405"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0xacec7367768798c2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x406",
+          "x407"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0x28e55b65dcd69b30"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x408",
+          "x409"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x407",
+          "x404"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x410",
+          "x411"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x409",
+          "x405",
+          "x402"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x412",
+          "x413"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x411",
+          "x403",
+          "x400"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x414",
+          "x415"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x413",
+          "x401",
+          "x398"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x416",
+          "x417"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x415",
+          "x399",
+          "x396"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x418",
+          "x419"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x417",
+          "x397",
+          "x394"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x420",
+          "x421"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x382",
+          "x406"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x422",
+          "x423"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x421",
+          "x384",
+          "x408"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x424",
+          "x425"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x423",
+          "x386",
+          "x410"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x426",
+          "x427"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x425",
+          "x388",
+          "x412"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x428",
+          "x429"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x427",
+          "x390",
+          "x414"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x430",
+          "x431"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x429",
+          "x392",
+          "x416"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x432",
+          "x433"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x431",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x393"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x353"
+                        ]
+                      },
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "static_cast",
+                            "arguments": [
+                              "x339"
+                            ]
+                          },
+                          "x315"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x379"
+                    ]
+                  },
+                  "x355"
+                ]
+              }
+            ]
+          },
+          "x418"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x434",
+          "x435"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x420",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x436",
+          "x437"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x420",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x438",
+          "x439"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x420",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x440",
+          "x441"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x420",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x442",
+          "x443"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x420",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x444",
+          "x445"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x420",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x446",
+          "x447"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x420",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x448",
+          "x449"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x447",
+          "x444"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x450",
+          "x451"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x449",
+          "x445",
+          "x442"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x452",
+          "x453"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x451",
+          "x443",
+          "x440"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x454",
+          "x455"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x453",
+          "x441",
+          "x438"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x456",
+          "x457"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x455",
+          "x439",
+          "x436"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x458",
+          "x459"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x457",
+          "x437",
+          "x434"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x461"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x420",
+          "x446"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x462",
+          "x463"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x461",
+          "x422",
+          "x448"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x464",
+          "x465"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x463",
+          "x424",
+          "x450"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x466",
+          "x467"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x465",
+          "x426",
+          "x452"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x468",
+          "x469"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x467",
+          "x428",
+          "x454"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x470",
+          "x471"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x469",
+          "x430",
+          "x456"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x472",
+          "x473"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x471",
+          "x432",
+          "x458"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x474",
+          "x475"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0x25a89bcdd12a"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x476",
+          "x477"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0x69e16a61c7686d9a"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x478",
+          "x479"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0xabcd92bf2dde347e"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x480",
+          "x481"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0x175cc6af8d6c7c0b"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x482",
+          "x483"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0xab27973f8311688d"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x484",
+          "x485"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0xacec7367768798c2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x486",
+          "x487"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0x28e55b65dcd69b30"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x488",
+          "x489"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x487",
+          "x484"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x490",
+          "x491"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x489",
+          "x485",
+          "x482"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x492",
+          "x493"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x491",
+          "x483",
+          "x480"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x494",
+          "x495"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x493",
+          "x481",
+          "x478"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x496",
+          "x497"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x495",
+          "x479",
+          "x476"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x498",
+          "x499"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x497",
+          "x477",
+          "x474"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x500",
+          "x501"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x462",
+          "x486"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x502",
+          "x503"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x501",
+          "x464",
+          "x488"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x504",
+          "x505"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x503",
+          "x466",
+          "x490"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x506",
+          "x507"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x505",
+          "x468",
+          "x492"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x508",
+          "x509"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x507",
+          "x470",
+          "x494"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x510",
+          "x511"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x509",
+          "x472",
+          "x496"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x512",
+          "x513"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x511",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x473"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x433"
+                        ]
+                      },
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "static_cast",
+                            "arguments": [
+                              "x419"
+                            ]
+                          },
+                          "x395"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x459"
+                    ]
+                  },
+                  "x435"
+                ]
+              }
+            ]
+          },
+          "x498"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x514",
+          "x515"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x500",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x516",
+          "x517"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x500",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x518",
+          "x519"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x500",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x520",
+          "x521"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x500",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x522",
+          "x523"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x500",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x524",
+          "x525"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x500",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x526",
+          "x527"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x500",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x528",
+          "x529"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x527",
+          "x524"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x530",
+          "x531"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x529",
+          "x525",
+          "x522"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x532",
+          "x533"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x531",
+          "x523",
+          "x520"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x534",
+          "x535"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x533",
+          "x521",
+          "x518"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x536",
+          "x537"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x535",
+          "x519",
+          "x516"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x538",
+          "x539"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x537",
+          "x517",
+          "x514"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x541"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x500",
+          "x526"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x542",
+          "x543"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x541",
+          "x502",
+          "x528"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x544",
+          "x545"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x543",
+          "x504",
+          "x530"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x546",
+          "x547"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x545",
+          "x506",
+          "x532"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x548",
+          "x549"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x547",
+          "x508",
+          "x534"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x550",
+          "x551"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x549",
+          "x510",
+          "x536"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x552",
+          "x553"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x551",
+          "x512",
+          "x538"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x554"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x553"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x513"
+                    ]
+                  },
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x499"
+                        ]
+                      },
+                      "x475"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x539"
+                ]
+              },
+              "x515"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x555",
+          "x556"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x542",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x557",
+          "x558"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x556",
+          "x544",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x559",
+          "x560"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x558",
+          "x546",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x561",
+          "x562"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x560",
+          "x548",
+          "0xfdc1767ae2ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x563",
+          "x564"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x562",
+          "x550",
+          "0x7bc65c783158aea3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x565",
+          "x566"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x564",
+          "x552",
+          "0x6cfc5fd681c52056"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x567",
+          "x568"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x566",
+          "x554",
+          "0x2341f27177344"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x570"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x568",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x571"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x570",
+          "x555",
+          "x542"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x572"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x570",
+          "x557",
+          "x544"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x573"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x570",
+          "x559",
+          "x546"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x574"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x570",
+          "x561",
+          "x548"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x575"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x570",
+          "x563",
+          "x550"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x576"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x570",
+          "x565",
+          "x552"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x577"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x570",
+          "x567",
+          "x554"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x571"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x572"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x573"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x574"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x575"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x576"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x577"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p434_nonzero",
+    "arguments": [
+      {
+        "datatype": "u64[7]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "|",
+        "arguments": [
+          "arg1[0]",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "|",
+            "arguments": [
+              "arg1[1]",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "|",
+                "arguments": [
+                  "arg1[2]",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "|",
+                    "arguments": [
+                      "arg1[3]",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "|",
+                        "arguments": [
+                          "arg1[4]",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "|",
+                            "arguments": [
+                              "arg1[5]",
+                              "arg1[6]"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p434_selectznz",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[7]",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64[7]",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[7]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[0]",
+          "arg3[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[1]",
+          "arg3[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[2]",
+          "arg3[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[3]",
+          "arg3[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[4]",
+          "arg3[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[5]",
+          "arg3[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[6]",
+          "arg3[6]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p434_to_bytes",
+    "arguments": [
+      {
+        "datatype": "u64[7]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u8[55]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x8"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x7"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x7",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x10"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x9",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x12"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x11"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x11",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x14"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x13"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x13",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x16"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x15"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x15",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x18"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x17"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x17",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x20"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x19"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x21"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x19",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x22"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x6",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x24"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x23"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x23",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x26"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x25"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x25",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x28"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x27"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x27",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x30"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x29"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x29",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x32"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x31"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x31",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x34"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x33"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x35"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x33",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x36"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x5"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x5",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x38"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x37"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x37",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x40"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x39"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x39",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x42"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x41"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x41",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x44"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x43"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x43",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x46"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x45"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x45",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x48"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x47"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x49"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x47",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x50"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x4",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x52"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x51"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x51",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x54"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x53"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x53",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x56"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x55"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x55",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x58"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x57"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x57",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x60"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x59"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x59",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x62"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x61"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x63"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x61",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x64"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x65"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x3",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x66"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x65"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x67"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x65",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x68"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x67"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x69"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x67",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x70"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x69"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x71"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x69",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x72"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x71"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x73"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x71",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x74"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x73"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x75"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x73",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x76"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x75"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x77"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x75",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x78"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x2",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x80"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x79"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x79",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x82"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x81"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x81",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x84"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x83"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x85"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x83",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x86"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x85"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x85",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x88"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x87"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x87",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x90"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x89"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x91"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x89",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x92"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x93"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x1",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x94"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x93"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x95"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x93",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x96"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x95"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x97"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x95",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x98"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x97"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x99"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x97",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x100"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x99"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x101"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x99",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x102"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x101"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x103"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x101",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x10"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x12"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x14"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x21"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x22"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x24"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x26"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x28"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x30"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x32"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x34"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x35"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[16]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x36"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[17]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x38"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[18]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x40"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[19]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x42"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[20]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x44"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[21]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x46"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[22]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x48"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[23]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x49"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[24]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x50"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[25]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x52"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[26]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x54"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[27]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x56"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[28]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x58"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[29]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x60"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[30]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x62"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[31]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x63"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[32]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x64"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[33]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x66"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[34]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x68"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[35]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x70"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[36]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x72"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[37]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x74"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[38]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x76"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[39]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x77"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[40]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x78"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[41]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x80"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[42]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x82"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[43]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x84"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[44]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x86"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[45]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x88"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[46]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x90"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[47]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x91"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[48]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x92"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[49]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x94"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[50]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x96"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[51]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x98"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[52]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x100"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[53]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x102"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[54]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x103"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p434_from_bytes",
+    "arguments": [
+      {
+        "datatype": "u8[55]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[7]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[54]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[53]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[52]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[51]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[50]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[49]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[48]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[47]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[46]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[45]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[44]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[43]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[42]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[41]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x15"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[40]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[39]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[38]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[37]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[36]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[35]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[34]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[33]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x23"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[32]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[31]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[30]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[29]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[28]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[27]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[26]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[25]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x31"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[24]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[23]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[22]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[21]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[20]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[19]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[18]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[17]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x39"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[16]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x47"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x55"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x54",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x55"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x53",
+          "x56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x52",
+          "x57"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x51",
+          "x58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x50",
+          "x59"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x49",
+          "x60"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x48",
+          "x61"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x63"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x46",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x47"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x45",
+          "x63"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x65"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x44",
+          "x64"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x43",
+          "x65"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x67"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x42",
+          "x66"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x41",
+          "x67"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x69"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x40",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x38",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x39"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x71"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x37",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x36",
+          "x71"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x73"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x35",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x34",
+          "x73"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x75"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x33",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x76"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x32",
+          "x75"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x77"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x30",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x31"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x29",
+          "x77"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x28",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x80"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x27",
+          "x79"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x26",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x82"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x25",
+          "x81"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x24",
+          "x82"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x22",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x23"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x85"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x21",
+          "x84"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x86"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x20",
+          "x85"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x19",
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x18",
+          "x87"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x17",
+          "x88"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x16",
+          "x89"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x91"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x14",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x15"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x13",
+          "x91"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x93"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x12",
+          "x92"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x94"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x11",
+          "x93"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x95"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x10",
+          "x94"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x9",
+          "x95"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x97"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x8",
+          "x96"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x6",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x7"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x99"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x5",
+          "x98"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x4",
+          "x99"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x101"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x3",
+          "x100"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x2",
+          "x101"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x103"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x1",
+          "x102"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x62"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x69"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x76"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x83"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x90"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x97"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x103"
+        ]
+      }
+    ]
+  }
+]

--- a/fiat-json/src/p448_solinas_32.json
+++ b/fiat-json/src/p448_solinas_32.json
@@ -1,0 +1,31074 @@
+[
+  {
+    "operation": "fiat_p448_addcarryx_u28",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              },
+              "arg2"
+            ]
+          },
+          "arg3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x1",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_subborrowx_u28",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "i32",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "i32",
+            "name": [],
+            "operation": "-",
+            "arguments": [
+              {
+                "datatype": "i32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              },
+              {
+                "datatype": "i32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "i32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "i1",
+        "name": [
+          "x2"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "i1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_cmovznz_u32",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u1",
+        "name": [
+          "x1"
+        ],
+        "operation": "!",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "!",
+            "arguments": [
+              "arg1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "-",
+                "arguments": [
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "0x0"
+                    ]
+                  },
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x1"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "|",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "arg3"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "~",
+                "arguments": [
+                  "x2"
+                ]
+              },
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_carry_mul",
+    "arguments": [
+      {
+        "datatype": "u32[16]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[16]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[16]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x63"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x65"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x67"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x69"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x71"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x73"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x75"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x76"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x77"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x80"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x82"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x85"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x86"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x91"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x93"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x94"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x95"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x97"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x99"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x101"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x103"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x104"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x105"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x106"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x107"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x108"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x109"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x110"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x111"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x112"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x113"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x114"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x115"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x116"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x117"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x118"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x119"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x120"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x121"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x122"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x123"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x124"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x125"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x126"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x127"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x128"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x129"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x130"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x131"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x132"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x133"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x134"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x135"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x136"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x137"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x138"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x139"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x140"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x141"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x142"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x143"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x144"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x145"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x146"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x147"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x148"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x149"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x150"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x151"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x152"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x153"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x154"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x155"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x156"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x157"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x158"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x159"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x160"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x161"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x162"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x163"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x164"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x165"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x166"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x167"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x168"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x169"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x170"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x171"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x172"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x173"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x174"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x175"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x176"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x177"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x178"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x179"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x180"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x181"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x182"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x183"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x184"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x185"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x186"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x187"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x188"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x189"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x190"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x191"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x192"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x193"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x194"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x195"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x196"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x197"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x198"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x199"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x200"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x201"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x202"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x203"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x204"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x205"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x206"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x207"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x208"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x209"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x210"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x211"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x212"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x213"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x214"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x215"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x216"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x217"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x218"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x219"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x220"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x221"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x222"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x223"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x224"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x225"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x226"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x227"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x228"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x229"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x230"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x231"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x232"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x233"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x234"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x235"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x236"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x237"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x238"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x239"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x240"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x241"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x242"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x243"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x244"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x245"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x246"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x247"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x248"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x249"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x250"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x251"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x252"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x253"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x254"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x255"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x256"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x257"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x258"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x259"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x260"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x261"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x262"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x263"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x264"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x265"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x266"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x267"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x268"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x269"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x270"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x271"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x272"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x273"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x274"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x275"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x276"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x277"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x278"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x279"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x280"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x281"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x282"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x283"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x284"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x285"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x286"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x287"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x288"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x289"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x290"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x291"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x292"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x293"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x294"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x295"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x296"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x297"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x298"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x299"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x300"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x301"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x302"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x303"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x304"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x305"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x306"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x307"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x308"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x309"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x310"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x311"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x312"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x313"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x314"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x315"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x316"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x317"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x318"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x319"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x320"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x321"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x322"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x323"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x324"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x325"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x326"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x327"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x328"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x329"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x330"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x331"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x332"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x333"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x334"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x335"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x336"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x337"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x338"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x339"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x340"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x341"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x342"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x343"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x344"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x345"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x346"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x347"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x348"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x349"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x350"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x351"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x352"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x353"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x354"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x355"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x356"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x357"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x358"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x359"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x360"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x361"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x362"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x363"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x364"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x365"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x366"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x367"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x368"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x369"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x370"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x371"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x372"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x373"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x374"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x375"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x376"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x377"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x378"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x379"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x380"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x381"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x382"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x383"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x384"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x385"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x386"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x387"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x388"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x389"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[15]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x390"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[14]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x391"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[13]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x392"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[12]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x393"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[11]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x394"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[10]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x395"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[9]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x396"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x397"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x398"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x399"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x400"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x401"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x402"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x403"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x404"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x405"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x397",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x382",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x368",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x355",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x343",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x332",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x322",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x313",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x141",
+                                          {
+                                            "datatype": "u64",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x133",
+                                              {
+                                                "datatype": "u64",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x124",
+                                                  {
+                                                    "datatype": "u64",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x114",
+                                                      {
+                                                        "datatype": "u64",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x103",
+                                                          {
+                                                            "datatype": "u64",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x91",
+                                                              {
+                                                                "datatype": "u64",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x78",
+                                                                  "x64"
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x406"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x405",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x407"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x405"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x408"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x389",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x374",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x360",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x347",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x335",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x324",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x314",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x305",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x297",
+                                          {
+                                            "datatype": "u64",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x290",
+                                              {
+                                                "datatype": "u64",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x284",
+                                                  {
+                                                    "datatype": "u64",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x279",
+                                                      {
+                                                        "datatype": "u64",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x275",
+                                                          {
+                                                            "datatype": "u64",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x272",
+                                                              {
+                                                                "datatype": "u64",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x270",
+                                                                  {
+                                                                    "datatype": "u64",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x269",
+                                                                      {
+                                                                        "datatype": "u64",
+                                                                        "name": [],
+                                                                        "operation": "+",
+                                                                        "arguments": [
+                                                                          "x233",
+                                                                          {
+                                                                            "datatype": "u64",
+                                                                            "name": [],
+                                                                            "operation": "+",
+                                                                            "arguments": [
+                                                                              "x225",
+                                                                              {
+                                                                                "datatype": "u64",
+                                                                                "name": [],
+                                                                                "operation": "+",
+                                                                                "arguments": [
+                                                                                  "x217",
+                                                                                  {
+                                                                                    "datatype": "u64",
+                                                                                    "name": [],
+                                                                                    "operation": "+",
+                                                                                    "arguments": [
+                                                                                      "x209",
+                                                                                      {
+                                                                                        "datatype": "u64",
+                                                                                        "name": [],
+                                                                                        "operation": "+",
+                                                                                        "arguments": [
+                                                                                          "x201",
+                                                                                          {
+                                                                                            "datatype": "u64",
+                                                                                            "name": [],
+                                                                                            "operation": "+",
+                                                                                            "arguments": [
+                                                                                              "x193",
+                                                                                              {
+                                                                                                "datatype": "u64",
+                                                                                                "name": [],
+                                                                                                "operation": "+",
+                                                                                                "arguments": [
+                                                                                                  "x185",
+                                                                                                  "x177"
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x409"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x390",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x375",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x361",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x348",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x336",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x325",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x315",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x306",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x298",
+                                          {
+                                            "datatype": "u64",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x291",
+                                              {
+                                                "datatype": "u64",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x285",
+                                                  {
+                                                    "datatype": "u64",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x280",
+                                                      {
+                                                        "datatype": "u64",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x276",
+                                                          {
+                                                            "datatype": "u64",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x273",
+                                                              {
+                                                                "datatype": "u64",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x271",
+                                                                  {
+                                                                    "datatype": "u64",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x241",
+                                                                      {
+                                                                        "datatype": "u64",
+                                                                        "name": [],
+                                                                        "operation": "+",
+                                                                        "arguments": [
+                                                                          "x234",
+                                                                          {
+                                                                            "datatype": "u64",
+                                                                            "name": [],
+                                                                            "operation": "+",
+                                                                            "arguments": [
+                                                                              "x226",
+                                                                              {
+                                                                                "datatype": "u64",
+                                                                                "name": [],
+                                                                                "operation": "+",
+                                                                                "arguments": [
+                                                                                  "x218",
+                                                                                  {
+                                                                                    "datatype": "u64",
+                                                                                    "name": [],
+                                                                                    "operation": "+",
+                                                                                    "arguments": [
+                                                                                      "x210",
+                                                                                      {
+                                                                                        "datatype": "u64",
+                                                                                        "name": [],
+                                                                                        "operation": "+",
+                                                                                        "arguments": [
+                                                                                          "x202",
+                                                                                          {
+                                                                                            "datatype": "u64",
+                                                                                            "name": [],
+                                                                                            "operation": "+",
+                                                                                            "arguments": [
+                                                                                              "x194",
+                                                                                              {
+                                                                                                "datatype": "u64",
+                                                                                                "name": [],
+                                                                                                "operation": "+",
+                                                                                                "arguments": [
+                                                                                                  "x186",
+                                                                                                  {
+                                                                                                    "datatype": "u64",
+                                                                                                    "name": [],
+                                                                                                    "operation": "+",
+                                                                                                    "arguments": [
+                                                                                                      "x178",
+                                                                                                      {
+                                                                                                        "datatype": "u64",
+                                                                                                        "name": [],
+                                                                                                        "operation": "+",
+                                                                                                        "arguments": [
+                                                                                                          "x57",
+                                                                                                          "x29"
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x410"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x391",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x376",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x362",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x349",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x337",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x326",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x316",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x307",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x299",
+                                          {
+                                            "datatype": "u64",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x292",
+                                              {
+                                                "datatype": "u64",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x286",
+                                                  {
+                                                    "datatype": "u64",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x281",
+                                                      {
+                                                        "datatype": "u64",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x277",
+                                                          {
+                                                            "datatype": "u64",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x274",
+                                                              {
+                                                                "datatype": "u64",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x248",
+                                                                  {
+                                                                    "datatype": "u64",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x242",
+                                                                      {
+                                                                        "datatype": "u64",
+                                                                        "name": [],
+                                                                        "operation": "+",
+                                                                        "arguments": [
+                                                                          "x235",
+                                                                          {
+                                                                            "datatype": "u64",
+                                                                            "name": [],
+                                                                            "operation": "+",
+                                                                            "arguments": [
+                                                                              "x227",
+                                                                              {
+                                                                                "datatype": "u64",
+                                                                                "name": [],
+                                                                                "operation": "+",
+                                                                                "arguments": [
+                                                                                  "x219",
+                                                                                  {
+                                                                                    "datatype": "u64",
+                                                                                    "name": [],
+                                                                                    "operation": "+",
+                                                                                    "arguments": [
+                                                                                      "x211",
+                                                                                      {
+                                                                                        "datatype": "u64",
+                                                                                        "name": [],
+                                                                                        "operation": "+",
+                                                                                        "arguments": [
+                                                                                          "x203",
+                                                                                          {
+                                                                                            "datatype": "u64",
+                                                                                            "name": [],
+                                                                                            "operation": "+",
+                                                                                            "arguments": [
+                                                                                              "x195",
+                                                                                              {
+                                                                                                "datatype": "u64",
+                                                                                                "name": [],
+                                                                                                "operation": "+",
+                                                                                                "arguments": [
+                                                                                                  "x187",
+                                                                                                  {
+                                                                                                    "datatype": "u64",
+                                                                                                    "name": [],
+                                                                                                    "operation": "+",
+                                                                                                    "arguments": [
+                                                                                                      "x179",
+                                                                                                      {
+                                                                                                        "datatype": "u64",
+                                                                                                        "name": [],
+                                                                                                        "operation": "+",
+                                                                                                        "arguments": [
+                                                                                                          "x72",
+                                                                                                          {
+                                                                                                            "datatype": "u64",
+                                                                                                            "name": [],
+                                                                                                            "operation": "+",
+                                                                                                            "arguments": [
+                                                                                                              "x58",
+                                                                                                              {
+                                                                                                                "datatype": "u64",
+                                                                                                                "name": [],
+                                                                                                                "operation": "+",
+                                                                                                                "arguments": [
+                                                                                                                  "x36",
+                                                                                                                  "x30"
+                                                                                                                ]
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x411"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x392"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x377"
+                ]
+              },
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x363",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x350",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x338",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x327",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x317",
+                                      {
+                                        "datatype": "u128",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x308",
+                                          {
+                                            "datatype": "u128",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x300",
+                                              {
+                                                "datatype": "u128",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x293",
+                                                  {
+                                                    "datatype": "u128",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x287",
+                                                      {
+                                                        "datatype": "u128",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x282",
+                                                          {
+                                                            "datatype": "u128",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x278",
+                                                              {
+                                                                "datatype": "u128",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x254",
+                                                                  {
+                                                                    "datatype": "u128",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x249",
+                                                                      {
+                                                                        "datatype": "u128",
+                                                                        "name": [],
+                                                                        "operation": "+",
+                                                                        "arguments": [
+                                                                          "x243",
+                                                                          {
+                                                                            "datatype": "u128",
+                                                                            "name": [],
+                                                                            "operation": "+",
+                                                                            "arguments": [
+                                                                              "x236",
+                                                                              {
+                                                                                "datatype": "u128",
+                                                                                "name": [],
+                                                                                "operation": "+",
+                                                                                "arguments": [
+                                                                                  "x228",
+                                                                                  {
+                                                                                    "datatype": "u128",
+                                                                                    "name": [],
+                                                                                    "operation": "+",
+                                                                                    "arguments": [
+                                                                                      "x220",
+                                                                                      {
+                                                                                        "datatype": "u128",
+                                                                                        "name": [],
+                                                                                        "operation": "+",
+                                                                                        "arguments": [
+                                                                                          "x212",
+                                                                                          {
+                                                                                            "datatype": "u128",
+                                                                                            "name": [],
+                                                                                            "operation": "+",
+                                                                                            "arguments": [
+                                                                                              "x204",
+                                                                                              {
+                                                                                                "datatype": "u128",
+                                                                                                "name": [],
+                                                                                                "operation": "+",
+                                                                                                "arguments": [
+                                                                                                  "x196",
+                                                                                                  {
+                                                                                                    "datatype": "u128",
+                                                                                                    "name": [],
+                                                                                                    "operation": "+",
+                                                                                                    "arguments": [
+                                                                                                      "x188",
+                                                                                                      {
+                                                                                                        "datatype": "u128",
+                                                                                                        "name": [],
+                                                                                                        "operation": "+",
+                                                                                                        "arguments": [
+                                                                                                          "x180",
+                                                                                                          {
+                                                                                                            "datatype": "u128",
+                                                                                                            "name": [],
+                                                                                                            "operation": "+",
+                                                                                                            "arguments": [
+                                                                                                              "x86",
+                                                                                                              {
+                                                                                                                "datatype": "u128",
+                                                                                                                "name": [],
+                                                                                                                "operation": "+",
+                                                                                                                "arguments": [
+                                                                                                                  "x73",
+                                                                                                                  {
+                                                                                                                    "datatype": "u128",
+                                                                                                                    "name": [],
+                                                                                                                    "operation": "+",
+                                                                                                                    "arguments": [
+                                                                                                                      "x59",
+                                                                                                                      {
+                                                                                                                        "datatype": "u128",
+                                                                                                                        "name": [],
+                                                                                                                        "operation": "+",
+                                                                                                                        "arguments": [
+                                                                                                                          "x42",
+                                                                                                                          {
+                                                                                                                            "datatype": "u128",
+                                                                                                                            "name": [],
+                                                                                                                            "operation": "+",
+                                                                                                                            "arguments": [
+                                                                                                                              "x37",
+                                                                                                                              "x31"
+                                                                                                                            ]
+                                                                                                                          }
+                                                                                                                        ]
+                                                                                                                      }
+                                                                                                                    ]
+                                                                                                                  }
+                                                                                                                ]
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x412"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x393"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x378"
+                ]
+              },
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x364"
+                    ]
+                  },
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x351"
+                        ]
+                      },
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x339",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x328",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x318",
+                                      {
+                                        "datatype": "u128",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x309",
+                                          {
+                                            "datatype": "u128",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x301",
+                                              {
+                                                "datatype": "u128",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x294",
+                                                  {
+                                                    "datatype": "u128",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x288",
+                                                      {
+                                                        "datatype": "u128",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x283",
+                                                          {
+                                                            "datatype": "u128",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x259",
+                                                              {
+                                                                "datatype": "u128",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x255",
+                                                                  {
+                                                                    "datatype": "u128",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x250",
+                                                                      {
+                                                                        "datatype": "u128",
+                                                                        "name": [],
+                                                                        "operation": "+",
+                                                                        "arguments": [
+                                                                          "x244",
+                                                                          {
+                                                                            "datatype": "u128",
+                                                                            "name": [],
+                                                                            "operation": "+",
+                                                                            "arguments": [
+                                                                              "x237",
+                                                                              {
+                                                                                "datatype": "u128",
+                                                                                "name": [],
+                                                                                "operation": "+",
+                                                                                "arguments": [
+                                                                                  "x229",
+                                                                                  {
+                                                                                    "datatype": "u128",
+                                                                                    "name": [],
+                                                                                    "operation": "+",
+                                                                                    "arguments": [
+                                                                                      "x221",
+                                                                                      {
+                                                                                        "datatype": "u128",
+                                                                                        "name": [],
+                                                                                        "operation": "+",
+                                                                                        "arguments": [
+                                                                                          "x213",
+                                                                                          {
+                                                                                            "datatype": "u128",
+                                                                                            "name": [],
+                                                                                            "operation": "+",
+                                                                                            "arguments": [
+                                                                                              "x205",
+                                                                                              {
+                                                                                                "datatype": "u128",
+                                                                                                "name": [],
+                                                                                                "operation": "+",
+                                                                                                "arguments": [
+                                                                                                  "x197",
+                                                                                                  {
+                                                                                                    "datatype": "u128",
+                                                                                                    "name": [],
+                                                                                                    "operation": "+",
+                                                                                                    "arguments": [
+                                                                                                      "x189",
+                                                                                                      {
+                                                                                                        "datatype": "u128",
+                                                                                                        "name": [],
+                                                                                                        "operation": "+",
+                                                                                                        "arguments": [
+                                                                                                          "x181",
+                                                                                                          {
+                                                                                                            "datatype": "u128",
+                                                                                                            "name": [],
+                                                                                                            "operation": "+",
+                                                                                                            "arguments": [
+                                                                                                              "x99",
+                                                                                                              {
+                                                                                                                "datatype": "u128",
+                                                                                                                "name": [],
+                                                                                                                "operation": "+",
+                                                                                                                "arguments": [
+                                                                                                                  "x87",
+                                                                                                                  {
+                                                                                                                    "datatype": "u128",
+                                                                                                                    "name": [],
+                                                                                                                    "operation": "+",
+                                                                                                                    "arguments": [
+                                                                                                                      "x74",
+                                                                                                                      {
+                                                                                                                        "datatype": "u128",
+                                                                                                                        "name": [],
+                                                                                                                        "operation": "+",
+                                                                                                                        "arguments": [
+                                                                                                                          "x60",
+                                                                                                                          {
+                                                                                                                            "datatype": "u128",
+                                                                                                                            "name": [],
+                                                                                                                            "operation": "+",
+                                                                                                                            "arguments": [
+                                                                                                                              "x47",
+                                                                                                                              {
+                                                                                                                                "datatype": "u128",
+                                                                                                                                "name": [],
+                                                                                                                                "operation": "+",
+                                                                                                                                "arguments": [
+                                                                                                                                  "x43",
+                                                                                                                                  {
+                                                                                                                                    "datatype": "u128",
+                                                                                                                                    "name": [],
+                                                                                                                                    "operation": "+",
+                                                                                                                                    "arguments": [
+                                                                                                                                      "x38",
+                                                                                                                                      "x32"
+                                                                                                                                    ]
+                                                                                                                                  }
+                                                                                                                                ]
+                                                                                                                              }
+                                                                                                                            ]
+                                                                                                                          }
+                                                                                                                        ]
+                                                                                                                      }
+                                                                                                                    ]
+                                                                                                                  }
+                                                                                                                ]
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x413"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x394"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x379"
+                ]
+              },
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x365"
+                    ]
+                  },
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x352"
+                        ]
+                      },
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "static_cast",
+                            "arguments": [
+                              "x340"
+                            ]
+                          },
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "static_cast",
+                                "arguments": [
+                                  "x329"
+                                ]
+                              },
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "static_cast",
+                                "arguments": [
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x319",
+                                      {
+                                        "datatype": "u128",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x310",
+                                          {
+                                            "datatype": "u128",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x302",
+                                              {
+                                                "datatype": "u128",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x295",
+                                                  {
+                                                    "datatype": "u128",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x289",
+                                                      {
+                                                        "datatype": "u128",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x263",
+                                                          {
+                                                            "datatype": "u128",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x260",
+                                                              {
+                                                                "datatype": "u128",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x256",
+                                                                  {
+                                                                    "datatype": "u128",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x251",
+                                                                      {
+                                                                        "datatype": "u128",
+                                                                        "name": [],
+                                                                        "operation": "+",
+                                                                        "arguments": [
+                                                                          "x245",
+                                                                          {
+                                                                            "datatype": "u128",
+                                                                            "name": [],
+                                                                            "operation": "+",
+                                                                            "arguments": [
+                                                                              "x238",
+                                                                              {
+                                                                                "datatype": "u128",
+                                                                                "name": [],
+                                                                                "operation": "+",
+                                                                                "arguments": [
+                                                                                  "x230",
+                                                                                  {
+                                                                                    "datatype": "u128",
+                                                                                    "name": [],
+                                                                                    "operation": "+",
+                                                                                    "arguments": [
+                                                                                      "x222",
+                                                                                      {
+                                                                                        "datatype": "u128",
+                                                                                        "name": [],
+                                                                                        "operation": "+",
+                                                                                        "arguments": [
+                                                                                          "x214",
+                                                                                          {
+                                                                                            "datatype": "u128",
+                                                                                            "name": [],
+                                                                                            "operation": "+",
+                                                                                            "arguments": [
+                                                                                              "x206",
+                                                                                              {
+                                                                                                "datatype": "u128",
+                                                                                                "name": [],
+                                                                                                "operation": "+",
+                                                                                                "arguments": [
+                                                                                                  "x198",
+                                                                                                  {
+                                                                                                    "datatype": "u128",
+                                                                                                    "name": [],
+                                                                                                    "operation": "+",
+                                                                                                    "arguments": [
+                                                                                                      "x190",
+                                                                                                      {
+                                                                                                        "datatype": "u128",
+                                                                                                        "name": [],
+                                                                                                        "operation": "+",
+                                                                                                        "arguments": [
+                                                                                                          "x182",
+                                                                                                          {
+                                                                                                            "datatype": "u128",
+                                                                                                            "name": [],
+                                                                                                            "operation": "+",
+                                                                                                            "arguments": [
+                                                                                                              "x111",
+                                                                                                              {
+                                                                                                                "datatype": "u128",
+                                                                                                                "name": [],
+                                                                                                                "operation": "+",
+                                                                                                                "arguments": [
+                                                                                                                  "x100",
+                                                                                                                  {
+                                                                                                                    "datatype": "u128",
+                                                                                                                    "name": [],
+                                                                                                                    "operation": "+",
+                                                                                                                    "arguments": [
+                                                                                                                      "x88",
+                                                                                                                      {
+                                                                                                                        "datatype": "u128",
+                                                                                                                        "name": [],
+                                                                                                                        "operation": "+",
+                                                                                                                        "arguments": [
+                                                                                                                          "x75",
+                                                                                                                          {
+                                                                                                                            "datatype": "u128",
+                                                                                                                            "name": [],
+                                                                                                                            "operation": "+",
+                                                                                                                            "arguments": [
+                                                                                                                              "x61",
+                                                                                                                              {
+                                                                                                                                "datatype": "u128",
+                                                                                                                                "name": [],
+                                                                                                                                "operation": "+",
+                                                                                                                                "arguments": [
+                                                                                                                                  "x51",
+                                                                                                                                  {
+                                                                                                                                    "datatype": "u128",
+                                                                                                                                    "name": [],
+                                                                                                                                    "operation": "+",
+                                                                                                                                    "arguments": [
+                                                                                                                                      "x48",
+                                                                                                                                      {
+                                                                                                                                        "datatype": "u128",
+                                                                                                                                        "name": [],
+                                                                                                                                        "operation": "+",
+                                                                                                                                        "arguments": [
+                                                                                                                                          "x44",
+                                                                                                                                          {
+                                                                                                                                            "datatype": "u128",
+                                                                                                                                            "name": [],
+                                                                                                                                            "operation": "+",
+                                                                                                                                            "arguments": [
+                                                                                                                                              "x39",
+                                                                                                                                              "x33"
+                                                                                                                                            ]
+                                                                                                                                          }
+                                                                                                                                        ]
+                                                                                                                                      }
+                                                                                                                                    ]
+                                                                                                                                  }
+                                                                                                                                ]
+                                                                                                                              }
+                                                                                                                            ]
+                                                                                                                          }
+                                                                                                                        ]
+                                                                                                                      }
+                                                                                                                    ]
+                                                                                                                  }
+                                                                                                                ]
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x414"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x395"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x380"
+                ]
+              },
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x366"
+                    ]
+                  },
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x353"
+                        ]
+                      },
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "static_cast",
+                            "arguments": [
+                              "x341"
+                            ]
+                          },
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "static_cast",
+                                "arguments": [
+                                  "x330"
+                                ]
+                              },
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "static_cast",
+                                    "arguments": [
+                                      "x320"
+                                    ]
+                                  },
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      {
+                                        "datatype": "u128",
+                                        "name": [],
+                                        "operation": "static_cast",
+                                        "arguments": [
+                                          "x311"
+                                        ]
+                                      },
+                                      {
+                                        "datatype": "u128",
+                                        "name": [],
+                                        "operation": "static_cast",
+                                        "arguments": [
+                                          {
+                                            "datatype": "u128",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x303",
+                                              {
+                                                "datatype": "u128",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x296",
+                                                  {
+                                                    "datatype": "u128",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x266",
+                                                      {
+                                                        "datatype": "u128",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x264",
+                                                          {
+                                                            "datatype": "u128",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x261",
+                                                              {
+                                                                "datatype": "u128",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x257",
+                                                                  {
+                                                                    "datatype": "u128",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x252",
+                                                                      {
+                                                                        "datatype": "u128",
+                                                                        "name": [],
+                                                                        "operation": "+",
+                                                                        "arguments": [
+                                                                          "x246",
+                                                                          {
+                                                                            "datatype": "u128",
+                                                                            "name": [],
+                                                                            "operation": "+",
+                                                                            "arguments": [
+                                                                              "x239",
+                                                                              {
+                                                                                "datatype": "u128",
+                                                                                "name": [],
+                                                                                "operation": "+",
+                                                                                "arguments": [
+                                                                                  "x231",
+                                                                                  {
+                                                                                    "datatype": "u128",
+                                                                                    "name": [],
+                                                                                    "operation": "+",
+                                                                                    "arguments": [
+                                                                                      "x223",
+                                                                                      {
+                                                                                        "datatype": "u128",
+                                                                                        "name": [],
+                                                                                        "operation": "+",
+                                                                                        "arguments": [
+                                                                                          "x215",
+                                                                                          {
+                                                                                            "datatype": "u128",
+                                                                                            "name": [],
+                                                                                            "operation": "+",
+                                                                                            "arguments": [
+                                                                                              "x207",
+                                                                                              {
+                                                                                                "datatype": "u128",
+                                                                                                "name": [],
+                                                                                                "operation": "+",
+                                                                                                "arguments": [
+                                                                                                  "x199",
+                                                                                                  {
+                                                                                                    "datatype": "u128",
+                                                                                                    "name": [],
+                                                                                                    "operation": "+",
+                                                                                                    "arguments": [
+                                                                                                      "x191",
+                                                                                                      {
+                                                                                                        "datatype": "u128",
+                                                                                                        "name": [],
+                                                                                                        "operation": "+",
+                                                                                                        "arguments": [
+                                                                                                          "x183",
+                                                                                                          {
+                                                                                                            "datatype": "u128",
+                                                                                                            "name": [],
+                                                                                                            "operation": "+",
+                                                                                                            "arguments": [
+                                                                                                              "x122",
+                                                                                                              {
+                                                                                                                "datatype": "u128",
+                                                                                                                "name": [],
+                                                                                                                "operation": "+",
+                                                                                                                "arguments": [
+                                                                                                                  "x112",
+                                                                                                                  {
+                                                                                                                    "datatype": "u128",
+                                                                                                                    "name": [],
+                                                                                                                    "operation": "+",
+                                                                                                                    "arguments": [
+                                                                                                                      "x101",
+                                                                                                                      {
+                                                                                                                        "datatype": "u128",
+                                                                                                                        "name": [],
+                                                                                                                        "operation": "+",
+                                                                                                                        "arguments": [
+                                                                                                                          "x89",
+                                                                                                                          {
+                                                                                                                            "datatype": "u128",
+                                                                                                                            "name": [],
+                                                                                                                            "operation": "+",
+                                                                                                                            "arguments": [
+                                                                                                                              "x76",
+                                                                                                                              {
+                                                                                                                                "datatype": "u128",
+                                                                                                                                "name": [],
+                                                                                                                                "operation": "+",
+                                                                                                                                "arguments": [
+                                                                                                                                  "x62",
+                                                                                                                                  {
+                                                                                                                                    "datatype": "u128",
+                                                                                                                                    "name": [],
+                                                                                                                                    "operation": "+",
+                                                                                                                                    "arguments": [
+                                                                                                                                      "x54",
+                                                                                                                                      {
+                                                                                                                                        "datatype": "u128",
+                                                                                                                                        "name": [],
+                                                                                                                                        "operation": "+",
+                                                                                                                                        "arguments": [
+                                                                                                                                          "x52",
+                                                                                                                                          {
+                                                                                                                                            "datatype": "u128",
+                                                                                                                                            "name": [],
+                                                                                                                                            "operation": "+",
+                                                                                                                                            "arguments": [
+                                                                                                                                              "x49",
+                                                                                                                                              {
+                                                                                                                                                "datatype": "u128",
+                                                                                                                                                "name": [],
+                                                                                                                                                "operation": "+",
+                                                                                                                                                "arguments": [
+                                                                                                                                                  "x45",
+                                                                                                                                                  {
+                                                                                                                                                    "datatype": "u128",
+                                                                                                                                                    "name": [],
+                                                                                                                                                    "operation": "+",
+                                                                                                                                                    "arguments": [
+                                                                                                                                                      "x40",
+                                                                                                                                                      "x34"
+                                                                                                                                                    ]
+                                                                                                                                                  }
+                                                                                                                                                ]
+                                                                                                                                              }
+                                                                                                                                            ]
+                                                                                                                                          }
+                                                                                                                                        ]
+                                                                                                                                      }
+                                                                                                                                    ]
+                                                                                                                                  }
+                                                                                                                                ]
+                                                                                                                              }
+                                                                                                                            ]
+                                                                                                                          }
+                                                                                                                        ]
+                                                                                                                      }
+                                                                                                                    ]
+                                                                                                                  }
+                                                                                                                ]
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x415"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x396"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x381"
+                ]
+              },
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x367"
+                    ]
+                  },
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x354"
+                        ]
+                      },
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "static_cast",
+                            "arguments": [
+                              "x342"
+                            ]
+                          },
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "static_cast",
+                                "arguments": [
+                                  "x331"
+                                ]
+                              },
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "static_cast",
+                                    "arguments": [
+                                      "x321"
+                                    ]
+                                  },
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      {
+                                        "datatype": "u128",
+                                        "name": [],
+                                        "operation": "static_cast",
+                                        "arguments": [
+                                          "x312"
+                                        ]
+                                      },
+                                      {
+                                        "datatype": "u128",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          {
+                                            "datatype": "u128",
+                                            "name": [],
+                                            "operation": "static_cast",
+                                            "arguments": [
+                                              "x304"
+                                            ]
+                                          },
+                                          {
+                                            "datatype": "u128",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              {
+                                                "datatype": "u128",
+                                                "name": [],
+                                                "operation": "static_cast",
+                                                "arguments": [
+                                                  "x268"
+                                                ]
+                                              },
+                                              {
+                                                "datatype": "u128",
+                                                "name": [],
+                                                "operation": "static_cast",
+                                                "arguments": [
+                                                  {
+                                                    "datatype": "u128",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x267",
+                                                      {
+                                                        "datatype": "u128",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x265",
+                                                          {
+                                                            "datatype": "u128",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x262",
+                                                              {
+                                                                "datatype": "u128",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x258",
+                                                                  {
+                                                                    "datatype": "u128",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x253",
+                                                                      {
+                                                                        "datatype": "u128",
+                                                                        "name": [],
+                                                                        "operation": "+",
+                                                                        "arguments": [
+                                                                          "x247",
+                                                                          {
+                                                                            "datatype": "u128",
+                                                                            "name": [],
+                                                                            "operation": "+",
+                                                                            "arguments": [
+                                                                              "x240",
+                                                                              {
+                                                                                "datatype": "u128",
+                                                                                "name": [],
+                                                                                "operation": "+",
+                                                                                "arguments": [
+                                                                                  "x232",
+                                                                                  {
+                                                                                    "datatype": "u128",
+                                                                                    "name": [],
+                                                                                    "operation": "+",
+                                                                                    "arguments": [
+                                                                                      "x224",
+                                                                                      {
+                                                                                        "datatype": "u128",
+                                                                                        "name": [],
+                                                                                        "operation": "+",
+                                                                                        "arguments": [
+                                                                                          "x216",
+                                                                                          {
+                                                                                            "datatype": "u128",
+                                                                                            "name": [],
+                                                                                            "operation": "+",
+                                                                                            "arguments": [
+                                                                                              "x208",
+                                                                                              {
+                                                                                                "datatype": "u128",
+                                                                                                "name": [],
+                                                                                                "operation": "+",
+                                                                                                "arguments": [
+                                                                                                  "x200",
+                                                                                                  {
+                                                                                                    "datatype": "u128",
+                                                                                                    "name": [],
+                                                                                                    "operation": "+",
+                                                                                                    "arguments": [
+                                                                                                      "x192",
+                                                                                                      {
+                                                                                                        "datatype": "u128",
+                                                                                                        "name": [],
+                                                                                                        "operation": "+",
+                                                                                                        "arguments": [
+                                                                                                          "x184",
+                                                                                                          {
+                                                                                                            "datatype": "u128",
+                                                                                                            "name": [],
+                                                                                                            "operation": "+",
+                                                                                                            "arguments": [
+                                                                                                              "x132",
+                                                                                                              {
+                                                                                                                "datatype": "u128",
+                                                                                                                "name": [],
+                                                                                                                "operation": "+",
+                                                                                                                "arguments": [
+                                                                                                                  "x123",
+                                                                                                                  {
+                                                                                                                    "datatype": "u128",
+                                                                                                                    "name": [],
+                                                                                                                    "operation": "+",
+                                                                                                                    "arguments": [
+                                                                                                                      "x113",
+                                                                                                                      {
+                                                                                                                        "datatype": "u128",
+                                                                                                                        "name": [],
+                                                                                                                        "operation": "+",
+                                                                                                                        "arguments": [
+                                                                                                                          "x102",
+                                                                                                                          {
+                                                                                                                            "datatype": "u128",
+                                                                                                                            "name": [],
+                                                                                                                            "operation": "+",
+                                                                                                                            "arguments": [
+                                                                                                                              "x90",
+                                                                                                                              {
+                                                                                                                                "datatype": "u128",
+                                                                                                                                "name": [],
+                                                                                                                                "operation": "+",
+                                                                                                                                "arguments": [
+                                                                                                                                  "x77",
+                                                                                                                                  {
+                                                                                                                                    "datatype": "u128",
+                                                                                                                                    "name": [],
+                                                                                                                                    "operation": "+",
+                                                                                                                                    "arguments": [
+                                                                                                                                      "x63",
+                                                                                                                                      {
+                                                                                                                                        "datatype": "u128",
+                                                                                                                                        "name": [],
+                                                                                                                                        "operation": "+",
+                                                                                                                                        "arguments": [
+                                                                                                                                          "x56",
+                                                                                                                                          {
+                                                                                                                                            "datatype": "u128",
+                                                                                                                                            "name": [],
+                                                                                                                                            "operation": "+",
+                                                                                                                                            "arguments": [
+                                                                                                                                              "x55",
+                                                                                                                                              {
+                                                                                                                                                "datatype": "u128",
+                                                                                                                                                "name": [],
+                                                                                                                                                "operation": "+",
+                                                                                                                                                "arguments": [
+                                                                                                                                                  "x53",
+                                                                                                                                                  {
+                                                                                                                                                    "datatype": "u128",
+                                                                                                                                                    "name": [],
+                                                                                                                                                    "operation": "+",
+                                                                                                                                                    "arguments": [
+                                                                                                                                                      "x50",
+                                                                                                                                                      {
+                                                                                                                                                        "datatype": "u128",
+                                                                                                                                                        "name": [],
+                                                                                                                                                        "operation": "+",
+                                                                                                                                                        "arguments": [
+                                                                                                                                                          "x46",
+                                                                                                                                                          {
+                                                                                                                                                            "datatype": "u128",
+                                                                                                                                                            "name": [],
+                                                                                                                                                            "operation": "+",
+                                                                                                                                                            "arguments": [
+                                                                                                                                                              "x41",
+                                                                                                                                                              "x35"
+                                                                                                                                                            ]
+                                                                                                                                                          }
+                                                                                                                                                        ]
+                                                                                                                                                      }
+                                                                                                                                                    ]
+                                                                                                                                                  }
+                                                                                                                                                ]
+                                                                                                                                              }
+                                                                                                                                            ]
+                                                                                                                                          }
+                                                                                                                                        ]
+                                                                                                                                      }
+                                                                                                                                    ]
+                                                                                                                                  }
+                                                                                                                                ]
+                                                                                                                              }
+                                                                                                                            ]
+                                                                                                                          }
+                                                                                                                        ]
+                                                                                                                      }
+                                                                                                                    ]
+                                                                                                                  }
+                                                                                                                ]
+                                                                                                              }
+                                                                                                            ]
+                                                                                                          }
+                                                                                                        ]
+                                                                                                      }
+                                                                                                    ]
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x416"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x398",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x383",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x369",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x356",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x344",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x333",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x323",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x149",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x142",
+                                          {
+                                            "datatype": "u64",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x134",
+                                              {
+                                                "datatype": "u64",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x125",
+                                                  {
+                                                    "datatype": "u64",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x115",
+                                                      {
+                                                        "datatype": "u64",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x104",
+                                                          {
+                                                            "datatype": "u64",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x92",
+                                                              {
+                                                                "datatype": "u64",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x79",
+                                                                  {
+                                                                    "datatype": "u64",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x65",
+                                                                      "x1"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x417"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x399",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x384",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x370",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x357",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x345",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x334",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x156",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x150",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x143",
+                                          {
+                                            "datatype": "u64",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x135",
+                                              {
+                                                "datatype": "u64",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x126",
+                                                  {
+                                                    "datatype": "u64",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x116",
+                                                      {
+                                                        "datatype": "u64",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x105",
+                                                          {
+                                                            "datatype": "u64",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x93",
+                                                              {
+                                                                "datatype": "u64",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x80",
+                                                                  {
+                                                                    "datatype": "u64",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x66",
+                                                                      {
+                                                                        "datatype": "u64",
+                                                                        "name": [],
+                                                                        "operation": "+",
+                                                                        "arguments": [
+                                                                          "x8",
+                                                                          "x2"
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x418"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x400",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x385",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x371",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x358",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x346",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x162",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x157",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x151",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x144",
+                                          {
+                                            "datatype": "u64",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x136",
+                                              {
+                                                "datatype": "u64",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x127",
+                                                  {
+                                                    "datatype": "u64",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x117",
+                                                      {
+                                                        "datatype": "u64",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x106",
+                                                          {
+                                                            "datatype": "u64",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x94",
+                                                              {
+                                                                "datatype": "u64",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x81",
+                                                                  {
+                                                                    "datatype": "u64",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x67",
+                                                                      {
+                                                                        "datatype": "u64",
+                                                                        "name": [],
+                                                                        "operation": "+",
+                                                                        "arguments": [
+                                                                          "x14",
+                                                                          {
+                                                                            "datatype": "u64",
+                                                                            "name": [],
+                                                                            "operation": "+",
+                                                                            "arguments": [
+                                                                              "x9",
+                                                                              "x3"
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x419"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x401",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x386",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x372",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x359",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x167",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x163",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x158",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x152",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x145",
+                                          {
+                                            "datatype": "u64",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x137",
+                                              {
+                                                "datatype": "u64",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x128",
+                                                  {
+                                                    "datatype": "u64",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x118",
+                                                      {
+                                                        "datatype": "u64",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x107",
+                                                          {
+                                                            "datatype": "u64",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x95",
+                                                              {
+                                                                "datatype": "u64",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x82",
+                                                                  {
+                                                                    "datatype": "u64",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x68",
+                                                                      {
+                                                                        "datatype": "u64",
+                                                                        "name": [],
+                                                                        "operation": "+",
+                                                                        "arguments": [
+                                                                          "x19",
+                                                                          {
+                                                                            "datatype": "u64",
+                                                                            "name": [],
+                                                                            "operation": "+",
+                                                                            "arguments": [
+                                                                              "x15",
+                                                                              {
+                                                                                "datatype": "u64",
+                                                                                "name": [],
+                                                                                "operation": "+",
+                                                                                "arguments": [
+                                                                                  "x10",
+                                                                                  "x4"
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x420"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x402",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x387",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x373",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x171",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x168",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x164",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x159",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x153",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x146",
+                                          {
+                                            "datatype": "u64",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x138",
+                                              {
+                                                "datatype": "u64",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x129",
+                                                  {
+                                                    "datatype": "u64",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x119",
+                                                      {
+                                                        "datatype": "u64",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x108",
+                                                          {
+                                                            "datatype": "u64",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x96",
+                                                              {
+                                                                "datatype": "u64",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x83",
+                                                                  {
+                                                                    "datatype": "u64",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x69",
+                                                                      {
+                                                                        "datatype": "u64",
+                                                                        "name": [],
+                                                                        "operation": "+",
+                                                                        "arguments": [
+                                                                          "x23",
+                                                                          {
+                                                                            "datatype": "u64",
+                                                                            "name": [],
+                                                                            "operation": "+",
+                                                                            "arguments": [
+                                                                              "x20",
+                                                                              {
+                                                                                "datatype": "u64",
+                                                                                "name": [],
+                                                                                "operation": "+",
+                                                                                "arguments": [
+                                                                                  "x16",
+                                                                                  {
+                                                                                    "datatype": "u64",
+                                                                                    "name": [],
+                                                                                    "operation": "+",
+                                                                                    "arguments": [
+                                                                                      "x11",
+                                                                                      "x5"
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x421"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x403",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x388",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x174",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x172",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x169",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x165",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x160",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x154",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x147",
+                                          {
+                                            "datatype": "u64",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x139",
+                                              {
+                                                "datatype": "u64",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x130",
+                                                  {
+                                                    "datatype": "u64",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x120",
+                                                      {
+                                                        "datatype": "u64",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x109",
+                                                          {
+                                                            "datatype": "u64",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x97",
+                                                              {
+                                                                "datatype": "u64",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x84",
+                                                                  {
+                                                                    "datatype": "u64",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x70",
+                                                                      {
+                                                                        "datatype": "u64",
+                                                                        "name": [],
+                                                                        "operation": "+",
+                                                                        "arguments": [
+                                                                          "x26",
+                                                                          {
+                                                                            "datatype": "u64",
+                                                                            "name": [],
+                                                                            "operation": "+",
+                                                                            "arguments": [
+                                                                              "x24",
+                                                                              {
+                                                                                "datatype": "u64",
+                                                                                "name": [],
+                                                                                "operation": "+",
+                                                                                "arguments": [
+                                                                                  "x21",
+                                                                                  {
+                                                                                    "datatype": "u64",
+                                                                                    "name": [],
+                                                                                    "operation": "+",
+                                                                                    "arguments": [
+                                                                                      "x17",
+                                                                                      {
+                                                                                        "datatype": "u64",
+                                                                                        "name": [],
+                                                                                        "operation": "+",
+                                                                                        "arguments": [
+                                                                                          "x12",
+                                                                                          "x6"
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x422"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x404",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x176",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x175",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x173",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x170",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x166",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x161",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x155",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x148",
+                                          {
+                                            "datatype": "u64",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x140",
+                                              {
+                                                "datatype": "u64",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x131",
+                                                  {
+                                                    "datatype": "u64",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x121",
+                                                      {
+                                                        "datatype": "u64",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x110",
+                                                          {
+                                                            "datatype": "u64",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x98",
+                                                              {
+                                                                "datatype": "u64",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x85",
+                                                                  {
+                                                                    "datatype": "u64",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x71",
+                                                                      {
+                                                                        "datatype": "u64",
+                                                                        "name": [],
+                                                                        "operation": "+",
+                                                                        "arguments": [
+                                                                          "x28",
+                                                                          {
+                                                                            "datatype": "u64",
+                                                                            "name": [],
+                                                                            "operation": "+",
+                                                                            "arguments": [
+                                                                              "x27",
+                                                                              {
+                                                                                "datatype": "u64",
+                                                                                "name": [],
+                                                                                "operation": "+",
+                                                                                "arguments": [
+                                                                                  "x25",
+                                                                                  {
+                                                                                    "datatype": "u64",
+                                                                                    "name": [],
+                                                                                    "operation": "+",
+                                                                                    "arguments": [
+                                                                                      "x22",
+                                                                                      {
+                                                                                        "datatype": "u64",
+                                                                                        "name": [],
+                                                                                        "operation": "+",
+                                                                                        "arguments": [
+                                                                                          "x18",
+                                                                                          {
+                                                                                            "datatype": "u64",
+                                                                                            "name": [],
+                                                                                            "operation": "+",
+                                                                                            "arguments": [
+                                                                                              "x13",
+                                                                                              "x7"
+                                                                                            ]
+                                                                                          }
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x423"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x406"
+            ]
+          },
+          "x415"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x424"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x408",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x425"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x408"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x426"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x423",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x424"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x427"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x426",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x428"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x426"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x429"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x422",
+          "x424"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x430"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x427"
+            ]
+          },
+          "x414"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x431"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x429",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x432"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x429"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x433"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x431",
+          "x421"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x434"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x430",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x435"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x430"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x436"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x434"
+            ]
+          },
+          "x413"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x437"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x433",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x438"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x433"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x439"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x437",
+          "x420"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x440"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x436",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x441"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x436"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x442"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x440"
+            ]
+          },
+          "x412"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x443"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x439",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x444"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x439"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x445"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x443",
+          "x419"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x446"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x442",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x447"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x442"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x448"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x446"
+            ]
+          },
+          "x411"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x449"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x445",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x450"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x445"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x451"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x449",
+          "x418"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x452"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x448",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x453"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x448"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x454"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x452",
+          "x410"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x455"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x451",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x456"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x451"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x457"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x455",
+          "x417"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x458"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x454",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x459"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x454"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x460"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x458",
+          "x409"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x461"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x457",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x462"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x457"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x463"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x461",
+          "x416"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x464"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x460",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x465"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x460"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x466"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x464",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x425"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x467"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x463",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x468"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x463"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x469"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x467",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x407"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x470"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x466",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x471"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x466"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x472"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x469",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x473"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x469"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x474"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x428",
+          "x470"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x475"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x432",
+          "x470"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x476"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x472",
+          "x474"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x477"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x476",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x478"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x476",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x479"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x477"
+            ]
+          },
+          "x435"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x480"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x475",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x481"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x475",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x482"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x480"
+            ]
+          },
+          "x438"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x481"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x482"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x444"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x450"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x456"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x462"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x468"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x473"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x478"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x479"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x441"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x447"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x453"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x459"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x465"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x471"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_carry_square",
+    "arguments": [
+      {
+        "datatype": "u32[16]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[16]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[15]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[15]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x1",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x2",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[15]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[14]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[14]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x6",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x7",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[14]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[13]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[13]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x11",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x12",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[13]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[12]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[12]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x16",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x17",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[12]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x21",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x22",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[11]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x26",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x27",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[10]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x31",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x32",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[9]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[8]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[7]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[6]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[5]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[4]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x43"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[3]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[2]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x45"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[1]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x11"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x63"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x65"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x67"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x11"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x69"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x71"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x73"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x75"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x76"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x77"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x80"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x7"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x82"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x85"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x86"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x17"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x91"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x19"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x93"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x22"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x94"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x21"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x95"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x97"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x99"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x19"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x101"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x23"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x103"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x27"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x104"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x105"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x106"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x107"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x108"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x109"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x110"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x19"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x111"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x112"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x113"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x23"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x114"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x29"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x115"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x116"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x117"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x31"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x118"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x119"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x120"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x121"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x122"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x123"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x124"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x19"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x125"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x126"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x127"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x23"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x128"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x29"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x129"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x130"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x34"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x131"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x33"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x132"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x37"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x133"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x36"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x134"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x135"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x136"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x137"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x138"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x139"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x140"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x19"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x141"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x142"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x143"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x23"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x144"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x29"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x145"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x146"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x34"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x147"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x33"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x148"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x149"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x150"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x151"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x152"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x153"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x154"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x155"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x156"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x19"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x157"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x158"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x159"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x23"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x160"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x29"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x161"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x162"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x35"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x163"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x164"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x39"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x165"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x166"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x167"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x168"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x169"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x170"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x171"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x172"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x19"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x173"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x174"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x175"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x23"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x176"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x30"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x177"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x35"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x178"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x179"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x39"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x180"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x181"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x182"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x183"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x184"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x185"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x186"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x187"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x188"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x19"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x189"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x190"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x191"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x30"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x192"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x35"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x193"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x194"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x39"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x195"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x196"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x41"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x197"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x198"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x199"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x200"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x201"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x202"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x203"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x204"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x20"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x205"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x206"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x30"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x207"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x35"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x208"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x209"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x39"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x210"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x211"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x41"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x212"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x213"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x214"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x215"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x216"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x217"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x218"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x15"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x219"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x20"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x220"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x221"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x30"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x222"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x35"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x223"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x224"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x39"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x225"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x226"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x41"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x227"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x228"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x43"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x229"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x230"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x231"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x232"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x10"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x233"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x15"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x234"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x20"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x235"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x236"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x30"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x237"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x35"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x238"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x239"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x39"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x240"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x241"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x41"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x242"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x243"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x43"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x244"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x44"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x245"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x246"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x5"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x247"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x10"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x248"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x15"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x249"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x20"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x250"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x251"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x30"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x252"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x35"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x253"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x254"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x39"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x255"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x256"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x41"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x257"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x258"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x43"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x259"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x44"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x260"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x45"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x261"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x262"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x254",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x240",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x226",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x212",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x118",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x106",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x97",
+                                  "x91"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x263"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x262",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x264"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x262"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x265"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x246",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x232",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x218",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x204",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x190",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x176",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x162",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x148",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x119",
+                                          {
+                                            "datatype": "u64",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x107",
+                                              {
+                                                "datatype": "u64",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x98",
+                                                  "x92"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x266"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x247",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x233",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x219",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x205",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x191",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x177",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x163",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x149",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x135",
+                                          {
+                                            "datatype": "u64",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x121",
+                                              {
+                                                "datatype": "u64",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x109",
+                                                  {
+                                                    "datatype": "u64",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x100",
+                                                      {
+                                                        "datatype": "u64",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x94",
+                                                          {
+                                                            "datatype": "u64",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x78",
+                                                              "x62"
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x267"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x248",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x234",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x220",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x206",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x192",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x178",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x164",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x151",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x137",
+                                          {
+                                            "datatype": "u64",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x123",
+                                              {
+                                                "datatype": "u64",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x111",
+                                                  {
+                                                    "datatype": "u64",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x102",
+                                                      {
+                                                        "datatype": "u64",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x79",
+                                                          "x63"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x268"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x249"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x235",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x221",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x207",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x193",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x179",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x167",
+                                      {
+                                        "datatype": "u128",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x165",
+                                          {
+                                            "datatype": "u128",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x153",
+                                              {
+                                                "datatype": "u128",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x139",
+                                                  {
+                                                    "datatype": "u128",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x125",
+                                                      {
+                                                        "datatype": "u128",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x113",
+                                                          {
+                                                            "datatype": "u128",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x104",
+                                                              {
+                                                                "datatype": "u128",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x81",
+                                                                  {
+                                                                    "datatype": "u128",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x80",
+                                                                      {
+                                                                        "datatype": "u128",
+                                                                        "name": [],
+                                                                        "operation": "+",
+                                                                        "arguments": [
+                                                                          "x65",
+                                                                          "x64"
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x269"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x250"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x236"
+                ]
+              },
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x222",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x208",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x194",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x183",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x180",
+                                      {
+                                        "datatype": "u128",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x169",
+                                          {
+                                            "datatype": "u128",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x155",
+                                              {
+                                                "datatype": "u128",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x141",
+                                                  {
+                                                    "datatype": "u128",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x127",
+                                                      {
+                                                        "datatype": "u128",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x115",
+                                                          {
+                                                            "datatype": "u128",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x84",
+                                                              {
+                                                                "datatype": "u128",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x82",
+                                                                  {
+                                                                    "datatype": "u128",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x68",
+                                                                      "x66"
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x270"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x251"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x237"
+                ]
+              },
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x223"
+                    ]
+                  },
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x209",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x199",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x195",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x185",
+                                      {
+                                        "datatype": "u128",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x181",
+                                          {
+                                            "datatype": "u128",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x171",
+                                              {
+                                                "datatype": "u128",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x157",
+                                                  {
+                                                    "datatype": "u128",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x143",
+                                                      {
+                                                        "datatype": "u128",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x129",
+                                                          {
+                                                            "datatype": "u128",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x117",
+                                                              {
+                                                                "datatype": "u128",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x88",
+                                                                  {
+                                                                    "datatype": "u128",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x85",
+                                                                      {
+                                                                        "datatype": "u128",
+                                                                        "name": [],
+                                                                        "operation": "+",
+                                                                        "arguments": [
+                                                                          "x83",
+                                                                          {
+                                                                            "datatype": "u128",
+                                                                            "name": [],
+                                                                            "operation": "+",
+                                                                            "arguments": [
+                                                                              "x72",
+                                                                              {
+                                                                                "datatype": "u128",
+                                                                                "name": [],
+                                                                                "operation": "+",
+                                                                                "arguments": [
+                                                                                  "x69",
+                                                                                  "x67"
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x271"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x252"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x238"
+                ]
+              },
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x224"
+                    ]
+                  },
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x215"
+                        ]
+                      },
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x210",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x201",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x196",
+                                      {
+                                        "datatype": "u128",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x187",
+                                          {
+                                            "datatype": "u128",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x173",
+                                              {
+                                                "datatype": "u128",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x159",
+                                                  {
+                                                    "datatype": "u128",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x145",
+                                                      {
+                                                        "datatype": "u128",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x131",
+                                                          {
+                                                            "datatype": "u128",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x95",
+                                                              {
+                                                                "datatype": "u128",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x89",
+                                                                  {
+                                                                    "datatype": "u128",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x86",
+                                                                      {
+                                                                        "datatype": "u128",
+                                                                        "name": [],
+                                                                        "operation": "+",
+                                                                        "arguments": [
+                                                                          "x75",
+                                                                          {
+                                                                            "datatype": "u128",
+                                                                            "name": [],
+                                                                            "operation": "+",
+                                                                            "arguments": [
+                                                                              "x73",
+                                                                              "x70"
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x272"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x253"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x239"
+                ]
+              },
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x231"
+                    ]
+                  },
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "static_cast",
+                        "arguments": [
+                          "x225"
+                        ]
+                      },
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "static_cast",
+                            "arguments": [
+                              "x217"
+                            ]
+                          },
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "static_cast",
+                            "arguments": [
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x211",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x203",
+                                      {
+                                        "datatype": "u128",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x197",
+                                          {
+                                            "datatype": "u128",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x189",
+                                              {
+                                                "datatype": "u128",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x175",
+                                                  {
+                                                    "datatype": "u128",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x161",
+                                                      {
+                                                        "datatype": "u128",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x147",
+                                                          {
+                                                            "datatype": "u128",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x133",
+                                                              {
+                                                                "datatype": "u128",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x105",
+                                                                  {
+                                                                    "datatype": "u128",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x96",
+                                                                      {
+                                                                        "datatype": "u128",
+                                                                        "name": [],
+                                                                        "operation": "+",
+                                                                        "arguments": [
+                                                                          "x90",
+                                                                          {
+                                                                            "datatype": "u128",
+                                                                            "name": [],
+                                                                            "operation": "+",
+                                                                            "arguments": [
+                                                                              "x87",
+                                                                              {
+                                                                                "datatype": "u128",
+                                                                                "name": [],
+                                                                                "operation": "+",
+                                                                                "arguments": [
+                                                                                  "x77",
+                                                                                  {
+                                                                                    "datatype": "u128",
+                                                                                    "name": [],
+                                                                                    "operation": "+",
+                                                                                    "arguments": [
+                                                                                      "x76",
+                                                                                      {
+                                                                                        "datatype": "u128",
+                                                                                        "name": [],
+                                                                                        "operation": "+",
+                                                                                        "arguments": [
+                                                                                          "x74",
+                                                                                          "x71"
+                                                                                        ]
+                                                                                      }
+                                                                                    ]
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x273"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x255",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x241",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x227",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x213",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x134",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x120",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x108",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x99",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x93",
+                                          "x46"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x274"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x256",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x242",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x228",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x150",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x136",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x122",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x110",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x101",
+                                      "x47"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x275"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x257",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x243",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x229",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x166",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x152",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x138",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x124",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x112",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x103",
+                                          {
+                                            "datatype": "u64",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x49",
+                                              "x48"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x276"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x258",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x244",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x182",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x168",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x154",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x140",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x126",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x114",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x52",
+                                          "x50"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x277"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x259",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x245",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x198",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x184",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x170",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x156",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x142",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x128",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x116",
+                                          {
+                                            "datatype": "u64",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x56",
+                                              {
+                                                "datatype": "u64",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x53",
+                                                  "x51"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x278"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x260",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x214",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x200",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x186",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x172",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x158",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x144",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x130",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x59",
+                                          {
+                                            "datatype": "u64",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x57",
+                                              "x54"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x279"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x261",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x230",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x216",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x202",
+                      {
+                        "datatype": "u64",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x188",
+                          {
+                            "datatype": "u64",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x174",
+                              {
+                                "datatype": "u64",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x160",
+                                  {
+                                    "datatype": "u64",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x146",
+                                      {
+                                        "datatype": "u64",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x132",
+                                          {
+                                            "datatype": "u64",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x61",
+                                              {
+                                                "datatype": "u64",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x60",
+                                                  {
+                                                    "datatype": "u64",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x58",
+                                                      "x55"
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x280"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x263"
+            ]
+          },
+          "x272"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x281"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x265",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x282"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x265"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x283"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x280",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x281"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x284"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x283",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x285"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x283"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x286"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x279",
+          "x281"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x287"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x284"
+            ]
+          },
+          "x271"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x288"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x286",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x289"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x286"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x290"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x288",
+          "x278"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x291"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x287",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x292"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x287"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x293"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x291"
+            ]
+          },
+          "x270"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x294"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x290",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x295"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x290"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x296"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x294",
+          "x277"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x297"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x293",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x298"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x293"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x299"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x297"
+            ]
+          },
+          "x269"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x300"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x296",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x301"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x296"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x302"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x300",
+          "x276"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x303"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x299",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x304"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x299"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x305"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x303"
+            ]
+          },
+          "x268"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x306"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x302",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x307"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x302"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x308"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x306",
+          "x275"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x309"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x305",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x310"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x305"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x311"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x309",
+          "x267"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x312"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x308",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x313"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x308"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x314"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x312",
+          "x274"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x315"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x311",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x316"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x311"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x317"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x315",
+          "x266"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x318"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x314",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x319"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x314"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x320"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x318",
+          "x273"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x321"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x317",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x322"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x317"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x323"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x321",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x282"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x324"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x320",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x325"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x320"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x326"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x324",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x264"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x327"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x323",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x328"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x323"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x329"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x326",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x330"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x326"
+            ]
+          },
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x331"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x285",
+          "x327"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x332"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x289",
+          "x327"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x333"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x329",
+          "x331"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x334"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x333",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x335"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x333",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x336"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x334"
+            ]
+          },
+          "x292"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x337"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x332",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x338"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x332",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x339"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x337"
+            ]
+          },
+          "x295"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x338"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x339"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x301"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x307"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x313"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x319"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x325"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x330"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x335"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x336"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x298"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x304"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x310"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x316"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x322"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x328"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_carry",
+    "arguments": [
+      {
+        "datatype": "u32[16]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[16]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[15]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x2",
+          "28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": ">>",
+                "arguments": [
+                  "x1",
+                  "28"
+                ]
+              },
+              "arg1[8]"
+            ]
+          },
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[0]",
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x4",
+              "28"
+            ]
+          },
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x5",
+              "28"
+            ]
+          },
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x6",
+              "28"
+            ]
+          },
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x7",
+              "28"
+            ]
+          },
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x8",
+              "28"
+            ]
+          },
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x9",
+              "28"
+            ]
+          },
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x10",
+              "28"
+            ]
+          },
+          "arg1[12]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x11",
+              "28"
+            ]
+          },
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x12",
+              "28"
+            ]
+          },
+          "arg1[13]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x13",
+              "28"
+            ]
+          },
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x14",
+              "28"
+            ]
+          },
+          "arg1[14]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x15",
+              "28"
+            ]
+          },
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x16",
+              "28"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "0xfffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x17",
+              "28"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x1",
+              "0xfffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x20"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x18",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x5",
+              "0xfffffff"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x20"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": ">>",
+                    "arguments": [
+                      "x19",
+                      "28"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "&",
+                "arguments": [
+                  "x4",
+                  "0xfffffff"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x20"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x21",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": ">>",
+                    "arguments": [
+                      "x21",
+                      "28"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x7",
+              "0xfffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x9",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x11",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x13",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x15",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x17",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x19",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x22",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": ">>",
+                    "arguments": [
+                      "x22",
+                      "28"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x6",
+              "0xfffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x8",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x10",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x12",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x14",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x16",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x18",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x23"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x24"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x25"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x26"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x27"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x28"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x29"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x30"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x31"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x32"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x33"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x34"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x35"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x36"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x37"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x38"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_add",
+    "arguments": [
+      {
+        "datatype": "u32[16]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[16]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[16]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[4]",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[5]",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[6]",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[7]",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[8]",
+          "arg2[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[9]",
+          "arg2[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[10]",
+          "arg2[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[11]",
+          "arg2[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[12]",
+          "arg2[12]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[13]",
+          "arg2[13]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[14]",
+          "arg2[14]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[15]",
+          "arg2[15]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x10"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x11"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x12"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x13"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x14"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x15"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_sub",
+    "arguments": [
+      {
+        "datatype": "u32[16]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[16]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[16]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1ffffffe",
+              "arg1[0]"
+            ]
+          },
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1ffffffe",
+              "arg1[1]"
+            ]
+          },
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1ffffffe",
+              "arg1[2]"
+            ]
+          },
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1ffffffe",
+              "arg1[3]"
+            ]
+          },
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1ffffffe",
+              "arg1[4]"
+            ]
+          },
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1ffffffe",
+              "arg1[5]"
+            ]
+          },
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1ffffffe",
+              "arg1[6]"
+            ]
+          },
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1ffffffe",
+              "arg1[7]"
+            ]
+          },
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1ffffffc",
+              "arg1[8]"
+            ]
+          },
+          "arg2[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1ffffffe",
+              "arg1[9]"
+            ]
+          },
+          "arg2[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1ffffffe",
+              "arg1[10]"
+            ]
+          },
+          "arg2[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1ffffffe",
+              "arg1[11]"
+            ]
+          },
+          "arg2[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1ffffffe",
+              "arg1[12]"
+            ]
+          },
+          "arg2[12]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1ffffffe",
+              "arg1[13]"
+            ]
+          },
+          "arg2[13]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1ffffffe",
+              "arg1[14]"
+            ]
+          },
+          "arg2[14]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1ffffffe",
+              "arg1[15]"
+            ]
+          },
+          "arg2[15]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x10"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x11"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x12"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x13"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x14"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x15"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_opp",
+    "arguments": [
+      {
+        "datatype": "u32[16]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[16]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1ffffffe",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1ffffffe",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1ffffffe",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1ffffffe",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1ffffffe",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1ffffffe",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1ffffffe",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1ffffffe",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1ffffffc",
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1ffffffe",
+          "arg1[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1ffffffe",
+          "arg1[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1ffffffe",
+          "arg1[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1ffffffe",
+          "arg1[12]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1ffffffe",
+          "arg1[13]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1ffffffe",
+          "arg1[14]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1ffffffe",
+          "arg1[15]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x10"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x11"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x12"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x13"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x14"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x15"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_selectznz",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[16]",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32[16]",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[16]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[0]",
+          "arg3[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[1]",
+          "arg3[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[2]",
+          "arg3[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[3]",
+          "arg3[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[4]",
+          "arg3[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[5]",
+          "arg3[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[6]",
+          "arg3[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[7]",
+          "arg3[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[8]",
+          "arg3[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[9]",
+          "arg3[9]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[10]",
+          "arg3[10]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[11]",
+          "arg3[11]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[12]",
+          "arg3[12]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[13]",
+          "arg3[13]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[14]",
+          "arg3[14]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[15]",
+          "arg3[15]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x10"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x11"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x12"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x13"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x14"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x15"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_to_bytes",
+    "arguments": [
+      {
+        "datatype": "u32[16]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u8[56]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u16",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x8",
+          "arg1[4]",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x10",
+          "arg1[5]",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x12",
+          "arg1[6]",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x14",
+          "arg1[7]",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x16",
+          "arg1[8]",
+          "0xffffffe"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x18",
+          "arg1[9]",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x20",
+          "arg1[10]",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x22",
+          "arg1[11]",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x25",
+          "x26"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x24",
+          "arg1[12]",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x27",
+          "x28"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x26",
+          "arg1[13]",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x29",
+          "x30"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x28",
+          "arg1[14]",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x31",
+          "x32"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x30",
+          "arg1[15]",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x32",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x34",
+          "x35"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x33",
+              "0xfffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x36",
+          "x37"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x35",
+          "x3",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x33",
+              "0xfffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x38",
+          "x39"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x37",
+          "x5",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x33",
+              "0xfffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x40",
+          "x41"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x39",
+          "x7",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x33",
+              "0xfffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x42",
+          "x43"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x41",
+          "x9",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x33",
+              "0xfffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x44",
+          "x45"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x43",
+          "x11",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x33",
+              "0xfffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x46",
+          "x47"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x45",
+          "x13",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x33",
+              "0xfffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x48",
+          "x49"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x47",
+          "x15",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x33",
+              "0xfffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x50",
+          "x51"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x49",
+          "x17",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x33",
+              "0xffffffe"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x52",
+          "x53"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x51",
+          "x19",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x33",
+              "0xfffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x54",
+          "x55"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x53",
+          "x21",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x33",
+              "0xfffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x56",
+          "x57"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x55",
+          "x23",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x33",
+              "0xfffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x58",
+          "x59"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x57",
+          "x25",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x33",
+              "0xfffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x59",
+          "x27",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x33",
+              "0xfffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x61",
+          "x29",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x33",
+              "0xfffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x64",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x63",
+          "x31",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x33",
+              "0xfffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x66"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x64",
+          "4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x67"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x60",
+          "4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x68"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x56",
+          "4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x69"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x52",
+          "4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x70"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x48",
+          "4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x71"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x44",
+          "4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x72"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x40",
+          "4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x73"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x36",
+          "4"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x74"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x34"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x75"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x34",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x76"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x75"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x77"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x75",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x78"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x77"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x79"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x77",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x80"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x73",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x79"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x81"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x80"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x82"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x80",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x83"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x82"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x84"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x82",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x85"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x84"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x86"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x84",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x87"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x88"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x38",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x89"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x88"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x90"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x88",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x91"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x90"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x92"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x90",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x93"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x72",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x92"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x94"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x93"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x95"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x93",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x96"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x95"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x97"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x95",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x98"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x97"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x99"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x97",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x100"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x101"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x42",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x102"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x101"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x103"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x101",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x104"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x103"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x105"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x103",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x106"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x71",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x105"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x107"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x106"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x108"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x106",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x109"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x108"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x110"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x108",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x111"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x110"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x112"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x110",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x113"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x46"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x114"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x46",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x115"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x114"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x116"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x114",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x117"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x116"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x118"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x116",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x119"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x70",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x118"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x120"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x119"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x121"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x119",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x122"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x121"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x123"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x121",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x124"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x123"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x125"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x123",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x126"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x50"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x127"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x50",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x128"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x127"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x129"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x127",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x130"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x129"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x131"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x129",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x132"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x69",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x131"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x133"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x132"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x134"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x132",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x135"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x134"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x136"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x134",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x137"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x136"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x138"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x136",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x139"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x54"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x140"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x54",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x141"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x140"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x142"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x140",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x143"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x142"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x144"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x142",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x145"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x68",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x144"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x146"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x145"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x147"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x145",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x148"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x147"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x149"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x147",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x150"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x149"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x151"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x149",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x152"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x58"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x153"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x58",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x154"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x153"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x155"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x153",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x156"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x155"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x157"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x155",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x158"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x67",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x157"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x159"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x158"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x160"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x158",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x161"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x160"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x162"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x160",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x163"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x162"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x164"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x162",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x165"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x62"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x166"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x62",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x167"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x166"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x168"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x166",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x169"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x168"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x170"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x168",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x171"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x66",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x170"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x172"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x171"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x173"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x171",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x174"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x173"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x175"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x173",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x176"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x175"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x177"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x175",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x74"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x76"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x78"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x81"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x83"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x85"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x86"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x87"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x89"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x91"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x94"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x96"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x98"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x99"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x100"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x102"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[16]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x104"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[17]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x107"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[18]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x109"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[19]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x111"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[20]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x112"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[21]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x113"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[22]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x115"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[23]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x117"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[24]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x120"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[25]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x122"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[26]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x124"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[27]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x125"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[28]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x126"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[29]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x128"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[30]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x130"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[31]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x133"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[32]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x135"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[33]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x137"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[34]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x138"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[35]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x139"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[36]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x141"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[37]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x143"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[38]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x146"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[39]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x148"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[40]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x150"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[41]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x151"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[42]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x152"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[43]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x154"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[44]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x156"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[45]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x159"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[46]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x161"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[47]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x163"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[48]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x164"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[49]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x165"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[50]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x167"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[51]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x169"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[52]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x172"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[53]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x174"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[54]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x176"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[55]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x177"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_from_bytes",
+    "arguments": [
+      {
+        "datatype": "u8[56]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[16]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[55]"
+            ]
+          },
+          "20"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[54]"
+            ]
+          },
+          "12"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[53]"
+            ]
+          },
+          "4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[52]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[51]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[50]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[49]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[48]"
+            ]
+          },
+          "20"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[47]"
+            ]
+          },
+          "12"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[46]"
+            ]
+          },
+          "4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[45]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[44]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[43]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x14"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[42]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[41]"
+            ]
+          },
+          "20"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[40]"
+            ]
+          },
+          "12"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[39]"
+            ]
+          },
+          "4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[38]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[37]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[36]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x21"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[35]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[34]"
+            ]
+          },
+          "20"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[33]"
+            ]
+          },
+          "12"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[32]"
+            ]
+          },
+          "4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[31]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[30]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[29]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x28"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[28]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[27]"
+            ]
+          },
+          "20"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[26]"
+            ]
+          },
+          "12"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[25]"
+            ]
+          },
+          "4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[24]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[23]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[22]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x35"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[21]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[20]"
+            ]
+          },
+          "20"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[19]"
+            ]
+          },
+          "12"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[18]"
+            ]
+          },
+          "4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[17]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[16]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x42"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[14]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x43"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          "20"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          "12"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x45"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          "4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x47"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x48"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x49"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x50"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          "20"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x51"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          "12"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x52"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          "4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x53"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x54"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x55"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x56"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x57"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x55",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x58"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x54",
+          "x57"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x59"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x53",
+          "x58"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x60"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x59",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x61"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x59",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x62"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x52",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x61"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x63"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x51",
+          "x62"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x64"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x50",
+          "x63"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x65"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x48",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x49"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x66"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x47",
+          "x65"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x67"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x46",
+          "x66"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x68"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x67",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x69"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x67",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x70"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x45",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x69"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x71"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x44",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x72"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x43",
+          "x71"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x73"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x41",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x74"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x40",
+          "x73"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x75"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x39",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x76"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x75",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x77"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x75",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x78"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x38",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x77"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x79"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x37",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x80"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x36",
+          "x79"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x81"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x34",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x35"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x82"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x33",
+          "x81"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x83"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x32",
+          "x82"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x84"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x83",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x85"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x83",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x86"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x31",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x85"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x87"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x30",
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x88"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x29",
+          "x87"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x89"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x27",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x90"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x26",
+          "x89"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x91"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x25",
+          "x90"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x92"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x91",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x93"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x91",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x94"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x24",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x93"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x95"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x23",
+          "x94"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x96"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x22",
+          "x95"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x97"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x20",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x21"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x98"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x19",
+          "x97"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x99"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x18",
+          "x98"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x100"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x99",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x101"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x99",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x102"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x17",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x101"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x103"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x16",
+          "x102"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x104"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x15",
+          "x103"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x105"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x13",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x106"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x12",
+          "x105"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x107"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x11",
+          "x106"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x108"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x107",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x109"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x107",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x110"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x10",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x109"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x111"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x9",
+          "x110"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x112"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x8",
+          "x111"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x113"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x6",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x7"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x114"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x5",
+          "x113"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x115"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x4",
+          "x114"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x116"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x115",
+          "0xfffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x117"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x115",
+              "28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x118"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x3",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x117"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x119"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x2",
+          "x118"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x120"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x1",
+          "x119"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x60"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x64"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x68"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x72"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x76"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x80"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x84"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x88"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x92"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x96"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x100"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x104"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x108"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x112"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x116"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x120"
+        ]
+      }
+    ]
+  }
+]

--- a/fiat-json/src/p448_solinas_64.json
+++ b/fiat-json/src/p448_solinas_64.json
@@ -1,0 +1,12315 @@
+[
+  {
+    "operation": "fiat_p448_addcarryx_u56",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              },
+              "arg2"
+            ]
+          },
+          "arg3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x1",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_subborrowx_u56",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "i64",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "i64",
+            "name": [],
+            "operation": "-",
+            "arguments": [
+              {
+                "datatype": "i64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              },
+              {
+                "datatype": "i64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "i64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "i1",
+        "name": [
+          "x2"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "i1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_cmovznz_u64",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u1",
+        "name": [
+          "x1"
+        ],
+        "operation": "!",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "!",
+            "arguments": [
+              "arg1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "-",
+                "arguments": [
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "0x0"
+                    ]
+                  },
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x1"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "|",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "arg3"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "~",
+                "arguments": [
+                  "x2"
+                ]
+              },
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_carry_mul",
+    "arguments": [
+      {
+        "datatype": "u64[8]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[8]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u128",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x2"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x3"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x4"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x5"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x6"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x7"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x8"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x9"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x10"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x11"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x12"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x13"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x14"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x15"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x16"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x17"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x18"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x19"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x20"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x21"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x22"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x23"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x24"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x25"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x26"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x27"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x28"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x29"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x30"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x31"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x32"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x33"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x34"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x35"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x36"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x37"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x38"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x39"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x40"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x41"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x42"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x43"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x44"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x45"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x46"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x47"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x48"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x49"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x50"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x51"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x52"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x53"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x54"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x55"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x56"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x57"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x58"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x59"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x60"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x61"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x62"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x63"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x64"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x65"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x66"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x67"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x68"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x69"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x70"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x71"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x72"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x73"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x74"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x75"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x76"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x77"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x78"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x79"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x80"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x81"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x82"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x83"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x84"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x85"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x86"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x87"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x88"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x89"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x90"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x91"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x92"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x93"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x94"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x95"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x96"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x97"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x98"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x99"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x95",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x88",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x82",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x77",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x31",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x27",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x22",
+                                  "x16"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x99",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x101"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x99"
+            ]
+          },
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x102"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x91",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x84",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x78",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x73",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x69",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x66",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x64",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x63",
+                                      {
+                                        "datatype": "u128",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x53",
+                                          {
+                                            "datatype": "u128",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x49",
+                                              {
+                                                "datatype": "u128",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x45",
+                                                  "x41"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x103"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x92",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x85",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x79",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x74",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x70",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x67",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x65",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x57",
+                                      {
+                                        "datatype": "u128",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x54",
+                                          {
+                                            "datatype": "u128",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x50",
+                                              {
+                                                "datatype": "u128",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x46",
+                                                  {
+                                                    "datatype": "u128",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x42",
+                                                      {
+                                                        "datatype": "u128",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x13",
+                                                          "x7"
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x104"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x93",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x86",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x80",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x75",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x71",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x68",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x60",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x58",
+                                      {
+                                        "datatype": "u128",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x55",
+                                          {
+                                            "datatype": "u128",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x51",
+                                              {
+                                                "datatype": "u128",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x47",
+                                                  {
+                                                    "datatype": "u128",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x43",
+                                                      {
+                                                        "datatype": "u128",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x20",
+                                                          {
+                                                            "datatype": "u128",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x14",
+                                                              {
+                                                                "datatype": "u128",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x10",
+                                                                  "x8"
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x105"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x94",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x87",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x81",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x76",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x72",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x62",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x61",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x59",
+                                      {
+                                        "datatype": "u128",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x56",
+                                          {
+                                            "datatype": "u128",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x52",
+                                              {
+                                                "datatype": "u128",
+                                                "name": [],
+                                                "operation": "+",
+                                                "arguments": [
+                                                  "x48",
+                                                  {
+                                                    "datatype": "u128",
+                                                    "name": [],
+                                                    "operation": "+",
+                                                    "arguments": [
+                                                      "x44",
+                                                      {
+                                                        "datatype": "u128",
+                                                        "name": [],
+                                                        "operation": "+",
+                                                        "arguments": [
+                                                          "x26",
+                                                          {
+                                                            "datatype": "u128",
+                                                            "name": [],
+                                                            "operation": "+",
+                                                            "arguments": [
+                                                              "x21",
+                                                              {
+                                                                "datatype": "u128",
+                                                                "name": [],
+                                                                "operation": "+",
+                                                                "arguments": [
+                                                                  "x15",
+                                                                  {
+                                                                    "datatype": "u128",
+                                                                    "name": [],
+                                                                    "operation": "+",
+                                                                    "arguments": [
+                                                                      "x12",
+                                                                      {
+                                                                        "datatype": "u128",
+                                                                        "name": [],
+                                                                        "operation": "+",
+                                                                        "arguments": [
+                                                                          "x11",
+                                                                          "x9"
+                                                                        ]
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    ]
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x106"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x96",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x89",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x83",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x35",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x32",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x28",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x23",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x17",
+                                      "x1"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x107"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x97",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x90",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x38",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x36",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x33",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x29",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x24",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x18",
+                                      {
+                                        "datatype": "u128",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x4",
+                                          "x2"
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x108"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x98",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x40",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x39",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x37",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x34",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x30",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x25",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x19",
+                                      {
+                                        "datatype": "u128",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x6",
+                                          {
+                                            "datatype": "u128",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x5",
+                                              "x3"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x109"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x100"
+            ]
+          },
+          "x105"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x110"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x102",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x111"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x102"
+            ]
+          },
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x112"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x109",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x110"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x113"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x112",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x114"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x112"
+            ]
+          },
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x115"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x108",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x110"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x116"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x113"
+            ]
+          },
+          "x104"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x117"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x115",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x118"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x115"
+            ]
+          },
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x119"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x117"
+            ]
+          },
+          "x107"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x120"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x116",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x121"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x116"
+            ]
+          },
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x122"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x120"
+            ]
+          },
+          "x103"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x123"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x119",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x124"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x119"
+            ]
+          },
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x125"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x123"
+            ]
+          },
+          "x106"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x126"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x122",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x127"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x122"
+            ]
+          },
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x128"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x126",
+          "x111"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x129"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x125",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x130"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x125"
+            ]
+          },
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x131"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x129",
+          "x101"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x132"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x128",
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x133"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x128",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x134"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x131",
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x135"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x131",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x136"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x114",
+          "x132"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x137"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x118",
+          "x132"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x138"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x134",
+          "x136"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x139"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x138",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x140"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x138",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x141"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x139"
+            ]
+          },
+          "x121"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x142"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x137",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x143"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x137",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x144"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x142"
+            ]
+          },
+          "x124"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x143"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x144"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x130"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x135"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x140"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x141"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x127"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x133"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_carry_square",
+    "arguments": [
+      {
+        "datatype": "u64[8]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x1",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x2",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[7]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x6",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x7",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[6]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x11",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x12",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[5]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[4]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[3]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[2]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[1]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x22"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x23"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x24"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x25"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x26"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x27"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x28"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x29"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x30"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x31"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x32"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x7"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x33"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x34"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x35"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x36"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x37"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x11"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x38"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x39"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x40"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x41"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x42"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x43"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x44"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x17"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x45"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x46"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x47"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x48"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x49"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x50"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x51"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x52"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x53"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x54"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x55"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x56"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x57"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x58"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x15"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x59"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x60"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x19"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x61"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x62"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x63"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x64"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x10"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x65"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x15"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x66"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x67"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x19"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x68"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x20"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x69"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x70"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x5"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x71"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x10"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x72"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x15"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x73"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x74"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x19"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x75"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x20"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x76"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x21"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x77"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x78"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x74",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x68",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x38",
+                  "x34"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x78",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x80"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x78"
+            ]
+          },
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x81"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x70",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x64",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x58",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x52",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x39",
+                          "x35"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x82"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x71",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x65",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x59",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x53",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x47",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x41",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x37",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x30",
+                                      "x26"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x83"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x72",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x66",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x60",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x55",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x49",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x43",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x31",
+                                  "x27"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x84"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x73",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x67",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x63",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x61",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x57",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x51",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x45",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x33",
+                                      {
+                                        "datatype": "u128",
+                                        "name": [],
+                                        "operation": "+",
+                                        "arguments": [
+                                          "x32",
+                                          {
+                                            "datatype": "u128",
+                                            "name": [],
+                                            "operation": "+",
+                                            "arguments": [
+                                              "x29",
+                                              "x28"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x85"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x75",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x69",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x46",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x40",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x36",
+                          "x22"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x86"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x76",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x54",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x48",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x42",
+                      "x23"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x87"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x77",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x62",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x56",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x50",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x44",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x25",
+                              "x24"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x88"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x79"
+            ]
+          },
+          "x84"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x81",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x81"
+            ]
+          },
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x91"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x88",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x89"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x91",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x93"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x91"
+            ]
+          },
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x94"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x87",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x89"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x95"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x92"
+            ]
+          },
+          "x83"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x94",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x97"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x94"
+            ]
+          },
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x98"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x96"
+            ]
+          },
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x99"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x95",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x95"
+            ]
+          },
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x101"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x99"
+            ]
+          },
+          "x82"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x98",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x103"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x98"
+            ]
+          },
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x104"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x102"
+            ]
+          },
+          "x85"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x105"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x101",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x106"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x101"
+            ]
+          },
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x107"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x105",
+          "x90"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x108"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x104",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x109"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x104"
+            ]
+          },
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x110"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x108",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x111"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x107",
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x112"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x107",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x113"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x110",
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x114"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x110",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x115"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x93",
+          "x111"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x116"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x97",
+          "x111"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x117"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x113",
+          "x115"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x118"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x117",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x119"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x117",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x120"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x118"
+            ]
+          },
+          "x100"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x121"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x116",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x122"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x116",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x123"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x121"
+            ]
+          },
+          "x103"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x122"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x123"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x109"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x114"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x119"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x120"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x106"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x112"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_carry",
+    "arguments": [
+      {
+        "datatype": "u64[8]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x2",
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": ">>",
+                "arguments": [
+                  "x1",
+                  "56"
+                ]
+              },
+              "arg1[4]"
+            ]
+          },
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[0]",
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x4",
+              "56"
+            ]
+          },
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x5",
+              "56"
+            ]
+          },
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x6",
+              "56"
+            ]
+          },
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x7",
+              "56"
+            ]
+          },
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x8",
+              "56"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "0xffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x9",
+              "56"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x1",
+              "0xffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x12"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x10",
+              "56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x5",
+              "0xffffffffffffff"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": ">>",
+                    "arguments": [
+                      "x11",
+                      "56"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "&",
+                "arguments": [
+                  "x4",
+                  "0xffffffffffffff"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x12"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x13",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": ">>",
+                    "arguments": [
+                      "x13",
+                      "56"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x7",
+              "0xffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x9",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x11",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x14",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": ">>",
+                    "arguments": [
+                      "x14",
+                      "56"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x6",
+              "0xffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x8",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x10",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x15"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x17"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x19"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x21"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x22"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_add",
+    "arguments": [
+      {
+        "datatype": "u64[8]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[8]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[4]",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[5]",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[6]",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[7]",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_sub",
+    "arguments": [
+      {
+        "datatype": "u64[8]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[8]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1fffffffffffffe",
+              "arg1[0]"
+            ]
+          },
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1fffffffffffffe",
+              "arg1[1]"
+            ]
+          },
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1fffffffffffffe",
+              "arg1[2]"
+            ]
+          },
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1fffffffffffffe",
+              "arg1[3]"
+            ]
+          },
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1fffffffffffffc",
+              "arg1[4]"
+            ]
+          },
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1fffffffffffffe",
+              "arg1[5]"
+            ]
+          },
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1fffffffffffffe",
+              "arg1[6]"
+            ]
+          },
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1fffffffffffffe",
+              "arg1[7]"
+            ]
+          },
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_opp",
+    "arguments": [
+      {
+        "datatype": "u64[8]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1fffffffffffffe",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1fffffffffffffe",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1fffffffffffffe",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1fffffffffffffe",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1fffffffffffffc",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1fffffffffffffe",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1fffffffffffffe",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1fffffffffffffe",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_selectznz",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[8]",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64[8]",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[0]",
+          "arg3[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[1]",
+          "arg3[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[2]",
+          "arg3[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[3]",
+          "arg3[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[4]",
+          "arg3[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[5]",
+          "arg3[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[6]",
+          "arg3[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[7]",
+          "arg3[7]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_to_bytes",
+    "arguments": [
+      {
+        "datatype": "u64[8]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u8[56]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x8",
+          "arg1[4]",
+          "0xfffffffffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x10",
+          "arg1[5]",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x12",
+          "arg1[6]",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x14",
+          "arg1[7]",
+          "0xffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x16",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x17",
+              "0xffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x19",
+          "x3",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x17",
+              "0xffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x21",
+          "x5",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x17",
+              "0xffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x7",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x17",
+              "0xffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x9",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x17",
+              "0xfffffffffffffe"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x11",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x17",
+              "0xffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x13",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x17",
+              "0xffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          "x15",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x17",
+              "0xffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x34"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x18",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x36"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x35"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x35",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x38"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x37"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x37",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x40"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x39"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x39",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x42"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x41"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x41",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x44"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x43"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x45"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x43",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x46"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x20"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x20",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x48"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x47"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x47",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x50"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x49"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x49",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x52"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x51"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x51",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x54"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x53"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x53",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x56"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x55"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x57"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x55",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x58"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x22"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x22",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x60"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x59"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x59",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x62"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x61"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x63"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x61",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x64"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x63"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x65"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x63",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x66"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x65"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x67"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x65",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x68"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x67"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x69"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x67",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x70"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x71"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x24",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x72"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x71"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x73"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x71",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x74"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x73"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x75"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x73",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x76"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x75"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x77"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x75",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x78"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x77"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x77",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x80"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x79"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x81"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x79",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x82"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x26"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x26",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x84"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x83"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x85"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x83",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x86"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x85"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x85",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x88"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x87"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x87",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x90"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x89"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x91"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x89",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x92"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x91"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x93"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x91",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x94"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x95"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x28",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x96"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x95"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x97"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x95",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x98"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x97"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x99"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x97",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x100"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x99"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x101"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x99",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x102"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x101"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x103"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x101",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x104"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x103"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x105"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x103",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x106"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x30"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x107"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x30",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x108"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x107"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x109"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x107",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x110"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x109"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x111"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x109",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x112"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x111"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x113"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x111",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x114"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x113"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x115"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x113",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x116"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x115"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x117"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x115",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x118"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x32"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x119"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x32",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x120"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x119"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x121"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x119",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x122"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x121"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x123"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x121",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x124"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x123"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x125"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x123",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x126"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x125"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x127"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x125",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x128"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x127"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x129"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x127",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x34"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x36"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x38"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x40"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x42"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x44"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x45"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x46"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x48"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x50"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x52"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x54"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x56"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x57"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x58"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x60"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[16]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x62"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[17]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x64"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[18]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x66"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[19]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x68"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[20]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x69"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[21]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x70"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[22]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x72"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[23]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x74"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[24]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x76"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[25]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x78"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[26]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x80"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[27]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x81"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[28]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x82"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[29]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x84"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[30]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x86"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[31]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x88"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[32]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x90"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[33]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x92"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[34]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x93"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[35]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x94"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[36]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x96"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[37]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x98"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[38]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x100"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[39]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x102"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[40]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x104"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[41]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x105"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[42]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x106"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[43]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x108"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[44]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x110"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[45]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x112"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[46]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x114"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[47]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x116"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[48]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x117"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[49]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x118"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[50]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x120"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[51]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x122"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[52]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x124"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[53]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x126"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[54]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x128"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[55]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x129"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p448_from_bytes",
+    "arguments": [
+      {
+        "datatype": "u8[56]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[55]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[54]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[53]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[52]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[51]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[50]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[49]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[48]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[47]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[46]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[45]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[44]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[43]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x14"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[42]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[41]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[40]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[39]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[38]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[37]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[36]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x21"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[35]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[34]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[33]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[32]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[31]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[30]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[29]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x28"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[28]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[27]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[26]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[25]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[24]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[23]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[22]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x35"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[21]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[20]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[19]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[18]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[17]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[16]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x42"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[14]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x49"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x56"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x55",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x56"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x54",
+          "x57"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x53",
+          "x58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x52",
+          "x59"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x51",
+          "x60"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x50",
+          "x61"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x63"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x48",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x49"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x47",
+          "x63"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x65"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x46",
+          "x64"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x45",
+          "x65"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x67"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x44",
+          "x66"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x43",
+          "x67"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x69"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x41",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x40",
+          "x69"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x71"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x39",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x38",
+          "x71"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x73"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x37",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x36",
+          "x73"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x75"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x34",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x35"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x76"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x33",
+          "x75"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x77"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x32",
+          "x76"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x31",
+          "x77"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x30",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x80"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x29",
+          "x79"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x27",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x82"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x26",
+          "x81"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x25",
+          "x82"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x24",
+          "x83"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x85"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x23",
+          "x84"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x86"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x22",
+          "x85"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x20",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x21"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x19",
+          "x87"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x18",
+          "x88"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x17",
+          "x89"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x91"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x16",
+          "x90"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x15",
+          "x91"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x93"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x13",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x94"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x12",
+          "x93"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x95"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x11",
+          "x94"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x10",
+          "x95"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x97"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x9",
+          "x96"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x8",
+          "x97"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x99"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x6",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x7"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x5",
+          "x99"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x101"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x4",
+          "x100"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x3",
+          "x101"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x103"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x2",
+          "x102"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x104"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x1",
+          "x103"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x62"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x68"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x74"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x80"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x86"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x92"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x98"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x104"
+        ]
+      }
+    ]
+  }
+]

--- a/fiat-json/src/p521_64.json
+++ b/fiat-json/src/p521_64.json
@@ -1,0 +1,13091 @@
+[
+  {
+    "operation": "fiat_p521_addcarryx_u58",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              },
+              "arg2"
+            ]
+          },
+          "arg3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x1",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "58"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p521_subborrowx_u58",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "i64",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "i64",
+            "name": [],
+            "operation": "-",
+            "arguments": [
+              {
+                "datatype": "i64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              },
+              {
+                "datatype": "i64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "i64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "i1",
+        "name": [
+          "x2"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "i1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "58"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p521_addcarryx_u57",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              },
+              "arg2"
+            ]
+          },
+          "arg3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x1",
+          "0x1ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "57"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p521_subborrowx_u57",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "i64",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "i64",
+            "name": [],
+            "operation": "-",
+            "arguments": [
+              {
+                "datatype": "i64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              },
+              {
+                "datatype": "i64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "i64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "i1",
+        "name": [
+          "x2"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "i1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "57"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0x1ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p521_cmovznz_u64",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u1",
+        "name": [
+          "x1"
+        ],
+        "operation": "!",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "!",
+            "arguments": [
+              "arg1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "-",
+                "arguments": [
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "0x0"
+                    ]
+                  },
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x1"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "|",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "arg3"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "~",
+                "arguments": [
+                  "x2"
+                ]
+              },
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p521_carry_mul",
+    "arguments": [
+      {
+        "datatype": "u64[9]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[9]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[9]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u128",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[8]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x2"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[7]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x3"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[6]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x4"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[5]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x5"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[4]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x6"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[3]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x7"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[2]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x8"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[1]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x9"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[8]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x10"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[7]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x11"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[6]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x12"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[5]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x13"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[4]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x14"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[3]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x15"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[2]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x16"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[8]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x17"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[7]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x18"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[6]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x19"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[5]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x20"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[4]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x21"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[3]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x22"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[8]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x23"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[7]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x24"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[6]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x25"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[5]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x26"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[4]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x27"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[8]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x28"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[7]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x29"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[6]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x30"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[5]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x31"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[8]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x32"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[7]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x33"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[6]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x34"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[8]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x35"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[7]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x36"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[8]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x37"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x38"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x39"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x40"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x41"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x42"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x43"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x44"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x45"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x46"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x47"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x48"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x49"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x50"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x51"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x52"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x53"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x54"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x55"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x56"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x57"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x58"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x59"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x60"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x61"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x62"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x63"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x64"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x65"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x66"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x67"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x68"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x69"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x70"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x71"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x72"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x73"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[8]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x74"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[7]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x75"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[6]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x76"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[5]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x77"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x78"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x79"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x80"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x81"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x82"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x81",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x36",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x35",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x33",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x30",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x26",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x21",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x15",
+                                      "x8"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x83"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x82",
+          "58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x82"
+            ]
+          },
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x85"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x73",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x65",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x58",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x52",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x47",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x43",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x40",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x38",
+                                      "x37"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x86"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x74",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x66",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x59",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x53",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x48",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x44",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x41",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x39",
+                                      "x1"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x87"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x75",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x67",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x60",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x54",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x49",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x45",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x42",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x9",
+                                      "x2"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x88"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x76",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x68",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x61",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x55",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x50",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x46",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x16",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x10",
+                                      "x3"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x89"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x77",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x69",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x62",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x56",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x51",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x22",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x17",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x11",
+                                      "x4"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x90"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x78",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x70",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x63",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x57",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x27",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x23",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x18",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x12",
+                                      "x5"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x91"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x79",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x71",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x64",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x31",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x28",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x24",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x19",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x13",
+                                      "x6"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x92"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x80",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x72",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x34",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x32",
+                      {
+                        "datatype": "u128",
+                        "name": [],
+                        "operation": "+",
+                        "arguments": [
+                          "x29",
+                          {
+                            "datatype": "u128",
+                            "name": [],
+                            "operation": "+",
+                            "arguments": [
+                              "x25",
+                              {
+                                "datatype": "u128",
+                                "name": [],
+                                "operation": "+",
+                                "arguments": [
+                                  "x20",
+                                  {
+                                    "datatype": "u128",
+                                    "name": [],
+                                    "operation": "+",
+                                    "arguments": [
+                                      "x14",
+                                      "x7"
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x93"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x83",
+          "x92"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x94"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x93",
+          "58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x95"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x93"
+            ]
+          },
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x96"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x94",
+          "x91"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x97"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x96",
+          "58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x96"
+            ]
+          },
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x99"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x97",
+          "x90"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x100"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x99",
+          "58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x101"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x99"
+            ]
+          },
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x102"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x100",
+          "x89"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x103"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x102",
+          "58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x104"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x102"
+            ]
+          },
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x105"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x103",
+          "x88"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x106"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x105",
+          "58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x107"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x105"
+            ]
+          },
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x108"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x106",
+          "x87"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x109"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x108",
+          "58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x110"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x108"
+            ]
+          },
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x111"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x109",
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x112"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x111",
+          "58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x113"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x111"
+            ]
+          },
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x114"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x112",
+          "x85"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x115"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x114",
+          "57"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x116"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x114"
+            ]
+          },
+          "0x1ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x117"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x84"
+            ]
+          },
+          "x115"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x118"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x117",
+              "58"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x119"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x117"
+            ]
+          },
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x120"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x118",
+          "x95"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x121"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x120",
+              "58"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x122"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x120",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x123"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x121"
+            ]
+          },
+          "x98"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x119"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x122"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x123"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x101"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x104"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x107"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x110"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x113"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x116"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p521_carry_square",
+    "arguments": [
+      {
+        "datatype": "u64[9]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[9]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x1",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[8]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x4",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[7]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x7",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[6]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x10",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[5]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[4]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[3]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[2]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[1]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x17"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x1",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x18"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x2",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x19"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x4",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x20"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x2",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x21"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x5",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x22"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x7",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x23"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x2",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x24"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x5",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x25"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x8",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x26"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x10",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x27"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x2",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x28"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x5",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x29"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x8",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x30"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x11",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x31"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x32"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x2",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x33"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x5",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x34"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x8",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x35"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x36"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x37"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x38"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x2",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x39"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x5",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x40"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x41"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x42"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x43"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x44"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x45"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x2",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x46"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x47"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x48"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x49"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x50"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x51"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x15"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x52"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x53"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x54"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x55"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x56"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x57"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x58"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x59"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x15"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x60"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x61"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x62"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x61",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x45",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x39",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x34",
+                      "x30"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x63"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x62",
+          "58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x62"
+            ]
+          },
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x65"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x53",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x46",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x40",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x35",
+                      "x31"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x66"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x54",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x47",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x41",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x36",
+                      "x17"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x67"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x55",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x48",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x42",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x37",
+                      "x18"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x68"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x56",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x49",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x43",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x20",
+                      "x19"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x69"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x57",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x50",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x44",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x23",
+                      "x21"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x70"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x58",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x51",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x27",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x24",
+                      "x22"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x71"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x59",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x52",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x32",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x28",
+                      "x25"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x72"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x60",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x38",
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x33",
+                  {
+                    "datatype": "u128",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x29",
+                      "x26"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x73"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x63",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x74"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x73",
+          "58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x75"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x73"
+            ]
+          },
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x76"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x74",
+          "x71"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x77"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x76",
+          "58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x76"
+            ]
+          },
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x79"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x77",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x80"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x79",
+          "58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x79"
+            ]
+          },
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x82"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x80",
+          "x69"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x83"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x82",
+          "58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x82"
+            ]
+          },
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x85"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x83",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x86"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x85",
+          "58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x85"
+            ]
+          },
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x88"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x86",
+          "x67"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x89"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x88",
+          "58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x88"
+            ]
+          },
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x91"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x89",
+          "x66"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x92"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x91",
+          "58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x93"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x91"
+            ]
+          },
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x94"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x92",
+          "x65"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x95"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x94",
+          "57"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x94"
+            ]
+          },
+          "0x1ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x97"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x64"
+            ]
+          },
+          "x95"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x97",
+              "58"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x99"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x97"
+            ]
+          },
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x98",
+          "x75"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x101"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x100",
+              "58"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x100",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x103"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x101"
+            ]
+          },
+          "x78"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x99"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x102"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x103"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x81"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x84"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x87"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x90"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x93"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x96"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p521_carry",
+    "arguments": [
+      {
+        "datatype": "u64[9]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[9]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "58"
+            ]
+          },
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x2",
+              "58"
+            ]
+          },
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x3",
+              "58"
+            ]
+          },
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x4",
+              "58"
+            ]
+          },
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x5",
+              "58"
+            ]
+          },
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x6",
+              "58"
+            ]
+          },
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x7",
+              "58"
+            ]
+          },
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x8",
+              "58"
+            ]
+          },
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x1",
+              "0x3ffffffffffffff"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x9",
+              "57"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": ">>",
+                    "arguments": [
+                      "x10",
+                      "58"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "0x3ffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x10",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x11",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": ">>",
+                    "arguments": [
+                      "x11",
+                      "58"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x3",
+              "0x3ffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x4",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x5",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x6",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x7",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x8",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x9",
+          "0x1ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x12"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x13"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x14"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x15"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x17"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x19"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p521_add",
+    "arguments": [
+      {
+        "datatype": "u64[9]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[9]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[9]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[4]",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[5]",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[6]",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[7]",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[8]",
+          "arg2[8]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p521_sub",
+    "arguments": [
+      {
+        "datatype": "u64[9]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[9]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[9]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x7fffffffffffffe",
+              "arg1[0]"
+            ]
+          },
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x7fffffffffffffe",
+              "arg1[1]"
+            ]
+          },
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x7fffffffffffffe",
+              "arg1[2]"
+            ]
+          },
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x7fffffffffffffe",
+              "arg1[3]"
+            ]
+          },
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x7fffffffffffffe",
+              "arg1[4]"
+            ]
+          },
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x7fffffffffffffe",
+              "arg1[5]"
+            ]
+          },
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x7fffffffffffffe",
+              "arg1[6]"
+            ]
+          },
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x7fffffffffffffe",
+              "arg1[7]"
+            ]
+          },
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x3fffffffffffffe",
+              "arg1[8]"
+            ]
+          },
+          "arg2[8]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p521_opp",
+    "arguments": [
+      {
+        "datatype": "u64[9]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[9]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x7fffffffffffffe",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x7fffffffffffffe",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x7fffffffffffffe",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x7fffffffffffffe",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x7fffffffffffffe",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x7fffffffffffffe",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x7fffffffffffffe",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x7fffffffffffffe",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x3fffffffffffffe",
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p521_selectznz",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[9]",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64[9]",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[9]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[0]",
+          "arg3[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[1]",
+          "arg3[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[2]",
+          "arg3[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[3]",
+          "arg3[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[4]",
+          "arg3[4]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[5]",
+          "arg3[5]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[6]",
+          "arg3[6]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[7]",
+          "arg3[7]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[8]",
+          "arg3[8]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p521_to_bytes",
+    "arguments": [
+      {
+        "datatype": "u64[9]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u8[66]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x8",
+          "arg1[4]",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x10",
+          "arg1[5]",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x12",
+          "arg1[6]",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x14",
+          "arg1[7]",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x16",
+          "arg1[8]",
+          "0x1ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x18",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x19",
+              "0x3ffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x21",
+          "x3",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x19",
+              "0x3ffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x5",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x19",
+              "0x3ffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x7",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x19",
+              "0x3ffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x9",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x19",
+              "0x3ffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x11",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x19",
+              "0x3ffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          "x13",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x19",
+              "0x3ffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34",
+          "x35"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x33",
+          "x15",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x19",
+              "0x3ffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x35",
+          "x17",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x19",
+              "0x1ffffffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x34",
+          "6"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x32",
+          "4"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x30",
+          "2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x26",
+          "6"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x24",
+          "4"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x22",
+          "2"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x44"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x20"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x20",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x46"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x45"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x45",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x48"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x47"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x47",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x50"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x49"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x49",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x52"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x51"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x51",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x54"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x53"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x53",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x56"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x55"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x57"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x55",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x43",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x57"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x59"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x58"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x58",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x61"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x60"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x60",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x63"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x62"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x62",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x65"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x64"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x64",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x67"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x66"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x66",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x69"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x68"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x68",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x71"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x70"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x72"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x70",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x73"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x42",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x72"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x74"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x73"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x75"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x73",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x76"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x75"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x77"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x75",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x78"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x77"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x77",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x80"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x79"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x79",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x82"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x81"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x81",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x84"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x83"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x85"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x83",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x86"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x85"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x87"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x85",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x41",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x87"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x89"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x88"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x88",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x91"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x90"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x90",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x93"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x92"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x94"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x92",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x95"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x94"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x94",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x97"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x96"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x96",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x99"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x98"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x98",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x101"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x100"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x102"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x100",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x103"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x104"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x28",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x105"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x104"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x106"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x104",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x107"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x106"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x108"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x106",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x109"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x108"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x110"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x108",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x111"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x110"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x112"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x110",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x113"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x112"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x114"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x112",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x115"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x114"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x116"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x114",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x117"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x40",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x116"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x118"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x117"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x119"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x117",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x120"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x119"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x121"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x119",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x122"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x121"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x123"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x121",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x124"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x123"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x125"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x123",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x126"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x125"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x127"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x125",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x128"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x127"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x129"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x127",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x130"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x129"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x131"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x129",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x132"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x39",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x131"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x133"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x132"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x134"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x132",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x135"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x134"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x136"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x134",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x137"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x136"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x138"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x136",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x139"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x138"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x140"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x138",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x141"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x140"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x142"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x140",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x143"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x142"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x144"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x142",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x145"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x144"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x146"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x144",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x147"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x38",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x146"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x148"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x147"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x149"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x147",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x150"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x149"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x151"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x149",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x152"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x151"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x153"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x151",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x154"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x153"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x155"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x153",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x156"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x155"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x157"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x155",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x158"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x157"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x159"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x157",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x160"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x159"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x161"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x159",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x162"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x36"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x163"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x36",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x164"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x163"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x165"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x163",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x166"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x165"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x167"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x165",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x168"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x167"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x169"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x167",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x170"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x169"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x171"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x169",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x172"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x171"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x173"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x171",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x174"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x173"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x175"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x173",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x44"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x46"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x48"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x50"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x52"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x54"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x56"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x59"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x61"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x63"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x65"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x67"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x69"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x71"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x74"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x76"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[16]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x78"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[17]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x80"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[18]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x82"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[19]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x84"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[20]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x86"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[21]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x89"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[22]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x91"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[23]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x93"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[24]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x95"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[25]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x97"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[26]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x99"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[27]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x101"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[28]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x102"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[29]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x103"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[30]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x105"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[31]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x107"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[32]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x109"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[33]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x111"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[34]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x113"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[35]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x115"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[36]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x118"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[37]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x120"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[38]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x122"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[39]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x124"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[40]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x126"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[41]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x128"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[42]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x130"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[43]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x133"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[44]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x135"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[45]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x137"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[46]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x139"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[47]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x141"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[48]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x143"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[49]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x145"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[50]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x148"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[51]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x150"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[52]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x152"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[53]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x154"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[54]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x156"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[55]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x158"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[56]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x160"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[57]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x161"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[58]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x162"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[59]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x164"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[60]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x166"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[61]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x168"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[62]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x170"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[63]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x172"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[64]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x174"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "out1[65]"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          "x175"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_p521_from_bytes",
+    "arguments": [
+      {
+        "datatype": "u8[66]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[9]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1[65]"
+                ]
+              }
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[64]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[63]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[62]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[61]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[60]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[59]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x8"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[58]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[57]"
+            ]
+          },
+          "50"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[56]"
+            ]
+          },
+          "42"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[55]"
+            ]
+          },
+          "34"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[54]"
+            ]
+          },
+          "26"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[53]"
+            ]
+          },
+          "18"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[52]"
+            ]
+          },
+          "10"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[51]"
+            ]
+          },
+          "2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[50]"
+            ]
+          },
+          "52"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[49]"
+            ]
+          },
+          "44"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[48]"
+            ]
+          },
+          "36"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[47]"
+            ]
+          },
+          "28"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[46]"
+            ]
+          },
+          "20"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[45]"
+            ]
+          },
+          "12"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[44]"
+            ]
+          },
+          "4"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[43]"
+            ]
+          },
+          "54"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[42]"
+            ]
+          },
+          "46"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[41]"
+            ]
+          },
+          "38"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[40]"
+            ]
+          },
+          "30"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[39]"
+            ]
+          },
+          "22"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[38]"
+            ]
+          },
+          "14"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[37]"
+            ]
+          },
+          "6"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[36]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[35]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[34]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[33]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[32]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[31]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[30]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x37"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[29]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[28]"
+            ]
+          },
+          "50"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[27]"
+            ]
+          },
+          "42"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[26]"
+            ]
+          },
+          "34"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[25]"
+            ]
+          },
+          "26"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[24]"
+            ]
+          },
+          "18"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[23]"
+            ]
+          },
+          "10"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[22]"
+            ]
+          },
+          "2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[21]"
+            ]
+          },
+          "52"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[20]"
+            ]
+          },
+          "44"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[19]"
+            ]
+          },
+          "36"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[18]"
+            ]
+          },
+          "28"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[17]"
+            ]
+          },
+          "20"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[16]"
+            ]
+          },
+          "12"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          "4"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          "54"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          "46"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          "38"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          "30"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          "22"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          "14"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          "6"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x63"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x65"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x66"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x67"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x65",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x66"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x64",
+          "x67"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x69"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x63",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x62",
+          "x69"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x71"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x61",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x60",
+          "x71"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x73"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x59",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x73",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x75"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x73",
+              "58"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x76"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x58",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x75"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x77"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x57",
+          "x76"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x56",
+          "x77"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x55",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x80"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x54",
+          "x79"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x53",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x82"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x52",
+          "x81"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x82",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x84"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x82",
+              "58"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x85"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x51",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x84"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x86"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x50",
+          "x85"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x49",
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x48",
+          "x87"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x47",
+          "x88"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x46",
+          "x89"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x91"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x45",
+          "x90"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x91",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x93"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x91",
+              "58"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x94"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x44",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x93"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x95"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x43",
+          "x94"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x42",
+          "x95"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x97"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x41",
+          "x96"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x40",
+          "x97"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x99"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x39",
+          "x98"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x38",
+          "x99"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x101"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x36",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x37"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x35",
+          "x101"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x103"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x34",
+          "x102"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x104"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x33",
+          "x103"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x105"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x32",
+          "x104"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x106"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x31",
+          "x105"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x107"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x30",
+          "x106"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x108"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x107",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x109"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x107",
+              "58"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x110"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x29",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x109"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x111"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x28",
+          "x110"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x112"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x27",
+          "x111"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x113"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x26",
+          "x112"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x114"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x25",
+          "x113"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x115"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x24",
+          "x114"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x116"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x23",
+          "x115"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x117"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x116",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x118"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x116",
+              "58"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x119"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x22",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x118"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x120"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x21",
+          "x119"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x121"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x20",
+          "x120"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x122"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x19",
+          "x121"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x123"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x18",
+          "x122"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x124"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x17",
+          "x123"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x125"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x16",
+          "x124"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x126"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x125",
+          "0x3ffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x127"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x125",
+              "58"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x128"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x15",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x127"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x129"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x14",
+          "x128"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x130"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x13",
+          "x129"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x131"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x12",
+          "x130"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x132"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x11",
+          "x131"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x133"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x10",
+          "x132"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x134"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x9",
+          "x133"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x135"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x7",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x136"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x6",
+          "x135"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x137"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x5",
+          "x136"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x138"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x4",
+          "x137"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x139"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x3",
+          "x138"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x140"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x2",
+          "x139"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x141"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x1",
+          "x140"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x74"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x83"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x92"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x100"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x108"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x117"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x126"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x134"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x141"
+        ]
+      }
+    ]
+  }
+]

--- a/fiat-json/src/poly1305_32.json
+++ b/fiat-json/src/poly1305_32.json
@@ -1,0 +1,5047 @@
+[
+  {
+    "operation": "fiat_poly1305_addcarryx_u26",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              },
+              "arg2"
+            ]
+          },
+          "arg3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x1",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_subborrowx_u26",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "i32",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "i32",
+            "name": [],
+            "operation": "-",
+            "arguments": [
+              {
+                "datatype": "i32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              },
+              {
+                "datatype": "i32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "i32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "i1",
+        "name": [
+          "x2"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "i1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_cmovznz_u32",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u1",
+        "name": [
+          "x1"
+        ],
+        "operation": "!",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "!",
+            "arguments": [
+              "arg1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "-",
+                "arguments": [
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "0x0"
+                    ]
+                  },
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x1"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "|",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "arg3"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "~",
+                "arguments": [
+                  "x2"
+                ]
+              },
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_carry_mul",
+    "arguments": [
+      {
+        "datatype": "u32[5]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[5]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[5]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[4]",
+                  "0x5"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[3]",
+                  "0x5"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[2]",
+                  "0x5"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[1]",
+                  "0x5"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[4]",
+                  "0x5"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[3]",
+                  "0x5"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[2]",
+                  "0x5"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[4]",
+                  "0x5"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[3]",
+                  "0x5"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[4]",
+                  "0x5"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[4]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[3]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x25",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x10",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x9",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x7",
+                      "x4"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x26",
+          "26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x26"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x21",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x17",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x14",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x12",
+                      "x11"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x22",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x18",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x15",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x13",
+                      "x1"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x23",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x19",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x16",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x5",
+                      "x2"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x24",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x20",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "+",
+                "arguments": [
+                  "x8",
+                  {
+                    "datatype": "u64",
+                    "name": [],
+                    "operation": "+",
+                    "arguments": [
+                      "x6",
+                      "x3"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x27",
+          "x32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x33",
+          "26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x33"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x34",
+          "x31"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x36",
+          "26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x36"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x37",
+          "x30"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x39",
+          "26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x39"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x40",
+          "x29"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x43"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x42",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x43"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x5"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          },
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x47"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x46",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x48"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x46"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x49"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x47",
+          "x35"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x50"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x49",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x51"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x49",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x52"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x50"
+            ]
+          },
+          "x38"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x48"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x51"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x52"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x41"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x44"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_carry_square",
+    "arguments": [
+      {
+        "datatype": "u32[5]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[5]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[4]",
+          "0x5"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x1",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[4]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[3]",
+          "0x5"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x4",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[3]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[2]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[1]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x5"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x7"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x7"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x23",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x15",
+              "x13"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x24",
+          "26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x19",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x16",
+              "x14"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x20",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x17",
+              "x9"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x21",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x18",
+              "x10"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x22",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x12",
+              "x11"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x25",
+          "x30"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x31",
+          "26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x31"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x32",
+          "x29"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x34",
+          "26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x34"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x35",
+          "x28"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x37",
+          "26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x37"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x38",
+          "x27"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x40",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x41"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x5"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x26"
+            ]
+          },
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x45"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x44",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x44"
+            ]
+          },
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x47"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x45",
+          "x33"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x48"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x47",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x49"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x47",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x50"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x48"
+            ]
+          },
+          "x36"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x46"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x49"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x50"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x39"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x42"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_carry",
+    "arguments": [
+      {
+        "datatype": "u32[5]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[5]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "26"
+            ]
+          },
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x2",
+              "26"
+            ]
+          },
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x3",
+              "26"
+            ]
+          },
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x4",
+              "26"
+            ]
+          },
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x1",
+              "0x3ffffff"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "*",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": ">>",
+                "arguments": [
+                  "x5",
+                  "26"
+                ]
+              },
+              "0x5"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": ">>",
+                    "arguments": [
+                      "x6",
+                      "26"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "0x3ffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x6",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x7",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": ">>",
+                    "arguments": [
+                      "x7",
+                      "26"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x3",
+              "0x3ffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x4",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x5",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x10"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x11"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x12"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_add",
+    "arguments": [
+      {
+        "datatype": "u32[5]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[5]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[5]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[4]",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_sub",
+    "arguments": [
+      {
+        "datatype": "u32[5]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[5]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[5]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x7fffff6",
+              "arg1[0]"
+            ]
+          },
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x7fffffe",
+              "arg1[1]"
+            ]
+          },
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x7fffffe",
+              "arg1[2]"
+            ]
+          },
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x7fffffe",
+              "arg1[3]"
+            ]
+          },
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x7fffffe",
+              "arg1[4]"
+            ]
+          },
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_opp",
+    "arguments": [
+      {
+        "datatype": "u32[5]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[5]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x7fffff6",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x7fffffe",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x7fffffe",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x7fffffe",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x7fffffe",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_selectznz",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[5]",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32[5]",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[5]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[0]",
+          "arg3[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[1]",
+          "arg3[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[2]",
+          "arg3[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[3]",
+          "arg3[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[4]",
+          "arg3[4]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_to_bytes",
+    "arguments": [
+      {
+        "datatype": "u32[5]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u8[17]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u16",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "0x3fffffb"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x8",
+          "arg1[4]",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x10",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x11",
+              "0x3fffffb"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x13",
+          "x3",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x11",
+              "0x3ffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x15",
+          "x5",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x11",
+              "0x3ffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x17",
+          "x7",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x11",
+              "0x3ffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u16",
+        "name": [
+          "x20",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x19",
+          "x9",
+          {
+            "datatype": "u16",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x11",
+              "0x3ffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x18",
+          "6"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x16",
+          "4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x14",
+          "2"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x25"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x12",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x27"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x26"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x26",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x29"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x30"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x28",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x24",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x30"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x32"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x31"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x31",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x34"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x33"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x33",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x36"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x35"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x37"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x35",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x23",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x37"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x39"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x38",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x41"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x40",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x43"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x44"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x42",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x45"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x22",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x44"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x46"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x45"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x47"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x45",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x48"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x47"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x49"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x47",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x50"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x49"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x51"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x49",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x52"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x20"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x53"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x20",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x54"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x53"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x55"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x53",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x56"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x55"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x57"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x55",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x25"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x27"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x29"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x32"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x34"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x36"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x39"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x41"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x43"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x46"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x48"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x50"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x51"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x52"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x54"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x56"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[16]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x57"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_from_bytes",
+    "arguments": [
+      {
+        "datatype": "u8[17]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[5]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[16]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[13]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          "18"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          "10"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          "2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          "20"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          "12"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          "4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          "22"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          "14"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          "6"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x17"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x16",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x17"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x15",
+          "x18"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x14",
+          "x19"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x20",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x22"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x20",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x13",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x22"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x12",
+          "x23"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x11",
+          "x24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x25",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x27"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x25",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x10",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x27"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x9",
+          "x28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x8",
+          "x29"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x30",
+          "0x3ffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x32"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x30",
+              "26"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x7",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x6",
+          "x33"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x5",
+          "x34"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x3",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x2",
+          "x36"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x1",
+          "x37"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x21"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x26"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x31"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x35"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x38"
+        ]
+      }
+    ]
+  }
+]

--- a/fiat-json/src/poly1305_64.json
+++ b/fiat-json/src/poly1305_64.json
@@ -1,0 +1,3804 @@
+[
+  {
+    "operation": "fiat_poly1305_addcarryx_u44",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              },
+              "arg2"
+            ]
+          },
+          "arg3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x1",
+          "0xfffffffffff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "44"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_subborrowx_u44",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "i64",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "i64",
+            "name": [],
+            "operation": "-",
+            "arguments": [
+              {
+                "datatype": "i64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              },
+              {
+                "datatype": "i64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "i64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "i1",
+        "name": [
+          "x2"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "i1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "44"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xfffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_addcarryx_u43",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              },
+              "arg2"
+            ]
+          },
+          "arg3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x1",
+          "0x7ffffffffff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "43"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_subborrowx_u43",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "i64",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "i64",
+            "name": [],
+            "operation": "-",
+            "arguments": [
+              {
+                "datatype": "i64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              },
+              {
+                "datatype": "i64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "i64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "i1",
+        "name": [
+          "x2"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "i1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "43"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0x7ffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_cmovznz_u64",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u1",
+        "name": [
+          "x1"
+        ],
+        "operation": "!",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "!",
+            "arguments": [
+              "arg1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "-",
+                "arguments": [
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "0x0"
+                    ]
+                  },
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x1"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "|",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "arg3"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "~",
+                "arguments": [
+                  "x2"
+                ]
+              },
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_carry_mul",
+    "arguments": [
+      {
+        "datatype": "u64[3]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[3]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[3]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u128",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[2]",
+                  "0x5"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x2"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[1]",
+                  "0xa"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x3"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[2]",
+                  "0xa"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x4"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x5"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg2[1]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x6"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x7"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[2]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x8"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[1]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x9"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x10"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x9",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x3",
+              "x2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x10",
+              "44"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x10"
+            ]
+          },
+          "0xfffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x13"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x7",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x5",
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x14"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x8",
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "x6",
+              "x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x15"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x11"
+            ]
+          },
+          "x14"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x15",
+              "43"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x15"
+            ]
+          },
+          "0x7ffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x18"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          },
+          "x13"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x18",
+              "43"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          },
+          "0x7ffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x19",
+          "0x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x12",
+          "x21"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x22",
+          "44"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x22",
+          "0xfffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x23",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x26"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x25",
+              "43"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x25",
+          "0x7ffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x26"
+            ]
+          },
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x24"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x27"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x28"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_carry_square",
+    "arguments": [
+      {
+        "datatype": "u64[3]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[3]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[2]",
+          "0x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x1",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[2]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "*",
+        "arguments": [
+          "arg1[1]",
+          "0x2"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x5"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x6"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "x2",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x7"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "*",
+                "arguments": [
+                  "arg1[1]",
+                  "0x2"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x8"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x9"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x10"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[0]"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x11"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x10",
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x11",
+              "44"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x11"
+            ]
+          },
+          "0xfffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x14"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x8",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x15"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x9",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x16"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          },
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x16",
+              "43"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          },
+          "0x7ffffffffff"
+        ]
+      },
+      {
+        "datatype": "u128",
+        "name": [
+          "x19"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x17"
+            ]
+          },
+          "x14"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x19",
+              "43"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x19"
+            ]
+          },
+          "0x7ffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "*",
+        "arguments": [
+          "x20",
+          "0x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x13",
+          "x22"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x23",
+          "44"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x23",
+          "0xfffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x24",
+          "x18"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x27"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x26",
+              "43"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x26",
+          "0x7ffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x27"
+            ]
+          },
+          "x21"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x25"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x28"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x29"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_carry",
+    "arguments": [
+      {
+        "datatype": "u64[3]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[3]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "44"
+            ]
+          },
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x2",
+              "43"
+            ]
+          },
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x1",
+              "0xfffffffffff"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "*",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": ">>",
+                "arguments": [
+                  "x3",
+                  "43"
+                ]
+              },
+              "0x5"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": ">>",
+                    "arguments": [
+                      "x4",
+                      "44"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "0x7ffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x4",
+          "0xfffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x5",
+          "0x7ffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u1",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  {
+                    "datatype": "u1",
+                    "name": [],
+                    "operation": ">>",
+                    "arguments": [
+                      "x5",
+                      "43"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x3",
+              "0x7ffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_add",
+    "arguments": [
+      {
+        "datatype": "u64[3]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[3]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[3]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "+",
+        "arguments": [
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_sub",
+    "arguments": [
+      {
+        "datatype": "u64[3]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[3]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[3]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0x1ffffffffff6",
+              "arg1[0]"
+            ]
+          },
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0xffffffffffe",
+              "arg1[1]"
+            ]
+          },
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              "0xffffffffffe",
+              "arg1[2]"
+            ]
+          },
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_opp",
+    "arguments": [
+      {
+        "datatype": "u64[3]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[3]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x1ffffffffff6",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0xffffffffffe",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0xffffffffffe",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_selectznz",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[3]",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64[3]",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[3]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[0]",
+          "arg3[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[1]",
+          "arg3[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[2]",
+          "arg3[2]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_to_bytes",
+    "arguments": [
+      {
+        "datatype": "u64[3]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u8[17]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "0xffffffffffb"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "0x7ffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "0x7ffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x6",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8",
+          "x9"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x7",
+              "0xffffffffffb"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x9",
+          "x3",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x7",
+              "0x7ffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x11",
+          "x5",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x7",
+              "0x7ffffffffff"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x12",
+          "7"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": "<<",
+        "arguments": [
+          "x10",
+          "4"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x16"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x8",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x18"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x17"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x17",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x20"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x19"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x19",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x22"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x21"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x21",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x24"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x23"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x25"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x23",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x15",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x25"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x27"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x26"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x26",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x29"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x28",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x31"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x30"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x30",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x33"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x32"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x32",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x35"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x34"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x36"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x34",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x14",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x36"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x38"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x37"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x37",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x40"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x39"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x39",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x42"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x41"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x41",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x44"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x43"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x43",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x46"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x45"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x45",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x48"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x47"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x49"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x47",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x22"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x24"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x27"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x29"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x31"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x33"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x35"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x38"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x40"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x42"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x44"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x46"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x48"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[16]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x49"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_poly1305_from_bytes",
+    "arguments": [
+      {
+        "datatype": "u8[17]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[3]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[16]"
+            ]
+          },
+          "41"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          "33"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          "25"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          "17"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          "9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          "36"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          "28"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[8]"
+            ]
+          },
+          "20"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          "12"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          "4"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x17"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x16",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x17"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x15",
+          "x18"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x14",
+          "x19"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x13",
+          "x20"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x12",
+          "x21"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x22",
+          "0xfffffffffff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x24"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x22",
+              "44"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x11",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x10",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x9",
+          "x26"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x8",
+          "x27"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x7",
+          "x28"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30"
+        ],
+        "operation": "&",
+        "arguments": [
+          "x29",
+          "0x7ffffffffff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x31"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x29",
+              "43"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x6",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x31"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x5",
+          "x32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x4",
+          "x33"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x3",
+          "x34"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x2",
+          "x35"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x1",
+          "x36"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x23"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x30"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x37"
+        ]
+      }
+    ]
+  }
+]

--- a/fiat-json/src/secp256k1_32.json
+++ b/fiat-json/src/secp256k1_32.json
@@ -1,0 +1,24357 @@
+[
+  {
+    "operation": "fiat_secp256k1_addcarryx_u32",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_subborrowx_u32",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "i64",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "i64",
+            "name": [],
+            "operation": "-",
+            "arguments": [
+              {
+                "datatype": "i64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              },
+              {
+                "datatype": "i64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "i64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "i1",
+        "name": [
+          "x2"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "i1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_mulx_u32",
+    "arguments": [
+      {
+        "datatype": "u32",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      },
+      {
+        "datatype": "u32",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_cmovznz_u32",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u1",
+        "name": [
+          "x1"
+        ],
+        "operation": "!",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "!",
+            "arguments": [
+              "arg1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "-",
+                "arguments": [
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "0x0"
+                    ]
+                  },
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x1"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "|",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "arg3"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "~",
+                "arguments": [
+                  "x2"
+                ]
+              },
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_mul",
+    "arguments": [
+      {
+        "datatype": "u32[8]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[8]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25",
+          "x26"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x24",
+          "x21"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27",
+          "x28"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x26",
+          "x22",
+          "x19"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29",
+          "x30"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x28",
+          "x20",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31",
+          "x32"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x30",
+          "x18",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33",
+          "x34"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x32",
+          "x16",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35",
+          "x36"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x34",
+          "x14",
+          "x11"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x36",
+          "x12",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          },
+          "x10"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x23",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42",
+          "x43"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44",
+          "x45"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46",
+          "x47"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x48",
+          "x49"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x50",
+          "x51"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x52",
+          "x53"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x54",
+          "x55"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x56",
+          "x57"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x58",
+          "x59"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x57",
+          "x54"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x59",
+          "x55",
+          "x52"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x61",
+          "x53",
+          "x50"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x63",
+          "x51",
+          "x48"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x65",
+          "x49",
+          "x46"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x67",
+          "x47",
+          "x44"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x69",
+          "x45",
+          "x42"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x72"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x71"
+            ]
+          },
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x74"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x23",
+          "x56"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x75",
+          "x76"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x74",
+          "x25",
+          "x58"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x77",
+          "x78"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x76",
+          "x27",
+          "x60"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x79",
+          "x80"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x78",
+          "x29",
+          "x62"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x81",
+          "x82"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x80",
+          "x31",
+          "x64"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x83",
+          "x84"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x82",
+          "x33",
+          "x66"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x85",
+          "x86"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x84",
+          "x35",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x87",
+          "x88"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x86",
+          "x37",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x89",
+          "x90"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x88",
+          "x39",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x91",
+          "x92"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x93",
+          "x94"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x95",
+          "x96"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x97",
+          "x98"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x99",
+          "x100"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x101",
+          "x102"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x103",
+          "x104"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x105",
+          "x106"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x107",
+          "x108"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x106",
+          "x103"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x109",
+          "x110"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x108",
+          "x104",
+          "x101"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x111",
+          "x112"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x110",
+          "x102",
+          "x99"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x113",
+          "x114"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x112",
+          "x100",
+          "x97"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x115",
+          "x116"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x114",
+          "x98",
+          "x95"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x117",
+          "x118"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x116",
+          "x96",
+          "x93"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x119",
+          "x120"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x118",
+          "x94",
+          "x91"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x121"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x120"
+            ]
+          },
+          "x92"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x122",
+          "x123"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x75",
+          "x105"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x124",
+          "x125"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x123",
+          "x77",
+          "x107"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x126",
+          "x127"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x125",
+          "x79",
+          "x109"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x128",
+          "x129"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x127",
+          "x81",
+          "x111"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x130",
+          "x131"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x129",
+          "x83",
+          "x113"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x132",
+          "x133"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x131",
+          "x85",
+          "x115"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x134",
+          "x135"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x133",
+          "x87",
+          "x117"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x136",
+          "x137"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x135",
+          "x89",
+          "x119"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x138",
+          "x139"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x137",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x90"
+            ]
+          },
+          "x121"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x140",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x122",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x142",
+          "x143"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x140",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x144",
+          "x145"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x140",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x146",
+          "x147"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x140",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x148",
+          "x149"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x140",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x150",
+          "x151"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x140",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x152",
+          "x153"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x140",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x154",
+          "x155"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x140",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x156",
+          "x157"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x140",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x158",
+          "x159"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x157",
+          "x154"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x160",
+          "x161"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x159",
+          "x155",
+          "x152"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x162",
+          "x163"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x161",
+          "x153",
+          "x150"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x164",
+          "x165"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x163",
+          "x151",
+          "x148"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x166",
+          "x167"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x165",
+          "x149",
+          "x146"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x168",
+          "x169"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x167",
+          "x147",
+          "x144"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x170",
+          "x171"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x169",
+          "x145",
+          "x142"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x172"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x171"
+            ]
+          },
+          "x143"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x174"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x122",
+          "x156"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x175",
+          "x176"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x174",
+          "x124",
+          "x158"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x177",
+          "x178"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x176",
+          "x126",
+          "x160"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x179",
+          "x180"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x178",
+          "x128",
+          "x162"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x181",
+          "x182"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x180",
+          "x130",
+          "x164"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x183",
+          "x184"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x182",
+          "x132",
+          "x166"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x185",
+          "x186"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x184",
+          "x134",
+          "x168"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x187",
+          "x188"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x186",
+          "x136",
+          "x170"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x189",
+          "x190"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x188",
+          "x138",
+          "x172"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x191"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x190"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x139"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x192",
+          "x193"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x194",
+          "x195"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x196",
+          "x197"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x198",
+          "x199"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x200",
+          "x201"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x202",
+          "x203"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x204",
+          "x205"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x206",
+          "x207"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x208",
+          "x209"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x207",
+          "x204"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x210",
+          "x211"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x209",
+          "x205",
+          "x202"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x212",
+          "x213"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x211",
+          "x203",
+          "x200"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x214",
+          "x215"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x213",
+          "x201",
+          "x198"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x216",
+          "x217"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x215",
+          "x199",
+          "x196"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x218",
+          "x219"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x217",
+          "x197",
+          "x194"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x220",
+          "x221"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x219",
+          "x195",
+          "x192"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x222"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x221"
+            ]
+          },
+          "x193"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x223",
+          "x224"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x175",
+          "x206"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x225",
+          "x226"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x224",
+          "x177",
+          "x208"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x227",
+          "x228"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x226",
+          "x179",
+          "x210"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x229",
+          "x230"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x228",
+          "x181",
+          "x212"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x231",
+          "x232"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x230",
+          "x183",
+          "x214"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x233",
+          "x234"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x232",
+          "x185",
+          "x216"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x235",
+          "x236"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x234",
+          "x187",
+          "x218"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x237",
+          "x238"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x236",
+          "x189",
+          "x220"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x239",
+          "x240"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x238",
+          "x191",
+          "x222"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x241",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x223",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x243",
+          "x244"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x241",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x245",
+          "x246"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x241",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x247",
+          "x248"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x241",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x249",
+          "x250"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x241",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x251",
+          "x252"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x241",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x253",
+          "x254"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x241",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x255",
+          "x256"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x241",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x257",
+          "x258"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x241",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x259",
+          "x260"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x258",
+          "x255"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x261",
+          "x262"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x260",
+          "x256",
+          "x253"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x263",
+          "x264"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x262",
+          "x254",
+          "x251"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x265",
+          "x266"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x264",
+          "x252",
+          "x249"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x267",
+          "x268"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x266",
+          "x250",
+          "x247"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x269",
+          "x270"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x268",
+          "x248",
+          "x245"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x271",
+          "x272"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x270",
+          "x246",
+          "x243"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x273"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x272"
+            ]
+          },
+          "x244"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x275"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x223",
+          "x257"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x276",
+          "x277"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x275",
+          "x225",
+          "x259"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x278",
+          "x279"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x277",
+          "x227",
+          "x261"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x280",
+          "x281"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x279",
+          "x229",
+          "x263"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x282",
+          "x283"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x281",
+          "x231",
+          "x265"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x284",
+          "x285"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x283",
+          "x233",
+          "x267"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x286",
+          "x287"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x285",
+          "x235",
+          "x269"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x288",
+          "x289"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x287",
+          "x237",
+          "x271"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x290",
+          "x291"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x289",
+          "x239",
+          "x273"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x292"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x291"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x240"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x293",
+          "x294"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x295",
+          "x296"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x297",
+          "x298"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x299",
+          "x300"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x301",
+          "x302"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x303",
+          "x304"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x305",
+          "x306"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x307",
+          "x308"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x309",
+          "x310"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x308",
+          "x305"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x311",
+          "x312"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x310",
+          "x306",
+          "x303"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x313",
+          "x314"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x312",
+          "x304",
+          "x301"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x315",
+          "x316"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x314",
+          "x302",
+          "x299"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x317",
+          "x318"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x316",
+          "x300",
+          "x297"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x319",
+          "x320"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x318",
+          "x298",
+          "x295"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x321",
+          "x322"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x320",
+          "x296",
+          "x293"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x323"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x322"
+            ]
+          },
+          "x294"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x324",
+          "x325"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x276",
+          "x307"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x326",
+          "x327"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x325",
+          "x278",
+          "x309"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x328",
+          "x329"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x327",
+          "x280",
+          "x311"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x330",
+          "x331"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x329",
+          "x282",
+          "x313"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x332",
+          "x333"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x331",
+          "x284",
+          "x315"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x334",
+          "x335"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x333",
+          "x286",
+          "x317"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x336",
+          "x337"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x335",
+          "x288",
+          "x319"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x338",
+          "x339"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x337",
+          "x290",
+          "x321"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x340",
+          "x341"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x339",
+          "x292",
+          "x323"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x342",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x324",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x344",
+          "x345"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x346",
+          "x347"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x348",
+          "x349"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x350",
+          "x351"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x352",
+          "x353"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x354",
+          "x355"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x356",
+          "x357"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x358",
+          "x359"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x360",
+          "x361"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x359",
+          "x356"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x362",
+          "x363"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x361",
+          "x357",
+          "x354"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x364",
+          "x365"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x363",
+          "x355",
+          "x352"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x366",
+          "x367"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x365",
+          "x353",
+          "x350"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x368",
+          "x369"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x367",
+          "x351",
+          "x348"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x370",
+          "x371"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x369",
+          "x349",
+          "x346"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x372",
+          "x373"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x371",
+          "x347",
+          "x344"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x374"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x373"
+            ]
+          },
+          "x345"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x376"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x324",
+          "x358"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x377",
+          "x378"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x376",
+          "x326",
+          "x360"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x379",
+          "x380"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x378",
+          "x328",
+          "x362"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x381",
+          "x382"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x380",
+          "x330",
+          "x364"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x383",
+          "x384"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x382",
+          "x332",
+          "x366"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x385",
+          "x386"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x384",
+          "x334",
+          "x368"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x387",
+          "x388"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x386",
+          "x336",
+          "x370"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x389",
+          "x390"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x388",
+          "x338",
+          "x372"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x391",
+          "x392"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x390",
+          "x340",
+          "x374"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x393"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x392"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x341"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x394",
+          "x395"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x396",
+          "x397"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x398",
+          "x399"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x400",
+          "x401"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x402",
+          "x403"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x404",
+          "x405"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x406",
+          "x407"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x408",
+          "x409"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x410",
+          "x411"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x409",
+          "x406"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x412",
+          "x413"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x411",
+          "x407",
+          "x404"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x414",
+          "x415"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x413",
+          "x405",
+          "x402"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x416",
+          "x417"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x415",
+          "x403",
+          "x400"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x418",
+          "x419"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x417",
+          "x401",
+          "x398"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x420",
+          "x421"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x419",
+          "x399",
+          "x396"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x422",
+          "x423"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x421",
+          "x397",
+          "x394"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x424"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x423"
+            ]
+          },
+          "x395"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x425",
+          "x426"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x377",
+          "x408"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x427",
+          "x428"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x426",
+          "x379",
+          "x410"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x429",
+          "x430"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x428",
+          "x381",
+          "x412"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x431",
+          "x432"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x430",
+          "x383",
+          "x414"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x433",
+          "x434"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x432",
+          "x385",
+          "x416"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x435",
+          "x436"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x434",
+          "x387",
+          "x418"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x437",
+          "x438"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x436",
+          "x389",
+          "x420"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x439",
+          "x440"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x438",
+          "x391",
+          "x422"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x441",
+          "x442"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x440",
+          "x393",
+          "x424"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x443",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x425",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x445",
+          "x446"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x443",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x447",
+          "x448"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x443",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x449",
+          "x450"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x443",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x451",
+          "x452"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x443",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x453",
+          "x454"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x443",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x455",
+          "x456"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x443",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x457",
+          "x458"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x443",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x459",
+          "x460"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x443",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x461",
+          "x462"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x460",
+          "x457"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x463",
+          "x464"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x462",
+          "x458",
+          "x455"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x465",
+          "x466"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x464",
+          "x456",
+          "x453"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x467",
+          "x468"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x466",
+          "x454",
+          "x451"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x469",
+          "x470"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x468",
+          "x452",
+          "x449"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x471",
+          "x472"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x470",
+          "x450",
+          "x447"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x473",
+          "x474"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x472",
+          "x448",
+          "x445"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x475"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x474"
+            ]
+          },
+          "x446"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x477"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x425",
+          "x459"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x478",
+          "x479"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x477",
+          "x427",
+          "x461"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x480",
+          "x481"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x479",
+          "x429",
+          "x463"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x482",
+          "x483"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x481",
+          "x431",
+          "x465"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x484",
+          "x485"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x483",
+          "x433",
+          "x467"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x486",
+          "x487"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x485",
+          "x435",
+          "x469"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x488",
+          "x489"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x487",
+          "x437",
+          "x471"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x490",
+          "x491"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x489",
+          "x439",
+          "x473"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x492",
+          "x493"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x491",
+          "x441",
+          "x475"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x494"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x493"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x442"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x495",
+          "x496"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x497",
+          "x498"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x499",
+          "x500"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x501",
+          "x502"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x503",
+          "x504"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x505",
+          "x506"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x507",
+          "x508"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x509",
+          "x510"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x511",
+          "x512"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x510",
+          "x507"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x513",
+          "x514"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x512",
+          "x508",
+          "x505"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x515",
+          "x516"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x514",
+          "x506",
+          "x503"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x517",
+          "x518"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x516",
+          "x504",
+          "x501"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x519",
+          "x520"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x518",
+          "x502",
+          "x499"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x521",
+          "x522"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x520",
+          "x500",
+          "x497"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x523",
+          "x524"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x522",
+          "x498",
+          "x495"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x525"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x524"
+            ]
+          },
+          "x496"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x526",
+          "x527"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x478",
+          "x509"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x528",
+          "x529"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x527",
+          "x480",
+          "x511"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x530",
+          "x531"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x529",
+          "x482",
+          "x513"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x532",
+          "x533"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x531",
+          "x484",
+          "x515"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x534",
+          "x535"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x533",
+          "x486",
+          "x517"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x536",
+          "x537"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x535",
+          "x488",
+          "x519"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x538",
+          "x539"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x537",
+          "x490",
+          "x521"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x540",
+          "x541"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x539",
+          "x492",
+          "x523"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x542",
+          "x543"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x541",
+          "x494",
+          "x525"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x544",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x526",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x546",
+          "x547"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x544",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x548",
+          "x549"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x544",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x550",
+          "x551"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x544",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x552",
+          "x553"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x544",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x554",
+          "x555"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x544",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x556",
+          "x557"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x544",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x558",
+          "x559"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x544",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x560",
+          "x561"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x544",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x562",
+          "x563"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x561",
+          "x558"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x564",
+          "x565"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x563",
+          "x559",
+          "x556"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x566",
+          "x567"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x565",
+          "x557",
+          "x554"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x568",
+          "x569"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x567",
+          "x555",
+          "x552"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x570",
+          "x571"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x569",
+          "x553",
+          "x550"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x572",
+          "x573"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x571",
+          "x551",
+          "x548"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x574",
+          "x575"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x573",
+          "x549",
+          "x546"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x576"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x575"
+            ]
+          },
+          "x547"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x578"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x526",
+          "x560"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x579",
+          "x580"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x578",
+          "x528",
+          "x562"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x581",
+          "x582"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x580",
+          "x530",
+          "x564"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x583",
+          "x584"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x582",
+          "x532",
+          "x566"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x585",
+          "x586"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x584",
+          "x534",
+          "x568"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x587",
+          "x588"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x586",
+          "x536",
+          "x570"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x589",
+          "x590"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x588",
+          "x538",
+          "x572"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x591",
+          "x592"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x590",
+          "x540",
+          "x574"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x593",
+          "x594"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x592",
+          "x542",
+          "x576"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x595"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x594"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x543"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x596",
+          "x597"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x598",
+          "x599"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x600",
+          "x601"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x602",
+          "x603"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x604",
+          "x605"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x606",
+          "x607"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x608",
+          "x609"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x610",
+          "x611"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x612",
+          "x613"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x611",
+          "x608"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x614",
+          "x615"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x613",
+          "x609",
+          "x606"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x616",
+          "x617"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x615",
+          "x607",
+          "x604"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x618",
+          "x619"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x617",
+          "x605",
+          "x602"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x620",
+          "x621"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x619",
+          "x603",
+          "x600"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x622",
+          "x623"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x621",
+          "x601",
+          "x598"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x624",
+          "x625"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x623",
+          "x599",
+          "x596"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x626"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x625"
+            ]
+          },
+          "x597"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x627",
+          "x628"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x579",
+          "x610"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x629",
+          "x630"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x628",
+          "x581",
+          "x612"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x631",
+          "x632"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x630",
+          "x583",
+          "x614"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x633",
+          "x634"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x632",
+          "x585",
+          "x616"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x635",
+          "x636"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x634",
+          "x587",
+          "x618"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x637",
+          "x638"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x636",
+          "x589",
+          "x620"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x639",
+          "x640"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x638",
+          "x591",
+          "x622"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x641",
+          "x642"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x640",
+          "x593",
+          "x624"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x643",
+          "x644"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x642",
+          "x595",
+          "x626"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x645",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x627",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x647",
+          "x648"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x645",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x649",
+          "x650"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x645",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x651",
+          "x652"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x645",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x653",
+          "x654"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x645",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x655",
+          "x656"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x645",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x657",
+          "x658"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x645",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x659",
+          "x660"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x645",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x661",
+          "x662"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x645",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x663",
+          "x664"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x662",
+          "x659"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x665",
+          "x666"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x664",
+          "x660",
+          "x657"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x667",
+          "x668"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x666",
+          "x658",
+          "x655"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x669",
+          "x670"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x668",
+          "x656",
+          "x653"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x671",
+          "x672"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x670",
+          "x654",
+          "x651"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x673",
+          "x674"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x672",
+          "x652",
+          "x649"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x675",
+          "x676"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x674",
+          "x650",
+          "x647"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x677"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x676"
+            ]
+          },
+          "x648"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x679"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x627",
+          "x661"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x680",
+          "x681"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x679",
+          "x629",
+          "x663"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x682",
+          "x683"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x681",
+          "x631",
+          "x665"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x684",
+          "x685"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x683",
+          "x633",
+          "x667"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x686",
+          "x687"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x685",
+          "x635",
+          "x669"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x688",
+          "x689"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x687",
+          "x637",
+          "x671"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x690",
+          "x691"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x689",
+          "x639",
+          "x673"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x692",
+          "x693"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x691",
+          "x641",
+          "x675"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x694",
+          "x695"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x693",
+          "x643",
+          "x677"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x696"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x695"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x644"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x697",
+          "x698"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x699",
+          "x700"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x701",
+          "x702"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x703",
+          "x704"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x705",
+          "x706"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x707",
+          "x708"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x709",
+          "x710"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x711",
+          "x712"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x713",
+          "x714"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x712",
+          "x709"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x715",
+          "x716"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x714",
+          "x710",
+          "x707"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x717",
+          "x718"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x716",
+          "x708",
+          "x705"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x719",
+          "x720"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x718",
+          "x706",
+          "x703"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x721",
+          "x722"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x720",
+          "x704",
+          "x701"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x723",
+          "x724"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x722",
+          "x702",
+          "x699"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x725",
+          "x726"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x724",
+          "x700",
+          "x697"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x727"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x726"
+            ]
+          },
+          "x698"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x728",
+          "x729"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x680",
+          "x711"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x730",
+          "x731"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x729",
+          "x682",
+          "x713"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x732",
+          "x733"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x731",
+          "x684",
+          "x715"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x734",
+          "x735"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x733",
+          "x686",
+          "x717"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x736",
+          "x737"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x735",
+          "x688",
+          "x719"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x738",
+          "x739"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x737",
+          "x690",
+          "x721"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x740",
+          "x741"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x739",
+          "x692",
+          "x723"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x742",
+          "x743"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x741",
+          "x694",
+          "x725"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x744",
+          "x745"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x743",
+          "x696",
+          "x727"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x746",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x728",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x748",
+          "x749"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x746",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x750",
+          "x751"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x746",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x752",
+          "x753"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x746",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x754",
+          "x755"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x746",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x756",
+          "x757"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x746",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x758",
+          "x759"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x746",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x760",
+          "x761"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x746",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x762",
+          "x763"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x746",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x764",
+          "x765"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x763",
+          "x760"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x766",
+          "x767"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x765",
+          "x761",
+          "x758"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x768",
+          "x769"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x767",
+          "x759",
+          "x756"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x770",
+          "x771"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x769",
+          "x757",
+          "x754"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x772",
+          "x773"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x771",
+          "x755",
+          "x752"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x774",
+          "x775"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x773",
+          "x753",
+          "x750"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x776",
+          "x777"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x775",
+          "x751",
+          "x748"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x778"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x777"
+            ]
+          },
+          "x749"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x780"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x728",
+          "x762"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x781",
+          "x782"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x780",
+          "x730",
+          "x764"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x783",
+          "x784"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x782",
+          "x732",
+          "x766"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x785",
+          "x786"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x784",
+          "x734",
+          "x768"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x787",
+          "x788"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x786",
+          "x736",
+          "x770"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x789",
+          "x790"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x788",
+          "x738",
+          "x772"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x791",
+          "x792"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x790",
+          "x740",
+          "x774"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x793",
+          "x794"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x792",
+          "x742",
+          "x776"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x795",
+          "x796"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x794",
+          "x744",
+          "x778"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x797"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x796"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x745"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x798",
+          "x799"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x781",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x800",
+          "x801"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x799",
+          "x783",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x802",
+          "x803"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x801",
+          "x785",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x804",
+          "x805"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x803",
+          "x787",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x806",
+          "x807"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x805",
+          "x789",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x808",
+          "x809"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x807",
+          "x791",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x810",
+          "x811"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x809",
+          "x793",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x812",
+          "x813"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x811",
+          "x795",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x815"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x813",
+          "x797",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x816"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x815",
+          "x798",
+          "x781"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x817"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x815",
+          "x800",
+          "x783"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x818"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x815",
+          "x802",
+          "x785"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x819"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x815",
+          "x804",
+          "x787"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x820"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x815",
+          "x806",
+          "x789"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x821"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x815",
+          "x808",
+          "x791"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x822"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x815",
+          "x810",
+          "x793"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x823"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x815",
+          "x812",
+          "x795"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x816"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x817"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x818"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x819"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x820"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x821"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x822"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x823"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_square",
+    "arguments": [
+      {
+        "datatype": "u32[8]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25",
+          "x26"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x24",
+          "x21"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27",
+          "x28"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x26",
+          "x22",
+          "x19"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29",
+          "x30"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x28",
+          "x20",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31",
+          "x32"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x30",
+          "x18",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33",
+          "x34"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x32",
+          "x16",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35",
+          "x36"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x34",
+          "x14",
+          "x11"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x36",
+          "x12",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          },
+          "x10"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x23",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42",
+          "x43"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44",
+          "x45"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46",
+          "x47"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x48",
+          "x49"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x50",
+          "x51"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x52",
+          "x53"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x54",
+          "x55"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x56",
+          "x57"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x40",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x58",
+          "x59"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x57",
+          "x54"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x59",
+          "x55",
+          "x52"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x61",
+          "x53",
+          "x50"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x63",
+          "x51",
+          "x48"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x65",
+          "x49",
+          "x46"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x67",
+          "x47",
+          "x44"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x69",
+          "x45",
+          "x42"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x72"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x71"
+            ]
+          },
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x74"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x23",
+          "x56"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x75",
+          "x76"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x74",
+          "x25",
+          "x58"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x77",
+          "x78"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x76",
+          "x27",
+          "x60"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x79",
+          "x80"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x78",
+          "x29",
+          "x62"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x81",
+          "x82"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x80",
+          "x31",
+          "x64"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x83",
+          "x84"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x82",
+          "x33",
+          "x66"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x85",
+          "x86"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x84",
+          "x35",
+          "x68"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x87",
+          "x88"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x86",
+          "x37",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x89",
+          "x90"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x88",
+          "x39",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x91",
+          "x92"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x93",
+          "x94"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x95",
+          "x96"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x97",
+          "x98"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x99",
+          "x100"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x101",
+          "x102"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x103",
+          "x104"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x105",
+          "x106"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x107",
+          "x108"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x106",
+          "x103"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x109",
+          "x110"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x108",
+          "x104",
+          "x101"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x111",
+          "x112"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x110",
+          "x102",
+          "x99"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x113",
+          "x114"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x112",
+          "x100",
+          "x97"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x115",
+          "x116"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x114",
+          "x98",
+          "x95"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x117",
+          "x118"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x116",
+          "x96",
+          "x93"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x119",
+          "x120"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x118",
+          "x94",
+          "x91"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x121"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x120"
+            ]
+          },
+          "x92"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x122",
+          "x123"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x75",
+          "x105"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x124",
+          "x125"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x123",
+          "x77",
+          "x107"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x126",
+          "x127"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x125",
+          "x79",
+          "x109"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x128",
+          "x129"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x127",
+          "x81",
+          "x111"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x130",
+          "x131"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x129",
+          "x83",
+          "x113"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x132",
+          "x133"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x131",
+          "x85",
+          "x115"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x134",
+          "x135"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x133",
+          "x87",
+          "x117"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x136",
+          "x137"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x135",
+          "x89",
+          "x119"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x138",
+          "x139"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x137",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x90"
+            ]
+          },
+          "x121"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x140",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x122",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x142",
+          "x143"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x140",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x144",
+          "x145"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x140",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x146",
+          "x147"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x140",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x148",
+          "x149"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x140",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x150",
+          "x151"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x140",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x152",
+          "x153"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x140",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x154",
+          "x155"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x140",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x156",
+          "x157"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x140",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x158",
+          "x159"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x157",
+          "x154"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x160",
+          "x161"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x159",
+          "x155",
+          "x152"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x162",
+          "x163"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x161",
+          "x153",
+          "x150"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x164",
+          "x165"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x163",
+          "x151",
+          "x148"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x166",
+          "x167"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x165",
+          "x149",
+          "x146"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x168",
+          "x169"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x167",
+          "x147",
+          "x144"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x170",
+          "x171"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x169",
+          "x145",
+          "x142"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x172"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x171"
+            ]
+          },
+          "x143"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x174"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x122",
+          "x156"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x175",
+          "x176"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x174",
+          "x124",
+          "x158"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x177",
+          "x178"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x176",
+          "x126",
+          "x160"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x179",
+          "x180"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x178",
+          "x128",
+          "x162"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x181",
+          "x182"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x180",
+          "x130",
+          "x164"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x183",
+          "x184"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x182",
+          "x132",
+          "x166"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x185",
+          "x186"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x184",
+          "x134",
+          "x168"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x187",
+          "x188"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x186",
+          "x136",
+          "x170"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x189",
+          "x190"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x188",
+          "x138",
+          "x172"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x191"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x190"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x139"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x192",
+          "x193"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x194",
+          "x195"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x196",
+          "x197"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x198",
+          "x199"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x200",
+          "x201"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x202",
+          "x203"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x204",
+          "x205"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x206",
+          "x207"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x208",
+          "x209"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x207",
+          "x204"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x210",
+          "x211"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x209",
+          "x205",
+          "x202"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x212",
+          "x213"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x211",
+          "x203",
+          "x200"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x214",
+          "x215"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x213",
+          "x201",
+          "x198"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x216",
+          "x217"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x215",
+          "x199",
+          "x196"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x218",
+          "x219"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x217",
+          "x197",
+          "x194"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x220",
+          "x221"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x219",
+          "x195",
+          "x192"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x222"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x221"
+            ]
+          },
+          "x193"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x223",
+          "x224"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x175",
+          "x206"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x225",
+          "x226"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x224",
+          "x177",
+          "x208"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x227",
+          "x228"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x226",
+          "x179",
+          "x210"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x229",
+          "x230"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x228",
+          "x181",
+          "x212"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x231",
+          "x232"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x230",
+          "x183",
+          "x214"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x233",
+          "x234"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x232",
+          "x185",
+          "x216"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x235",
+          "x236"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x234",
+          "x187",
+          "x218"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x237",
+          "x238"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x236",
+          "x189",
+          "x220"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x239",
+          "x240"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x238",
+          "x191",
+          "x222"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x241",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x223",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x243",
+          "x244"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x241",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x245",
+          "x246"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x241",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x247",
+          "x248"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x241",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x249",
+          "x250"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x241",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x251",
+          "x252"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x241",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x253",
+          "x254"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x241",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x255",
+          "x256"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x241",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x257",
+          "x258"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x241",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x259",
+          "x260"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x258",
+          "x255"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x261",
+          "x262"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x260",
+          "x256",
+          "x253"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x263",
+          "x264"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x262",
+          "x254",
+          "x251"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x265",
+          "x266"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x264",
+          "x252",
+          "x249"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x267",
+          "x268"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x266",
+          "x250",
+          "x247"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x269",
+          "x270"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x268",
+          "x248",
+          "x245"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x271",
+          "x272"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x270",
+          "x246",
+          "x243"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x273"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x272"
+            ]
+          },
+          "x244"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x275"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x223",
+          "x257"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x276",
+          "x277"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x275",
+          "x225",
+          "x259"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x278",
+          "x279"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x277",
+          "x227",
+          "x261"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x280",
+          "x281"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x279",
+          "x229",
+          "x263"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x282",
+          "x283"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x281",
+          "x231",
+          "x265"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x284",
+          "x285"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x283",
+          "x233",
+          "x267"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x286",
+          "x287"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x285",
+          "x235",
+          "x269"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x288",
+          "x289"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x287",
+          "x237",
+          "x271"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x290",
+          "x291"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x289",
+          "x239",
+          "x273"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x292"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x291"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x240"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x293",
+          "x294"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x295",
+          "x296"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x297",
+          "x298"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x299",
+          "x300"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x301",
+          "x302"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x303",
+          "x304"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x305",
+          "x306"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x307",
+          "x308"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x309",
+          "x310"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x308",
+          "x305"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x311",
+          "x312"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x310",
+          "x306",
+          "x303"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x313",
+          "x314"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x312",
+          "x304",
+          "x301"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x315",
+          "x316"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x314",
+          "x302",
+          "x299"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x317",
+          "x318"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x316",
+          "x300",
+          "x297"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x319",
+          "x320"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x318",
+          "x298",
+          "x295"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x321",
+          "x322"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x320",
+          "x296",
+          "x293"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x323"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x322"
+            ]
+          },
+          "x294"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x324",
+          "x325"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x276",
+          "x307"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x326",
+          "x327"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x325",
+          "x278",
+          "x309"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x328",
+          "x329"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x327",
+          "x280",
+          "x311"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x330",
+          "x331"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x329",
+          "x282",
+          "x313"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x332",
+          "x333"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x331",
+          "x284",
+          "x315"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x334",
+          "x335"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x333",
+          "x286",
+          "x317"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x336",
+          "x337"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x335",
+          "x288",
+          "x319"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x338",
+          "x339"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x337",
+          "x290",
+          "x321"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x340",
+          "x341"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x339",
+          "x292",
+          "x323"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x342",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x324",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x344",
+          "x345"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x346",
+          "x347"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x348",
+          "x349"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x350",
+          "x351"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x352",
+          "x353"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x354",
+          "x355"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x356",
+          "x357"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x358",
+          "x359"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x342",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x360",
+          "x361"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x359",
+          "x356"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x362",
+          "x363"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x361",
+          "x357",
+          "x354"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x364",
+          "x365"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x363",
+          "x355",
+          "x352"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x366",
+          "x367"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x365",
+          "x353",
+          "x350"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x368",
+          "x369"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x367",
+          "x351",
+          "x348"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x370",
+          "x371"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x369",
+          "x349",
+          "x346"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x372",
+          "x373"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x371",
+          "x347",
+          "x344"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x374"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x373"
+            ]
+          },
+          "x345"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x376"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x324",
+          "x358"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x377",
+          "x378"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x376",
+          "x326",
+          "x360"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x379",
+          "x380"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x378",
+          "x328",
+          "x362"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x381",
+          "x382"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x380",
+          "x330",
+          "x364"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x383",
+          "x384"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x382",
+          "x332",
+          "x366"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x385",
+          "x386"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x384",
+          "x334",
+          "x368"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x387",
+          "x388"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x386",
+          "x336",
+          "x370"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x389",
+          "x390"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x388",
+          "x338",
+          "x372"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x391",
+          "x392"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x390",
+          "x340",
+          "x374"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x393"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x392"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x341"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x394",
+          "x395"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x396",
+          "x397"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x398",
+          "x399"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x400",
+          "x401"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x402",
+          "x403"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x404",
+          "x405"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x406",
+          "x407"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x408",
+          "x409"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x410",
+          "x411"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x409",
+          "x406"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x412",
+          "x413"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x411",
+          "x407",
+          "x404"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x414",
+          "x415"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x413",
+          "x405",
+          "x402"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x416",
+          "x417"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x415",
+          "x403",
+          "x400"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x418",
+          "x419"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x417",
+          "x401",
+          "x398"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x420",
+          "x421"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x419",
+          "x399",
+          "x396"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x422",
+          "x423"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x421",
+          "x397",
+          "x394"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x424"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x423"
+            ]
+          },
+          "x395"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x425",
+          "x426"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x377",
+          "x408"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x427",
+          "x428"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x426",
+          "x379",
+          "x410"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x429",
+          "x430"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x428",
+          "x381",
+          "x412"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x431",
+          "x432"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x430",
+          "x383",
+          "x414"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x433",
+          "x434"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x432",
+          "x385",
+          "x416"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x435",
+          "x436"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x434",
+          "x387",
+          "x418"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x437",
+          "x438"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x436",
+          "x389",
+          "x420"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x439",
+          "x440"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x438",
+          "x391",
+          "x422"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x441",
+          "x442"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x440",
+          "x393",
+          "x424"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x443",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x425",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x445",
+          "x446"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x443",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x447",
+          "x448"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x443",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x449",
+          "x450"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x443",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x451",
+          "x452"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x443",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x453",
+          "x454"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x443",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x455",
+          "x456"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x443",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x457",
+          "x458"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x443",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x459",
+          "x460"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x443",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x461",
+          "x462"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x460",
+          "x457"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x463",
+          "x464"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x462",
+          "x458",
+          "x455"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x465",
+          "x466"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x464",
+          "x456",
+          "x453"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x467",
+          "x468"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x466",
+          "x454",
+          "x451"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x469",
+          "x470"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x468",
+          "x452",
+          "x449"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x471",
+          "x472"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x470",
+          "x450",
+          "x447"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x473",
+          "x474"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x472",
+          "x448",
+          "x445"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x475"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x474"
+            ]
+          },
+          "x446"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x477"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x425",
+          "x459"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x478",
+          "x479"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x477",
+          "x427",
+          "x461"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x480",
+          "x481"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x479",
+          "x429",
+          "x463"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x482",
+          "x483"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x481",
+          "x431",
+          "x465"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x484",
+          "x485"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x483",
+          "x433",
+          "x467"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x486",
+          "x487"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x485",
+          "x435",
+          "x469"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x488",
+          "x489"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x487",
+          "x437",
+          "x471"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x490",
+          "x491"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x489",
+          "x439",
+          "x473"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x492",
+          "x493"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x491",
+          "x441",
+          "x475"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x494"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x493"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x442"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x495",
+          "x496"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x497",
+          "x498"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x499",
+          "x500"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x501",
+          "x502"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x503",
+          "x504"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x505",
+          "x506"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x507",
+          "x508"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x509",
+          "x510"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x511",
+          "x512"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x510",
+          "x507"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x513",
+          "x514"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x512",
+          "x508",
+          "x505"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x515",
+          "x516"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x514",
+          "x506",
+          "x503"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x517",
+          "x518"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x516",
+          "x504",
+          "x501"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x519",
+          "x520"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x518",
+          "x502",
+          "x499"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x521",
+          "x522"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x520",
+          "x500",
+          "x497"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x523",
+          "x524"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x522",
+          "x498",
+          "x495"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x525"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x524"
+            ]
+          },
+          "x496"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x526",
+          "x527"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x478",
+          "x509"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x528",
+          "x529"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x527",
+          "x480",
+          "x511"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x530",
+          "x531"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x529",
+          "x482",
+          "x513"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x532",
+          "x533"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x531",
+          "x484",
+          "x515"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x534",
+          "x535"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x533",
+          "x486",
+          "x517"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x536",
+          "x537"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x535",
+          "x488",
+          "x519"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x538",
+          "x539"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x537",
+          "x490",
+          "x521"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x540",
+          "x541"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x539",
+          "x492",
+          "x523"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x542",
+          "x543"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x541",
+          "x494",
+          "x525"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x544",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x526",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x546",
+          "x547"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x544",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x548",
+          "x549"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x544",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x550",
+          "x551"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x544",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x552",
+          "x553"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x544",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x554",
+          "x555"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x544",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x556",
+          "x557"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x544",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x558",
+          "x559"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x544",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x560",
+          "x561"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x544",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x562",
+          "x563"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x561",
+          "x558"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x564",
+          "x565"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x563",
+          "x559",
+          "x556"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x566",
+          "x567"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x565",
+          "x557",
+          "x554"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x568",
+          "x569"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x567",
+          "x555",
+          "x552"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x570",
+          "x571"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x569",
+          "x553",
+          "x550"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x572",
+          "x573"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x571",
+          "x551",
+          "x548"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x574",
+          "x575"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x573",
+          "x549",
+          "x546"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x576"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x575"
+            ]
+          },
+          "x547"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x578"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x526",
+          "x560"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x579",
+          "x580"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x578",
+          "x528",
+          "x562"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x581",
+          "x582"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x580",
+          "x530",
+          "x564"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x583",
+          "x584"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x582",
+          "x532",
+          "x566"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x585",
+          "x586"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x584",
+          "x534",
+          "x568"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x587",
+          "x588"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x586",
+          "x536",
+          "x570"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x589",
+          "x590"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x588",
+          "x538",
+          "x572"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x591",
+          "x592"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x590",
+          "x540",
+          "x574"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x593",
+          "x594"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x592",
+          "x542",
+          "x576"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x595"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x594"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x543"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x596",
+          "x597"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x598",
+          "x599"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x600",
+          "x601"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x602",
+          "x603"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x604",
+          "x605"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x606",
+          "x607"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x608",
+          "x609"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x610",
+          "x611"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x612",
+          "x613"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x611",
+          "x608"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x614",
+          "x615"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x613",
+          "x609",
+          "x606"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x616",
+          "x617"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x615",
+          "x607",
+          "x604"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x618",
+          "x619"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x617",
+          "x605",
+          "x602"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x620",
+          "x621"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x619",
+          "x603",
+          "x600"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x622",
+          "x623"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x621",
+          "x601",
+          "x598"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x624",
+          "x625"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x623",
+          "x599",
+          "x596"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x626"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x625"
+            ]
+          },
+          "x597"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x627",
+          "x628"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x579",
+          "x610"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x629",
+          "x630"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x628",
+          "x581",
+          "x612"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x631",
+          "x632"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x630",
+          "x583",
+          "x614"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x633",
+          "x634"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x632",
+          "x585",
+          "x616"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x635",
+          "x636"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x634",
+          "x587",
+          "x618"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x637",
+          "x638"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x636",
+          "x589",
+          "x620"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x639",
+          "x640"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x638",
+          "x591",
+          "x622"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x641",
+          "x642"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x640",
+          "x593",
+          "x624"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x643",
+          "x644"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x642",
+          "x595",
+          "x626"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x645",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x627",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x647",
+          "x648"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x645",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x649",
+          "x650"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x645",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x651",
+          "x652"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x645",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x653",
+          "x654"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x645",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x655",
+          "x656"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x645",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x657",
+          "x658"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x645",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x659",
+          "x660"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x645",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x661",
+          "x662"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x645",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x663",
+          "x664"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x662",
+          "x659"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x665",
+          "x666"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x664",
+          "x660",
+          "x657"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x667",
+          "x668"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x666",
+          "x658",
+          "x655"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x669",
+          "x670"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x668",
+          "x656",
+          "x653"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x671",
+          "x672"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x670",
+          "x654",
+          "x651"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x673",
+          "x674"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x672",
+          "x652",
+          "x649"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x675",
+          "x676"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x674",
+          "x650",
+          "x647"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x677"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x676"
+            ]
+          },
+          "x648"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x679"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x627",
+          "x661"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x680",
+          "x681"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x679",
+          "x629",
+          "x663"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x682",
+          "x683"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x681",
+          "x631",
+          "x665"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x684",
+          "x685"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x683",
+          "x633",
+          "x667"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x686",
+          "x687"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x685",
+          "x635",
+          "x669"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x688",
+          "x689"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x687",
+          "x637",
+          "x671"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x690",
+          "x691"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x689",
+          "x639",
+          "x673"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x692",
+          "x693"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x691",
+          "x641",
+          "x675"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x694",
+          "x695"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x693",
+          "x643",
+          "x677"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x696"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x695"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x644"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x697",
+          "x698"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x699",
+          "x700"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x701",
+          "x702"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x703",
+          "x704"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x705",
+          "x706"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x707",
+          "x708"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x709",
+          "x710"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x711",
+          "x712"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x713",
+          "x714"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x712",
+          "x709"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x715",
+          "x716"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x714",
+          "x710",
+          "x707"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x717",
+          "x718"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x716",
+          "x708",
+          "x705"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x719",
+          "x720"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x718",
+          "x706",
+          "x703"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x721",
+          "x722"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x720",
+          "x704",
+          "x701"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x723",
+          "x724"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x722",
+          "x702",
+          "x699"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x725",
+          "x726"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x724",
+          "x700",
+          "x697"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x727"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x726"
+            ]
+          },
+          "x698"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x728",
+          "x729"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x680",
+          "x711"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x730",
+          "x731"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x729",
+          "x682",
+          "x713"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x732",
+          "x733"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x731",
+          "x684",
+          "x715"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x734",
+          "x735"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x733",
+          "x686",
+          "x717"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x736",
+          "x737"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x735",
+          "x688",
+          "x719"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x738",
+          "x739"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x737",
+          "x690",
+          "x721"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x740",
+          "x741"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x739",
+          "x692",
+          "x723"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x742",
+          "x743"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x741",
+          "x694",
+          "x725"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x744",
+          "x745"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x743",
+          "x696",
+          "x727"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x746",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x728",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x748",
+          "x749"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x746",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x750",
+          "x751"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x746",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x752",
+          "x753"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x746",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x754",
+          "x755"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x746",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x756",
+          "x757"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x746",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x758",
+          "x759"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x746",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x760",
+          "x761"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x746",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x762",
+          "x763"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x746",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x764",
+          "x765"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x763",
+          "x760"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x766",
+          "x767"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x765",
+          "x761",
+          "x758"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x768",
+          "x769"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x767",
+          "x759",
+          "x756"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x770",
+          "x771"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x769",
+          "x757",
+          "x754"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x772",
+          "x773"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x771",
+          "x755",
+          "x752"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x774",
+          "x775"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x773",
+          "x753",
+          "x750"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x776",
+          "x777"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x775",
+          "x751",
+          "x748"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x778"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x777"
+            ]
+          },
+          "x749"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x780"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x728",
+          "x762"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x781",
+          "x782"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x780",
+          "x730",
+          "x764"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x783",
+          "x784"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x782",
+          "x732",
+          "x766"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x785",
+          "x786"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x784",
+          "x734",
+          "x768"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x787",
+          "x788"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x786",
+          "x736",
+          "x770"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x789",
+          "x790"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x788",
+          "x738",
+          "x772"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x791",
+          "x792"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x790",
+          "x740",
+          "x774"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x793",
+          "x794"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x792",
+          "x742",
+          "x776"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x795",
+          "x796"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x794",
+          "x744",
+          "x778"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x797"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x796"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x745"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x798",
+          "x799"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x781",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x800",
+          "x801"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x799",
+          "x783",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x802",
+          "x803"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x801",
+          "x785",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x804",
+          "x805"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x803",
+          "x787",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x806",
+          "x807"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x805",
+          "x789",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x808",
+          "x809"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x807",
+          "x791",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x810",
+          "x811"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x809",
+          "x793",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x812",
+          "x813"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x811",
+          "x795",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x815"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x813",
+          "x797",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x816"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x815",
+          "x798",
+          "x781"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x817"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x815",
+          "x800",
+          "x783"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x818"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x815",
+          "x802",
+          "x785"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x819"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x815",
+          "x804",
+          "x787"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x820"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x815",
+          "x806",
+          "x789"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x821"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x815",
+          "x808",
+          "x791"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x822"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x815",
+          "x810",
+          "x793"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x823"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x815",
+          "x812",
+          "x795"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x816"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x817"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x818"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x819"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x820"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x821"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x822"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x823"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_add",
+    "arguments": [
+      {
+        "datatype": "u32[8]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[8]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x8",
+          "arg1[4]",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x10",
+          "arg1[5]",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x12",
+          "arg1[6]",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x14",
+          "arg1[7]",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x18",
+          "x3",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x20",
+          "x5",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x22",
+          "x7",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25",
+          "x26"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x24",
+          "x9",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27",
+          "x28"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x26",
+          "x11",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29",
+          "x30"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x28",
+          "x13",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31",
+          "x32"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x30",
+          "x15",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x34"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x32",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x34",
+          "x17",
+          "x1"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x34",
+          "x19",
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x34",
+          "x21",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x34",
+          "x23",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x34",
+          "x25",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x34",
+          "x27",
+          "x11"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x34",
+          "x29",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x34",
+          "x31",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x35"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x36"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x37"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x38"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x39"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x40"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x41"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x42"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_sub",
+    "arguments": [
+      {
+        "datatype": "u32[8]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[8]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x8",
+          "arg1[4]",
+          "arg2[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x10",
+          "arg1[5]",
+          "arg2[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x12",
+          "arg1[6]",
+          "arg2[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x14",
+          "arg1[7]",
+          "arg2[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x16",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x17",
+              "0xfffffc2f"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x19",
+          "x3",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x17",
+              "0xfffffffe"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x21",
+          "x5",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x7",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x9",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x11",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x13",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          "x15",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x22"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x24"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x26"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x28"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x30"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x32"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_opp",
+    "arguments": [
+      {
+        "datatype": "u32[8]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x8",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x10",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x12",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x14",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x16",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x17",
+              "0xfffffc2f"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x19",
+          "x3",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x17",
+              "0xfffffffe"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x21",
+          "x5",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x7",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x9",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x11",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x13",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          "x15",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x22"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x24"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x26"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x28"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x30"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x32"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_from_montgomery",
+    "arguments": [
+      {
+        "datatype": "u32[8]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4",
+          "x5"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6",
+          "x7"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8",
+          "x9"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18",
+          "x19"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x19",
+          "x16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x21",
+          "x17",
+          "x14"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          "x15",
+          "x12"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          "x13",
+          "x10"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x27",
+          "x11",
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x9",
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          "x7",
+          "x4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x35"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "x18"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36",
+          "x37"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x35",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x20"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38",
+          "x39"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x37",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x22"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40",
+          "x41"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x39",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42",
+          "x43"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x41",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x26"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44",
+          "x45"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x43",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x28"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46",
+          "x47"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x45",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x30"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x48",
+          "x49"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x47",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x32"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x50",
+          "x51"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x49",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x33"
+                ]
+              },
+              "x5"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x52",
+          "x53"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x36",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x54",
+          "x55"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x53",
+          "x38",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x56",
+          "x57"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x55",
+          "x40",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x58",
+          "x59"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x57",
+          "x42",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x59",
+          "x44",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x61",
+          "x46",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x63",
+          "x48",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x65",
+          "x50",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x68",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x52",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x68",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x72",
+          "x73"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x68",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x68",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x76",
+          "x77"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x68",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x78",
+          "x79"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x68",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x80",
+          "x81"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x68",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x82",
+          "x83"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x68",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x84",
+          "x85"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x68",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x86",
+          "x87"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x85",
+          "x82"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x88",
+          "x89"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x87",
+          "x83",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x90",
+          "x91"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x89",
+          "x81",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x91",
+          "x79",
+          "x76"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x94",
+          "x95"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x93",
+          "x77",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x96",
+          "x97"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x95",
+          "x75",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x98",
+          "x99"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x97",
+          "x73",
+          "x70"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x101"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x52",
+          "x84"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x102",
+          "x103"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x101",
+          "x54",
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x104",
+          "x105"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x103",
+          "x56",
+          "x88"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x106",
+          "x107"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x105",
+          "x58",
+          "x90"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x108",
+          "x109"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x107",
+          "x60",
+          "x92"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x110",
+          "x111"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x109",
+          "x62",
+          "x94"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x112",
+          "x113"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x111",
+          "x64",
+          "x96"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x114",
+          "x115"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x113",
+          "x66",
+          "x98"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x116",
+          "x117"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x115",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x67"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x51"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x99"
+                ]
+              },
+              "x71"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x118",
+          "x119"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x102",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x120",
+          "x121"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x119",
+          "x104",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x122",
+          "x123"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x121",
+          "x106",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x124",
+          "x125"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x123",
+          "x108",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x126",
+          "x127"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x125",
+          "x110",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x128",
+          "x129"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x127",
+          "x112",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x130",
+          "x131"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x129",
+          "x114",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x132",
+          "x133"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x131",
+          "x116",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x134",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x118",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x136",
+          "x137"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x134",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x138",
+          "x139"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x134",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x140",
+          "x141"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x134",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x142",
+          "x143"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x134",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x144",
+          "x145"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x134",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x146",
+          "x147"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x134",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x148",
+          "x149"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x134",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x150",
+          "x151"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x134",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x152",
+          "x153"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x151",
+          "x148"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x154",
+          "x155"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x153",
+          "x149",
+          "x146"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x156",
+          "x157"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x155",
+          "x147",
+          "x144"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x158",
+          "x159"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x157",
+          "x145",
+          "x142"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x160",
+          "x161"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x159",
+          "x143",
+          "x140"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x162",
+          "x163"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x161",
+          "x141",
+          "x138"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x164",
+          "x165"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x163",
+          "x139",
+          "x136"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x167"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x118",
+          "x150"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x168",
+          "x169"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x167",
+          "x120",
+          "x152"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x170",
+          "x171"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x169",
+          "x122",
+          "x154"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x172",
+          "x173"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x171",
+          "x124",
+          "x156"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x174",
+          "x175"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x173",
+          "x126",
+          "x158"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x176",
+          "x177"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x175",
+          "x128",
+          "x160"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x178",
+          "x179"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x177",
+          "x130",
+          "x162"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x180",
+          "x181"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x179",
+          "x132",
+          "x164"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x182",
+          "x183"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x181",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x133"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x117"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x165"
+                ]
+              },
+              "x137"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x184",
+          "x185"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x168",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x186",
+          "x187"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x185",
+          "x170",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x188",
+          "x189"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x187",
+          "x172",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x190",
+          "x191"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x189",
+          "x174",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x192",
+          "x193"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x191",
+          "x176",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x194",
+          "x195"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x193",
+          "x178",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x196",
+          "x197"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x195",
+          "x180",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x198",
+          "x199"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x197",
+          "x182",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x200",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x184",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x202",
+          "x203"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x200",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x204",
+          "x205"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x200",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x206",
+          "x207"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x200",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x208",
+          "x209"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x200",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x210",
+          "x211"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x200",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x212",
+          "x213"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x200",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x214",
+          "x215"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x200",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x216",
+          "x217"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x200",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x218",
+          "x219"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x217",
+          "x214"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x220",
+          "x221"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x219",
+          "x215",
+          "x212"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x222",
+          "x223"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x221",
+          "x213",
+          "x210"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x224",
+          "x225"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x223",
+          "x211",
+          "x208"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x226",
+          "x227"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x225",
+          "x209",
+          "x206"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x228",
+          "x229"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x227",
+          "x207",
+          "x204"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x230",
+          "x231"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x229",
+          "x205",
+          "x202"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x233"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x184",
+          "x216"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x234",
+          "x235"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x233",
+          "x186",
+          "x218"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x236",
+          "x237"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x235",
+          "x188",
+          "x220"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x238",
+          "x239"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x237",
+          "x190",
+          "x222"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x240",
+          "x241"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x239",
+          "x192",
+          "x224"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x242",
+          "x243"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x241",
+          "x194",
+          "x226"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x244",
+          "x245"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x243",
+          "x196",
+          "x228"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x246",
+          "x247"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x245",
+          "x198",
+          "x230"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x248",
+          "x249"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x247",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x199"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x183"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x231"
+                ]
+              },
+              "x203"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x250",
+          "x251"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x234",
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x252",
+          "x253"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x251",
+          "x236",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x254",
+          "x255"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x253",
+          "x238",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x256",
+          "x257"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x255",
+          "x240",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x258",
+          "x259"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x257",
+          "x242",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x260",
+          "x261"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x259",
+          "x244",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x262",
+          "x263"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x261",
+          "x246",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x264",
+          "x265"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x263",
+          "x248",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x266",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x250",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x268",
+          "x269"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x270",
+          "x271"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x272",
+          "x273"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x274",
+          "x275"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x276",
+          "x277"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x278",
+          "x279"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x266",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x280",
+          "x281"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x266",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x282",
+          "x283"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x266",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x284",
+          "x285"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x283",
+          "x280"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x286",
+          "x287"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x285",
+          "x281",
+          "x278"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x288",
+          "x289"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x287",
+          "x279",
+          "x276"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x290",
+          "x291"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x289",
+          "x277",
+          "x274"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x292",
+          "x293"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x291",
+          "x275",
+          "x272"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x294",
+          "x295"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x293",
+          "x273",
+          "x270"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x296",
+          "x297"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x295",
+          "x271",
+          "x268"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x299"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x250",
+          "x282"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x300",
+          "x301"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x299",
+          "x252",
+          "x284"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x302",
+          "x303"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x301",
+          "x254",
+          "x286"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x304",
+          "x305"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x303",
+          "x256",
+          "x288"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x306",
+          "x307"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x305",
+          "x258",
+          "x290"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x308",
+          "x309"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x307",
+          "x260",
+          "x292"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x310",
+          "x311"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x309",
+          "x262",
+          "x294"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x312",
+          "x313"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x311",
+          "x264",
+          "x296"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x314",
+          "x315"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x313",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x265"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x249"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x297"
+                ]
+              },
+              "x269"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x316",
+          "x317"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x300",
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x318",
+          "x319"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x317",
+          "x302",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x320",
+          "x321"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x319",
+          "x304",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x322",
+          "x323"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x321",
+          "x306",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x324",
+          "x325"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x323",
+          "x308",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x326",
+          "x327"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x325",
+          "x310",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x328",
+          "x329"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x327",
+          "x312",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x330",
+          "x331"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x329",
+          "x314",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x332",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x316",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x334",
+          "x335"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x332",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x336",
+          "x337"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x332",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x338",
+          "x339"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x332",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x340",
+          "x341"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x332",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x342",
+          "x343"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x332",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x344",
+          "x345"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x332",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x346",
+          "x347"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x332",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x348",
+          "x349"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x332",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x350",
+          "x351"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x349",
+          "x346"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x352",
+          "x353"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x351",
+          "x347",
+          "x344"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x354",
+          "x355"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x353",
+          "x345",
+          "x342"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x356",
+          "x357"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x355",
+          "x343",
+          "x340"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x358",
+          "x359"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x357",
+          "x341",
+          "x338"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x360",
+          "x361"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x359",
+          "x339",
+          "x336"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x362",
+          "x363"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x361",
+          "x337",
+          "x334"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x365"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x316",
+          "x348"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x366",
+          "x367"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x365",
+          "x318",
+          "x350"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x368",
+          "x369"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x367",
+          "x320",
+          "x352"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x370",
+          "x371"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x369",
+          "x322",
+          "x354"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x372",
+          "x373"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x371",
+          "x324",
+          "x356"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x374",
+          "x375"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x373",
+          "x326",
+          "x358"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x376",
+          "x377"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x375",
+          "x328",
+          "x360"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x378",
+          "x379"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x377",
+          "x330",
+          "x362"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x380",
+          "x381"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x379",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x331"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x315"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x363"
+                ]
+              },
+              "x335"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x382",
+          "x383"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x366",
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x384",
+          "x385"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x383",
+          "x368",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x386",
+          "x387"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x385",
+          "x370",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x388",
+          "x389"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x387",
+          "x372",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x390",
+          "x391"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x389",
+          "x374",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x392",
+          "x393"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x391",
+          "x376",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x394",
+          "x395"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x393",
+          "x378",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x396",
+          "x397"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x395",
+          "x380",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x398",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x382",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x400",
+          "x401"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x398",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x402",
+          "x403"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x398",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x404",
+          "x405"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x398",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x406",
+          "x407"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x398",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x408",
+          "x409"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x398",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x410",
+          "x411"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x398",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x412",
+          "x413"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x398",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x414",
+          "x415"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x398",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x416",
+          "x417"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x415",
+          "x412"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x418",
+          "x419"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x417",
+          "x413",
+          "x410"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x420",
+          "x421"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x419",
+          "x411",
+          "x408"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x422",
+          "x423"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x421",
+          "x409",
+          "x406"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x424",
+          "x425"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x423",
+          "x407",
+          "x404"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x426",
+          "x427"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x425",
+          "x405",
+          "x402"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x428",
+          "x429"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x427",
+          "x403",
+          "x400"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x431"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x382",
+          "x414"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x432",
+          "x433"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x431",
+          "x384",
+          "x416"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x434",
+          "x435"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x433",
+          "x386",
+          "x418"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x436",
+          "x437"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x435",
+          "x388",
+          "x420"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x438",
+          "x439"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x437",
+          "x390",
+          "x422"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x440",
+          "x441"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x439",
+          "x392",
+          "x424"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x442",
+          "x443"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x441",
+          "x394",
+          "x426"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x444",
+          "x445"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x443",
+          "x396",
+          "x428"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x446",
+          "x447"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x445",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x397"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x381"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x429"
+                ]
+              },
+              "x401"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x448",
+          "x449"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x432",
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x450",
+          "x451"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x449",
+          "x434",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x452",
+          "x453"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x451",
+          "x436",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x454",
+          "x455"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x453",
+          "x438",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x456",
+          "x457"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x455",
+          "x440",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x458",
+          "x459"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x457",
+          "x442",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x460",
+          "x461"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x459",
+          "x444",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x462",
+          "x463"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x461",
+          "x446",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x464",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x448",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x466",
+          "x467"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x464",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x468",
+          "x469"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x464",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x470",
+          "x471"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x464",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x472",
+          "x473"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x464",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x474",
+          "x475"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x464",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x476",
+          "x477"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x464",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x478",
+          "x479"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x464",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x480",
+          "x481"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x464",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x482",
+          "x483"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x481",
+          "x478"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x484",
+          "x485"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x483",
+          "x479",
+          "x476"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x486",
+          "x487"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x485",
+          "x477",
+          "x474"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x488",
+          "x489"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x487",
+          "x475",
+          "x472"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x490",
+          "x491"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x489",
+          "x473",
+          "x470"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x492",
+          "x493"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x491",
+          "x471",
+          "x468"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x494",
+          "x495"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x493",
+          "x469",
+          "x466"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x497"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x448",
+          "x480"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x498",
+          "x499"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x497",
+          "x450",
+          "x482"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x500",
+          "x501"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x499",
+          "x452",
+          "x484"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x502",
+          "x503"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x501",
+          "x454",
+          "x486"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x504",
+          "x505"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x503",
+          "x456",
+          "x488"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x506",
+          "x507"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x505",
+          "x458",
+          "x490"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x508",
+          "x509"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x507",
+          "x460",
+          "x492"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x510",
+          "x511"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x509",
+          "x462",
+          "x494"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x512",
+          "x513"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x511",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x463"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x447"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x495"
+                ]
+              },
+              "x467"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x514",
+          "x515"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x498",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x516",
+          "x517"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x515",
+          "x500",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x518",
+          "x519"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x517",
+          "x502",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x520",
+          "x521"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x519",
+          "x504",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x522",
+          "x523"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x521",
+          "x506",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x524",
+          "x525"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x523",
+          "x508",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x526",
+          "x527"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x525",
+          "x510",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x528",
+          "x529"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x527",
+          "x512",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x531"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x529",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x513"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x532"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x531",
+          "x514",
+          "x498"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x533"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x531",
+          "x516",
+          "x500"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x534"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x531",
+          "x518",
+          "x502"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x535"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x531",
+          "x520",
+          "x504"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x536"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x531",
+          "x522",
+          "x506"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x537"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x531",
+          "x524",
+          "x508"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x538"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x531",
+          "x526",
+          "x510"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x539"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x531",
+          "x528",
+          "x512"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x532"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x533"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x534"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x535"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x536"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x537"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x538"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x539"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_to_montgomery",
+    "arguments": [
+      {
+        "datatype": "u32[8]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "0x7a2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x8",
+          "0xe90a1"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x12",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x14",
+          "x10",
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x17",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x17",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x17",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25",
+          "x26"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x17",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27",
+          "x28"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x17",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29",
+          "x30"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x17",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31",
+          "x32"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x17",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33",
+          "x34"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x17",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35",
+          "x36"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x34",
+          "x31"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x36",
+          "x32",
+          "x29"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39",
+          "x40"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x38",
+          "x30",
+          "x27"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41",
+          "x42"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x40",
+          "x28",
+          "x25"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x43",
+          "x44"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x42",
+          "x26",
+          "x23"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x45",
+          "x46"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x44",
+          "x24",
+          "x21"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x47",
+          "x48"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x46",
+          "x22",
+          "x19"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x50"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x11",
+          "x33"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x51",
+          "x52"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x50",
+          "x13",
+          "x35"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x53",
+          "x54"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x52",
+          "x15",
+          "x37"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x55",
+          "x56"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x54",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          },
+          "x39"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x57",
+          "x58"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x56",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x41"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x59",
+          "x60"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x58",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x61",
+          "x62"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x60",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x63",
+          "x64"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x62",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x47"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x65",
+          "x66"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x64",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x48"
+                ]
+              },
+              "x20"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x67",
+          "x68"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0x7a2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x69",
+          "x70"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xe90a1"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x71",
+          "x72"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x70",
+          "x67"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x73",
+          "x74"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x72",
+          "x68",
+          "x1"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x75",
+          "x76"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x51",
+          "x69"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x77",
+          "x78"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x76",
+          "x53",
+          "x71"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x79",
+          "x80"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x78",
+          "x55",
+          "x73"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x81",
+          "x82"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x80",
+          "x57",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x74"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x83",
+          "x84"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x82",
+          "x59",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x85",
+          "x86"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x84",
+          "x61",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x87",
+          "x88"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x86",
+          "x63",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x89",
+          "x90"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x88",
+          "x65",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x91",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x75",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x93",
+          "x94"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x91",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x95",
+          "x96"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x91",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x97",
+          "x98"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x91",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x99",
+          "x100"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x91",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x101",
+          "x102"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x91",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x103",
+          "x104"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x91",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x105",
+          "x106"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x91",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x107",
+          "x108"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x91",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x109",
+          "x110"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x108",
+          "x105"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x111",
+          "x112"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x110",
+          "x106",
+          "x103"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x113",
+          "x114"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x112",
+          "x104",
+          "x101"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x115",
+          "x116"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x114",
+          "x102",
+          "x99"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x117",
+          "x118"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x116",
+          "x100",
+          "x97"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x119",
+          "x120"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x118",
+          "x98",
+          "x95"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x121",
+          "x122"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x120",
+          "x96",
+          "x93"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x124"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x75",
+          "x107"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x125",
+          "x126"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x124",
+          "x77",
+          "x109"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x127",
+          "x128"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x126",
+          "x79",
+          "x111"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x129",
+          "x130"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x128",
+          "x81",
+          "x113"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x131",
+          "x132"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x130",
+          "x83",
+          "x115"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x133",
+          "x134"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x132",
+          "x85",
+          "x117"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x135",
+          "x136"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x134",
+          "x87",
+          "x119"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x137",
+          "x138"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x136",
+          "x89",
+          "x121"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x139",
+          "x140"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x138",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x90"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x66"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x122"
+                ]
+              },
+              "x94"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x141",
+          "x142"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0x7a2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x143",
+          "x144"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xe90a1"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x145",
+          "x146"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x144",
+          "x141"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x147",
+          "x148"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x146",
+          "x142",
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x149",
+          "x150"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x125",
+          "x143"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x151",
+          "x152"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x150",
+          "x127",
+          "x145"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x153",
+          "x154"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x152",
+          "x129",
+          "x147"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x155",
+          "x156"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x154",
+          "x131",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x148"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x157",
+          "x158"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x156",
+          "x133",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x159",
+          "x160"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x158",
+          "x135",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x161",
+          "x162"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x160",
+          "x137",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x163",
+          "x164"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x162",
+          "x139",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x165",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x149",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x167",
+          "x168"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x165",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x169",
+          "x170"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x165",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x171",
+          "x172"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x165",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x173",
+          "x174"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x165",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x175",
+          "x176"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x165",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x177",
+          "x178"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x165",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x179",
+          "x180"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x165",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x181",
+          "x182"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x165",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x183",
+          "x184"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x182",
+          "x179"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x185",
+          "x186"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x184",
+          "x180",
+          "x177"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x187",
+          "x188"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x186",
+          "x178",
+          "x175"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x189",
+          "x190"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x188",
+          "x176",
+          "x173"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x191",
+          "x192"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x190",
+          "x174",
+          "x171"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x193",
+          "x194"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x192",
+          "x172",
+          "x169"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x195",
+          "x196"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x194",
+          "x170",
+          "x167"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x198"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x149",
+          "x181"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x199",
+          "x200"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x198",
+          "x151",
+          "x183"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x201",
+          "x202"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x200",
+          "x153",
+          "x185"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x203",
+          "x204"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x202",
+          "x155",
+          "x187"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x205",
+          "x206"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x204",
+          "x157",
+          "x189"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x207",
+          "x208"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x206",
+          "x159",
+          "x191"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x209",
+          "x210"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x208",
+          "x161",
+          "x193"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x211",
+          "x212"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x210",
+          "x163",
+          "x195"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x213",
+          "x214"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x212",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x164"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x140"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x196"
+                ]
+              },
+              "x168"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x215",
+          "x216"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0x7a2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x217",
+          "x218"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0xe90a1"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x219",
+          "x220"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x218",
+          "x215"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x221",
+          "x222"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x220",
+          "x216",
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x223",
+          "x224"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x199",
+          "x217"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x225",
+          "x226"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x224",
+          "x201",
+          "x219"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x227",
+          "x228"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x226",
+          "x203",
+          "x221"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x229",
+          "x230"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x228",
+          "x205",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x222"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x231",
+          "x232"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x230",
+          "x207",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x233",
+          "x234"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x232",
+          "x209",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x235",
+          "x236"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x234",
+          "x211",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x237",
+          "x238"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x236",
+          "x213",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x239",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x223",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x241",
+          "x242"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x239",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x243",
+          "x244"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x239",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x245",
+          "x246"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x239",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x247",
+          "x248"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x239",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x249",
+          "x250"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x239",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x251",
+          "x252"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x239",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x253",
+          "x254"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x239",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x255",
+          "x256"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x239",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x257",
+          "x258"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x256",
+          "x253"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x259",
+          "x260"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x258",
+          "x254",
+          "x251"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x261",
+          "x262"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x260",
+          "x252",
+          "x249"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x263",
+          "x264"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x262",
+          "x250",
+          "x247"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x265",
+          "x266"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x264",
+          "x248",
+          "x245"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x267",
+          "x268"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x266",
+          "x246",
+          "x243"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x269",
+          "x270"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x268",
+          "x244",
+          "x241"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x272"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x223",
+          "x255"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x273",
+          "x274"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x272",
+          "x225",
+          "x257"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x275",
+          "x276"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x274",
+          "x227",
+          "x259"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x277",
+          "x278"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x276",
+          "x229",
+          "x261"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x279",
+          "x280"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x278",
+          "x231",
+          "x263"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x281",
+          "x282"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x280",
+          "x233",
+          "x265"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x283",
+          "x284"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x282",
+          "x235",
+          "x267"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x285",
+          "x286"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x284",
+          "x237",
+          "x269"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x287",
+          "x288"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x286",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x238"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x214"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x270"
+                ]
+              },
+              "x242"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x289",
+          "x290"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0x7a2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x291",
+          "x292"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0xe90a1"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x293",
+          "x294"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x292",
+          "x289"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x295",
+          "x296"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x294",
+          "x290",
+          "x4"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x297",
+          "x298"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x273",
+          "x291"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x299",
+          "x300"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x298",
+          "x275",
+          "x293"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x301",
+          "x302"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x300",
+          "x277",
+          "x295"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x303",
+          "x304"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x302",
+          "x279",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x296"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x305",
+          "x306"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x304",
+          "x281",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x307",
+          "x308"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x306",
+          "x283",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x309",
+          "x310"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x308",
+          "x285",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x311",
+          "x312"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x310",
+          "x287",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x313",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x297",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x315",
+          "x316"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x313",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x317",
+          "x318"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x313",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x319",
+          "x320"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x313",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x321",
+          "x322"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x313",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x323",
+          "x324"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x313",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x325",
+          "x326"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x313",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x327",
+          "x328"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x313",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x329",
+          "x330"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x313",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x331",
+          "x332"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x330",
+          "x327"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x333",
+          "x334"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x332",
+          "x328",
+          "x325"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x335",
+          "x336"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x334",
+          "x326",
+          "x323"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x337",
+          "x338"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x336",
+          "x324",
+          "x321"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x339",
+          "x340"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x338",
+          "x322",
+          "x319"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x341",
+          "x342"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x340",
+          "x320",
+          "x317"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x343",
+          "x344"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x342",
+          "x318",
+          "x315"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x346"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x297",
+          "x329"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x347",
+          "x348"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x346",
+          "x299",
+          "x331"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x349",
+          "x350"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x348",
+          "x301",
+          "x333"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x351",
+          "x352"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x350",
+          "x303",
+          "x335"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x353",
+          "x354"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x352",
+          "x305",
+          "x337"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x355",
+          "x356"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x354",
+          "x307",
+          "x339"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x357",
+          "x358"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x356",
+          "x309",
+          "x341"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x359",
+          "x360"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x358",
+          "x311",
+          "x343"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x361",
+          "x362"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x360",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x312"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x288"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x344"
+                ]
+              },
+              "x316"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x363",
+          "x364"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0x7a2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x365",
+          "x366"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0xe90a1"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x367",
+          "x368"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x366",
+          "x363"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x369",
+          "x370"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x368",
+          "x364",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x371",
+          "x372"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x347",
+          "x365"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x373",
+          "x374"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x372",
+          "x349",
+          "x367"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x375",
+          "x376"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x374",
+          "x351",
+          "x369"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x377",
+          "x378"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x376",
+          "x353",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x370"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x379",
+          "x380"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x378",
+          "x355",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x381",
+          "x382"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x380",
+          "x357",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x383",
+          "x384"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x382",
+          "x359",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x385",
+          "x386"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x384",
+          "x361",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x387",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x371",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x389",
+          "x390"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x387",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x391",
+          "x392"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x387",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x393",
+          "x394"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x387",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x395",
+          "x396"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x387",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x397",
+          "x398"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x387",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x399",
+          "x400"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x387",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x401",
+          "x402"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x387",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x403",
+          "x404"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x387",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x405",
+          "x406"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x404",
+          "x401"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x407",
+          "x408"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x406",
+          "x402",
+          "x399"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x409",
+          "x410"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x408",
+          "x400",
+          "x397"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x411",
+          "x412"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x410",
+          "x398",
+          "x395"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x413",
+          "x414"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x412",
+          "x396",
+          "x393"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x415",
+          "x416"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x414",
+          "x394",
+          "x391"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x417",
+          "x418"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x416",
+          "x392",
+          "x389"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x420"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x371",
+          "x403"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x421",
+          "x422"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x420",
+          "x373",
+          "x405"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x423",
+          "x424"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x422",
+          "x375",
+          "x407"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x425",
+          "x426"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x424",
+          "x377",
+          "x409"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x427",
+          "x428"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x426",
+          "x379",
+          "x411"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x429",
+          "x430"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x428",
+          "x381",
+          "x413"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x431",
+          "x432"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x430",
+          "x383",
+          "x415"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x433",
+          "x434"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x432",
+          "x385",
+          "x417"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x435",
+          "x436"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x434",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x386"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x362"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x418"
+                ]
+              },
+              "x390"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x437",
+          "x438"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0x7a2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x439",
+          "x440"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x6",
+          "0xe90a1"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x441",
+          "x442"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x440",
+          "x437"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x443",
+          "x444"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x442",
+          "x438",
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x445",
+          "x446"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x421",
+          "x439"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x447",
+          "x448"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x446",
+          "x423",
+          "x441"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x449",
+          "x450"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x448",
+          "x425",
+          "x443"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x451",
+          "x452"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x450",
+          "x427",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x444"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x453",
+          "x454"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x452",
+          "x429",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x455",
+          "x456"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x454",
+          "x431",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x457",
+          "x458"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x456",
+          "x433",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x459",
+          "x460"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x458",
+          "x435",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x461",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x445",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x463",
+          "x464"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x461",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x465",
+          "x466"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x461",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x467",
+          "x468"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x461",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x469",
+          "x470"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x461",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x471",
+          "x472"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x461",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x473",
+          "x474"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x461",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x475",
+          "x476"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x461",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x477",
+          "x478"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x461",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x479",
+          "x480"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x478",
+          "x475"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x481",
+          "x482"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x480",
+          "x476",
+          "x473"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x483",
+          "x484"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x482",
+          "x474",
+          "x471"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x485",
+          "x486"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x484",
+          "x472",
+          "x469"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x487",
+          "x488"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x486",
+          "x470",
+          "x467"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x489",
+          "x490"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x488",
+          "x468",
+          "x465"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x491",
+          "x492"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x490",
+          "x466",
+          "x463"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x494"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x445",
+          "x477"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x495",
+          "x496"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x494",
+          "x447",
+          "x479"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x497",
+          "x498"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x496",
+          "x449",
+          "x481"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x499",
+          "x500"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x498",
+          "x451",
+          "x483"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x501",
+          "x502"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x500",
+          "x453",
+          "x485"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x503",
+          "x504"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x502",
+          "x455",
+          "x487"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x505",
+          "x506"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x504",
+          "x457",
+          "x489"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x507",
+          "x508"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x506",
+          "x459",
+          "x491"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x509",
+          "x510"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x508",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x460"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x436"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x492"
+                ]
+              },
+              "x464"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x511",
+          "x512"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0x7a2"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x513",
+          "x514"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x7",
+          "0xe90a1"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x515",
+          "x516"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x514",
+          "x511"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x517",
+          "x518"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x516",
+          "x512",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x519",
+          "x520"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x495",
+          "x513"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x521",
+          "x522"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x520",
+          "x497",
+          "x515"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x523",
+          "x524"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x522",
+          "x499",
+          "x517"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x525",
+          "x526"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x524",
+          "x501",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x518"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x527",
+          "x528"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x526",
+          "x503",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x529",
+          "x530"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x528",
+          "x505",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x531",
+          "x532"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x530",
+          "x507",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x533",
+          "x534"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x532",
+          "x509",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x535",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x519",
+          "0xd2253531"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x537",
+          "x538"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x535",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x539",
+          "x540"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x535",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x541",
+          "x542"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x535",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x543",
+          "x544"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x535",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x545",
+          "x546"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x535",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x547",
+          "x548"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x535",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x549",
+          "x550"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x535",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x551",
+          "x552"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x535",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x553",
+          "x554"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x552",
+          "x549"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x555",
+          "x556"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x554",
+          "x550",
+          "x547"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x557",
+          "x558"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x556",
+          "x548",
+          "x545"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x559",
+          "x560"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x558",
+          "x546",
+          "x543"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x561",
+          "x562"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x560",
+          "x544",
+          "x541"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x563",
+          "x564"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x562",
+          "x542",
+          "x539"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x565",
+          "x566"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x564",
+          "x540",
+          "x537"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x568"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x519",
+          "x551"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x569",
+          "x570"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x568",
+          "x521",
+          "x553"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x571",
+          "x572"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x570",
+          "x523",
+          "x555"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x573",
+          "x574"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x572",
+          "x525",
+          "x557"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x575",
+          "x576"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x574",
+          "x527",
+          "x559"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x577",
+          "x578"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x576",
+          "x529",
+          "x561"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x579",
+          "x580"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x578",
+          "x531",
+          "x563"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x581",
+          "x582"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x580",
+          "x533",
+          "x565"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x583",
+          "x584"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x582",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x534"
+                ]
+              },
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x510"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x566"
+                ]
+              },
+              "x538"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x585",
+          "x586"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x569",
+          "0xfffffc2f"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x587",
+          "x588"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x586",
+          "x571",
+          "0xfffffffe"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x589",
+          "x590"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x588",
+          "x573",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x591",
+          "x592"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x590",
+          "x575",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x593",
+          "x594"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x592",
+          "x577",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x595",
+          "x596"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x594",
+          "x579",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x597",
+          "x598"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x596",
+          "x581",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x599",
+          "x600"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x598",
+          "x583",
+          "0xffffffff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "_",
+          "x602"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x600",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x584"
+            ]
+          },
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x603"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x602",
+          "x585",
+          "x569"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x604"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x602",
+          "x587",
+          "x571"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x605"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x602",
+          "x589",
+          "x573"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x606"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x602",
+          "x591",
+          "x575"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x607"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x602",
+          "x593",
+          "x577"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x608"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x602",
+          "x595",
+          "x579"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x609"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x602",
+          "x597",
+          "x581"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x610"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x602",
+          "x599",
+          "x583"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x603"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x604"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x605"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x606"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x607"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x608"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x609"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x610"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_nonzero",
+    "arguments": [
+      {
+        "datatype": "u32[8]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "|",
+        "arguments": [
+          "arg1[0]",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "|",
+            "arguments": [
+              "arg1[1]",
+              {
+                "datatype": "u32",
+                "name": [],
+                "operation": "|",
+                "arguments": [
+                  "arg1[2]",
+                  {
+                    "datatype": "u32",
+                    "name": [],
+                    "operation": "|",
+                    "arguments": [
+                      "arg1[3]",
+                      {
+                        "datatype": "u32",
+                        "name": [],
+                        "operation": "|",
+                        "arguments": [
+                          "arg1[4]",
+                          {
+                            "datatype": "u32",
+                            "name": [],
+                            "operation": "|",
+                            "arguments": [
+                              "arg1[5]",
+                              {
+                                "datatype": "u32",
+                                "name": [],
+                                "operation": "|",
+                                "arguments": [
+                                  "arg1[6]",
+                                  "arg1[7]"
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_selectznz",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u32[8]",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u32[8]",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[0]",
+          "arg3[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[1]",
+          "arg3[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[2]",
+          "arg3[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[3]",
+          "arg3[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[4]",
+          "arg3[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[5]",
+          "arg3[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[6]",
+          "arg3[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[7]",
+          "arg3[7]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x6"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x8"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_to_bytes",
+    "arguments": [
+      {
+        "datatype": "u32[8]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u8[32]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[7]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[6]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[5]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x8"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x9"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x8",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x11"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x10"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x12"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x10",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x13"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x14"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x12",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x15"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x7"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x16"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x7",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x17"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x16",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x19"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x20"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x18",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x21"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x6",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x23"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x22"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x24"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x22",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x25"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x26"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x24",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x27"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x5"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x28"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x5",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x29"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x28",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x31"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x30"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x32"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x30",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x33"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x4",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x35"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x34"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x34",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x37"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x36"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x38"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x36",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x39"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x3",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x41"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x40",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x43"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x44"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x42",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x45"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x2",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x47"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x46"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x48"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x46",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x49"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x48"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x50"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x48",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x51"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x52"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x1",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x53"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x52"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x54"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x52",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x55"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x54"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x56"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x54",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x11"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x13"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x14"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x15"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x17"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x19"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x21"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x23"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x25"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x26"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x27"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x29"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x31"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x32"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[16]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x33"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[17]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x35"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[18]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x37"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[19]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x38"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[20]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x39"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[21]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x41"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[22]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x43"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[23]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x44"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[24]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x45"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[25]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x47"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[26]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x49"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[27]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x50"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[28]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x51"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[29]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x53"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[30]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x55"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[31]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x56"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_from_bytes",
+    "arguments": [
+      {
+        "datatype": "u8[32]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u32[8]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u32",
+        "name": [
+          "x1"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[31]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x2"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[30]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x3"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[29]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[28]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x5"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[27]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x6"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[26]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x7"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[25]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x8"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[24]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x9"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[23]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x10"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[22]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x11"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[21]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x12"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[20]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x13"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[19]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x14"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[18]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x15"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[17]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x16"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[16]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x17"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x18"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x19"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x20"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[12]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x21"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x22"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x23"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x24"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x25"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x26"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x27"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x28"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[4]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x29"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x30"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x31"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x32"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x33"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x31",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x34"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x30",
+          "x33"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x35"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x29",
+          "x34"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x36"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x27",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x37"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x26",
+          "x36"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x38"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x25",
+          "x37"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x39"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x23",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x40"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x22",
+          "x39"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x41"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x21",
+          "x40"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x42"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x19",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x20"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x43"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x18",
+          "x42"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x44"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x17",
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x45"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x15",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x46"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x14",
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x47"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x13",
+          "x46"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x48"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x11",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x49"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x10",
+          "x48"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x50"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x9",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x51"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x7",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x52"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x6",
+          "x51"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x53"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x5",
+          "x52"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x54"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x3",
+          {
+            "datatype": "u32",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x55"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x2",
+          "x54"
+        ]
+      },
+      {
+        "datatype": "u32",
+        "name": [
+          "x56"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x1",
+          "x55"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x35"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x38"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x41"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x44"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x47"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x50"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x53"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x56"
+        ]
+      }
+    ]
+  }
+]

--- a/fiat-json/src/secp256k1_64.json
+++ b/fiat-json/src/secp256k1_64.json
@@ -1,0 +1,9297 @@
+[
+  {
+    "operation": "fiat_secp256k1_addcarryx_u64",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u128",
+        "name": [
+          "x1"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              },
+              {
+                "datatype": "u128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "64"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_subborrowx_u64",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u1",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "i128",
+        "name": [
+          "x1"
+        ],
+        "operation": "-",
+        "arguments": [
+          {
+            "datatype": "i128",
+            "name": [],
+            "operation": "-",
+            "arguments": [
+              {
+                "datatype": "i128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg2"
+                ]
+              },
+              {
+                "datatype": "i128",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "arg1"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "i128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg3"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "i1",
+        "name": [
+          "x2"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "i1",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "64"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u1",
+        "name": [
+          "out2"
+        ],
+        "operation": "-",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_mulx_u64",
+    "arguments": [
+      {
+        "datatype": "u64",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      },
+      {
+        "datatype": "u64",
+        "name": "out2"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u128",
+        "name": [
+          "x1"
+        ],
+        "operation": "*",
+        "arguments": [
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1"
+            ]
+          },
+          {
+            "datatype": "u128",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x1",
+              "64"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_cmovznz_u64",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u1",
+        "name": [
+          "x1"
+        ],
+        "operation": "!",
+        "arguments": [
+          {
+            "datatype": "u1",
+            "name": [],
+            "operation": "!",
+            "arguments": [
+              "arg1"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "-",
+                "arguments": [
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "0x0"
+                    ]
+                  },
+                  {
+                    "datatype": "i1",
+                    "name": [],
+                    "operation": "static_cast",
+                    "arguments": [
+                      "x1"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "|",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x2",
+              "arg3"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "~",
+                "arguments": [
+                  "x2"
+                ]
+              },
+              "arg2"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_mul",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[4]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x12",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x14",
+          "x10",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x16",
+          "x8",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          },
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "0xd838091dd2253531"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x29",
+          "x26"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          "x27",
+          "x24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34",
+          "x35"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x33",
+          "x25",
+          "x22"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x35"
+            ]
+          },
+          "x23"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x38"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x11",
+          "x28"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39",
+          "x40"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x38",
+          "x13",
+          "x30"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41",
+          "x42"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x40",
+          "x15",
+          "x32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43",
+          "x44"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x42",
+          "x17",
+          "x34"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45",
+          "x46"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x44",
+          "x19",
+          "x36"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47",
+          "x48"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49",
+          "x50"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51",
+          "x52"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53",
+          "x54"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55",
+          "x56"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x54",
+          "x51"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57",
+          "x58"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x56",
+          "x52",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59",
+          "x60"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x58",
+          "x50",
+          "x47"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x60"
+            ]
+          },
+          "x48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x39",
+          "x53"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x63",
+          "x41",
+          "x55"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x65",
+          "x43",
+          "x57"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x67",
+          "x45",
+          "x59"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x69",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x46"
+            ]
+          },
+          "x61"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x62",
+          "0xd838091dd2253531"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x72",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x76",
+          "x77"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x72",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78",
+          "x79"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x72",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x80",
+          "x81"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x72",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x82",
+          "x83"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x81",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84",
+          "x85"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x83",
+          "x79",
+          "x76"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x86",
+          "x87"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x85",
+          "x77",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x87"
+            ]
+          },
+          "x75"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x90"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x62",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x91",
+          "x92"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x90",
+          "x64",
+          "x82"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x93",
+          "x94"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x92",
+          "x66",
+          "x84"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x95",
+          "x96"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x94",
+          "x68",
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x97",
+          "x98"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x96",
+          "x70",
+          "x88"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x99"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x98"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x71"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100",
+          "x101"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102",
+          "x103"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x104",
+          "x105"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x106",
+          "x107"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x108",
+          "x109"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x107",
+          "x104"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x110",
+          "x111"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x109",
+          "x105",
+          "x102"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x112",
+          "x113"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x111",
+          "x103",
+          "x100"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x114"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x113"
+            ]
+          },
+          "x101"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x115",
+          "x116"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x91",
+          "x106"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x117",
+          "x118"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x116",
+          "x93",
+          "x108"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x119",
+          "x120"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x118",
+          "x95",
+          "x110"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x121",
+          "x122"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x120",
+          "x97",
+          "x112"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x123",
+          "x124"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x122",
+          "x99",
+          "x114"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x125",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x115",
+          "0xd838091dd2253531"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x127",
+          "x128"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x125",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x129",
+          "x130"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x125",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x131",
+          "x132"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x125",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x133",
+          "x134"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x125",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x135",
+          "x136"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x134",
+          "x131"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x137",
+          "x138"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x136",
+          "x132",
+          "x129"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x139",
+          "x140"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x138",
+          "x130",
+          "x127"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x141"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x140"
+            ]
+          },
+          "x128"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x143"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x115",
+          "x133"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x144",
+          "x145"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x143",
+          "x117",
+          "x135"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x146",
+          "x147"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x145",
+          "x119",
+          "x137"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x148",
+          "x149"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x147",
+          "x121",
+          "x139"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x150",
+          "x151"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x149",
+          "x123",
+          "x141"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x152"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x151"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x124"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x153",
+          "x154"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x155",
+          "x156"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x157",
+          "x158"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x159",
+          "x160"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x161",
+          "x162"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x160",
+          "x157"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x163",
+          "x164"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x162",
+          "x158",
+          "x155"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x165",
+          "x166"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x164",
+          "x156",
+          "x153"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x167"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x166"
+            ]
+          },
+          "x154"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x168",
+          "x169"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x144",
+          "x159"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x170",
+          "x171"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x169",
+          "x146",
+          "x161"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x172",
+          "x173"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x171",
+          "x148",
+          "x163"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x174",
+          "x175"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x173",
+          "x150",
+          "x165"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x176",
+          "x177"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x175",
+          "x152",
+          "x167"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x178",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x168",
+          "0xd838091dd2253531"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x180",
+          "x181"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x178",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x182",
+          "x183"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x178",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x184",
+          "x185"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x178",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x186",
+          "x187"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x178",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x188",
+          "x189"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x187",
+          "x184"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x190",
+          "x191"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x189",
+          "x185",
+          "x182"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x192",
+          "x193"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x191",
+          "x183",
+          "x180"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x194"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x193"
+            ]
+          },
+          "x181"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x196"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x168",
+          "x186"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x197",
+          "x198"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x196",
+          "x170",
+          "x188"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x199",
+          "x200"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x198",
+          "x172",
+          "x190"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x201",
+          "x202"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x200",
+          "x174",
+          "x192"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x203",
+          "x204"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x202",
+          "x176",
+          "x194"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x205"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x204"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x177"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x206",
+          "x207"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x197",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x208",
+          "x209"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x207",
+          "x199",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x210",
+          "x211"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x209",
+          "x201",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x212",
+          "x213"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x211",
+          "x203",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x215"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x213",
+          "x205",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x216"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x215",
+          "x206",
+          "x197"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x217"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x215",
+          "x208",
+          "x199"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x218"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x215",
+          "x210",
+          "x201"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x219"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x215",
+          "x212",
+          "x203"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x216"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x217"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x218"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x219"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_square",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x12",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x14",
+          "x10",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x16",
+          "x8",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x18"
+            ]
+          },
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x11",
+          "0xd838091dd2253531"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x20",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x29",
+          "x26"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          "x27",
+          "x24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34",
+          "x35"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x33",
+          "x25",
+          "x22"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x35"
+            ]
+          },
+          "x23"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x38"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x11",
+          "x28"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39",
+          "x40"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x38",
+          "x13",
+          "x30"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41",
+          "x42"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x40",
+          "x15",
+          "x32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43",
+          "x44"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x42",
+          "x17",
+          "x34"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45",
+          "x46"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x44",
+          "x19",
+          "x36"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47",
+          "x48"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49",
+          "x50"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51",
+          "x52"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53",
+          "x54"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55",
+          "x56"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x54",
+          "x51"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57",
+          "x58"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x56",
+          "x52",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59",
+          "x60"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x58",
+          "x50",
+          "x47"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x60"
+            ]
+          },
+          "x48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x39",
+          "x53"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x63",
+          "x41",
+          "x55"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x65",
+          "x43",
+          "x57"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x67",
+          "x45",
+          "x59"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70",
+          "x71"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x69",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x46"
+            ]
+          },
+          "x61"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x62",
+          "0xd838091dd2253531"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x72",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x76",
+          "x77"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x72",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78",
+          "x79"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x72",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x80",
+          "x81"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x72",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x82",
+          "x83"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x81",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84",
+          "x85"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x83",
+          "x79",
+          "x76"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x86",
+          "x87"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x85",
+          "x77",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x87"
+            ]
+          },
+          "x75"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x90"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x62",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x91",
+          "x92"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x90",
+          "x64",
+          "x82"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x93",
+          "x94"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x92",
+          "x66",
+          "x84"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x95",
+          "x96"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x94",
+          "x68",
+          "x86"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x97",
+          "x98"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x96",
+          "x70",
+          "x88"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x99"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x98"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x71"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100",
+          "x101"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102",
+          "x103"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x104",
+          "x105"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x106",
+          "x107"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x108",
+          "x109"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x107",
+          "x104"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x110",
+          "x111"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x109",
+          "x105",
+          "x102"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x112",
+          "x113"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x111",
+          "x103",
+          "x100"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x114"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x113"
+            ]
+          },
+          "x101"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x115",
+          "x116"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x91",
+          "x106"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x117",
+          "x118"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x116",
+          "x93",
+          "x108"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x119",
+          "x120"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x118",
+          "x95",
+          "x110"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x121",
+          "x122"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x120",
+          "x97",
+          "x112"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x123",
+          "x124"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x122",
+          "x99",
+          "x114"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x125",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x115",
+          "0xd838091dd2253531"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x127",
+          "x128"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x125",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x129",
+          "x130"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x125",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x131",
+          "x132"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x125",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x133",
+          "x134"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x125",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x135",
+          "x136"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x134",
+          "x131"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x137",
+          "x138"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x136",
+          "x132",
+          "x129"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x139",
+          "x140"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x138",
+          "x130",
+          "x127"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x141"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x140"
+            ]
+          },
+          "x128"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x143"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x115",
+          "x133"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x144",
+          "x145"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x143",
+          "x117",
+          "x135"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x146",
+          "x147"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x145",
+          "x119",
+          "x137"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x148",
+          "x149"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x147",
+          "x121",
+          "x139"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x150",
+          "x151"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x149",
+          "x123",
+          "x141"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x152"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x151"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x124"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x153",
+          "x154"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x155",
+          "x156"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x157",
+          "x158"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x159",
+          "x160"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x161",
+          "x162"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x160",
+          "x157"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x163",
+          "x164"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x162",
+          "x158",
+          "x155"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x165",
+          "x166"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x164",
+          "x156",
+          "x153"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x167"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x166"
+            ]
+          },
+          "x154"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x168",
+          "x169"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x144",
+          "x159"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x170",
+          "x171"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x169",
+          "x146",
+          "x161"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x172",
+          "x173"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x171",
+          "x148",
+          "x163"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x174",
+          "x175"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x173",
+          "x150",
+          "x165"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x176",
+          "x177"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x175",
+          "x152",
+          "x167"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x178",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x168",
+          "0xd838091dd2253531"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x180",
+          "x181"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x178",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x182",
+          "x183"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x178",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x184",
+          "x185"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x178",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x186",
+          "x187"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x178",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x188",
+          "x189"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x187",
+          "x184"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x190",
+          "x191"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x189",
+          "x185",
+          "x182"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x192",
+          "x193"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x191",
+          "x183",
+          "x180"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x194"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x193"
+            ]
+          },
+          "x181"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x196"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x168",
+          "x186"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x197",
+          "x198"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x196",
+          "x170",
+          "x188"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x199",
+          "x200"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x198",
+          "x172",
+          "x190"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x201",
+          "x202"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x200",
+          "x174",
+          "x192"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x203",
+          "x204"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x202",
+          "x176",
+          "x194"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x205"
+        ],
+        "operation": "+",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x204"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x177"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x206",
+          "x207"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x197",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x208",
+          "x209"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x207",
+          "x199",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x210",
+          "x211"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x209",
+          "x201",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x212",
+          "x213"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x211",
+          "x203",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x215"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x213",
+          "x205",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x216"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x215",
+          "x206",
+          "x197"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x217"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x215",
+          "x208",
+          "x199"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x218"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x215",
+          "x210",
+          "x201"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x219"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x215",
+          "x212",
+          "x203"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x216"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x217"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x218"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x219"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_add",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[4]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "x10"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x10",
+          "x3",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x12",
+          "x5",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x14",
+          "x7",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x18"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x16",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x18",
+          "x9",
+          "x1"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x18",
+          "x11",
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x18",
+          "x13",
+          "x5"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x18",
+          "x15",
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x19"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x20"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x21"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x22"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_sub",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[4]",
+        "name": "arg2"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "arg1[0]",
+          "arg2[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          "arg1[1]",
+          "arg2[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          "arg1[2]",
+          "arg2[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          "arg1[3]",
+          "arg2[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x8",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x9",
+              "0xfffffffefffffc2f"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x11",
+          "x3",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x13",
+          "x5",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x15",
+          "x7",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x10"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x12"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x14"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_opp",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1",
+          "x2"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3",
+          "x4"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x2",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x4",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x6",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x8",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "&",
+            "arguments": [
+              "x9",
+              "0xfffffffefffffc2f"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x11",
+          "x3",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x13",
+          "x5",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16",
+          "_"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x15",
+          "x7",
+          "x9"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x10"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x12"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x14"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x16"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_from_montgomery",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0xd838091dd2253531"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4",
+          "x5"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6",
+          "x7"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8",
+          "x9"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10",
+          "x11"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12",
+          "x13"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x11",
+          "x8"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14",
+          "x15"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x13",
+          "x9",
+          "x6"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16",
+          "x17"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x15",
+          "x7",
+          "x4"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x19"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x1",
+          "x10"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20",
+          "x21"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x19",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x12"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22",
+          "x23"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x21",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x14"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24",
+          "x25"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x23",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26",
+          "x27"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x25",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x17"
+                ]
+              },
+              "x5"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28",
+          "x29"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x20",
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30",
+          "x31"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x29",
+          "x22",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x32",
+          "x33"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x31",
+          "x24",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34",
+          "x35"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x33",
+          "x26",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x28",
+          "0xd838091dd2253531"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38",
+          "x39"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x36",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40",
+          "x41"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x36",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42",
+          "x43"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x36",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44",
+          "x45"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x36",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46",
+          "x47"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x45",
+          "x42"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48",
+          "x49"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x47",
+          "x43",
+          "x40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50",
+          "x51"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x49",
+          "x41",
+          "x38"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x53"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x28",
+          "x44"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54",
+          "x55"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x53",
+          "x30",
+          "x46"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56",
+          "x57"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x55",
+          "x32",
+          "x48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58",
+          "x59"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x57",
+          "x34",
+          "x50"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60",
+          "x61"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x59",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x35"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x27"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x51"
+                ]
+              },
+              "x39"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x62",
+          "x63"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x54",
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x64",
+          "x65"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x63",
+          "x56",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x66",
+          "x67"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x65",
+          "x58",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x68",
+          "x69"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x67",
+          "x60",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x70",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x62",
+          "0xd838091dd2253531"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x72",
+          "x73"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x70",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x74",
+          "x75"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x70",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x76",
+          "x77"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x70",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x78",
+          "x79"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x70",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x80",
+          "x81"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x79",
+          "x76"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x82",
+          "x83"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x81",
+          "x77",
+          "x74"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x84",
+          "x85"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x83",
+          "x75",
+          "x72"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x87"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x62",
+          "x78"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x88",
+          "x89"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x87",
+          "x64",
+          "x80"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x90",
+          "x91"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x89",
+          "x66",
+          "x82"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x92",
+          "x93"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x91",
+          "x68",
+          "x84"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x94",
+          "x95"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x93",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x69"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x61"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x85"
+                ]
+              },
+              "x73"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x96",
+          "x97"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x88",
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x98",
+          "x99"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x97",
+          "x90",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x100",
+          "x101"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x99",
+          "x92",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x102",
+          "x103"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x101",
+          "x94",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x104",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x96",
+          "0xd838091dd2253531"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x106",
+          "x107"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x104",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x108",
+          "x109"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x104",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x110",
+          "x111"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x104",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x112",
+          "x113"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x104",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x114",
+          "x115"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x113",
+          "x110"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x116",
+          "x117"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x115",
+          "x111",
+          "x108"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x118",
+          "x119"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x117",
+          "x109",
+          "x106"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x121"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x96",
+          "x112"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x122",
+          "x123"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x121",
+          "x98",
+          "x114"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x124",
+          "x125"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x123",
+          "x100",
+          "x116"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x126",
+          "x127"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x125",
+          "x102",
+          "x118"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x128",
+          "x129"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x127",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x103"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x95"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x119"
+                ]
+              },
+              "x107"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x130",
+          "x131"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x122",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x132",
+          "x133"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x131",
+          "x124",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x134",
+          "x135"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x133",
+          "x126",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x136",
+          "x137"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x135",
+          "x128",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x139"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x137",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x129"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x140"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x139",
+          "x130",
+          "x122"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x141"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x139",
+          "x132",
+          "x124"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x142"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x139",
+          "x134",
+          "x126"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x143"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x139",
+          "x136",
+          "x128"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x140"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x141"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x142"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x143"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_to_montgomery",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5",
+          "x6"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x4",
+          "0x7a2000e90a1"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7",
+          "x8"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x6",
+          "x4"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x5",
+          "0xd838091dd2253531"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11",
+          "x12"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13",
+          "x14"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15",
+          "x16"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17",
+          "x18"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x9",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19",
+          "x20"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x18",
+          "x15"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21",
+          "x22"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x20",
+          "x16",
+          "x13"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23",
+          "x24"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x22",
+          "x14",
+          "x11"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x26"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x5",
+          "x17"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27",
+          "x28"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x26",
+          "x7",
+          "x19"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29",
+          "x30"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x28",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          },
+          "x21"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31",
+          "x32"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x30",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          "x23"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33",
+          "x34"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x32",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x24"
+                ]
+              },
+              "x12"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35",
+          "x36"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x1",
+          "0x7a2000e90a1"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37",
+          "x38"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x36",
+          "x1"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39",
+          "x40"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x27",
+          "x35"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41",
+          "x42"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x40",
+          "x29",
+          "x37"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43",
+          "x44"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x42",
+          "x31",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45",
+          "x46"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x44",
+          "x33",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x39",
+          "0xd838091dd2253531"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49",
+          "x50"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x47",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51",
+          "x52"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x47",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53",
+          "x54"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x47",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55",
+          "x56"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x47",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57",
+          "x58"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x56",
+          "x53"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59",
+          "x60"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x58",
+          "x54",
+          "x51"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x61",
+          "x62"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x60",
+          "x52",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x64"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x39",
+          "x55"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x65",
+          "x66"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x64",
+          "x41",
+          "x57"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x67",
+          "x68"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x66",
+          "x43",
+          "x59"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x69",
+          "x70"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x68",
+          "x45",
+          "x61"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x71",
+          "x72"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x70",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x46"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x34"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x62"
+                ]
+              },
+              "x50"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x73",
+          "x74"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x2",
+          "0x7a2000e90a1"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x75",
+          "x76"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x74",
+          "x2"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x77",
+          "x78"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x65",
+          "x73"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x79",
+          "x80"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x78",
+          "x67",
+          "x75"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x81",
+          "x82"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x80",
+          "x69",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x76"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x83",
+          "x84"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x82",
+          "x71",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x85",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x77",
+          "0xd838091dd2253531"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x87",
+          "x88"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x85",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x89",
+          "x90"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x85",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x91",
+          "x92"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x85",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x93",
+          "x94"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x85",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x95",
+          "x96"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x94",
+          "x91"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x97",
+          "x98"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x96",
+          "x92",
+          "x89"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x99",
+          "x100"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x98",
+          "x90",
+          "x87"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x102"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x77",
+          "x93"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x103",
+          "x104"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x102",
+          "x79",
+          "x95"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x105",
+          "x106"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x104",
+          "x81",
+          "x97"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x107",
+          "x108"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x106",
+          "x83",
+          "x99"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x109",
+          "x110"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x108",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x84"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x72"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x100"
+                ]
+              },
+              "x88"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x111",
+          "x112"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x3",
+          "0x7a2000e90a1"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x113",
+          "x114"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x112",
+          "x3"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x115",
+          "x116"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x103",
+          "x111"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x117",
+          "x118"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x116",
+          "x105",
+          "x113"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x119",
+          "x120"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x118",
+          "x107",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x114"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x121",
+          "x122"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x120",
+          "x109",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x123",
+          "_"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x115",
+          "0xd838091dd2253531"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x125",
+          "x126"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x123",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x127",
+          "x128"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x123",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x129",
+          "x130"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x123",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x131",
+          "x132"
+        ],
+        "operation": "mulx",
+        "arguments": [
+          "x123",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x133",
+          "x134"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x132",
+          "x129"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x135",
+          "x136"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x134",
+          "x130",
+          "x127"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x137",
+          "x138"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x136",
+          "x128",
+          "x125"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x140"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "0x0",
+          "x115",
+          "x131"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x141",
+          "x142"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x140",
+          "x117",
+          "x133"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x143",
+          "x144"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x142",
+          "x119",
+          "x135"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x145",
+          "x146"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x144",
+          "x121",
+          "x137"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x147",
+          "x148"
+        ],
+        "operation": "addcarryx",
+        "arguments": [
+          "x146",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x122"
+                ]
+              },
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x110"
+                ]
+              }
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "+",
+            "arguments": [
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "static_cast",
+                "arguments": [
+                  "x138"
+                ]
+              },
+              "x126"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x149",
+          "x150"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "0x0",
+          "x141",
+          "0xfffffffefffffc2f"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x151",
+          "x152"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x150",
+          "x143",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x153",
+          "x154"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x152",
+          "x145",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x155",
+          "x156"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x154",
+          "x147",
+          "0xffffffffffffffff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "_",
+          "x158"
+        ],
+        "operation": "subborrowx",
+        "arguments": [
+          "x156",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x148"
+            ]
+          },
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "0x0"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x159"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x158",
+          "x149",
+          "x141"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x160"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x158",
+          "x151",
+          "x143"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x161"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x158",
+          "x153",
+          "x145"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x162"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "x158",
+          "x155",
+          "x147"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x159"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x160"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x161"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x162"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_nonzero",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "|",
+        "arguments": [
+          "arg1[0]",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "|",
+            "arguments": [
+              "arg1[1]",
+              {
+                "datatype": "u64",
+                "name": [],
+                "operation": "|",
+                "arguments": [
+                  "arg1[2]",
+                  "arg1[3]"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "out1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_selectznz",
+    "arguments": [
+      {
+        "datatype": "u1",
+        "name": "arg1"
+      },
+      {
+        "datatype": "u64[4]",
+        "name": "arg2"
+      },
+      {
+        "datatype": "u64[4]",
+        "name": "arg3"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[0]",
+          "arg3[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[1]",
+          "arg3[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[2]",
+          "arg3[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "cmovznz",
+        "arguments": [
+          "arg1",
+          "arg2[3]",
+          "arg3[3]"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x1"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x2"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x3"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x4"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_to_bytes",
+    "arguments": [
+      {
+        "datatype": "u64[4]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u8[32]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[3]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[2]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[1]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x5"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x4"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x4",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x7"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x6"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x8"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x6",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x9"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x8",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x11"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x10"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x10",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x13"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x12"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x12",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x15"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x14"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x16"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x14",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x17"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x18"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x16",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x19"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x3"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x3",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x21"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x20"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x20",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x23"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x22"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x24"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x22",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x25"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x24",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x27"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x26"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x26",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x29"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x28"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x28",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x31"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x30"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x32"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x30",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x33"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x2"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x2",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x35"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x34"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x34",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x37"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x36"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x36",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x39"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x38"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x38",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x41"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x40"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x40",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x43"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x42"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x42",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x45"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x44"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x46"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x44",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x47"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x1"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x1",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x49"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x48"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x48",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x51"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x50"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x50",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x53"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x52"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x52",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x55"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x54"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x54",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x57"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x56"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58"
+        ],
+        "operation": ">>",
+        "arguments": [
+          "x56",
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x59"
+        ],
+        "operation": "&",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x58"
+            ]
+          },
+          "0xff"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x60"
+        ],
+        "operation": "static_cast",
+        "arguments": [
+          {
+            "datatype": "u8",
+            "name": [],
+            "operation": ">>",
+            "arguments": [
+              "x58",
+              "8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x5"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x7"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x9"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x11"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[4]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x13"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[5]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x15"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[6]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x17"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[7]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x18"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[8]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x19"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[9]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x21"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[10]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x23"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[11]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x25"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[12]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x27"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[13]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x29"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[14]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x31"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[15]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x32"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[16]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x33"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[17]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x35"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[18]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x37"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[19]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x39"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[20]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x41"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[21]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x43"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[22]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x45"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[23]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x46"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[24]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x47"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[25]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x49"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[26]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x51"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[27]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x53"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[28]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x55"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[29]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x57"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[30]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x59"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[31]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x60"
+        ]
+      }
+    ]
+  },
+  {
+    "operation": "fiat_secp256k1_from_bytes",
+    "arguments": [
+      {
+        "datatype": "u8[32]",
+        "name": "arg1"
+      }
+    ],
+    "returns": [
+      {
+        "datatype": "u64[4]",
+        "name": "out1"
+      }
+    ],
+    "body": [
+      {
+        "datatype": "u64",
+        "name": [
+          "x1"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[31]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x2"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[30]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x3"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[29]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x4"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[28]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x5"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[27]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x6"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[26]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x7"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[25]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x8"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[24]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x9"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[23]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x10"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[22]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x11"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[21]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x12"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[20]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x13"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[19]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x14"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[18]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x15"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[17]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x16"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[16]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x17"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[15]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x18"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[14]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x19"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[13]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x20"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[12]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x21"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[11]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x22"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[10]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x23"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[9]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x24"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[8]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x25"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[7]"
+            ]
+          },
+          "56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x26"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[6]"
+            ]
+          },
+          "48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x27"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[5]"
+            ]
+          },
+          "40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x28"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[4]"
+            ]
+          },
+          "32"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x29"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[3]"
+            ]
+          },
+          "24"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x30"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[2]"
+            ]
+          },
+          "16"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x31"
+        ],
+        "operation": "<<",
+        "arguments": [
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "arg1[1]"
+            ]
+          },
+          "8"
+        ]
+      },
+      {
+        "datatype": "u8",
+        "name": [
+          "x32"
+        ],
+        "operation": "=",
+        "arguments": [
+          "arg1[0]"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x33"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x31",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x32"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x34"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x30",
+          "x33"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x35"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x29",
+          "x34"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x36"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x28",
+          "x35"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x37"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x27",
+          "x36"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x38"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x26",
+          "x37"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x39"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x25",
+          "x38"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x40"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x23",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x24"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x41"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x22",
+          "x40"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x42"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x21",
+          "x41"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x43"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x20",
+          "x42"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x44"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x19",
+          "x43"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x45"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x18",
+          "x44"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x46"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x17",
+          "x45"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x47"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x15",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x16"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x48"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x14",
+          "x47"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x49"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x13",
+          "x48"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x50"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x12",
+          "x49"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x51"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x11",
+          "x50"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x52"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x10",
+          "x51"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x53"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x9",
+          "x52"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x54"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x7",
+          {
+            "datatype": "u64",
+            "name": [],
+            "operation": "static_cast",
+            "arguments": [
+              "x8"
+            ]
+          }
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x55"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x6",
+          "x54"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x56"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x5",
+          "x55"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x57"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x4",
+          "x56"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x58"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x3",
+          "x57"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x59"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x2",
+          "x58"
+        ]
+      },
+      {
+        "datatype": "u64",
+        "name": [
+          "x60"
+        ],
+        "operation": "+",
+        "arguments": [
+          "x1",
+          "x59"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[0]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x39"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[1]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x46"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[2]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x53"
+        ]
+      },
+      {
+        "datatype": "(auto)",
+        "name": [
+          "out1[3]"
+        ],
+        "operation": "=",
+        "arguments": [
+          "x60"
+        ]
+      }
+    ]
+  }
+]

--- a/src/CLI.v
+++ b/src/CLI.v
@@ -23,6 +23,7 @@ Require Import Crypto.BoundsPipeline.
 Require Import Crypto.Stringification.Rust.
 Require Import Crypto.Stringification.Go.
 Require Import Crypto.Stringification.Java.
+Require Import Crypto.Stringification.JSON.
 Require Crypto.Util.Arg.
 Import ListNotations. Local Open Scope Z_scope. Local Open Scope string_scope.
 
@@ -192,7 +193,8 @@ Module ForExtraction.
     := [("C", ToString.OutputCAPI)
         ; ("Rust", Rust.OutputRustAPI)
         ; ("Go", Go.OutputGoAPI)
-        ; ("Java", Java.OutputJavaAPI)].
+        ; ("Java", Java.OutputJavaAPI)
+        ; ("JSON", JSON.OutputJSONAPI)].
 
   Local Notation anon_argT := (string * Arg.spec * Arg.doc)%type (only parsing).
   Local Notation named_argT := (list Arg.key * Arg.spec * Arg.doc)%type (only parsing).
@@ -460,8 +462,9 @@ Module ForExtraction.
         := match CollectErrors (PipelineLines invocation curve_description str_machine_wordsize args) with
            | inl ls
              => inl
-                  (List.map (fun s => String.concat String.NewLine (List.map strip_trailing_spaces s) ++ String.NewLine ++ String.NewLine)
-                            ls)
+                  (List.flat_map (fun s => ((List.map (fun s => s ++ String.NewLine) (List.map strip_trailing_spaces s))%string)
+                                             ++ [String.NewLine])%list
+                                 ls)
            | inr nil => inr nil
            | inr (l :: ls)
              => inr (l ++ (List.flat_map

--- a/src/Stringification/JSON.v
+++ b/src/Stringification/JSON.v
@@ -1,0 +1,367 @@
+From Coq Require Import ZArith.ZArith MSets.MSetPositive FSets.FMapPositive
+     Strings.String Strings.Ascii Bool.Bool Lists.List Strings.HexString.
+From Crypto.Util Require Import
+     ListUtil
+     Strings.String Strings.Decimal Strings.Show
+     ZRange.Operations ZRange.Show
+     Option OptionList Bool.Equality.
+(* Work around COQBUG(https://github.com/coq/coq/issues/12251) *)
+Require Import Crypto.Util.ZRange.
+
+From Crypto Require Import IR Stringification.Language AbstractInterpretation.ZRange.
+
+Import ListNotations.
+
+Local Open Scope string_scope.
+Local Open Scope list_scope.
+Local Open Scope zrange_scope.
+Local Open Scope Z_scope.
+
+Import IR.Compilers.ToString.
+Import Stringification.Language.Compilers.
+Import Stringification.Language.Compilers.Options.
+Import Stringification.Language.Compilers.ToString.
+Import Stringification.Language.Compilers.ToString.int.Notations.
+
+Module JSON.
+  Definition indent (indent : string) : list string -> list string
+    := List.map (fun s => indent ++ s)%string.
+
+  Definition int_type_to_string (t : ToString.int.type) : string :=
+    ((if ToString.int.is_unsigned t then "u" else "i")
+       ++ Decimal.Z.to_string (ToString.int.bitwidth_of t))%string.
+
+  Definition primitive_type_to_string (t : IR.type.primitive)
+             (r : option ToString.int.type) : string :=
+    match t with
+    | IR.type.Zptr => "*"
+    | IR.type.Z => ""
+    end ++ match r with
+           | Some int_t => int_type_to_string int_t
+           | None => "(auto)"
+           end.
+
+  Definition int_literal_to_string (t : IR.type.primitive) (v : BinInt.Z) : string :=
+    match t with
+    | IR.type.Z => HexString.of_Z v
+    | IR.type.Zptr => "#error ""literal address " ++ HexString.of_Z v ++ """;"
+    end.
+
+  Import IR.Notations.
+
+  Record op_data :=
+    { datatype : string ; name : list string ; operation : string ; arguments : list (list string) }.
+
+  Definition comma_concat (ls : list (list string)) : list string
+    := let ret := List.flat_map (fun s => match s with
+                                          | [] => []
+                                          | _ => s ++ [","]
+                                          end) ls in
+       (* drop the final , *)
+       List.firstn (List.length ret - 1) ret.
+
+  Definition op_data_to_JSON (v : op_data) : list string
+    := (["{"
+         ; " ""datatype"": """ ++ v.(datatype) ++ ""","
+         ; " ""name"": [" ++ String.concat ", " (List.map (fun n => """" ++ n ++ """")%string v.(name)) ++ "],"
+         ; " ""operation"": """ ++ v.(operation) ++ ""","
+         ; " ""arguments"": ["]%string)
+         ++ (indent "  " (comma_concat v.(arguments)))
+         ++ [" ]"
+             ; "}"].
+
+  Fixpoint arith_to_string (outargs : list string)
+           {t} (sz : option ToString.int.type)
+           (e : IR.arith_expr t)
+    : list (list string)
+    := let handle_op sz op outargs inargs
+           := [op_data_to_JSON
+                 {| datatype := match sz with None => "(auto)" | Some ty => int_type_to_string ty end
+                    ; name := outargs
+                    ; operation := op
+                    ; arguments := inargs |}] in
+       let handle_op1 op {t} inargs
+           := handle_op sz op outargs (@arith_to_string [] t sz inargs) in
+       let wrap_value res
+           := match outargs with
+              | [] => res
+              | _ => handle_op sz "=" outargs res
+              end in
+       match e with
+       (* integer literals *)
+       | (IR.literal v @@@ _)
+         => wrap_value [ ["""" ++ int_literal_to_string IR.type.Z v ++ """"] ]
+       (* array dereference *)
+       | (IR.List_nth n @@@ IR.Var _ v)
+         => wrap_value [ ["""" ++ v ++ "[" ++ Decimal.Z.to_string (Z.of_nat n) ++ "]"""] ]
+       (* (de)referencing *)
+       | (IR.Addr @@@ IR.Var _ v)
+         => wrap_value [ ["""&" ++ v ++ """"] ]
+       | (IR.Dereference @@@ IR.Var _ v)
+         => wrap_value [ ["""*" ++ v ++ """"] ]
+       | (IR.Dereference @@@ e)
+         => handle_op sz "dereference" [] (arith_to_string [] sz e)
+       (* bitwise operations *)
+       | (IR.Z_shiftr offset @@@ e)
+         => handle_op sz ">>" outargs
+                      ((arith_to_string [] sz e)
+                         ++ [ ["""" ++ Decimal.Z.to_string offset ++ """"]%string ])%list
+       | (IR.Z_shiftl offset @@@ e)
+         => handle_op sz "<<" outargs
+                      ((arith_to_string [] sz e)
+                         ++ [ ["""" ++ Decimal.Z.to_string offset ++ """"]%string ])%list
+       | (IR.Z_land @@@ args)
+         => handle_op1 "&" args
+       | (IR.Z_lor @@@ args)
+         => handle_op1 "|" args
+       | (IR.Z_lnot _ @@@ args)
+         => handle_op1 "~" args
+       (* arithmetic operations *)
+       | (IR.Z_add @@@ args)
+         => handle_op1 "+" args
+       | (IR.Z_mul @@@ args)
+         => handle_op1 "*" args
+       | (IR.Z_sub @@@ args)
+         => handle_op1 "-" args
+       | (IR.Z_bneg @@@ args)
+         => handle_op1 "!" args
+       | (IR.Z_mul_split lg2s @@@ ((IR.Addr @@@ IR.Var _ x1, IR.Addr @@@ IR.Var _ x2), args))
+         => let sz := Some (int.of_bitwidth false lg2s) in
+            wrap_value (handle_op sz "mulx" [x1; x2] (arith_to_string [] sz args))
+       | (IR.Z_add_with_get_carry lg2s @@@ ((IR.Addr @@@ IR.Var _ x1, IR.Addr @@@ IR.Var _ x2), args))
+         => let sz := Some (int.of_bitwidth false lg2s) in
+            wrap_value (handle_op sz "addcarryx" [x1; x2] (arith_to_string [] sz args))
+       | (IR.Z_sub_with_get_borrow lg2s @@@ ((IR.Addr @@@ IR.Var _ x1, IR.Addr @@@ IR.Var _ x2), args))
+         => let sz := Some (int.of_bitwidth false lg2s) in
+            wrap_value (handle_op sz "subborrowx" [x1; x2] (arith_to_string [] sz args))
+       | (IR.Z_value_barrier ty @@@ args) => arith_to_string outargs sz args
+       | (IR.Z_zselect ty @@@ (IR.Addr @@@ IR.Var _ v, args))
+         => wrap_value (handle_op (Some ty) "cmovznz" [v] (arith_to_string [] (Some ty) args))
+       | (IR.Z_static_cast int_t @@@ args)
+         => handle_op (Some int_t) "static_cast" outargs (arith_to_string [] (Some int_t) args)
+       | IR.Var _ v
+         => wrap_value [ [ """" ++ v ++ """" ] ]
+       | IR.Pair A B a b
+         => wrap_value (arith_to_string [] sz a ++ arith_to_string [] sz b)%list
+       | (IR.Z_add_modulo @@@ _)
+         => wrap_value [ [ "#error addmodulo" ] ]
+       | (IR.List_nth _ @@@ _)
+       | (IR.Addr @@@ _)
+       | (IR.Z_mul_split _ @@@ _)
+       | (IR.Z_add_with_get_carry _ @@@ _)
+       | (IR.Z_sub_with_get_borrow _ @@@ _)
+       | (IR.Z_zselect _ @@@ _)
+         => wrap_value [ [ "#error bad_arg" ] ]
+       | IR.TT => wrap_value [ [ "#error tt" ] ]
+       end%string%Cexpr.
+
+  Fixpoint stmt_to_string (e : IR.stmt) : list string
+    := List.concat
+         match e with
+         | IR.Call val
+           => arith_to_string [] None val
+         | IR.Assign _ _ sz name val
+           => arith_to_string [name] sz val
+         | IR.AssignZPtr name sz val
+           => arith_to_string [name] sz val
+         | IR.AssignNth name n val
+           => let name := (name ++ "[" ++ Decimal.Z.to_string (Z.of_nat n) ++ "]")%string in
+              arith_to_string [name] None val
+         | IR.DeclareVar _ _ _
+         | IR.Comment _ _
+           => []
+         end.
+
+  Definition to_strings (e : IR.expr) : list string :=
+    comma_concat (List.map stmt_to_string e).
+
+
+  Import Rewriter.Language.Language.Compilers Crypto.Language.API.Compilers IR.OfPHOAS.
+
+  Local Notation tZ := (base.type.type_base base.type.Z).
+
+  Fixpoint to_base_arg_list {t} : base_var_data t -> list (string * string)
+    := match t return base_var_data t -> _ with
+       | tZ
+         => fun '(n, is_ptr, r) => [(primitive_type_to_string IR.type.Z r, n)]
+       | base.type.prod A B
+         => fun '(va, vb) => (@to_base_arg_list A va ++ @to_base_arg_list B vb)%list
+       | base.type.list tZ
+         => fun '(n, r, len) => [(primitive_type_to_string IR.type.Z r ++ "[" ++ Decimal.Z.to_string (Z.of_nat len) ++ "]", n)]
+       | base.type.list _ => fun _ => [("#error ""complex list""", "")]
+       | base.type.option _ => fun _ => [("#error option", "")]
+       | base.type.unit => fun _ => [("#error unit", "")]
+       | base.type.type_base t => fun _ => [("#error " ++ show false t, "")]
+       end%string.
+
+  Definition to_arg_list {t} : var_data t -> list (string * string) :=
+    match t return var_data t -> _ with
+    | type.base t => to_base_arg_list
+    | type.arrow _ _ => fun _ => [("#error arrow", "")]
+    end%string.
+
+  Fixpoint to_arg_list_for_each_lhs_of_arrow {t} : type.for_each_lhs_of_arrow var_data t -> list (string * string)
+    := match t return type.for_each_lhs_of_arrow var_data t -> _ with
+       | type.base t => fun _ => nil
+       | type.arrow s d
+         => fun '(x, xs)
+            => to_arg_list x ++ @to_arg_list_for_each_lhs_of_arrow d xs
+       end%list.
+
+  (** * Language-specific numeric conversions to be passed to the PHOAS -> IR translation *)
+
+  Definition JSON_bin_op_natural_output
+    : IR.Z_binop -> ToString.int.type * ToString.int.type -> ToString.int.type
+    := fun idc '(t1, t2)
+       => ToString.int.union t1 t2.
+
+  (* Does the binary operation commute with (-- mod 2^bw)? *)
+  Definition bin_op_commutes_with_mod_pow2 (idc : IR.Z_binop)
+    := match idc with
+       | IR.Z_land
+       | IR.Z_lor
+       | IR.Z_add
+       | IR.Z_mul
+       | IR.Z_sub
+         => true
+       end.
+
+  Definition JSON_bin_op_casts
+    : IR.Z_binop -> option ToString.int.type -> ToString.int.type * ToString.int.type -> option ToString.int.type * (option ToString.int.type * option ToString.int.type)
+    := fun idc desired_type '(t1, t2)
+       => match desired_type with
+          | Some desired_type
+            => let ct := ToString.int.union t1 t2 in
+               if bin_op_commutes_with_mod_pow2 idc
+               then
+                 (* these operations commute with mod, so we just pre-cast them *)
+                 (None, (Some desired_type, Some desired_type))
+               else
+                 let desired_type' := Some (ToString.int.union ct desired_type) in
+                 (desired_type',
+                  (get_Zcast_up_if_needed desired_type' (Some t1),
+                   get_Zcast_up_if_needed desired_type' (Some t2)))
+          | None => (None, (None, None))
+          end.
+
+  Definition JSON_un_op_casts
+    : IR.Z_unop -> option ToString.int.type -> ToString.int.type -> option ToString.int.type * option ToString.int.type
+    := fun idc desired_type t
+       => match idc with
+          | IR.Z_shiftr offset
+            => (** N.B. We must cast the expression up to a large
+                   enough type to fit 2^offset (importantly, not just
+                   2^offset-1), because C considers it to be undefined
+                   behavior to shift >= width of the type.  We should
+                   probably figure out how to not generate these
+                   things in the first place...
+
+                   N.B. We must preserve signedness of the value being
+                   shifted, because shift does not commute with
+                   mod. *)
+            let t' := ToString.int.union_zrange r[0~>2^offset]%zrange t in
+            ((** We cast the result down to the specified type, if needed *)
+              get_Zcast_down_if_needed desired_type (Some t'),
+              (** We cast the argument up to a large enough type *)
+              get_Zcast_up_if_needed (Some t') (Some t))
+          | IR.Z_shiftl offset
+            => (** N.B. We must cast the expression up to a large
+                   enough type to fit 2^offset (importantly, not just
+                   2^offset-1), because C considers it to be undefined
+                   behavior to shift >= width of the type.  We should
+                   probably figure out how to not generate these
+                   things in the first place...
+
+                   N.B. We make sure that we only left-shift unsigned
+                   values, since shifting into the sign bit is
+                   undefined behavior. *)
+            let rpre_out := match desired_type with
+                            | Some rout => Some (ToString.int.union_zrange r[0~>2^offset] (ToString.int.unsigned_counterpart_of rout))
+                            | None => Some (ToString.int.of_zrange_relaxed r[0~>2^offset]%zrange)
+                            end in
+            ((** We cast the result down to the specified type, if needed *)
+              get_Zcast_down_if_needed desired_type rpre_out,
+              (** We cast the argument up to a large enough type *)
+              get_Zcast_up_if_needed rpre_out (Some t))
+          | IR.Z_lnot ty
+            => ((* if the result is too big, we cast it down; we
+                       don't need to upcast it because it'll get
+                       picked up by implicit casts if necessary *)
+              get_Zcast_down_if_needed desired_type (Some ty),
+              (** always cast to the width of the type, unless we are already exactly that type (which the machinery in IR handles *)
+              Some ty)
+          | Z_bneg
+            => ((* bneg is !, i.e., takes the argument to 1 if its not zero, and to zero if it is zero; so we don't ever need to cast *)
+              None, None)
+          end.
+
+  Local Instance JSONLanguageCasts : LanguageCasts :=
+    {| bin_op_natural_output := JSON_bin_op_natural_output
+       ; bin_op_casts := JSON_bin_op_casts
+       ; un_op_casts := JSON_un_op_casts
+       ; upcast_on_assignment := true
+       ; upcast_on_funcall := true
+       ; explicit_pointer_variables := false
+    |}.
+
+  Definition to_function_lines (static : bool) (name : string)
+             {t}
+             (f : type.for_each_lhs_of_arrow var_data t * var_data (type.base (type.final_codomain t)) * IR.expr)
+    : list string :=
+    let '(args, rets, body) := f in
+    let args_list_to_string ls
+        := ("["
+              ++ (String.concat
+                    ", "
+                    (List.map
+                       (fun '(typ, name) => "{""datatype"": """ ++ typ ++ """, ""name"": """ ++ name ++ """}")
+                       ls))
+              ++ "]")%string in
+    ["{"]
+      ++ (["""operation"": """ ++ name ++ ""","
+           ; """arguments"": " ++ args_list_to_string (to_arg_list_for_each_lhs_of_arrow args) ++ ","
+           ; """returns"": " ++ args_list_to_string (to_arg_list rets) ++ ","
+           ; """body"": ["]%string)
+      ++ to_strings body
+      ++ ["]"
+          ; "}"].
+
+  (** We will treat all dead variables as _ *)
+  Local Instance : consider_retargs_live_opt := fun _ _ _ => false.
+  Local Instance : rename_dead_opt := fun s => "_".
+  (** No need to lift declarations to the top *)
+  Local Instance : lift_declarations_opt := false.
+
+  Definition ToFunctionLines
+             {relax_zrange : relax_zrange_opt}
+             (machine_wordsize : Z)
+             (do_bounds_check : bool) (static : bool) (prefix : string) (name : string)
+             {t}
+             (e : API.Expr t)
+             (comment : type.for_each_lhs_of_arrow var_data t -> var_data (type.base (type.final_codomain t)) -> list string)
+             (name_list : option (list string))
+             (inbounds : type.for_each_lhs_of_arrow Compilers.ZRange.type.option.interp t)
+             (outbounds : Compilers.ZRange.type.base.option.interp (type.final_codomain t))
+    : (list string * ToString.ident_infos) + string :=
+    match ExprOfPHOAS do_bounds_check e name_list inbounds with
+    | inl (indata, outdata, f) =>
+      inl (to_function_lines static name (indata, outdata, f),
+           IR.ident_infos.collect_infos f)
+    | inr nil =>
+      inr ("Unknown internal error in converting " ++ name ++ " to JSON")%string
+    | inr [err] =>
+      inr ("Error in converting " ++ name ++ " to JSON:" ++ String.NewLine ++ err)%string
+    | inr errs =>
+      inr ("Errors in converting " ++ name ++ " to JSON:" ++ String.NewLine ++ String.concat String.NewLine errs)%string
+    end.
+
+  Definition OutputJSONAPI : ToString.OutputLanguageAPI :=
+    {| ToString.comment_block _ := [];
+       ToString.comment_file_header_block _ := [];
+       ToString.ToFunctionLines := @ToFunctionLines;
+       ToString.header := fun _ _ _ _ => [];
+       ToString.footer := fun _ _ _ _ => [];
+       (** No special handling for any functions *)
+       ToString.strip_special_infos machine_wordsize infos := infos |}.
+
+End JSON.


### PR DESCRIPTION
Note that we need to keep the individual lines of each function separate
so as to not stack-overflow when joining strings before printing,
because JSON has many, many more lines than most of the other languages.