### PR TITLE
Remove unused axioms from bedrock2 backend

### DIFF
--- a/src/Bedrock/Field/Common/Arrays/MakeAccessSizes.v
+++ b/src/Bedrock/Field/Common/Arrays/MakeAccessSizes.v
@@ -148,16 +148,6 @@ Section __.
     Context {p_ok : @Types.ok p}.
     Existing Instance semantics_ok.
 
-    Lemma zrange_to_access_size_ok r sz :
-      zrange_to_access_size r = Some sz ->
-      (r <=? access_size_to_zrange sz)%zrange = true.
-    Admitted.
-
-    Lemma access_size_to_zrange_word_upper_bound :
-      upper (access_size_to_zrange
-               access_size.word) < 2 ^ Semantics.width.
-    Admitted.
-
     Lemma access_size_to_zrange_lower s :
       lower (access_size_to_zrange s) = 0.
     Proof. reflexivity. Qed.

--- a/src/Bedrock/Field/Synthesis/Generic/Bignum.v
+++ b/src/Bedrock/Field/Synthesis/Generic/Bignum.v
@@ -29,20 +29,22 @@ Section Bignum.
     Context {ok : Types.ok}.
     Existing Instance semantics_ok.
 
+    (* TODO: lemmas along these lines might be convenient for stack allocation
     Lemma Bignum_of_bytes n addr bs :
       length bs = (n * Z.to_nat word_size_in_bytes)%nat ->
       Lift1Prop.iff1
         (array ptsto (word.of_Z 1) addr bs)
         (Bignum n addr (map word.of_Z
                             (eval_bytes (width:=Semantics.width) bs))).
-    Admitted. (* TODO *)
+    Admitted.
 
     Lemma Bignum_to_bytes n addr x :
       list_Z_bounded_by (max_bounds n) (map word.unsigned x) ->
       Lift1Prop.iff1
         (Bignum n addr x)
         (array ptsto (word.of_Z 1) addr (encode_bytes x)).
-    Admitted. (* TODO *)
+    Admitted.
+    *)
   End Proofs.
 End Bignum.
 Notation BignumSuchThat :=


### PR DESCRIPTION
See discussion in #736 

`coqchk` found four axioms. Two were completely unused and left in by mistake, so they were deleted. The `Bignum_to_bytes` and `Bignum_from_bytes` lemmas are currently unused but possibly could be useful once stack allocation is incorporated, so I've commented them out for now.