### PR TITLE
Connect bedrock2 montladder with algebraic scalarmult

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -108,6 +108,7 @@ src/Bedrock/Field/Translation/Proofs/ValidComputable/Func.v
 src/Bedrock/Group/Loops.v
 src/Bedrock/Group/Point.v
 src/Bedrock/Group/ScalarMult/LadderStep.v
+src/Bedrock/Group/ScalarMult/MontgomeryEquivalence.v
 src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
 src/Bedrock/Group/ScalarMult/ScalarMult.v
 src/Bedrock/Specs/Field.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -105,9 +105,11 @@ src/Bedrock/Field/Translation/Proofs/VarnameSet.v
 src/Bedrock/Field/Translation/Proofs/ValidComputable/Cmd.v
 src/Bedrock/Field/Translation/Proofs/ValidComputable/Expr.v
 src/Bedrock/Field/Translation/Proofs/ValidComputable/Func.v
+src/Bedrock/Group/Loops.v
 src/Bedrock/Group/Point.v
 src/Bedrock/Group/ScalarMult/LadderStep.v
 src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
+src/Bedrock/Group/ScalarMult/ScalarMult.v
 src/Bedrock/Specs/Field.v
 src/Bedrock/Specs/Group.v
 src/Bedrock/Specs/ScalarField.v

--- a/src/Bedrock/Field/Common/Util.v
+++ b/src/Bedrock/Field/Common/Util.v
@@ -667,11 +667,11 @@ Section Scalars.
 
   Lemma scalar_to_bytes a x :
     Lift1Prop.iff1
+      (scalar a x)
       (array ptsto (word.of_Z 1) a
              (HList.tuple.to_list
                 (LittleEndian.split bytes_per_word
-                                    (word.unsigned x))))
-      (scalar a x).
+                                    (word.unsigned x)))).
   Proof. reflexivity. Qed.
 
   Lemma scalar_of_bytes

--- a/src/Bedrock/Field/Interface/Compilation.v
+++ b/src/Bedrock/Field/Interface/Compilation.v
@@ -13,6 +13,10 @@ Section Compile.
            spec_of_scmula24 spec_of_inv spec_of_felem_copy
            spec_of_felem_small_literal.
 
+  (* "Hidden" alias protects a Placeholder (e.g. the pointer reserved for the
+     final output value) from having intermediate values stored in it *)
+  Definition Hidden := Placeholder.
+
   Local Ltac prove_field_compilation :=
     repeat straightline';
     handle_call;
@@ -486,6 +490,7 @@ Ltac compile_compose_step :=
         | simple eapply compile_overwrite2 ];
   [ solve [repeat compile_step] .. | intros ].
 
+(* Change an FElem into a Placeholder to indicate that it is overwritable *)
 Ltac free p :=
   match goal with
   | H : sep ?P ?Q ?m |- context [?m] =>
@@ -502,3 +507,10 @@ Ltac free p :=
             ecancel_assumption);
     cbv beta in H'; clear H
   end.
+
+(* Protect a pointer (e.g. the pointer reserved for final output) by "hiding"
+   the fact that it is available under the "Hidden" alias *)
+Ltac hide p :=
+  change (Placeholder p) with (Hidden p) in *.
+Ltac unhide p :=
+  change (Hidden p) with (Placeholder p) in *.

--- a/src/Bedrock/Field/Interface/Representation.v
+++ b/src/Bedrock/Field/Interface/Representation.v
@@ -11,6 +11,7 @@ Require Import Crypto.Bedrock.Field.Synthesis.Generic.Bignum.
 Require Import Crypto.Bedrock.Specs.Field.
 Require Import Crypto.COperationSpecifications.
 Require Import Crypto.Util.ZRange.
+Require Import Crypto.Util.ZUtil.Tactics.PullPush.Modulo.
 
 Section Representation.
   Context {p : Types.parameters} {field_parameters : FieldParameters}
@@ -38,7 +39,7 @@ Section Representation.
     { felem := list word;
       feval := eval_words;
       feval_bytes := eval_bytes;
-      felem_size_in_bytes := word_size_in_bytes;
+      felem_size_in_bytes := (Z.of_nat n * word_size_in_bytes)%Z;
       FElem := Bignum n;
       FElemBytes := EncodedBignum n;
       bounds := list (option zrange);
@@ -62,7 +63,7 @@ Section Representation.
         apply Z.div_str_pos; auto with zarith. }
 
       cbn [bytes_per]. rewrite Z2Nat.id by auto with zarith.
-      apply Z.mod_same; auto with zarith. }
+      push_Zmod. autorewrite with zsimplify_fast. reflexivity. }
     { cbn [bounded_by frep]; intros.
       apply relax_bounds; auto. }
   Qed.

--- a/src/Bedrock/Field/Interface/Representation.v
+++ b/src/Bedrock/Field/Interface/Representation.v
@@ -1,8 +1,10 @@
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.Lists.List.
+Require Import coqutil.Byte.
 Require Import coqutil.Word.Interface.
 Require Import bedrock2.Semantics.
 Require Import Crypto.Arithmetic.Core.
+Require Import Crypto.Arithmetic.ModOps.
 Require Import Crypto.Arithmetic.PrimeFieldTheorems.
 Require Import Crypto.Bedrock.Field.Common.Types.
 Require Import Crypto.Bedrock.Field.Synthesis.Generic.Bignum.
@@ -11,19 +13,34 @@ Require Import Crypto.COperationSpecifications.
 Require Import Crypto.Util.ZRange.
 
 Section Representation.
-  Context {p : Types.parameters} {field_parameters : FieldParameters}.
+  Context {p : Types.parameters} {field_parameters : FieldParameters}
+          {p_ok : Types.ok}.
   Context (n : nat) (weight : nat -> Z)
-          (loose_bounds tight_bounds : list (option zrange)).
+          (loose_bounds tight_bounds : list (option zrange))
+          (relax_bounds :
+             forall X : list Z,
+               list_Z_bounded_by tight_bounds X ->
+               list_Z_bounded_by loose_bounds X).
+  Existing Instance semantics_ok.
 
   Definition eval_words : list word -> F M_pos :=
     fun ws =>
       F.of_Z _ (Positional.eval weight n (map word.unsigned ws)).
 
-  Instance frep : FieldRepresentation :=
+  Definition eval_bytes : list byte -> F M_pos :=
+    fun bs =>
+      F.of_Z _ (Positional.eval
+                           (ModOps.weight 8 1)
+                           (Z.to_nat word_size_in_bytes)
+                           (map byte.unsigned bs)).
+
+  Local Instance frep : FieldRepresentation :=
     { felem := list word;
       feval := eval_words;
+      feval_bytes := eval_bytes;
       felem_size_in_bytes := word_size_in_bytes;
       FElem := Bignum n;
+      FElemBytes := EncodedBignum n;
       bounds := list (option zrange);
       bounded_by :=
         fun bs ws =>
@@ -31,4 +48,22 @@ Section Representation.
       loose_bounds := loose_bounds;
       tight_bounds := tight_bounds;
     }.
