### PR TITLE
Added info on dependencies package

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,21 @@ Building
 
 This repository requires [Coq](https://coq.inria.fr/) [8.9](https://github.com/coq/coq/releases/tag/V8.9.0) or later.
 Note that if you install Coq from Ubuntu aptitude packages, you need `libcoq-ocaml-dev` in addition to `coq`.
-Note that in some cases (such as installing Coq via homebrew on Mac), you may also need to install `ocamlfind`.
+Note that in some cases (such as installing Coq via homebrew on Mac), you may also need to install `ocaml-findlib` and `ocaml-num`.
 If you want to build the bedrock2 code, you need [Coq 8.10](https://github.com/coq/coq/releases/tag/V8.10.0) or later (otherwise you can pass `SKIP_BEDROCK2=1` to `make`).
 We suggest downloading [the latest version of Coq](https://github.com/coq/coq/wiki#coq-installation).
 
+Choose your packagemanager to install dependencies
+
+    #Aptitude (Ubuntu / Debian)
+    apt install coq ocaml-findlib libcoq-ocaml-dev
+    
+    #Homebrew (OS X)
+    brew install coq ocaml-findlib ocaml-num
+    
+    #Pacman (Archlinux)
+    pacman -S coq ocaml-findlib ocaml-num
+    
 You can clone this repository with
 
     git clone --recursive https://github.com/mit-plv/fiat-crypto.git


### PR DESCRIPTION
Apparently, the package `ocamlfind` has been renamed to `ocaml-findlib`
Added convenience cmd lines to install the required dependencies.

 (Checked package names in brew / pacman and apt package-lists)