### PR TITLE
Remove bedrock_func notation

### DIFF
--- a/src/Bedrock/Field/Synthesis/Examples/EncodeDecode.v
+++ b/src/Bedrock/Field/Synthesis/Examples/EncodeDecode.v
@@ -23,6 +23,7 @@ Require Import Crypto.COperationSpecifications.
 Require Import Crypto.UnsaturatedSolinasHeuristics.
 Require Import bedrock2.Semantics.
 Import ListNotations.
+Import Syntax.Coercions.
 Local Open Scope Z_scope.
 
 Existing Instances
@@ -30,7 +31,6 @@ Existing Instances
          curve25519_bedrock2_funcs curve25519_bedrock2_specs
          curve25519_bedrock2_correctness.
 Local Open Scope string_scope.
-Local Coercion name_of_func (f : bedrock_func) := fst f.
 
 (* Notations to make spec more readable *)
 Local Notation n := X25519_64.n.
@@ -53,7 +53,7 @@ Local Notation prime_bytes_bounds_value :=
 Local Infix "*" := sep : sep_scope.
 Delimit Scope sep_scope with sep.
 
-Definition encode_decode : bedrock_func :=
+Definition encode_decode : func :=
   let x := "x" in
   let tmp := "tmp" in
   ("encode_decode",

--- a/src/Bedrock/Field/Synthesis/Examples/LadderStep.v
+++ b/src/Bedrock/Field/Synthesis/Examples/LadderStep.v
@@ -56,7 +56,6 @@ Local Notation loose_bounds := (UnsaturatedSolinasHeuristics.loose_bounds n s c)
 Local Notation tight_bounds := (UnsaturatedSolinasHeuristics.tight_bounds n s c).
 
 Local Open Scope string_scope.
-Local Coercion name_of_func (f : bedrock_func) := fst f.
 Local Infix "*" := sep : sep_scope.
 Delimit Scope sep_scope with sep.
 

--- a/src/Bedrock/Field/Synthesis/Examples/MulTwice.v
+++ b/src/Bedrock/Field/Synthesis/Examples/MulTwice.v
@@ -21,6 +21,7 @@ Require Import Crypto.COperationSpecifications.
 Require Import Crypto.UnsaturatedSolinasHeuristics.
 Require Import bedrock2.Semantics.
 Import ListNotations.
+Import Syntax.Coercions.
 Local Open Scope Z_scope.
 
 Existing Instances
@@ -28,7 +29,6 @@ Existing Instances
          curve25519_bedrock2_funcs curve25519_bedrock2_specs
          curve25519_bedrock2_correctness.
 Local Open Scope string_scope.
-Local Coercion name_of_func (f : bedrock_func) := fst f.
 
 (* Notations to make spec more readable *)
 Local Notation n := X25519_64.n.
@@ -48,7 +48,7 @@ Local Infix "*" := sep : sep_scope.
 Delimit Scope sep_scope with sep.
 
 (* test function; computes x * y * y *)
-Definition mul_twice : bedrock_func :=
+Definition mul_twice : func :=
   let x := "x" in
   let y := "y" in
   let xy := "xy" in

--- a/src/Bedrock/Field/Synthesis/Generic/Operation.v
+++ b/src/Bedrock/Field/Synthesis/Generic/Operation.v
@@ -80,7 +80,7 @@ Section op.
 
   Definition make_bedrock_func
              {t} (name : string) (op : operation t) (res : API.Expr t)
-    : bedrock_func :=
+    : func :=
     (name, make_bedrock_func_with_sizes
              (op.(input_array_sizes)) (op.(output_array_sizes))
              (op.(input_array_lengths)) res).

--- a/src/Bedrock/Field/Synthesis/Specialized/ReifiedOperation.v
+++ b/src/Bedrock/Field/Synthesis/Specialized/ReifiedOperation.v
@@ -27,7 +27,7 @@ Record reified_op {p t}
        {start : ErrorT.ErrorT Pipeline.ErrorMessage
                               (API.Expr t)} :=
   { res : API.Expr t;
-    computed_bedrock_func : bedrock_func;
+    computed_bedrock_func : Syntax.func;
     computed_bedrock_func_eq :
       computed_bedrock_func = make_bedrock_func name op res;
     reified_eq : start = ErrorT.Success res;

--- a/src/Bedrock/Field/Synthesis/Specialized/UnsaturatedSolinas.v
+++ b/src/Bedrock/Field/Synthesis/Specialized/UnsaturatedSolinas.v
@@ -20,15 +20,15 @@ Import ListNotations.
 Import AbstractInterpretation.Compilers.
 
 Class bedrock2_unsaturated_solinas_funcs :=
-  { carry_mul : bedrock_func;
-    carry_square : bedrock_func;
-    carry : bedrock_func;
-    add : bedrock_func;
-    sub : bedrock_func;
-    opp : bedrock_func;
-    selectznz : bedrock_func;
-    to_bytes : bedrock_func;
-    from_bytes : bedrock_func }.
+  { carry_mul : func;
+    carry_square : func;
+    carry : func;
+    add : func;
+    sub : func;
+    opp : func;
+    selectznz : func;
+    to_bytes : func;
+    from_bytes : func }.
 
 Class bedrock2_unsaturated_solinas_specs
       {funcs : bedrock2_unsaturated_solinas_funcs }:=
@@ -74,7 +74,7 @@ Class bedrock2_unsaturated_solinas_correctness
         spec_of_from_bytes (from_bytes :: functions) }.
 
 Class bedrock2_unsaturated_solinas_scmul_func :=
-  { carry_scmul_const : bedrock_func }.
+  { carry_scmul_const : func }.
 
 Class bedrock2_unsaturated_solinas_scmul_spec
       {func : bedrock2_unsaturated_solinas_scmul_func }:=

--- a/src/Bedrock/Field/Synthesis/Specialized/WordByWordMontgomery.v
+++ b/src/Bedrock/Field/Synthesis/Specialized/WordByWordMontgomery.v
@@ -20,17 +20,17 @@ Import ListNotations.
 Import AbstractInterpretation.Compilers.
 
 Class bedrock2_wbwmontgomery_funcs :=
-  { mul : bedrock_func;
-    square : bedrock_func;
-    add : bedrock_func;
-    sub : bedrock_func;
-    opp : bedrock_func;
-    to_montgomery : bedrock_func;
-    from_montgomery : bedrock_func;
-    nonzero : bedrock_func;
-    selectznz : bedrock_func;
-    to_bytes : bedrock_func;
-    from_bytes : bedrock_func }.
+  { mul : func;
+    square : func;
+    add : func;
+    sub : func;
+    opp : func;
+    to_montgomery : func;
+    from_montgomery : func;
+    nonzero : func;
+    selectznz : func;
+    to_bytes : func;
+    from_bytes : func }.
 
 Class bedrock2_wbwmontgomery_specs
       {funcs : bedrock2_wbwmontgomery_funcs }:=

--- a/src/Bedrock/Field/Translation/Func.v
+++ b/src/Bedrock/Field/Translation/Func.v
@@ -16,7 +16,6 @@ Import Types.Notations.
 Section Func.
   Context {p : parameters}.
   Existing Instance rep.Z.
-  Local Notation bedrock_func := (string * (list string * list string * cmd))%type.
 
   (* Feeds arguments to function one by one and then calls translate_cmd *)
   Fixpoint translate_func' {t} (e : @API.expr ltype t) (nextn : nat)

--- a/src/Bedrock/Field/Translation/Parameters/Defaults.v
+++ b/src/Bedrock/Field/Translation/Parameters/Defaults.v
@@ -41,9 +41,6 @@ Global Existing Instances Types.rep.Z Types.rep.listZ_mem.
 Local Definition ERROR := "ERROR"%string.
 
 Section Defs.
-  Definition bedrock_func : Type :=
-    string * (list string * list string * cmd.cmd).
-
   (* quick check to make sure the expression produced no errors *)
   Fixpoint error_free_expr (x : Syntax.expr) : bool :=
     match x with

--- a/src/Bedrock/Field/Translation/Proofs/Func.v
+++ b/src/Bedrock/Field/Translation/Proofs/Func.v
@@ -37,7 +37,6 @@ Import Types.Notations.
 
 Section Func.
   Context {p : parameters} {p_ok : @ok p}.
-  Local Notation bedrock_func := (string * (list string * list string * cmd))%type.
 
   Local Existing Instance rep.Z.
   Local Instance sem_ok : Semantics.parameters_ok semantics
@@ -88,7 +87,7 @@ Section Func.
       forall (tr : Semantics.trace)
              (locals : Semantics.locals)
              (mem : Semantics.mem)
-             (functions : list bedrock_func),
+             (functions : list func),
         (* locals doesn't contain variables we could overwrite *)
         (forall n nvars,
             (nextn <= n)%nat ->
@@ -505,14 +504,14 @@ Section Func.
          (function arguments, function return variable names, body) *)
       let out := translate_func
                    e argnames arglengths argsizes retnames retsizes in
-      let f : bedrock_func := (fname, fst out) in
+      let f : func := (fname, fst out) in
       let lengths := snd out in
       forall (tr : Semantics.trace)
              (mem : Semantics.mem)
              (flat_args : list Semantics.word)
              (out_ptrs : list Semantics.word)
              (argvalues : list Semantics.word)
-             (functions : list bedrock_func)
+             (functions : list func)
              (R : Semantics.mem -> Prop),
         (* argument values are the concatenation of true argument values
            and output pointer values *)

--- a/src/Bedrock/Standalone/Stringification.v
+++ b/src/Bedrock/Standalone/Stringification.v
@@ -98,7 +98,7 @@ Section with_parameters.
     end.
 End with_parameters.
 
-Definition bedrock_func_to_lines (f : bedrock_func)
+Definition bedrock_func_to_lines (f : func)
   : list string :=
   [c_func f].
 
@@ -129,7 +129,7 @@ Definition Bedrock2_ToFunctionLines
         | Some insizes, Some outsizes =>
           let out := translate_func
                        e innames inlengths insizes outnames outsizes in
-          let f : bedrock_func := (name, fst out) in
+          let f : func := (name, fst out) in
           let outlengths := snd out in
           if error_free_cmd (snd (snd f))
           then


### PR DESCRIPTION
I previously used a convenience notation to represent the bedrock2 function type (which is a nested tuple of `(string, (list string, list string, cmd.cmd)`, but bedrock2 has now added a `Syntax.func` definition for this purpose and the convenience notation is no longer necessary.

This is a pretty mechanical change, and confined to the bedrock2 backend, so I'll consider myself free to merge it once the CI passes.