+
+  Local Instance frep_ok : FieldRepresentation_ok.
+  Proof.
+    constructor.
+    { cbn [felem_size_in_bytes frep].
+      rewrite word_size_in_bytes_eq.
+
+      (* TODO: should this be upstreamed to bedrock2? *)
+      assert (0 < bytes_per_word width).
+      { cbv [bytes_per_word].
+        pose proof word.width_pos.
+        apply Z.div_str_pos; auto with zarith. }
+
+      cbn [bytes_per]. rewrite Z2Nat.id by auto with zarith.
+      apply Z.mod_same; auto with zarith. }
+    { cbn [bounded_by frep]; intros.
+      apply relax_bounds; auto. }
+  Qed.
 End Representation.

--- a/src/Bedrock/Field/Interface/Representation.v
+++ b/src/Bedrock/Field/Interface/Representation.v
@@ -7,6 +7,7 @@ Require Import bedrock2.Semantics.
 Require Import Crypto.Arithmetic.Core.
 Require Import Crypto.Arithmetic.ModOps.
 Require Import Crypto.Arithmetic.PrimeFieldTheorems.
+Require Import Crypto.Bedrock.Field.Common.Tactics.
 Require Import Crypto.Bedrock.Field.Common.Types.
 Require Import Crypto.Bedrock.Field.Synthesis.Generic.Bignum.
 Require Import Crypto.Bedrock.Specs.Field.
@@ -69,8 +70,7 @@ Section Representation.
                | H : exists _, _ |- _ => destruct H
                | H : _ /\ _ |- _ => destruct H
                end.
-      { Check Bignum_of_bytes.
-        match goal with
+      { match goal with
           | H : Array.array _ _ _ _ _ |- _ =>
             eapply Bignum_of_bytes with (n0:=n) in H;
               [ destruct H | nia ]
@@ -80,11 +80,15 @@ Section Representation.
         pose proof word_size_in_bytes_pos.
         let H := match goal with
                  | H : Bignum _ _ _ _ |- _ => H end in
-        eapply Bignum_to_bytes in H;
+        eapply Bignum_to_bytes in H.
+        sepsimpl.
+        let H := match goal with
+                 | H : Array.array _ _ _ _ _ |- _ => H end in
         eapply Array.array_1_to_anybytes in H.
-        replace (Z.of_nat (length (Util.encode_bytes x0)))
-          with (bytes_per_word width * Z.of_nat n)%Z in * by admit.
-        eauto. } }
+        match goal with
+        | H : anybytes ?p ?n1 ?m |- anybytes ?p ?n2 ?m =>
+          replace n2 with n1 by nia; assumption
+        end. } }
     { cbn [bounded_by frep]; intros.
       apply relax_bounds; auto. }
   Qed.

