### PR TITLE
Multi-license under MIT OR Apache-2.0 OR BSD-1-Clause

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,7 @@
+SPDX-License-Identifier: MIT OR Apache-2.0 OR BSD-1-Clause
+
+Fiat Cryptography is licensed under the MIT License <LICENSE-MIT> or
+<http://opensource.org/licenses/MIT>, the Apache License, Version 2.0
+<LICENSE-APACHE> or <http://www.apache.org/licenses/LICENSE-2.0>, or
+the BSD 1-Clause License <LICENSE-BSD-1> or
+<https://spdx.org/licenses/BSD-1-Clause.html>, at your option.

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,15 @@
+The Apache License, Version 2.0 (Apache-2.0)
+
+Copyright 2015-2020 the fiat-crypto authors (see the AUTHORS file)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-BSD-1
+++ b/LICENSE-BSD-1
@@ -1,0 +1,23 @@
+The BSD 1-Clause License (BSD-1-Clause)
+
+Copyright (c) 2015-2020 the fiat-crypto authors (see the AUTHORS file)
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+THIS SOFTWARE IS PROVIDED BY the fiat-crypto authors "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL Berkeley Software Design,
+Inc. BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2019 the fiat-crypto authors (see the AUTHORS file).
+Copyright (c) 2015-2020 the fiat-crypto authors (see the AUTHORS file).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,10 @@ SOME_EARLY_VOFILES := \
 COPY_TO_FIAT_RUST := \
 	AUTHORS \
 	CONTRIBUTORS \
-	LICENSE
+	COPYRIGHT \
+	LICENSE-MIT \
+	LICENSE-APACHE \
+	LICENSE-BSD-1
 
 # computing the vo_reverse_closure is slow, so we only do it if we're
 # asked to make the lite target

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Package Manager | Command Line Invocation |
 Aptitude (Ubuntu / Debian) | `apt install coq ocaml-findlib libcoq-ocaml-dev` |
 Homebrew (OS X) | `brew install coq ocaml-findlib ocaml-num` |
 Pacman (Archlinux) | `pacman -S coq ocaml-findlib ocaml-num` |
-    
+
 You can clone this repository with
 
     git clone --recursive https://github.com/mit-plv/fiat-crypto.git
@@ -140,6 +140,14 @@ Here are some examples of ways to invoke the binaries (from the directories that
     ./bedrock2_unsaturated_solinas --no-wide-int --widen-carry --widen-bytes --split-multiret --no-select 'poly1305' '32' '5' '2^130 - 5' > poly1305_32.c
 
 You can find more examples in the `Makefile`.
+
+License
+-------
+
+Fiat-Crypto is distributed under the terms of the MIT License, the Apache License (Version 2.0), and the BSD 1-Clause License; users may pick which license to apply.
+
+See [`COPYRIGHT`](./COPYRIGHT), [`LICENSE-MIT`](./LICENSE-MIT), [`LICENSE-APACHE`](./LICENSE-APACHE), and [`LICENSE-BSD-1`](./LICENSE-BSD-1) for details.
+
 
 Extended Build Instructions
 ---------------------------

--- a/fiat-rust/COPYRIGHT
+++ b/fiat-rust/COPYRIGHT
@@ -1,0 +1,7 @@
+SPDX-License-Identifier: MIT OR Apache-2.0 OR BSD-1-Clause
+
+Fiat Cryptography is licensed under the MIT License <LICENSE-MIT> or
+<http://opensource.org/licenses/MIT>, the Apache License, Version 2.0
+<LICENSE-APACHE> or <http://www.apache.org/licenses/LICENSE-2.0>, or
+the BSD 1-Clause License <LICENSE-BSD-1> or
+<https://spdx.org/licenses/BSD-1-Clause.html>, at your option.

--- a/fiat-rust/Cargo.toml
+++ b/fiat-rust/Cargo.toml
@@ -7,7 +7,7 @@ description = "Fiat-crypto generated Rust"
 homepage = "https://github.com/mit-plv/fiat-crypto"
 repository = "https://github.com/mit-plv/fiat-crypto"
 readme = "README.md"
-license = "MIT"
+license = "MIT OR Apache-2.0 OR BSD-1-Clause"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/fiat-rust/LICENSE-APACHE
+++ b/fiat-rust/LICENSE-APACHE
@@ -1,0 +1,15 @@
+The Apache License, Version 2.0 (Apache-2.0)
+
+Copyright 2015-2020 the fiat-crypto authors (see the AUTHORS file)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/fiat-rust/LICENSE-BSD-1
+++ b/fiat-rust/LICENSE-BSD-1
@@ -1,0 +1,23 @@
+The BSD 1-Clause License (BSD-1-Clause)
+
+Copyright (c) 2015-2020 the fiat-crypto authors (see the AUTHORS file)
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+THIS SOFTWARE IS PROVIDED BY the fiat-crypto authors "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL Berkeley Software Design,
+Inc. BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/fiat-rust/LICENSE-MIT
+++ b/fiat-rust/LICENSE-MIT
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2019 the fiat-crypto authors (see the AUTHORS file).
+Copyright (c) 2015-2020 the fiat-crypto authors (see the AUTHORS file).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/fiat-rust/README.md
+++ b/fiat-rust/README.md
@@ -5,4 +5,6 @@ This crate provides the extracted Rust code from the Coq
 
 
 ## License
-This project is licensed under the terms of the [MIT license](LICENSE).
+This project is distributed under the terms of the MIT License, the Apache License (Version 2.0), and the BSD 1-Clause License; users may pick which license to apply.
+
+See [`COPYRIGHT`](COPYRIGHT), [`LICENSE-MIT`](LICENSE-MIT), [`LICENSE-APACHE`](LICENSE-APACHE), and [`LICENSE-BSD-1`](LICENSE-BSD-1) for details.


### PR DESCRIPTION
Hopefully this will satisfy the Go team and might come closer to getting
us into OpenSSL.

We follow
https://github.com/rust-lang/rust/tree/e0bc267512fc0cb49c86978192857e8187017f0b#license
and
https://github.com/rust-lang/rust/blob/e0bc267512fc0cb49c86978192857e8187017f0b/COPYRIGHT
for wording.

Got out-of-band approval from all the people (and representatives of all the companies) in `AUTHORS`.  Please review for whether the way I'm laying things out seems good.