### PR TITLE
Play some tricks to remove axioms from coqchk

### DIFF
--- a/src/Rewriter/PerfTesting/StandaloneOCamlMain.v
+++ b/src/Rewriter/PerfTesting/StandaloneOCamlMain.v
@@ -4,11 +4,23 @@ Require Import Crypto.Rewriter.PerfTesting.Core.
 Require Import Crypto.Util.Notations.
 Import ListNotations. Local Open Scope list_scope.
 
-Axiom float : Set.
-Axiom Unix_gettimeofday : unit -> float.
-Axiom Sys_time : unit -> float.
-Axiom fsub : float -> float -> float.
-Axiom printf_float : float -> unit.
+(** We pull a hack to get coqchk to not report these as axioms; for
+    this, all we care about is that there exists a model. *)
+Module Type OCamlPrimitivesT.
+  Axiom float : Set.
+  Axiom Unix_gettimeofday : unit -> float.
+  Axiom Sys_time : unit -> float.
+  Axiom fsub : float -> float -> float.
+  Axiom printf_float : float -> unit.
+End OCamlPrimitivesT.
+
+Module Export OCamlPrimitives : OCamlPrimitivesT.
+  Definition float : Set := unit.
+  Definition Unix_gettimeofday : unit -> float := fun 'tt => tt.
+  Definition Sys_time : unit -> float := fun 'tt => tt.
+  Definition fsub : float -> float -> float := fun _ _ => tt.
+  Definition printf_float : float -> unit := fun _ => tt.
+End OCamlPrimitives.
 
 Extract Inlined Constant float => "float".
 Extract Inlined Constant Unix_gettimeofday => "Unix.gettimeofday".

--- a/src/StandaloneHaskellMain.v
+++ b/src/StandaloneHaskellMain.v
@@ -12,15 +12,32 @@ Global Set Warnings Append "-extraction-opaque-accessed".
 Extraction Language Haskell.
 Global Unset Extraction Optimize.
 
-Axiom IO_unit : Set.
-Axiom _IO : Set -> Set.
-Axiom printf_string : string -> _IO unit.
-Axiom getArgs : _IO (list string).
-Axiom getProgName : _IO string.
-Axiom raise_failure : string -> _IO unit.
-Axiom _IO_bind : forall A B, _IO A -> (A -> _IO B) -> _IO B.
-Axiom _IO_return : forall A : Set, A -> _IO A.
-Axiom cast_io : _IO unit -> IO_unit.
+(** We pull a hack to get coqchk to not report these as axioms; for
+    this, all we care about is that there exists a model. *)
+Module Type HaskellPrimitivesT.
+  Axiom IO_unit : Set.
+  Axiom _IO : Set -> Set.
+  Axiom printf_string : string -> _IO unit.
+  Axiom getArgs : _IO (list string).
+  Axiom getProgName : _IO string.
+  Axiom raise_failure : string -> _IO unit.
+  Axiom _IO_bind : forall A B, _IO A -> (A -> _IO B) -> _IO B.
+  Axiom _IO_return : forall A : Set, A -> _IO A.
+  Axiom cast_io : _IO unit -> IO_unit.
+End HaskellPrimitivesT.
+
+Module Export HaskellPrimitives : HaskellPrimitivesT.
+  Definition IO_unit : Set := unit.
+  Definition _IO : Set -> Set := fun T => T.
+  Definition printf_string : string -> _IO unit := fun _ => tt.
+  Definition getArgs : _IO (list string) := nil.
+  Definition getProgName : _IO string := "".
+  Definition raise_failure : string -> _IO unit := fun _ => tt.
+  Definition _IO_bind : forall A B, _IO A -> (A -> _IO B) -> _IO B := fun A B x f => f x.
+  Definition _IO_return : forall A : Set, A -> _IO A := fun A x => x.
+  Definition cast_io : _IO unit -> IO_unit := fun x => x.
+End HaskellPrimitives.
+
 Extract Constant printf_string =>
 "\s -> Text.Printf.printf ""%s"" s".
 Extract Constant _IO "a" => "GHC.Base.IO a".

--- a/src/StandaloneOCamlMain.v
+++ b/src/StandaloneOCamlMain.v
@@ -15,14 +15,30 @@ Global Unset Extraction Optimize.
 
 Inductive int : Set := int_O | int_S (x : int).
 
-Axiom printf_char : Ascii.ascii -> unit.
-Axiom flush : unit -> unit.
-Axiom string : Set.
-Axiom string_length : string -> int.
-Axiom string_get : string -> int -> Ascii.ascii.
-Axiom sys_argv : list string.
-Axiom string_init : int -> (int -> Ascii.ascii) -> string.
-Axiom raise_Failure : string -> unit.
+(** We pull a hack to get coqchk to not report these as axioms; for
+    this, all we care about is that there exists a model. *)
+
+Module Type OCamlPrimitivesT.
+  Axiom printf_char : Ascii.ascii -> unit.
+  Axiom flush : unit -> unit.
+  Axiom string : Set.
+  Axiom string_length : string -> int.
+  Axiom string_get : string -> int -> Ascii.ascii.
+  Axiom sys_argv : list string.
+  Axiom string_init : int -> (int -> Ascii.ascii) -> string.
+  Axiom raise_Failure : string -> unit.
+End OCamlPrimitivesT.
+
+Module Export OCamlPrimitives : OCamlPrimitivesT.
+  Definition printf_char : Ascii.ascii -> unit := fun _ => tt.
+  Definition flush : unit -> unit := fun 'tt => tt.
+  Definition string : Set := unit.
+  Definition string_length : string -> int := fun _ => int_O.
+  Definition string_get : string -> int -> Ascii.ascii := fun _ _ => "000"%char.
+  Definition sys_argv : list string := nil.
+  Definition string_init : int -> (int -> Ascii.ascii) -> string := fun _ _ => tt.
+  Definition raise_Failure : string -> unit := fun _ => tt.
+End OCamlPrimitives.
 
 Extract Inductive int
 => int [ "0" "Pervasives.succ" ]


### PR DESCRIPTION
We provide dummy definitions locked inside opaque modules rather than
using axioms for constants to be extracted as stateful primitives.

Since all we care about with coqchk is that we cannot prove False, it
does not really matter if the model we provide for these constants does
not match their semantics. We only use them for interaction with the
system in any case.

This will make progress towards #736

@andres-erbsen , does this seem okay to you?