--- a/src/Bedrock/Field/Interface/Representation.v
+++ b/src/Bedrock/Field/Interface/Representation.v
@@ -39,9 +39,8 @@ Section Representation.
     { felem := list word;
       feval := eval_words;
       feval_bytes := eval_bytes;
-      felem_size_in_bytes := (Z.of_nat n * word_size_in_bytes)%Z;
+      felem_size_in_bytes := bytes_per_word Semantics.width * Z.of_nat n;
       FElem := Bignum n;
-      FElemBytes := EncodedBignum n;
       bounds := list (option zrange);
       bounded_by :=
         fun bs ws =>
@@ -54,15 +53,6 @@ Section Representation.
   Proof.
     constructor.
     { cbn [felem_size_in_bytes frep].
-      rewrite word_size_in_bytes_eq.
-
-      (* TODO: should this be upstreamed to bedrock2? *)
-      assert (0 < bytes_per_word width).
-      { cbv [bytes_per_word].
-        pose proof word.width_pos.
-        apply Z.div_str_pos; auto with zarith. }
-
-      cbn [bytes_per]. rewrite Z2Nat.id by auto with zarith.
       push_Zmod. autorewrite with zsimplify_fast. reflexivity. }
     { cbn [bounded_by frep]; intros.
       apply relax_bounds; auto. }

--- a/src/Bedrock/Field/Interface/Representation.v
+++ b/src/Bedrock/Field/Interface/Representation.v
@@ -22,6 +22,7 @@ Section Representation.
   Instance frep : FieldRepresentation :=
     { felem := list word;
       feval := eval_words;
+      felem_size_in_bytes := word_size_in_bytes;
       FElem := Bignum n;
       bounds := list (option zrange);
       bounded_by :=

--- a/src/Bedrock/Field/Synthesis/Generic/Bignum.v
+++ b/src/Bedrock/Field/Synthesis/Generic/Bignum.v
@@ -4,6 +4,7 @@ Require Import Coq.micromega.Lia.
 Require Import bedrock2.Array.
 Require Import bedrock2.Scalars.
 Require Import bedrock2.Map.Separation.
+Require Import bedrock2.Map.SeparationLogic.
 Require Import coqutil.Word.Interface.
 Require Import coqutil.Word.Properties.
 Require Import coqutil.Map.Interface.
@@ -32,6 +33,9 @@ Section Bignum.
     Context {ok : Types.ok}.
     Existing Instance semantics_ok.
 
+    (* TODO: factor this proof into a more general form that says if subarrays
+    of your arrays form a different kind of element, then you have an array of
+    the other type *)
     Lemma Bignum_of_bytes n :
       forall addr bs,
         length bs = (n * Z.to_nat word_size_in_bytes)%nat ->
@@ -46,7 +50,7 @@ Section Bignum.
         cbn [array length] in *. sepsimpl; eauto. }
       { rewrite <-(firstn_skipn (Z.to_nat word_size_in_bytes) bs).
         rewrite array_append.
-        rewrite Scalars.scalar_of_bytes with (l:=firstn _ _).
+        rewrite Scalars.scalar_of_bytes with (l:=List.firstn _ _).
         2:{
           rewrite word_size_in_bytes_eq in *.
           etransitivity;
@@ -61,10 +65,10 @@ Section Bignum.
         rewrite firstn_length, Min.min_l in Harr by nia.
         rewrite Z2Nat.id in Harr by lia.
         match type of Harr with
-        | array _ _ _ (skipn ?sz ?xs) _ =>
+        | array _ _ _ (List.skipn ?sz ?xs) _ =>
           match goal with
           | H : length xs = (S ?n * sz)%nat |- _ =>
-            assert (length (skipn sz xs) = (n * sz)%nat);
+            assert (length (List.skipn sz xs) = (n * sz)%nat);
               [ rewrite skipn_length, H; nia | ]
           end
         end.
@@ -81,11 +85,53 @@ Section Bignum.
         eauto. }
     Qed.
 
-    Lemma Bignum_to_bytes n addr x :
-      Lift1Prop.iff1
-        (Bignum n addr x)
-        (array ptsto (word.of_Z 1) addr (encode_bytes x)).
-    Admitted.
+    Lemma Bignum_to_bytes n :
+      forall addr x,
+        Lift1Prop.impl1
+          (Bignum n addr x)
+          (Lift1Prop.ex1
+             (fun bs =>
+                sep (emp (length bs = (n * Z.to_nat word_size_in_bytes)%nat))
+                    (array ptsto (word.of_Z 1) addr bs))).
+    Proof.
+      cbv [Bignum].
+      induction n; repeat intro; sepsimpl; destruct x;
+        cbn [length array] in *; try lia;
+        [ exists nil; cbn in *; sepsimpl; solve [eauto] | ].
+      match goal with
+      | H : sep _ _ _ |- _ =>
+        seprewrite_in scalar_to_bytes H
+      end.
+      match goal with
+      | H : sep _ _ _ |- _ =>
+        cbv [sep] in H; cleanup
+      end.
+      match goal with
+      | H : array scalar _ ?addr ?xs ?m |- _ =>
+        specialize (IHn addr xs m);
+          match type of IHn with ?P -> _ =>
+                                 assert P by (sepsimpl; auto; lia) end;
+          specialize (IHn ltac:(assumption))
+      end.
+      destruct IHn as [bs ?].
+      sepsimpl.
+      match goal with
+      | Htl : array ptsto _ _ bs _,
+              Hhd : array ptsto _ _ ?h _ |- _ =>
+        exists (h ++ bs)
+      end.
+      sepsimpl; [ | ].
+      { rewrite app_length.
+        rewrite HList.tuple.length_to_list.
+        rewrite word_size_in_bytes_eq in *.
+        rewrite !Nat2Z.id in *. lia. }
+      { apply array_append.
+        pose proof word_size_in_bytes_pos.
+        rewrite word.unsigned_of_Z_1, Z.mul_1_l.
+        rewrite HList.tuple.length_to_list.
+        rewrite <-word_size_in_bytes_eq.
+        do 2 eexists. eauto. }
+    Qed.
   End Proofs.
 End Bignum.
 Notation BignumSuchThat :=

--- a/src/Bedrock/Field/Synthesis/Generic/Bignum.v
+++ b/src/Bedrock/Field/Synthesis/Generic/Bignum.v
@@ -1,11 +1,14 @@
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.Lists.List.
+Require Import Coq.micromega.Lia.
 Require Import bedrock2.Array.
 Require Import bedrock2.Scalars.
 Require Import bedrock2.Map.Separation.
 Require Import coqutil.Word.Interface.
+Require Import coqutil.Word.Properties.
 Require Import coqutil.Map.Interface.
 Require Import Crypto.COperationSpecifications.
+Require Import Crypto.Bedrock.Field.Common.Tactics.
 Require Import Crypto.Bedrock.Field.Common.Types.
 Require Import Crypto.Bedrock.Field.Common.Util.
 Require Import Crypto.Bedrock.Field.Common.Arrays.MaxBounds.
@@ -29,22 +32,60 @@ Section Bignum.
     Context {ok : Types.ok}.
     Existing Instance semantics_ok.
 
-    (* TODO: lemmas along these lines might be convenient for stack allocation
-    Lemma Bignum_of_bytes n addr bs :
-      length bs = (n * Z.to_nat word_size_in_bytes)%nat ->
-      Lift1Prop.iff1
-        (array ptsto (word.of_Z 1) addr bs)
-        (Bignum n addr (map word.of_Z
-                            (eval_bytes (width:=Semantics.width) bs))).
-    Admitted.
+    Lemma Bignum_of_bytes n :
+      forall addr bs,
+        length bs = (n * Z.to_nat word_size_in_bytes)%nat ->
+        Lift1Prop.impl1
+          (array ptsto (word.of_Z 1) addr bs)
+          (Lift1Prop.ex1 (Bignum n addr)).
+    Proof.
+      cbv [Bignum].
+      induction n; intros.
+      { destruct bs; cbn [length] in *; try lia; [ ].
+        repeat intro. exists nil.
+        cbn [array length] in *. sepsimpl; eauto. }
+      { rewrite <-(firstn_skipn (Z.to_nat word_size_in_bytes) bs).
+        rewrite array_append.
+        rewrite Scalars.scalar_of_bytes with (l:=firstn _ _).
+        2:{
+          rewrite word_size_in_bytes_eq in *.
+          etransitivity;
+            [ symmetry; apply bits_per_word_eq_width;
+              solve [eauto using width_0mod_8] | ].
+          rewrite firstn_length, Min.min_l by lia.
+          lia. }
+        intros ? Hsep. destruct Hsep as [? [? [? [Hsca Harr]]]].
+        cbv [Lift1Prop.impl1] in *.
+        pose proof word_size_in_bytes_pos.
+        rewrite word.unsigned_of_Z_1, Z.mul_1_l in Harr.
+        rewrite firstn_length, Min.min_l in Harr by nia.
+        rewrite Z2Nat.id in Harr by lia.
+        match type of Harr with
+        | array _ _ _ (skipn ?sz ?xs) _ =>
+          match goal with
+          | H : length xs = (S ?n * sz)%nat |- _ =>
+            assert (length (skipn sz xs) = (n * sz)%nat);
+              [ rewrite skipn_length, H; nia | ]
+          end
+        end.
+        specialize (IHn _ _ ltac:(eauto) _ Harr).
+        destruct IHn; sepsimpl.
+        match goal with
+        | Htl : array scalar _ _ ?t _,
+                Hhd : scalar _ ?h _ |- _ =>
+          exists (h :: t)
+        end.
+        cbn [length array].
+        sepsimpl; eauto; [ ].
+        do 2 eexists.
+        eauto. }
+    Qed.
 
     Lemma Bignum_to_bytes n addr x :
-      list_Z_bounded_by (max_bounds n) (map word.unsigned x) ->
       Lift1Prop.iff1
         (Bignum n addr x)
         (array ptsto (word.of_Z 1) addr (encode_bytes x)).
     Admitted.
-    *)
   End Proofs.
 End Bignum.
 Notation BignumSuchThat :=

--- a/src/Bedrock/Group/Loops.v
+++ b/src/Bedrock/Group/Loops.v
@@ -1,0 +1,51 @@
+Require Import Coq.ZArith.ZArith.
+Require Import Coq.Lists.List.
+Require Import Rupicola.Lib.ControlFlow.DownTo.
+Require Import Crypto.Util.Loops.
+Require Import Crypto.Util.ListUtil.
+Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
+
+(** Helper lemmas for proving equivalence between different loop formats
+    (e.g. rupicola's [downto] and Util/Loops.v's [while] **)
+
+Section DownToWhile.
+  Lemma downto'_while
+        {state} (count : nat)
+        (step : state -> nat -> state) :
+    forall start init,
+      downto' init start count step =
+      fst (while (fun '(_, i) => (i >=? Z.of_nat start)%Z)
+                 (fun '(s, i) => (step s (Z.to_nat i), Z.pred i))
+               count (init, Z.pred (Z.of_nat count))).
+  Proof.
+    induction count; intros.
+    { destruct start; [ reflexivity | ].
+      cbn; autorewrite with push_skipn; reflexivity. }
+    { rewrite Nat2Z.inj_succ, Z.pred_succ.
+      cbn [while]; break_match;
+        LtbToLt.Z.ltb_to_lt;
+        match goal with
+        | H : (Z.of_nat _ < Z.of_nat _)%Z |- _ =>
+          apply Nat2Z.inj_lt in H
+        | H : (Z.of_nat _ >= Z.of_nat _)%Z |- _ =>
+          apply Nat2Z.inj_ge in H
+        end; [ | ].
+      { rewrite <-IHcount, Nat2Z.id.
+        cbv [downto']. rewrite seq_snoc.
+        autorewrite with natsimplify push_skipn distr_length.
+        rewrite rev_app_distr, fold_left_app.
+        reflexivity. }
+      { cbv [downto']. autorewrite with push_skipn.
+        reflexivity. } }
+  Qed.
+
+  Lemma downto_while
+        {state} (count : nat)
+        (step : state -> nat -> state) :
+    forall init : state,
+      downto init count step =
+      fst (while (fun '(_, i) => (i >=? 0)%Z)
+                 (fun '(s, i) => (step s (Z.to_nat i), Z.pred i))
+               count (init, Z.pred (Z.of_nat count))).
+  Proof. apply downto'_while. Qed.
+End DownToWhile.

--- a/src/Bedrock/Group/ScalarMult/LadderStep.v
+++ b/src/Bedrock/Group/ScalarMult/LadderStep.v
@@ -67,7 +67,7 @@ Section __.
              * FElem pDA DA' * FElem pCB CB'))%sep).
 
   Instance spec_of_ladderstep : spec_of "ladderstep" :=
-    forall! (X1 X2 Z2 X3 Z3 A AA B BB E C D DA CB : felem)
+    forall! (X1 X2 Z2 X3 Z3 : felem)
           (pX1 pX2 pZ2 pX3 pZ3
                pA pAA pB pBB pE pC pD pDA pCB : Semantics.word),
       (fun R m =>
@@ -79,11 +79,11 @@ Section __.
         /\ (FElem pX1 X1
             * FElem pX2 X2 * FElem pZ2 Z2
             * FElem pX3 X3 * FElem pZ3 Z3
-            * Placeholder pA A * Placeholder pAA AA
-            * Placeholder pB B * Placeholder pBB BB
-            * Placeholder pE E * Placeholder pC C
-            * Placeholder pD D * Placeholder pDA DA
-            * Placeholder pCB CB * R)%sep m)
+            * Placeholder pA * Placeholder pAA
+            * Placeholder pB * Placeholder pBB
+            * Placeholder pE * Placeholder pC
+            * Placeholder pD * Placeholder pDA
+            * Placeholder pCB * R)%sep m)
         ===>
         "ladderstep" @ [pX1; pX2; pZ2; pX3; pZ3; pA; pAA; pB; pBB; pE; pC; pD; pDA; pCB]
         ===>
@@ -101,9 +101,9 @@ Section __.
         x1 x2 z2 x3 z3
         X1 X1_ptr X1_var X2 X2_ptr X2_var Z2 Z2_ptr Z2_var
         X3 X3_ptr X3_var Z3 Z3_ptr Z3_var
-        A A_ptr A_var AA AA_ptr AA_var B B_ptr B_var BB BB_ptr BB_var
-        E E_ptr E_var C C_ptr C_var D D_ptr D_var
-        DA DA_ptr DA_var CB CB_ptr CB_var
+        A_ptr A_var AA_ptr AA_var B_ptr B_var BB_ptr BB_var
+        E_ptr E_var C_ptr C_var D_ptr D_var
+        DA_ptr DA_var CB_ptr CB_var
         k k_impl,
         spec_of_ladderstep functions ->
         feval X1 = x1 ->
@@ -119,11 +119,11 @@ Section __.
         (FElem X1_ptr X1
          * FElem X2_ptr X2 * FElem Z2_ptr Z2
          * FElem X3_ptr X3 * FElem Z3_ptr Z3
-         * Placeholder A_ptr A * Placeholder AA_ptr AA
-         * Placeholder B_ptr B * Placeholder BB_ptr BB
-         * Placeholder E_ptr E * Placeholder C_ptr C
-         * Placeholder D_ptr D * Placeholder DA_ptr DA
-         * Placeholder CB_ptr CB * R')%sep mem ->
+         * Placeholder A_ptr * Placeholder AA_ptr
+         * Placeholder B_ptr * Placeholder BB_ptr
+         * Placeholder E_ptr * Placeholder C_ptr
+         * Placeholder D_ptr * Placeholder DA_ptr
+         * Placeholder CB_ptr * R')%sep mem ->
         map.get locals X1_var = Some X1_ptr ->
         map.get locals X2_var = Some X2_ptr ->
         map.get locals Z2_var = Some Z2_ptr ->
@@ -183,7 +183,7 @@ Section __.
        Placeholder back into a FElem for the arguments precondition *)
     lazymatch goal with
     | |- sep _ _ _ =>
-      change Placeholder with FElem in * |- ;
+      seprewrite FElem_from_bytes;
       solve [repeat compile_step]
     | _ => idtac
     end;

--- a/src/Bedrock/Group/ScalarMult/LadderStep.v
+++ b/src/Bedrock/Group/ScalarMult/LadderStep.v
@@ -9,15 +9,11 @@ Section __.
   Context {semantics : Semantics.parameters}
           {semantics_ok : Semantics.parameters_ok semantics}.
   Context {field_parameters : FieldParameters}
-          {field_representaton : FieldRepresentation}.
+          {field_representaton : FieldRepresentation}
+          {field_representation_ok : FieldRepresentation_ok}.
   Existing Instances spec_of_mul spec_of_square spec_of_add
            spec_of_sub spec_of_scmula24 spec_of_inv spec_of_felem_copy
            spec_of_felem_small_literal.
-
-  Context {relax_bounds :
-             forall X : felem,
-               bounded_by tight_bounds X ->
-               bounded_by loose_bounds X}.
   Hint Resolve relax_bounds : compiler.
 
   Section Gallina.

--- a/src/Bedrock/Group/ScalarMult/MontgomeryEquivalence.v
+++ b/src/Bedrock/Group/ScalarMult/MontgomeryEquivalence.v
@@ -1,0 +1,87 @@
+Require Import Coq.micromega.Lia.
+Require Import Coq.ZArith.ZArith.
+Require Import Rupicola.Lib.ControlFlow.CondSwap.
+Require Import bedrock2.Semantics.
+Require Import coqutil.Tactics.Tactics.
+Require Import Crypto.Arithmetic.PrimeFieldTheorems.
+Require Import Crypto.Bedrock.Specs.Field.
+Require Import Crypto.Bedrock.Group.Loops.
+Require Import Crypto.Bedrock.Group.ScalarMult.LadderStep.
+Require Import Crypto.Bedrock.Group.ScalarMult.MontgomeryLadder.
+Require Import Crypto.Curves.Montgomery.XZ.
+Require Import Crypto.Curves.Montgomery.XZProofs.
+Require Import Crypto.Util.Loops.
+
+Section Equivalence.
+  Context {semantics : Semantics.parameters}.
+  Context {field_parameters : FieldParameters}
+          {field_representation : FieldRepresentation}.
+
+  Lemma ladderstep_gallina_equiv X1 P1 P2 :
+    ladderstep_gallina X1 P1 P2 =
+    @M.xzladderstep
+      _ F.add F.sub F.mul a24 X1 P1 P2.
+  Proof.
+    intros. cbv [ladderstep_gallina M.xzladderstep].
+    destruct P1 as [x1 z1]. destruct P2 as [x2 z2].
+    cbv [Rewriter.Util.LetIn.Let_In dlet.dlet]. cbn [fst snd].
+    rewrite !F.pow_2_r. reflexivity.
+  Qed.
+
+  Lemma montladder_gallina_equiv
+        n scalarbits testb point :
+    (forall i, testb i = Z.testbit n (Z.of_nat i)) ->
+    (0 <= scalarbits)%Z ->
+    montladder_gallina scalarbits testb point =
+    @M.montladder
+      _ F.zero F.one F.add F.sub F.mul F.inv
+      a24 cswap scalarbits (Z.testbit n) point.
+  Proof.
+    intros. cbv [montladder_gallina M.montladder].
+    cbv [Rewriter.Util.LetIn.Let_In dlet.dlet]. cbn [fst snd].
+    rewrite downto_while.
+    match goal with
+    | |- ?lhs = ?rhs =>
+      match lhs with
+        | context [while ?ltest ?lbody ?fuel ?linit] =>
+        match rhs with
+          | context [while ?rtest ?rbody ?fuel ?rinit] =>
+            rewrite (while.preservation
+                       ltest lbody rtest rbody
+                       (fun s1 s2 =>
+                          s1 =
+                          let '(x2, z2, x3, z3, swap, i) := s2 in
+                          (x2, z2, (x3, z3), swap, i)))
+              with (init2:=rinit);
+              [ remember (while rtest rbody fuel rinit) | .. ]
+        end end end.
+
+    (* first, finish proving post-loop equivalence *)
+    { destruct_products. rewrite cswap_pair. cbn [fst snd].
+      repeat match goal with
+             | |- context [match ?e with | pair _ _ => _ end] =>
+               destr e
+             end.
+      reflexivity. }
+
+    (* then, prove loop-equivalence preconditions *)
+    { intros. destruct_products. congruence. }
+    { intros. destruct_products. LtbToLt.Z.ltb_to_lt.
+      rewrite ladderstep_gallina_equiv.
+      repeat match goal with
+             | _ => progress rewrite Z2Nat.id by lia
+             | _ => progress cbn [fst snd]
+             | _ => rewrite cswap_pair
+             | _ => rewrite <-surjective_pairing
+             | H : forall i : nat, _ i = Z.testbit _ _ |- _ =>
+               rewrite H
+             | H : (_,_) = (_,_) |- _ => inversion H; subst; clear H
+             | H : context [match ?e with | pair _ _ => _ end] |- _ =>
+               destr e
+             | |- context [match ?e with | pair _ _ => _ end] =>
+               destr e
+             | _ => reflexivity
+             end. }
+    { rewrite Z2Nat.id by lia. reflexivity. }
+  Qed.
+End Equivalence.

--- a/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
+++ b/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
@@ -282,18 +282,6 @@ Section __.
       | _ => solve_field_subgoals_with_cswap
       end.
 
-    Lemma scalarbits_pos : 0 < scalarbits.
-    Proof.
-      rewrite scalarbits_eq. apply Z.log2_up_pos.
-      apply lt_1_p. apply L_prime.
-    Qed.
-
-    Definition Hidden := Placeholder.
-    Ltac hide p :=
-      change (Placeholder p) with (Hidden p) in *.
-    Ltac unhide p :=
-      change (Hidden p) with (Placeholder p) in *.
-
     Derive montladder_body SuchThat
            (let args := ["OUT"; "K"; "U"; "X1"; "Z1"; "X2"; "Z2";
                            "A"; "AA"; "B"; "BB"; "E"; "C"; "D"; "DA"; "CB"] in
@@ -357,7 +345,7 @@ Section __.
           [ .. | subst L | subst L ].
       { cbv [downto_inv].
         setup_downto_inv_init.
-        all:try solve_downto_inv_subgoals. }
+        all:solve_downto_inv_subgoals. }
       { subst. autorewrite with mapsimpl.
         reflexivity. }
       { rewrite word.unsigned_of_Z, Z2Nat.id by lia;

--- a/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
+++ b/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
@@ -19,16 +19,12 @@ Section __.
   Context {scalar_field_parameters_ok : ScalarFieldParameters_ok}.
   Context {field_representaton : FieldRepresentation}
           {scalar_representation : ScalarRepresentation}.
+  Context {field_representation_ok : FieldRepresentation_ok}.
   Existing Instances spec_of_mul spec_of_square spec_of_add
            spec_of_sub spec_of_scmula24 spec_of_inv spec_of_felem_copy
            spec_of_felem_small_literal spec_of_sctestbit
            spec_of_ladderstep.
-
-  Context {relax_bounds :
-             forall X : felem,
-               bounded_by tight_bounds X ->
-               bounded_by loose_bounds X}.
-  Hint Resolve relax_bounds : compiler.
+  Hint Resolve @relax_bounds : core.
 
   Section Gallina.
     Local Open Scope F_scope.

--- a/src/Bedrock/Group/ScalarMult/ScalarMult.v
+++ b/src/Bedrock/Group/ScalarMult/ScalarMult.v
@@ -97,11 +97,18 @@ Module M.
             {field_parameters : FieldParameters}
             {field_parameters_ok : FieldParameters_ok}
             {field_representation : FieldRepresentation}.
-    Context  (char_ge_3 :
-                @Ring.char_ge (F M_pos) Logic.eq F.zero F.one F.opp F.add
-                              F.sub F.mul 3)
-             (a b : F M_pos) (b_nonzero : b <> F.zero)
-             (scmul : string).
+    Context (char_ge_3 :
+               @Ring.char_ge (F M_pos) Logic.eq F.zero F.one F.opp F.add
+                             F.sub F.mul 3)
+            (char_ge_12 :
+               @Ring.char_ge (F M_pos) Logic.eq F.zero F.one F.opp F.add
+                              F.sub F.mul 12)
+            (char_ge_28 :
+               @Ring.char_ge (F M_pos) Logic.eq F.zero F.one F.opp F.add
+                             F.sub F.mul 28)
+            (a b : F M_pos) (b_nonzero : b <> F.zero)
+            (discriminant_nonzero : (a * a - (1 + 1 + 1 + 1) <> 0)%F)
+            (scmul : string).
     Local Notation to_xz := (M.to_xz (F:=F M_pos) (Feq:=Logic.eq)
                                      (Fzero:=F.zero) (Fone:=F.one)
                                      (Fadd:=F.add) (Fmul:=F.mul)
@@ -110,7 +117,7 @@ Module M.
                                    (Fzero:=F.zero) (Fdiv:=F.div)
                                    (Feq_dec:=F.eq_dec)).
 
-    Global Instance parameters
+    Global Instance group_parameters
       : GroupParameters :=
       { G := @M.point (F M_pos) Logic.eq F.add F.mul a b;
         eq := @M.eq (F M_pos) Logic.eq F.add F.mul a b;
@@ -131,6 +138,14 @@ Module M.
                              (b_nonzero := b_nonzero));
         scmul := scmul;
       }.
+
+    Global Instance group_parameters_ok : GroupParameters_ok.
+    Proof.
+      constructor.
+      { apply M.MontgomeryWeierstrassIsomorphism; auto. }
+      { apply @scalarmult_ref_is_scalarmult.
+        apply M.MontgomeryWeierstrassIsomorphism; auto. }
+    Qed.
 
     Definition xrepresents (x : felem) (P : G) : Prop :=
       feval x = to_x (to_xz P).

--- a/src/Bedrock/Group/ScalarMult/ScalarMult.v
+++ b/src/Bedrock/Group/ScalarMult/ScalarMult.v
@@ -1,0 +1,112 @@
+Require Import Rupicola.Lib.Api.
+Require Import Rupicola.Lib.ControlFlow.CondSwap.
+Require Import bedrock2.Syntax.
+Require Import Crypto.Algebra.Hierarchy.
+Require Import Crypto.Algebra.ScalarMult.
+Require Import Crypto.Arithmetic.PrimeFieldTheorems.
+Require Import Crypto.Bedrock.Group.Loops.
+Require Import Crypto.Bedrock.Group.Point.
+Require Import Crypto.Bedrock.Group.ScalarMult.LadderStep.
+Require Import Crypto.Bedrock.Group.ScalarMult.MontgomeryLadder.
+Require Import Crypto.Bedrock.Specs.Field.
+Require Import Crypto.Bedrock.Specs.ScalarField.
+Require Import Crypto.Bedrock.Specs.Group.
+Require Import Crypto.Curves.Montgomery.AffineInstances.
+Require Import Crypto.Curves.Montgomery.XZ.
+Require Import Crypto.Curves.Montgomery.XZProofs.
+Require Import Crypto.Spec.MontgomeryCurve.
+Require Import Crypto.Util.Loops.
+
+Instance montgomery_xz_parameters
+         {field_parameters : FieldParameters}
+         (M_prime : Znumtheory.prime M) (* TODO: move to field_parameters_ok or something *)
+         (char_ge_3 : Ring.char_ge 3)
+         (a b : F M_pos)
+         (b_nonzero : b <> F.zero)
+         (scmul : string)
+  : GroupParameters :=
+  { G := @M.point (F M_pos) Logic.eq F.add F.mul a b;
+    eq := @M.eq (F M_pos) Logic.eq F.add F.mul a b;
+    add := @M.add _ _ _ _ _ _ _ _ _ _ (@F.field_modulo M_pos M_prime) F.eq_dec char_ge_3 a b b_nonzero;
+    zero := @M.zero (F M_pos) Logic.eq F.add F.mul a b;
+    opp := @Affine.M.opp _ _ _ _ _ _ _ _ _ _ (@F.field_modulo M_pos M_prime) F.eq_dec a b b_nonzero;
+    scalarmult :=
+      @scalarmult_ref _ (M.add (b_nonzero:=b_nonzero))
+                      M.zero
+                      (Affine.M.opp (b_nonzero:=b_nonzero));
+    scmul := scmul;
+    }.
+
+Section Equivalence.
+  Context {semantics : Semantics.parameters}.
+  Context {field_parameters : FieldParameters}
+          {field_representation : FieldRepresentation}.
+
+  Lemma ladderstep_gallina_equiv X1 P1 P2 :
+    ladderstep_gallina X1 P1 P2 =
+    @M.xzladderstep
+      _ F.add F.sub F.mul a24 X1 P1 P2.
+  Proof.
+    intros. cbv [ladderstep_gallina M.xzladderstep].
+    destruct P1 as [x1 z1]. destruct P2 as [x2 z2].
+    cbv [Rewriter.Util.LetIn.Let_In dlet.dlet]. cbn [fst snd].
+    rewrite !F.pow_2_r. reflexivity.
+  Qed.
+
+  Lemma montladder_gallina_equiv
+        n scalarbits testb point :
+    (forall i, testb i = Z.testbit n (Z.of_nat i)) ->
+    (0 <= scalarbits)%Z ->
+    montladder_gallina scalarbits testb point =
+    @M.montladder
+      _ F.zero F.one F.add F.sub F.mul F.inv
+      a24 cswap scalarbits (Z.testbit n) point.
+  Proof.
+    intros. cbv [montladder_gallina M.montladder].
+    cbv [Rewriter.Util.LetIn.Let_In dlet.dlet]. cbn [fst snd].
+    rewrite downto_while.
+    match goal with
+    | |- ?lhs = ?rhs =>
+      match lhs with
+        | context [while ?ltest ?lbody ?fuel ?linit] =>
+        match rhs with
+          | context [while ?rtest ?rbody ?fuel ?rinit] =>
+            rewrite (while.preservation
+                       ltest lbody rtest rbody
+                       (fun s1 s2 =>
+                          s1 =
+                          let '(x2, z2, x3, z3, swap, i) := s2 in
+                          (x2, z2, (x3, z3), swap, i)))
+              with (init2:=rinit);
+              [ remember (while rtest rbody fuel rinit) | .. ]
+        end end end.
+
+    (* first, finish proving post-loop equivalence *)
+    { destruct_products. rewrite cswap_pair. cbn [fst snd].
+      repeat match goal with
+             | |- context [match ?e with | pair _ _ => _ end] =>
+               destr e
+             end.
+      reflexivity. }
+
+    (* then, prove loop-equivalence preconditions *)
+    { intros. destruct_products. congruence. }
+    { intros. destruct_products. LtbToLt.Z.ltb_to_lt.
+      rewrite ladderstep_gallina_equiv.
+      repeat match goal with
+             | _ => progress rewrite Z2Nat.id by lia
+             | _ => progress cbn [fst snd]
+             | _ => rewrite cswap_pair
+             | _ => rewrite <-surjective_pairing
+             | H : forall i : nat, _ i = Z.testbit _ _ |- _ =>
+               rewrite H
+             | H : (_,_) = (_,_) |- _ => inversion H; subst; clear H
+             | H : context [match ?e with | pair _ _ => _ end] |- _ =>
+               destr e
+             | |- context [match ?e with | pair _ _ => _ end] =>
+               destr e
+             | _ => reflexivity
+             end. }
+    { rewrite Z2Nat.id by lia. reflexivity. }
+  Qed.
+End Equivalence.

--- a/src/Bedrock/Group/ScalarMult/ScalarMult.v
+++ b/src/Bedrock/Group/ScalarMult/ScalarMult.v
@@ -192,6 +192,9 @@ Module M.
         (* plain straightline should do this but doesn't; using enhanced
            version from rupicola *)
         repeat straightline'.
+
+        (* TODO: finish once stack allocation is incorporated for
+           ladderstep/montladder functions *)
       Abort.
     End Implementation.
   End __.

--- a/src/Bedrock/Specs/Field.v
+++ b/src/Bedrock/Specs/Field.v
@@ -39,6 +39,7 @@ Class FieldRepresentation
       {semantics : Semantics.parameters} :=
   { felem : Type;
     feval : felem -> F M_pos;
+    felem_size_in_bytes : Z; (* for stack allocation *)
     FElem : word -> felem -> Semantics.mem -> Prop;
     bounds : Type;
     bounded_by : bounds -> felem -> Prop;
@@ -47,6 +48,17 @@ Class FieldRepresentation
     loose_bounds : bounds;
     tight_bounds : bounds;
   }.
+
+Class FieldRepresentation_ok
+      {field_parameters : FieldParameters}
+      {semantics : Semantics.parameters}
+      {field_representation : FieldRepresentation} :=
+  { felem_size_in_bytes_mod :
+      (felem_size_in_bytes mod Memory.bytes_per_word Semantics.width)%Z = 0%Z;
+    relax_bounds :
+      forall X : felem, bounded_by tight_bounds X
+                        -> bounded_by loose_bounds X;
+    }.
 
 Section Specs.
   Context {semantics : Semantics.parameters}

--- a/src/Bedrock/Specs/Group.v
+++ b/src/Bedrock/Specs/Group.v
@@ -26,7 +26,7 @@ Class GroupParameters_ok {group_parameters : GroupParameters} :=
 
 Class GroupRepresentation {G : Type} {semantics : Semantics.parameters} :=
   { gelem : Type;
-    geval : gelem -> G;
+    grepresents : gelem -> G -> Prop;
     GElem : word -> gelem -> Semantics.mem -> Prop;
   }.
 
@@ -38,16 +38,18 @@ Section Specs.
           {group_representaton : GroupRepresentation (G:=G)}.
 
   Definition spec_of_scmul : spec_of scmul :=
-    (forall! (x old_out : gelem) (k : scalar) (pout px pk : word),
+    (forall! (x old_out : gelem) (k : scalar) (X : G)
+           (pout px pk : word),
         (fun Rr mem =>
-           (exists Ra, (GElem px x * Scalar pk k * Ra)%sep mem)
+           grepresents x X
+           /\ (exists Ra, (GElem px x * Scalar pk k * Ra)%sep mem)
            /\ (GElem pout old_out * Rr)%sep mem)
           ===>
           scmul @ [pout; px; pk]
           ===>
           (fun _ =>
              liftexists (xk : gelem),
-             (emp (geval xk = scalarmult (F.to_Z (sceval k)) (geval x))
+             (emp (grepresents xk (scalarmult (F.to_Z (sceval k)) X))
               * GElem pout xk)%sep)).
 End Specs.
 

--- a/src/Bedrock/Specs/Group.v
+++ b/src/Bedrock/Specs/Group.v
@@ -37,20 +37,22 @@ Section Specs.
   Context {group_parameters : GroupParameters}
           {group_representaton : GroupRepresentation (G:=G)}.
 
+  (* N.B. spec_of_scmul has only one separation-logic condition for now because
+     using multiple results in problems with stack allocation. Should be further
+     looked into. *)
   Definition spec_of_scmul : spec_of scmul :=
     (forall! (x old_out : gelem) (k : scalar) (X : G)
            (pout px pk : word),
         (fun Rr mem =>
            grepresents x X
-           /\ (exists Ra, (GElem px x * Scalar pk k * Ra)%sep mem)
-           /\ (GElem pout old_out * Rr)%sep mem)
+           /\ (GElem pout old_out * GElem px x * Scalar pk k * Rr)%sep mem)
           ===>
           scmul @ [pout; px; pk]
           ===>
           (fun _ =>
              liftexists (xk : gelem),
              (emp (grepresents xk (scalarmult (F.to_Z (sceval k)) X))
-              * GElem pout xk)%sep)).
+              * GElem pout xk * GElem px x * Scalar pk k)%sep)).
 End Specs.
 
 

--- a/src/Bedrock/Specs/ScalarField.v
+++ b/src/Bedrock/Specs/ScalarField.v
@@ -46,6 +46,23 @@ Section Specs.
                 /\ r = word.of_Z (Z.b2z b)))).
 End Specs.
 
