### PR TITLE
Rupicola libonly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -408,7 +408,7 @@ install-bedrock2:
 	$(MAKE) --no-print-directory -C $(BEDROCK2_FOLDER) install
 
 rupicola: bedrock2
-	$(MAKE) --no-print-directory -C $(RUPICOLA_FOLDER)
+	$(MAKE) --no-print-directory -C $(RUPICOLA_FOLDER) lib
 
 clean-rupicola:
 	$(MAKE) --no-print-directory -C $(RUPICOLA_FOLDER) clean


### PR DESCRIPTION
See mit-plv/rupicola#7

The rupicola submodule build was slow because of some large examples, so I've added a `lib` target that builds the core library only (similar to bedrock2 `noex`). It's much faster now!

This is a pretty local change to the bedrock2 stuff, so I'll assume I'm free to merge once CI passes.