### PR TITLE
Use F for bedrock2 field specs

### DIFF
--- a/src/Bedrock/Field/Interface/Compilation.v
+++ b/src/Bedrock/Field/Interface/Compilation.v
@@ -26,23 +26,25 @@ Section Compile.
            (locals_ok : Semantics.locals -> Prop)
       tr retvars R Rin Rout functions T (pred: T -> list word -> Semantics.mem -> Prop)
       (x y out : felem) x_ptr x_var y_ptr y_var out_ptr out_var
-      k k_impl,
+      (X Y : F M_pos) k k_impl,
       spec_of_mul functions ->
       bounded_by loose_bounds x ->
       bounded_by loose_bounds y ->
+      feval x = X ->
+      feval y = Y ->
       (FElem x_ptr x * FElem y_ptr y * Rin)%sep mem ->
       (Placeholder out_ptr out * Rout)%sep mem ->
       map.get locals x_var = Some x_ptr ->
       map.get locals y_var = Some y_ptr ->
       map.get locals out_var = Some out_ptr ->
-      let v := (feval x * feval y)%F in
+      let v := (X * Y)%F in
       (let head := v in
        forall out m,
          feval out = head ->
          bounded_by tight_bounds out ->
          sep (FElem out_ptr out) Rout m ->
          (find k_impl
-          implementing (pred (k (feval out)))
+          implementing (pred (k head))
           and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
@@ -61,9 +63,7 @@ Section Compile.
     cbv [Placeholder] in *.
     repeat straightline'.
     handle_call; [ solve [eauto] .. | sepsimpl ].
-    repeat straightline'.
-    match goal with H : feval _ = _ |- _ => rewrite <-H end.
-    eauto.
+    repeat straightline'. subst; eauto.
   Qed.
 
   Lemma compile_add :
@@ -71,23 +71,25 @@ Section Compile.
            (locals_ok : Semantics.locals -> Prop)
       tr retvars R Rin Rout functions T (pred: T -> list word -> Semantics.mem -> Prop)
       (x y out : felem) x_ptr x_var y_ptr y_var out_ptr out_var
-      k k_impl,
+      (X Y : F M_pos) k k_impl,
       spec_of_add functions ->
       bounded_by tight_bounds x ->
       bounded_by tight_bounds y ->
+      feval x = X ->
+      feval y = Y ->
       (FElem x_ptr x * FElem y_ptr y * Rin)%sep mem ->
       (Placeholder out_ptr out * Rout)%sep mem ->
       map.get locals x_var = Some x_ptr ->
       map.get locals y_var = Some y_ptr ->
       map.get locals out_var = Some out_ptr ->
-      let v := (feval x + feval y)%F in
+      let v := (X + Y)%F in
       (let head := v in
        forall out m,
          feval out = head ->
          bounded_by loose_bounds out ->
          sep (FElem out_ptr out) Rout m ->
          (find k_impl
-          implementing (pred (k (feval out)))
+          implementing (pred (k head))
           and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
@@ -106,9 +108,7 @@ Section Compile.
     cbv [Placeholder] in *.
     repeat straightline'.
     handle_call; [ solve [eauto] .. | sepsimpl ].
-    repeat straightline'.
-    match goal with H : feval _ = _ |- _ => rewrite <-H end.
-    eauto.
+    repeat straightline'. subst; eauto.
   Qed.
 
   Lemma compile_sub :
@@ -116,23 +116,25 @@ Section Compile.
            (locals_ok : Semantics.locals -> Prop)
       tr retvars R Rin Rout functions T (pred: T -> list word -> Semantics.mem -> Prop)
       (x y out : felem) x_ptr x_var y_ptr y_var out_ptr out_var
-      k k_impl,
+      (X Y : F M_pos) k k_impl,
       spec_of_sub functions ->
       bounded_by tight_bounds x ->
       bounded_by tight_bounds y ->
+      feval x = X ->
+      feval y = Y ->
       (FElem x_ptr x * FElem y_ptr y * Rin)%sep mem ->
       (Placeholder out_ptr out * Rout)%sep mem ->
       map.get locals x_var = Some x_ptr ->
       map.get locals y_var = Some y_ptr ->
       map.get locals out_var = Some out_ptr ->
-      let v := (feval x - feval y)%F in
+      let v := (X - Y)%F in
       (let head := v in
        forall out m,
          feval out = head ->
          bounded_by loose_bounds out ->
          sep (FElem out_ptr out) Rout m ->
          (find k_impl
-          implementing (pred (k (feval out)))
+          implementing (pred (k head))
           and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
@@ -151,30 +153,29 @@ Section Compile.
     cbv [Placeholder] in *.
     repeat straightline'.
     handle_call; [ solve [eauto] .. | sepsimpl ].
-    repeat straightline'.
-    match goal with H : feval _ = _ |- _ => rewrite <-H end.
-    eauto.
+    repeat straightline'. subst; eauto.
   Qed.
 
   Lemma compile_square :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
       tr retvars R Rin Rout functions T (pred: T -> list word -> Semantics.mem -> Prop)
-      (x out : felem) x_ptr x_var out_ptr out_var k k_impl,
+      (x out : felem) x_ptr x_var out_ptr out_var (X : F M_pos) k k_impl,
       spec_of_square functions ->
       bounded_by loose_bounds x ->
+      feval x = X ->
       (FElem x_ptr x * Rin)%sep mem ->
       (Placeholder out_ptr out * Rout)%sep mem ->
       map.get locals x_var = Some x_ptr ->
       map.get locals out_var = Some out_ptr ->
-      let v := (feval x ^ 2)%F in
+      let v := (X ^ 2)%F in
       (let head := v in
        forall out m,
          feval out = head ->
          bounded_by tight_bounds out ->
          sep (FElem out_ptr out) Rout m ->
          (find k_impl
-          implementing (pred (k (feval out)))
+          implementing (pred (k head))
           and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
@@ -192,30 +193,29 @@ Section Compile.
     cbv [Placeholder] in *.
     repeat straightline'.
     handle_call; [ solve [eauto] .. | sepsimpl ].
-    repeat straightline'. rewrite F.pow_2_r in *.
-    match goal with H : feval _ = _ |- _ => rewrite <-H end.
-    eauto.
+    repeat straightline'. subst. rewrite F.pow_2_r in *. eauto.
   Qed.
 
   Lemma compile_scmula24 :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
       tr retvars R Rin Rout functions T (pred: T -> list word -> Semantics.mem -> Prop)
-      (x out : felem) x_ptr x_var out_ptr out_var k k_impl,
+      (x out : felem) x_ptr x_var out_ptr out_var (X : F M_pos) k k_impl,
       spec_of_scmula24 functions ->
       bounded_by loose_bounds x ->
+      feval x = X ->
       (FElem x_ptr x * Rin)%sep mem ->
       (Placeholder out_ptr out * Rout)%sep mem ->
       map.get locals x_var = Some x_ptr ->
       map.get locals out_var = Some out_ptr ->
-      let v := (a24 * feval x)%F in
+      let v := (a24 * X)%F in
       (let head := v in
        forall out m,
          feval out = head ->
          bounded_by tight_bounds out ->
          sep (FElem out_ptr out) Rout m ->
          (find k_impl
-          implementing (pred (k (feval out)))
+          implementing (pred (k head))
           and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
@@ -233,30 +233,29 @@ Section Compile.
     cbv [Placeholder] in *.
     repeat straightline'.
     handle_call; [ solve [eauto] .. | sepsimpl ].
-    repeat straightline'.
-    match goal with H : feval _ = _ |- _ => rewrite <-H end.
-    eauto.
+    repeat straightline'. subst; eauto.
   Qed.
 
   Lemma compile_inv :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
       tr retvars R Rin Rout functions T (pred: T -> list word -> Semantics.mem -> Prop)
-      (x out : felem) x_ptr x_var out_ptr out_var k k_impl,
+      (x out : felem) x_ptr x_var out_ptr out_var (X : F M_pos) k k_impl,
       spec_of_inv functions ->
       bounded_by tight_bounds x ->
+      feval x = X ->
       (FElem x_ptr x * Rin)%sep mem ->
       (Placeholder out_ptr out * Rout)%sep mem ->
       map.get locals x_var = Some x_ptr ->
       map.get locals out_var = Some out_ptr ->
-      let v := F.inv (feval x) in
+      let v := F.inv X in
       (let head := v in
        forall out m,
          feval out = head ->
          bounded_by loose_bounds out ->
          sep (FElem out_ptr out) Rout m ->
          (find k_impl
-          implementing (pred (k (feval out)))
+          implementing (pred (k head))
           and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
@@ -274,21 +273,21 @@ Section Compile.
     cbv [Placeholder] in *.
     repeat straightline'.
     handle_call; [ solve [eauto] .. | sepsimpl ].
-    repeat straightline'.
-    match goal with H : feval _ = _ |- _ => rewrite <-H end.
-    eauto.
+    repeat straightline'. subst; eauto.
   Qed.
 
   Lemma compile_felem_copy :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
       tr retvars R R' functions T (pred: T -> list word -> Semantics.mem -> Prop)
-      (x out : felem) x_ptr x_var out_ptr out_var k k_impl,
+      (x out : felem) x_ptr x_var out_ptr out_var
+      (X : F M_pos) k k_impl,
       spec_of_felem_copy functions ->
+      feval x = X ->
       (FElem x_ptr x * Placeholder out_ptr out * R')%sep mem ->
       map.get locals x_var = Some x_ptr ->
       map.get locals out_var = Some out_ptr ->
-      let v := feval x in
+      let v := X in
       (let head := v in
        forall m,
          (FElem x_ptr x * FElem out_ptr x * R')%sep m ->
@@ -311,7 +310,7 @@ Section Compile.
     cbv [Placeholder] in *.
     repeat straightline'.
     handle_call; [ solve [eauto] .. | sepsimpl ].
-    repeat straightline'.
+    repeat straightline'. subst.
     use_hyp_with_matching_cmd; eauto;
       ecancel_assumption.
   Qed.
@@ -351,7 +350,7 @@ Section Compile.
     cbv [Placeholder] in *.
     repeat straightline'. subst.
     handle_call; [ solve [eauto] .. | sepsimpl ].
-    repeat straightline'.
+    repeat straightline'. subst.
     match goal with H : _ |- _ =>
                     rewrite word.of_Z_unsigned in H end.
     use_hyp_with_matching_cmd; eauto; [ ].
@@ -433,11 +432,12 @@ Section Compile.
            (locals_ok : Semantics.locals -> Prop)
       tr retvars R Rin functions T (pred: T -> list word -> Semantics.mem -> Prop)
       (x : F M_pos) (op : F M_pos -> F M_pos -> F M_pos)
-      (y : felem) y_ptr y_var k k_impl,
+      (y : felem) y_ptr y_var (Y : F M_pos) k k_impl,
       (FElem y_ptr y * Rin)%sep mem ->
+      feval y = Y ->
       map.get locals y_var = Some y_ptr ->
-      let v := (overwrite1 op) x (feval y) in
-      let v' := op x (feval y) in
+      let v := (overwrite1 op) x Y in
+      let v' := op x Y in
       (let __ := 0 in (* placeholder *)
        forall m,
          sep (Placeholder y_ptr y) Rin m ->
@@ -465,11 +465,12 @@ Section Compile.
       tr retvars R Rin functions T (pred: T -> list word -> Semantics.mem -> Prop)
       {A} (y : A)
       (op : F M_pos -> A -> F M_pos)
-      (x : felem) x_ptr x_var k k_impl,
+      (x : felem) x_ptr x_var (X : F M_pos) k k_impl,
+      feval x = X ->
       (FElem x_ptr x * Rin)%sep mem ->
       map.get locals x_var = Some x_ptr ->
-      let v := (overwrite2 op) (feval x) y in
-      let v' := op (feval x) y in
+      let v := (overwrite2 op) X y in
+      let v' := op X y in
       (let __ := 0 in (* placeholder *)
        forall m,
          sep (Placeholder x_ptr x) Rin m ->
@@ -492,49 +493,19 @@ Section Compile.
   Qed.
 End Compile.
 
-(* TODO: unused?*)
-Module Z.
-  (* helper for Zpow_mod *)
-  Lemma pow_mod_nonneg a b m :
-    0 <= b -> (a ^ b) mod m = ((a mod m) ^ b) mod m.
-  Proof.
-    intros. revert a m.
-    apply natlike_ind with (x:=b); intros;
-      repeat first [ rewrite Z.pow_0_r
-                   | rewrite Z.pow_succ_r by auto
-                   | reflexivity
-                   | solve [auto] ]; [ ].
-    Z.push_mod.
-    match goal with
-      H : context [ (_ ^ _) mod _ = (_ ^ _) mod _ ] |- _ =>
-      rewrite H end.
-    Z.push_pull_mod. reflexivity.
-  Qed.
-
-  (* TODO: upstream to coqutil's Z.pull_mod *)
-  Lemma pow_mod a b m : (a ^ b) mod m = ((a mod m) ^ b) mod m.
-  Proof.
-    destruct (Z_le_dec 0 b); auto using pow_mod_nonneg; [ ].
-    rewrite !Z.pow_neg_r by lia. reflexivity.
-  Qed.
-End Z.
-
-(* TODO: replace with Z.pull_mod once Zpow_mod is upstreamed *)
-Ltac pull_mod :=
-  repeat first [ progress Z.pull_mod
-               | rewrite <-Z.pow_mod ].
-
 Ltac field_compile_step :=
-(*  Z.push_pull_mod; pull_mod; *)
-  first [ simple eapply compile_mul
+  first [ simple eapply compile_scmula24 (* must precede compile_mul *)
+        | simple eapply compile_mul
         | simple eapply compile_add
         | simple eapply compile_sub
         | simple eapply compile_square
-        | simple eapply compile_scmula24
-        | simple eapply compile_inv ].
+        | simple eapply compile_inv ];
+  lazymatch goal with
+  | |- feval _ = _ => try eassumption; try reflexivity
+  | |- _ => idtac
+  end.
 
 Ltac compile_compose_step :=
-  (*Z.push_mod; *)
   first [ simple eapply compile_compose_l
         | simple eapply compile_compose_r
         | simple eapply compile_overwrite1

--- a/src/Bedrock/Field/Interface/Compilation.v
+++ b/src/Bedrock/Field/Interface/Compilation.v
@@ -1,5 +1,6 @@
 Require Import Rupicola.Lib.Api.
 Require Import Crypto.Bedrock.Specs.Field.
+Require Import Crypto.Arithmetic.PrimeFieldTheorems.
 Local Open Scope Z_scope.
 
 Section Compile.
@@ -34,14 +35,14 @@ Section Compile.
       map.get locals x_var = Some x_ptr ->
       map.get locals y_var = Some y_ptr ->
       map.get locals out_var = Some out_ptr ->
-      let v := (feval x * feval y) mod M in
+      let v := (feval x * feval y)%F in
       (let head := v in
        forall out m,
-         feval out mod M = head ->
+         feval out = head ->
          bounded_by tight_bounds out ->
          sep (FElem out_ptr out) Rout m ->
          (find k_impl
-          implementing (pred (k (feval out mod M)))
+          implementing (pred (k (feval out)))
           and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
@@ -61,10 +62,7 @@ Section Compile.
     repeat straightline'.
     handle_call; [ solve [eauto] .. | sepsimpl ].
     repeat straightline'.
-    match goal with H : _ mod M = ?x mod M
-                    |- context [dlet (?x mod M)] =>
-                    rewrite <-H
-    end.
+    match goal with H : feval _ = _ |- _ => rewrite <-H end.
     eauto.
   Qed.
 
@@ -82,14 +80,14 @@ Section Compile.
       map.get locals x_var = Some x_ptr ->
       map.get locals y_var = Some y_ptr ->
       map.get locals out_var = Some out_ptr ->
-      let v := (feval x + feval y) mod M in
+      let v := (feval x + feval y)%F in
       (let head := v in
        forall out m,
-         feval out mod M = head ->
+         feval out = head ->
          bounded_by loose_bounds out ->
          sep (FElem out_ptr out) Rout m ->
          (find k_impl
-          implementing (pred (k (feval out mod M)))
+          implementing (pred (k (feval out)))
           and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
@@ -109,10 +107,7 @@ Section Compile.
     repeat straightline'.
     handle_call; [ solve [eauto] .. | sepsimpl ].
     repeat straightline'.
-    match goal with H : _ mod M = ?x mod M
-                    |- context [dlet (?x mod M)] =>
-                    rewrite <-H
-    end.
+    match goal with H : feval _ = _ |- _ => rewrite <-H end.
     eauto.
   Qed.
 
@@ -130,14 +125,14 @@ Section Compile.
       map.get locals x_var = Some x_ptr ->
       map.get locals y_var = Some y_ptr ->
       map.get locals out_var = Some out_ptr ->
-      let v := (feval x - feval y) mod M in
+      let v := (feval x - feval y)%F in
       (let head := v in
        forall out m,
-         feval out mod M = head ->
+         feval out = head ->
          bounded_by loose_bounds out ->
          sep (FElem out_ptr out) Rout m ->
          (find k_impl
-          implementing (pred (k (feval out mod M)))
+          implementing (pred (k (feval out)))
           and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
@@ -157,10 +152,7 @@ Section Compile.
     repeat straightline'.
     handle_call; [ solve [eauto] .. | sepsimpl ].
     repeat straightline'.
-    match goal with H : _ mod M = ?x mod M
-                    |- context [dlet (?x mod M)] =>
-                    rewrite <-H
-    end.
+    match goal with H : feval _ = _ |- _ => rewrite <-H end.
     eauto.
   Qed.
 
@@ -175,14 +167,14 @@ Section Compile.
       (Placeholder out_ptr out * Rout)%sep mem ->
       map.get locals x_var = Some x_ptr ->
       map.get locals out_var = Some out_ptr ->
-      let v := (feval x ^ 2) mod M in
+      let v := (feval x ^ 2)%F in
       (let head := v in
        forall out m,
-         feval out mod M = head ->
+         feval out = head ->
          bounded_by tight_bounds out ->
          sep (FElem out_ptr out) Rout m ->
          (find k_impl
-          implementing (pred (k (feval out mod M)))
+          implementing (pred (k (feval out)))
           and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
@@ -200,12 +192,8 @@ Section Compile.
     cbv [Placeholder] in *.
     repeat straightline'.
     handle_call; [ solve [eauto] .. | sepsimpl ].
-    repeat straightline'.
-    rewrite Z.pow_2_r in *.
-    match goal with H : _ mod M = ?x mod M
-                    |- context [dlet (?x mod M)] =>
-                    rewrite <-H
-    end.
+    repeat straightline'. rewrite F.pow_2_r in *.
+    match goal with H : feval _ = _ |- _ => rewrite <-H end.
     eauto.
   Qed.
 
@@ -220,14 +208,14 @@ Section Compile.
       (Placeholder out_ptr out * Rout)%sep mem ->
       map.get locals x_var = Some x_ptr ->
       map.get locals out_var = Some out_ptr ->
-      let v := (a24 * feval x) mod M in
+      let v := (a24 * feval x)%F in
       (let head := v in
        forall out m,
-         feval out mod M = head ->
+         feval out = head ->
          bounded_by tight_bounds out ->
          sep (FElem out_ptr out) Rout m ->
          (find k_impl
-          implementing (pred (k (feval out mod M)))
+          implementing (pred (k (feval out)))
           and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
@@ -246,10 +234,7 @@ Section Compile.
     repeat straightline'.
     handle_call; [ solve [eauto] .. | sepsimpl ].
     repeat straightline'.
-    match goal with H : _ mod M = ?x mod M
-                    |- context [dlet (?x mod M)] =>
-                    rewrite <-H
-    end.
+    match goal with H : feval _ = _ |- _ => rewrite <-H end.
     eauto.
   Qed.
 
@@ -264,14 +249,14 @@ Section Compile.
       (Placeholder out_ptr out * Rout)%sep mem ->
       map.get locals x_var = Some x_ptr ->
       map.get locals out_var = Some out_ptr ->
-      let v := (Finv (feval x mod M)) mod M in
+      let v := F.inv (feval x) in
       (let head := v in
        forall out m,
-         feval out mod M = head ->
+         feval out = head ->
          bounded_by loose_bounds out ->
          sep (FElem out_ptr out) Rout m ->
          (find k_impl
-          implementing (pred (k (feval out mod M)))
+          implementing (pred (k (feval out)))
           and-returning retvars
           and-locals-post locals_ok
           with-locals locals and-memory m and-trace tr and-rest R
@@ -290,10 +275,7 @@ Section Compile.
     repeat straightline'.
     handle_call; [ solve [eauto] .. | sepsimpl ].
     repeat straightline'.
-    match goal with H : _ mod M = ?x mod M
-                    |- context [dlet (?x mod M)] =>
-                    rewrite <-H
-    end.
+    match goal with H : feval _ = _ |- _ => rewrite <-H end.
     eauto.
   Qed.
 
@@ -306,7 +288,7 @@ Section Compile.
       (FElem x_ptr x * Placeholder out_ptr out * R')%sep mem ->
       map.get locals x_var = Some x_ptr ->
       map.get locals out_var = Some out_ptr ->
-      let v := (feval x mod M)%Z in
+      let v := feval x in
       (let head := v in
        forall m,
          (FElem x_ptr x * FElem out_ptr x * R')%sep m ->
@@ -343,11 +325,11 @@ Section Compile.
       (Placeholder out_ptr out * R')%sep mem ->
       map.get locals out_var = Some out_ptr ->
       word.unsigned wx = x ->
-      let v := (x mod M)%Z in
+      let v := F.of_Z M_pos x in
       (let head := v in
        forall X m,
          (FElem out_ptr X * R')%sep m ->
-         feval X mod M = head ->
+         feval X = head ->
          bounded_by tight_bounds X ->
          (find k_impl
           implementing (pred (k head))
@@ -372,7 +354,9 @@ Section Compile.
     repeat straightline'.
     match goal with H : _ |- _ =>
                     rewrite word.of_Z_unsigned in H end.
-    eauto.
+    use_hyp_with_matching_cmd; eauto; [ ].
+    match goal with H : F.to_Z _ = _ |- _ => rewrite <-H end.
+    rewrite F.of_Z_to_Z. eauto.
   Qed.
 
   (* noop indicating that the last argument should store output *)
@@ -383,16 +367,19 @@ Section Compile.
   Lemma compile_compose_l :
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
-      tr retvars R Rout functions T (pred: T -> list word -> Semantics.mem -> Prop)
-      (op1 op2 : Z -> Z -> Z)
-      x y z out out_ptr out_var k k_impl,
+           tr retvars R Rout functions T (pred: T -> list word -> Semantics.mem -> Prop)
+           {A1 A2 : Type} (* second arg is N for F.pow, so allow that *)
+           (op1 : F M_pos -> A1 -> F M_pos)
+           (op2 : F M_pos -> A2 -> F M_pos)
+           x y z out out_ptr out_var k k_impl,
       (Placeholder out_ptr out * Rout)%sep mem ->
       map.get locals out_var = Some out_ptr ->
-      let v := ((op2 (op1 x y mod M) z)) mod M in
+      let v := ((op2 (op1 x y) z)) in
       (let head := v in
        (find k_impl
-        implementing (pred (dlet (op1 x y mod M)
-        (fun xy => dlet ((overwrite2 op2) xy z mod M) k)))
+        implementing
+             (pred (dlet (op1 x y)
+                         (fun xy => dlet ((overwrite2 op2) xy z) k)))
         and-returning retvars
         and-locals-post locals_ok
         with-locals locals and-memory mem and-trace tr and-rest R
@@ -413,15 +400,18 @@ Section Compile.
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
       tr retvars R Rout functions T (pred: T -> list word -> Semantics.mem -> Prop)
-      (op1 op2 : Z -> Z -> Z)
-      x y z out out_ptr out_var k k_impl,
+           {A1 : Type} (* second arg is N for F.pow, so allow that *)
+           (op1 : F M_pos -> A1 -> F M_pos)
+           (op2 : F M_pos -> F M_pos -> F M_pos)
+           x y z out out_ptr out_var k k_impl,
       (Placeholder out_ptr out * Rout)%sep mem ->
       map.get locals out_var = Some out_ptr ->
-      let v := ((op2 z (op1 x y mod M))) mod M in
+      let v := (op2 z (op1 x y)) in
       (let head := v in
        (find k_impl
-        implementing (pred (dlet (op1 x y mod M)
-        (fun xy => dlet ((overwrite1 op2) z xy mod M) k)))
+        implementing
+             (pred (dlet (op1 x y)
+                         (fun xy => dlet ((overwrite1 op2) z xy) k)))
         and-returning retvars
         and-locals-post locals_ok
         with-locals locals and-memory mem and-trace tr and-rest R
@@ -442,11 +432,12 @@ Section Compile.
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
       tr retvars R Rin functions T (pred: T -> list word -> Semantics.mem -> Prop)
-      (x : Z) (op : Z -> Z -> Z) (y : felem) y_ptr y_var k k_impl,
+      (x : F M_pos) (op : F M_pos -> F M_pos -> F M_pos)
+      (y : felem) y_ptr y_var k k_impl,
       (FElem y_ptr y * Rin)%sep mem ->
       map.get locals y_var = Some y_ptr ->
-      let v := ((overwrite1 op) x (feval y mod M)) mod M in
-      let v' := (op x (feval y mod M)) mod M in
+      let v := (overwrite1 op) x (feval y) in
+      let v' := op x (feval y) in
       (let __ := 0 in (* placeholder *)
        forall m,
          sep (Placeholder y_ptr y) Rin m ->
@@ -472,11 +463,13 @@ Section Compile.
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
       tr retvars R Rin functions T (pred: T -> list word -> Semantics.mem -> Prop)
-      (y : Z) (op : Z -> Z -> Z) (x : felem) x_ptr x_var k k_impl,
+      {A} (y : A)
+      (op : F M_pos -> A -> F M_pos)
+      (x : felem) x_ptr x_var k k_impl,
       (FElem x_ptr x * Rin)%sep mem ->
       map.get locals x_var = Some x_ptr ->
-      let v := ((overwrite2 op) (feval x mod M) y) mod M in
-      let v' := (op (feval x mod M) y) mod M in
+      let v := (overwrite2 op) (feval x) y in
+      let v' := op (feval x) y in
       (let __ := 0 in (* placeholder *)
        forall m,
          sep (Placeholder x_ptr x) Rin m ->
@@ -499,6 +492,7 @@ Section Compile.
   Qed.
 End Compile.
 
+(* TODO: unused?*)
 Module Z.
   (* helper for Zpow_mod *)
   Lemma pow_mod_nonneg a b m :
@@ -531,7 +525,7 @@ Ltac pull_mod :=
                | rewrite <-Z.pow_mod ].
 
 Ltac field_compile_step :=
-  Z.push_pull_mod; pull_mod;
+(*  Z.push_pull_mod; pull_mod; *)
   first [ simple eapply compile_mul
         | simple eapply compile_add
         | simple eapply compile_sub
@@ -540,7 +534,7 @@ Ltac field_compile_step :=
         | simple eapply compile_inv ].
 
 Ltac compile_compose_step :=
-  Z.push_mod;
+  (*Z.push_mod; *)
   first [ simple eapply compile_compose_l
         | simple eapply compile_compose_r
         | simple eapply compile_overwrite1

--- a/src/Bedrock/Field/Interface/Representation.v
+++ b/src/Bedrock/Field/Interface/Representation.v
@@ -3,6 +3,7 @@ Require Import Coq.Lists.List.
 Require Import coqutil.Word.Interface.
 Require Import bedrock2.Semantics.
 Require Import Crypto.Arithmetic.Core.
+Require Import Crypto.Arithmetic.PrimeFieldTheorems.
 Require Import Crypto.Bedrock.Field.Common.Types.
 Require Import Crypto.Bedrock.Field.Synthesis.Generic.Bignum.
 Require Import Crypto.Bedrock.Specs.Field.
@@ -10,13 +11,13 @@ Require Import Crypto.COperationSpecifications.
 Require Import Crypto.Util.ZRange.
 
 Section Representation.
-  Context {p : Types.parameters}.
+  Context {p : Types.parameters} {field_parameters : FieldParameters}.
   Context (n : nat) (weight : nat -> Z)
           (loose_bounds tight_bounds : list (option zrange)).
 
-  Definition eval_words : list word -> Z :=
+  Definition eval_words : list word -> F M_pos :=
     fun ws =>
-      Positional.eval weight n (map word.unsigned ws).
+      F.of_Z _ (Positional.eval weight n (map word.unsigned ws)).
 
   Instance frep : FieldRepresentation :=
     { felem := list word;

--- a/src/Bedrock/Group/Point.v
+++ b/src/Bedrock/Group/Point.v
@@ -1,8 +1,10 @@
 Require Import Rupicola.Lib.Api.
+Require Import Crypto.Arithmetic.PrimeFieldTheorems.
 Require Import Crypto.Bedrock.Specs.Field.
 
 Section Gallina.
-  Definition point : Type := (Z * Z).
+  Definition point {field_parameters : FieldParameters} : Type
+    := (F M_pos * F M_pos).
 End Gallina.
 
 Section Compile.
@@ -15,12 +17,12 @@ Section Compile.
     forall (locals: Semantics.locals) (mem: Semantics.mem)
            (locals_ok : Semantics.locals -> Prop)
       tr retvars R functions T (pred: T -> _ -> _ -> Prop)
-      (x y : Z) k k_impl,
-      let v := (x mod M, y mod M)%Z in
+      (x y : F M_pos) k k_impl,
+      let v := (x, y) in
       (let __ := 0 in (* placeholder *)
        find k_impl
-       implementing (pred (dlet (x mod M)%Z
-                                (fun x => dlet (y mod M)%Z
+       implementing (pred (dlet x
+                                (fun x => dlet y
                                                (fun y => k (x, y)))))
        and-returning retvars
        and-locals-post locals_ok

--- a/src/Bedrock/Group/ScalarMult/LadderStep.v
+++ b/src/Bedrock/Group/ScalarMult/LadderStep.v
@@ -236,7 +236,7 @@ Section __.
         | |- bounded_by _ _ => solve [auto with compiler]
         | _ => idtac
         end.
-    reflexivity.
+    congruence.
   Qed.
 End __.
 

--- a/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
+++ b/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
@@ -466,8 +466,7 @@ Section __.
 
         repeat safe_compile_step. (cbv match zeta beta).
 
-        subst_lets_in_goal.
-        erewrite <-!feval_fst_cswap by eauto.
+        subst_lets_in_goal. erewrite <-!feval_fst_cswap by eauto.
         safe_field_compile_step.
         repeat safe_compile_step.
 
@@ -487,7 +486,7 @@ Section __.
         destruct_one_match_hyp_of_type bool.
         all:cleanup; subst.
         all:lift_eexists.
-        all:sepsimpl; [ reflexivity | ].
+        all:sepsimpl; [ solve [eauto] | ].
         all:ecancel_assumption. }
     Qed.
   End MontLadder.

--- a/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
+++ b/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
@@ -111,7 +111,7 @@ Section __.
           (MontLadderResult
              K pK pU pX1 pZ1 pX2 pZ2 pA pAA pB pBB pE pC pD pDA pCB
              (montladder_gallina
-                (fun i => Z.testbit (sceval K) (Z.of_nat i))
+                (fun i => Z.testbit (F.to_Z (sceval K)) (Z.of_nat i))
                 (feval U))).
 
     Ltac apply_compile_cswap_nocopy :=
@@ -199,7 +199,7 @@ Section __.
                (K : scalar) (st : point * point * bool)
                (gst : bool) (i : nat) :=
       let swap := snd st in
-      let swap := xorb swap (Z.testbit (sceval K) (Z.of_nat i)) in
+      let swap := xorb swap (Z.testbit (F.to_Z (sceval K)) (Z.of_nat i)) in
       xorb gst swap.
 
     Ltac setup_downto_inv_init :=

--- a/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
+++ b/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
@@ -264,9 +264,8 @@ Section __.
         apply cswap_cases_fst; solve [auto]
       | |- bounded_by _ (snd (cswap _ _ _)) =>
         apply cswap_cases_snd; solve [auto]
-      | |- context [WeakestPrecondition.cmd] => idtac
-      | _ => solve [eauto]
-      end.
+      | _ => idtac
+      end; solve [eauto].
 
     (* create a new evar to take on the second swap clause *)
     Ltac rewrite_cswap_iff1_with_evar_frame :=

--- a/src/Bedrock/Specs/Group.v
+++ b/src/Bedrock/Specs/Group.v
@@ -1,9 +1,10 @@
 Require Import bedrock2.Semantics.
 Require Import Rupicola.Lib.Api.
-Require Import Crypto.Bedrock.Specs.ScalarField.
-Require Import Crypto.Algebra.Hierarchy.
 Require Import Crypto.Algebra.Group.
+Require Import Crypto.Algebra.Hierarchy.
 Require Import Crypto.Algebra.ScalarMult.
+Require Import Crypto.Arithmetic.PrimeFieldTheorems.
+Require Import Crypto.Bedrock.Specs.ScalarField.
 
 Class GroupParameters :=
   { (** mathematical parameters **)
@@ -31,6 +32,7 @@ Class GroupRepresentation {G : Type} {semantics : Semantics.parameters} :=
 
 Section Specs.
   Context {semantics : Semantics.parameters}
+          {scalar_field_parameters : ScalarFieldParameters}
           {scalar_representaton : ScalarRepresentation}.
   Context {group_parameters : GroupParameters}
           {group_representaton : GroupRepresentation (G:=G)}.
@@ -45,7 +47,7 @@ Section Specs.
           ===>
           (fun _ =>
              liftexists (xk : gelem),
-             (emp (geval xk = scalarmult (sceval k) (geval x))
+             (emp (geval xk = scalarmult (F.to_Z (sceval k)) (geval x))
               * GElem pout xk)%sep)).
 End Specs.
 


### PR DESCRIPTION
On top of #869 

Uses fiat-crypto's F datatype from `PrimeFieldTheorems` to represent field elements. This removes all the messing around with `Z.modulo` and makes the definition of Montgomery ladder functions easier and closer to the original ones from `Curves/Montgomery/XZ.v`.

@andres-erbsen Do you think this is a good idea, or should I stick with the version from #869?