+Section Proofs.
+  Context {semantics : Semantics.parameters}
+          {semantics_ok : Semantics.parameters_ok semantics}.
+  Context {scalar_field_parameters : ScalarFieldParameters}
+          {scalar_field_parameters_ok : ScalarFieldParameters_ok}
+          {scalar_representation : ScalarRepresentation}.
+
+  Lemma sceval_range k :
+    0 <= F.to_Z (sceval k) < 2 ^ scalarbits.
+  Proof.
+    pose proof (Znumtheory.prime_ge_2 (Z.pos L_pos) L_prime).
+    pose proof (@F.to_Z_range L_pos (sceval k) ltac:(lia)).
+    pose proof (Z.log2_log2_up_spec (Z.pos L_pos) ltac:(lia)).
+    rewrite scalarbits_eq. change L with (Z.pos L_pos). lia.
+  Qed.
+End Proofs.
+
 Section Compile.
   Context {semantics : Semantics.parameters}
           {semantics_ok : Semantics.parameters_ok semantics}.

--- a/src/Bedrock/Specs/ScalarField.v
+++ b/src/Bedrock/Specs/ScalarField.v
@@ -61,6 +61,12 @@ Section Proofs.
     pose proof (Z.log2_log2_up_spec (Z.pos L_pos) ltac:(lia)).
     rewrite scalarbits_eq. change L with (Z.pos L_pos). lia.
   Qed.
+
+  Lemma scalarbits_pos : 0 < scalarbits.
+  Proof.
+    rewrite scalarbits_eq. apply Z.log2_up_pos.
+    apply lt_1_p. apply L_prime.
+  Qed.
 End Proofs.
 
 Section Compile.

--- a/src/Bedrock/Specs/ScalarField.v
+++ b/src/Bedrock/Specs/ScalarField.v
@@ -10,6 +10,10 @@ Class ScalarFieldParameters :=
     sctestbit : string;
   }.
 
+Class ScalarFieldParameters_ok
+      {scalar_field_parameters : ScalarFieldParameters} :=
+  { L_prime : Znumtheory.prime L }.
+
 Class ScalarRepresentation
       {scalar_field_parameters : ScalarFieldParameters}
       {semantics : Semantics.parameters} :=

--- a/src/Bedrock/Specs/ScalarField.v
+++ b/src/Bedrock/Specs/ScalarField.v
@@ -1,5 +1,6 @@
 Require Import Rupicola.Lib.Api.
 Require Import Crypto.Arithmetic.PrimeFieldTheorems.
+Require Import Crypto.Util.NumTheoryUtil.
 Local Open Scope Z_scope.
 
 Class ScalarFieldParameters :=

--- a/src/Bedrock/Specs/ScalarField.v
+++ b/src/Bedrock/Specs/ScalarField.v
@@ -6,13 +6,17 @@ Class ScalarFieldParameters :=
   { (** mathematical parameters **)
     L_pos : positive; (* modulus *)
     L : Z := Z.pos L_pos;
+    scalarbits : Z;
+
     (** function names for bedrock2 **)
     sctestbit : string;
   }.
 
 Class ScalarFieldParameters_ok
       {scalar_field_parameters : ScalarFieldParameters} :=
-  { L_prime : Znumtheory.prime L }.
+  { L_prime : Znumtheory.prime L;
+    scalarbits_eq : scalarbits = Z.log2_up L;
+  }.
 
 Class ScalarRepresentation
       {scalar_field_parameters : ScalarFieldParameters}

--- a/src/Util/Loops.v
+++ b/src/Util/Loops.v
@@ -453,6 +453,24 @@ Module while.
   End While.
   Global Arguments by_invariant_fuel {state test body} inv measure P.
   Global Arguments by_invariant {state test body} inv measure P.
+
+  Section TwoLoops.
+    Context {state1 state2 : Type}
+            (test1 : state1 -> bool) (body1 : state1 -> state1)
+            (test2 : state2 -> bool) (body2 : state2 -> state2).
+
+    Lemma preservation
+          (R : state1 -> state2 -> Prop)
+          (Htest: forall s1 s2, R s1 s2 -> test1 s1 = test2 s2)
+          (Hbody: forall s1 s2, test2 s2 = true -> R s1 s2 -> R (body1 s1) (body2 s2)) :
+      forall fuel init1 init2,
+        R init1 init2 ->
+        R (while test1 body1 fuel init1) (while test2 body2 fuel init2).
+    Proof.
+      induction fuel; intros; cbn [while];
+        erewrite Htest by eauto; case_eq (test2 init2); auto.
+    Qed.
+  End TwoLoops.
 End while.
 Notation while := while.while.
 


### PR DESCRIPTION
In terms of the "next steps" discussion on #869, this PR is the second bulletpoint :
 > - proving that the ladderstep and montladder Gallina implementations match the Gallina implementations from `Curves/Montgomery/XZ.v` so we can use the proofs from `XZProofs` to say that montgomery ladder is a group scalarmult

The punchline here is `scmul_func_correct`, which goes through `XZProofs` to prove that a bedrock2 implementation of group scalar multiplication corresponds to the specification in `Bedrock/Specs/Group.v`, where the group is instantiated with a Montgomery curve. `Print Assumptions` tells me it's closed under the global context, and `Check`ing it shows the following:
```coq
M.scmul_func_correct
     : forall char_ge_3 : Ring.char_ge 3,
       Ring.char_ge 5 ->
       Ring.char_ge 12 ->
       Ring.char_ge 28 ->
       forall (a b : F M_pos) (scmul : string) (b_nonzero : b <> 0%F),
       ((1 + 1 + 1 + 1) * a24)%F = (a - (1 + 1))%F ->
       (forall r : F M_pos, (r * r)%F <> (a * a - (1 + 1 + 1 + 1))%F) ->
       forall scalar_field_parameters : ScalarFieldParameters,
       ScalarFieldParameters_ok ->
       forall scalar_field_representation : ScalarRepresentation,
       program_logic_goal_for (M.scmul_func scmul)
         (forall
            functions : list (string * (list string * list string * cmd)),
          M.spec_of_from_bytes functions ->
          spec_of_montladder functions ->
          M.spec_of_to_bytes functions ->
          M.spec_of_scmul char_ge_3 a b scmul b_nonzero
            (M.scmul_func scmul :: functions))
where
?semantics : [ |- Semantics.parameters]
?semantics_ok : [ |- Semantics.parameters_ok ?semantics]
?field_parameters : [ |- FieldParameters]
?field_parameters_ok : [ |- FieldParameters_ok]
?field_representation : [ |- FieldRepresentation]
?field_representation_ok : [ |- FieldRepresentation_ok]
```

In order to make sure the field representation typeclasses are possible to instantiate, I've kept up a file `Field/Interface/Representation.v` that instantiates `FieldRepresentation` and `FieldRepresentation_ok`, but it is not currently hooked up to anything. The other typeclass instances (e.g. `FieldParameters`, `ScalarFieldParameters_ok`) are pretty simple and I'm not worried about them.

The top-level scalar multiplication function is implemented by:
1. stack-allocating the intermediate values needed by the Montgomery ladder
2. calling `from_bytes` on the input
3. calling the Montgomery ladder function
4. calling `to_bytes` to serialize the result
5. deallocating intermediates

Getting everything to play nicely together (rupicola-generated specs, bedrock2 stack allocation, algebraic proofs, etc) required a fair amount of side work. Other changes you'll see in this PR include:
- a proven correspondence between `Bignum` and byte arrays (this could be generalized into a correspondence between `array scalar` and `array ptsto` and upstreamed to bedrock2)
- `Placeholder` is now `Memory.anybytes` instead of just an alias for `FElem`, in order to fit with stack allocation and simplify specifications (they no longer need to take several arguments for all the placeholder values because there's an existential in `Memory.anybytes`; now specs only need the pointers)
- field compilation proofs are now better automated because I didn't want to change them all one by one
- scalar fields now have a parameter that declares how many bits they have, and this is used as the loop bound for Montgomery ladder instead of an extra standalone parameter

Next steps now are to:
- make the code generated in `Bedrock/Field` proven against the specs in `Bedrock/Specs/Field` instead of `COperationSpecifications`
- create an X25519 end-to-end example with assumed implementations for missing pieces like field-element inverse