### PR TITLE
Clean up field specifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,11 +224,15 @@ bedrock2-extra-cflags:
 	@echo "$(BEDROCK2_EXTRA_CFLAGS)"
 
 OUTPUT_VOS := \
+	src/Bedrock/Group/ScalarMult/LadderStep.vo \
+	src/Bedrock/Group/ScalarMult/MontgomeryLadder.vo \
 	src/Fancy/Montgomery256.vo \
 	src/Fancy/Barrett256.vo \
 	src/UnsaturatedSolinasHeuristics/Tests.vo
 
 OUTPUT_PREOUTS := \
+	Crypto.Bedrock.Group.ScalarMult.LadderStep.ladderstep_body \
+	Crypto.Bedrock.Group.ScalarMult.MontgomeryLadder.montladder_body \
 	Crypto.Fancy.Montgomery256.Prod.MontRed256 \
 	Crypto.Fancy.Montgomery256.prod_montred256_correct \
 	Crypto.Fancy.Montgomery256.prod_montred256_correct.Assumptions \

--- a/Makefile
+++ b/Makefile
@@ -241,12 +241,10 @@ OUTPUT_PREOUTS := \
 	Crypto.UnsaturatedSolinasHeuristics.Tests.get_balances
 
 ifneq ($(SKIP_BEDROCK2), 1)
-OUTPUT_VOS := \
-	$(OUPUT_VOS) \
+OUTPUT_VOS += \
 	src/Bedrock/Group/ScalarMult/LadderStep.vo \
 	src/Bedrock/Group/ScalarMult/MontgomeryLadder.vo
-OUTPUT_PREOUTS := \
-	$(OUTPUT_PREOUTS) \
+OUTPUT_PREOUTS += \
 	Crypto.Bedrock.Group.ScalarMult.LadderStep.ladderstep_body \
 	Crypto.Bedrock.Group.ScalarMult.MontgomeryLadder.montladder_body
 endif

--- a/Makefile
+++ b/Makefile
@@ -224,15 +224,11 @@ bedrock2-extra-cflags:
 	@echo "$(BEDROCK2_EXTRA_CFLAGS)"
 
 OUTPUT_VOS := \
-	src/Bedrock/Group/ScalarMult/LadderStep.vo \
-	src/Bedrock/Group/ScalarMult/MontgomeryLadder.vo \
 	src/Fancy/Montgomery256.vo \
 	src/Fancy/Barrett256.vo \
 	src/UnsaturatedSolinasHeuristics/Tests.vo
 
 OUTPUT_PREOUTS := \
-	Crypto.Bedrock.Group.ScalarMult.LadderStep.ladderstep_body \
-	Crypto.Bedrock.Group.ScalarMult.MontgomeryLadder.montladder_body \
 	Crypto.Fancy.Montgomery256.Prod.MontRed256 \
 	Crypto.Fancy.Montgomery256.prod_montred256_correct \
 	Crypto.Fancy.Montgomery256.prod_montred256_correct.Assumptions \
@@ -243,6 +239,17 @@ OUTPUT_PREOUTS := \
 	Crypto.Fancy.Barrett256.barrett_red256 \
 	Crypto.UnsaturatedSolinasHeuristics.Tests.get_possible_limbs \
 	Crypto.UnsaturatedSolinasHeuristics.Tests.get_balances
+
+ifneq ($(SKIP_BEDROCK2), 1)
+OUTPUT_VOS := \
+	$(OUPUT_VOS) \
+	src/Bedrock/Group/ScalarMult/LadderStep.vo \
+	src/Bedrock/Group/ScalarMult/MontgomeryLadder.vo
+OUTPUT_PREOUTS := \
+	$(OUTPUT_PREOUTS) \
+	Crypto.Bedrock.Group.ScalarMult.LadderStep.ladderstep_body \
+	Crypto.Bedrock.Group.ScalarMult.MontgomeryLadder.montladder_body
+endif
 
 CHECK_OUTPUTS := $(addprefix check-,$(OUTPUT_PREOUTS))
 ACCEPT_OUTPUTS := $(addprefix accept-,$(OUTPUT_PREOUTS))

--- a/_CoqProject
+++ b/_CoqProject
@@ -111,6 +111,7 @@ src/Bedrock/Group/ScalarMult/LadderStep.v
 src/Bedrock/Group/ScalarMult/MontgomeryEquivalence.v
 src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
 src/Bedrock/Group/ScalarMult/ScalarMult.v
+src/Bedrock/ScalarField/Interface/Compilation.v
 src/Bedrock/Specs/Field.v
 src/Bedrock/Specs/Group.v
 src/Bedrock/Specs/ScalarField.v

--- a/output-tests/Crypto.Bedrock.Group.ScalarMult.LadderStep.ladderstep_body.expected
+++ b/output-tests/Crypto.Bedrock.Group.ScalarMult.LadderStep.ladderstep_body.expected
@@ -1,24 +1,33 @@
 ladderstep_body = 
 fun field_parameters : FieldParameters =>
-(cmd.call [] add ["A"; "X2"; "Z2"];;
- cmd.call [] square ["AA"; "A"];;
- cmd.call [] sub ["B"; "X2"; "Z2"];;
- cmd.call [] square ["BB"; "B"];;
- cmd.call [] sub ["E"; "AA"; "BB"];;
- cmd.call [] add ["C"; "X3"; "Z3"];;
- cmd.call [] sub ["D"; "X3"; "Z3"];;
- cmd.call [] mul ["DA"; "D"; "A"];;
- cmd.call [] mul ["CB"; "C"; "B"];;
- cmd.call [] add ["X3"; "DA"; "CB"];;
- cmd.call [] square ["X3"; "X3"];;
- cmd.call [] sub ["Z3"; "DA"; "CB"];;
- cmd.call [] square ["Z3"; "Z3"];;
- cmd.call [] mul ["Z3"; "X1"; "Z3"];;
- cmd.call [] mul ["X2"; "AA"; "BB"];;
- cmd.call [] scmula24 ["Z2"; "E"];;
- cmd.call [] add ["Z2"; "AA"; "Z2"];;
- cmd.call [] mul ["Z2"; "E"; "Z2"];;
- /*skip*/)%bedrock_cmd
+cmd.seq (cmd.call [] add ["A"; "X2"; "Z2"])
+  (cmd.seq (cmd.call [] square ["AA"; "A"])
+     (cmd.seq (cmd.call [] sub ["B"; "X2"; "Z2"])
+        (cmd.seq (cmd.call [] square ["BB"; "B"])
+           (cmd.seq (cmd.call [] sub ["E"; "AA"; "BB"])
+              (cmd.seq (cmd.call [] add ["C"; "X3"; "Z3"])
+                 (cmd.seq (cmd.call [] sub ["D"; "X3"; "Z3"])
+                    (cmd.seq (cmd.call [] mul ["DA"; "D"; "A"])
+                       (cmd.seq (cmd.call [] mul ["CB"; "C"; "B"])
+                          (cmd.seq (cmd.call [] add ["X3"; "DA"; "CB"])
+                             (cmd.seq (cmd.call [] square ["X3"; "X3"])
+                                (cmd.seq (cmd.call [] sub ["Z3"; "DA"; "CB"])
+                                   (cmd.seq (cmd.call [] square ["Z3"; "Z3"])
+                                      (cmd.seq
+                                         (cmd.call [] mul ["Z3"; "X1"; "Z3"])
+                                         (cmd.seq
+                                            (cmd.call [] mul
+                                               ["X2"; "AA"; "BB"])
+                                            (cmd.seq
+                                               (cmd.call [] scmula24
+                                                  ["Z2"; "E"])
+                                               (cmd.seq
+                                                  (cmd.call [] add
+                                                     ["Z2"; "AA"; "Z2"])
+                                                  (cmd.seq
+                                                     (cmd.call [] mul
+                                                        ["Z2"; "E"; "Z2"])
+                                                     cmd.skip)))))))))))))))))
      : FieldParameters -> cmd
 
 Arguments ladderstep_body {field_parameters}

--- a/output-tests/Crypto.Bedrock.Group.ScalarMult.LadderStep.ladderstep_body.expected
+++ b/output-tests/Crypto.Bedrock.Group.ScalarMult.LadderStep.ladderstep_body.expected
@@ -1,0 +1,24 @@
+ladderstep_body = 
+fun field_parameters : FieldParameters =>
+(cmd.call [] add ["A"; "X2"; "Z2"];;
+ cmd.call [] square ["AA"; "A"];;
+ cmd.call [] sub ["B"; "X2"; "Z2"];;
+ cmd.call [] square ["BB"; "B"];;
+ cmd.call [] sub ["E"; "AA"; "BB"];;
+ cmd.call [] add ["C"; "X3"; "Z3"];;
+ cmd.call [] sub ["D"; "X3"; "Z3"];;
+ cmd.call [] mul ["DA"; "D"; "A"];;
+ cmd.call [] mul ["CB"; "C"; "B"];;
+ cmd.call [] add ["X3"; "DA"; "CB"];;
+ cmd.call [] square ["X3"; "X3"];;
+ cmd.call [] sub ["Z3"; "DA"; "CB"];;
+ cmd.call [] square ["Z3"; "Z3"];;
+ cmd.call [] mul ["Z3"; "X1"; "Z3"];;
+ cmd.call [] mul ["X2"; "AA"; "BB"];;
+ cmd.call [] scmula24 ["Z2"; "E"];;
+ cmd.call [] add ["Z2"; "AA"; "Z2"];;
+ cmd.call [] mul ["Z2"; "E"; "Z2"];;
+ /*skip*/)%bedrock_cmd
+     : FieldParameters -> cmd
+
+Arguments ladderstep_body {field_parameters}

--- a/output-tests/Crypto.Bedrock.Group.ScalarMult.MontgomeryLadder.montladder_body.expected
+++ b/output-tests/Crypto.Bedrock.Group.ScalarMult.MontgomeryLadder.montladder_body.expected
@@ -1,0 +1,51 @@
+montladder_body = 
+fun (field_parameters : FieldParameters)
+  (scalar_field_parameters : ScalarFieldParameters) =>
+(cmd.call [] felem_small_literal ["X1"; (uintptr_t)1ULL];;
+ cmd.call [] felem_small_literal ["Z1"; (uintptr_t)0ULL];;
+ cmd.call [] felem_copy ["X2"; "U"];;
+ cmd.call [] felem_small_literal ["Z2"; (uintptr_t)1ULL];;
+ "v6" = (uintptr_t)0ULL;;
+ "v7" = (uintptr_t)scalarbitsULL;;
+ (while ((uintptr_t)0ULL < "v7") {{
+    "v7" = "v7" - (uintptr_t)1ULL;;
+    cmd.call ["v8"] sctestbit ["K"; "v7"];;
+    "v9" = "v6" .^ "v8";;
+    (if ("v9") {{
+       (("tmp" = "X1";;
+         "X1" = "X2");;
+        "X2" = "tmp");;
+       cmd.unset "tmp"
+     }});;
+    (if ("v9") {{
+       (("tmp" = "Z1";;
+         "Z1" = "Z2");;
+        "Z2" = "tmp");;
+       cmd.unset "tmp"
+     }});;
+    cmd.call [] "ladderstep"
+      ["U"; "X1"; "Z1"; "X2"; "Z2"; "A"; "AA"; "B"; "BB"; "E"; "C"; "D";
+      "DA"; "CB"];;
+    "v6" = "v8";;
+    cmd.unset "v9";;
+    cmd.unset "v8";;
+    /*skip*/
+  }});;
+ (if ("v6") {{
+    (("tmp" = "X1";;
+      "X1" = "X2");;
+     "X2" = "tmp");;
+    cmd.unset "tmp"
+  }});;
+ (if ("v6") {{
+    (("tmp" = "Z1";;
+      "Z1" = "Z2");;
+     "Z2" = "tmp");;
+    cmd.unset "tmp"
+  }});;
+ cmd.call [] inv ["A"; "Z1"];;
+ cmd.call [] mul ["OUT"; "X1"; "A"];;
+ /*skip*/)%bedrock_cmd
+     : FieldParameters -> ScalarFieldParameters -> cmd
+
+Arguments montladder_body {field_parameters scalar_field_parameters}

--- a/output-tests/Crypto.Bedrock.Group.ScalarMult.MontgomeryLadder.montladder_body.expected
+++ b/output-tests/Crypto.Bedrock.Group.ScalarMult.MontgomeryLadder.montladder_body.expected
@@ -1,51 +1,63 @@
 montladder_body = 
 fun (field_parameters : FieldParameters)
   (scalar_field_parameters : ScalarFieldParameters) =>
-(cmd.call [] felem_small_literal ["X1"; (uintptr_t)1ULL];;
- cmd.call [] felem_small_literal ["Z1"; (uintptr_t)0ULL];;
- cmd.call [] felem_copy ["X2"; "U"];;
- cmd.call [] felem_small_literal ["Z2"; (uintptr_t)1ULL];;
- "v6" = (uintptr_t)0ULL;;
- "v7" = (uintptr_t)scalarbitsULL;;
- (while ((uintptr_t)0ULL < "v7") {{
-    "v7" = "v7" - (uintptr_t)1ULL;;
-    cmd.call ["v8"] sctestbit ["K"; "v7"];;
-    "v9" = "v6" .^ "v8";;
-    (if ("v9") {{
-       (("tmp" = "X1";;
-         "X1" = "X2");;
-        "X2" = "tmp");;
-       cmd.unset "tmp"
-     }});;
-    (if ("v9") {{
-       (("tmp" = "Z1";;
-         "Z1" = "Z2");;
-        "Z2" = "tmp");;
-       cmd.unset "tmp"
-     }});;
-    cmd.call [] "ladderstep"
-      ["U"; "X1"; "Z1"; "X2"; "Z2"; "A"; "AA"; "B"; "BB"; "E"; "C"; "D";
-      "DA"; "CB"];;
-    "v6" = "v8";;
-    cmd.unset "v9";;
-    cmd.unset "v8";;
-    /*skip*/
-  }});;
- (if ("v6") {{
-    (("tmp" = "X1";;
-      "X1" = "X2");;
-     "X2" = "tmp");;
-    cmd.unset "tmp"
-  }});;
- (if ("v6") {{
-    (("tmp" = "Z1";;
-      "Z1" = "Z2");;
-     "Z2" = "tmp");;
-    cmd.unset "tmp"
-  }});;
- cmd.call [] inv ["A"; "Z1"];;
- cmd.call [] mul ["OUT"; "X1"; "A"];;
- /*skip*/)%bedrock_cmd
+cmd.seq (cmd.call [] felem_small_literal ["X1"; expr.literal 1])
+  (cmd.seq (cmd.call [] felem_small_literal ["Z1"; expr.literal 0])
+     (cmd.seq (cmd.call [] felem_copy ["X2"; "U"])
+        (cmd.seq (cmd.call [] felem_small_literal ["Z2"; expr.literal 1])
+           (cmd.seq (cmd.set "v6" (expr.literal 0))
+              (cmd.seq (cmd.set "v7" (expr.literal scalarbits))
+                 (cmd.seq
+                    (cmd.while (expr.op bopname.ltu (expr.literal 0) "v7")
+                       (cmd.seq
+                          (cmd.set "v7"
+                             (expr.op bopname.sub "v7" (expr.literal 1)))
+                          (cmd.seq (cmd.call ["v8"] sctestbit ["K"; "v7"])
+                             (cmd.seq
+                                (cmd.set "v9" (expr.op bopname.xor "v6" "v8"))
+                                (cmd.seq
+                                   (cmd.cond "v9"
+                                      (cmd.seq
+                                         (cmd.seq
+                                            (cmd.seq (cmd.set "tmp" "X1")
+                                               (cmd.set "X1" "X2"))
+                                            (cmd.set "X2" "tmp"))
+                                         (cmd.unset "tmp")) cmd.skip)
+                                   (cmd.seq
+                                      (cmd.cond "v9"
+                                         (cmd.seq
+                                            (cmd.seq
+                                               (cmd.seq (cmd.set "tmp" "Z1")
+                                                  (cmd.set "Z1" "Z2"))
+                                               (cmd.set "Z2" "tmp"))
+                                            (cmd.unset "tmp")) cmd.skip)
+                                      (cmd.seq
+                                         (cmd.call [] "ladderstep"
+                                            ["U"; "X1"; "Z1"; "X2"; "Z2";
+                                            "A"; "AA"; "B"; "BB"; "E"; "C";
+                                            "D"; "DA"; "CB"])
+                                         (cmd.seq (cmd.set "v6" "v8")
+                                            (cmd.seq (cmd.unset "v9")
+                                               (cmd.seq (cmd.unset "v8")
+                                                  cmd.skip))))))))))
+                    (cmd.seq
+                       (cmd.cond "v6"
+                          (cmd.seq
+                             (cmd.seq
+                                (cmd.seq (cmd.set "tmp" "X1")
+                                   (cmd.set "X1" "X2")) (cmd.set "X2" "tmp"))
+                             (cmd.unset "tmp")) cmd.skip)
+                       (cmd.seq
+                          (cmd.cond "v6"
+                             (cmd.seq
+                                (cmd.seq
+                                   (cmd.seq (cmd.set "tmp" "Z1")
+                                      (cmd.set "Z1" "Z2"))
+                                   (cmd.set "Z2" "tmp")) (cmd.unset "tmp"))
+                             cmd.skip)
+                          (cmd.seq (cmd.call [] inv ["A"; "Z1"])
+                             (cmd.seq (cmd.call [] mul ["OUT"; "X1"; "A"])
+                                cmd.skip))))))))))
      : FieldParameters -> ScalarFieldParameters -> cmd
 
 Arguments montladder_body {field_parameters scalar_field_parameters}

--- a/src/Bedrock/Field/Common/Arrays/MakeAccessSizes.v
+++ b/src/Bedrock/Field/Common/Arrays/MakeAccessSizes.v
@@ -271,6 +271,11 @@ Section __.
       reflexivity.
     Qed.
 
+    Lemma bytes_per_word_eq :
+      Z.to_nat (Memory.bytes_per_word Semantics.width)
+      = Memory.bytes_per (width:=Semantics.width) access_size.word.
+    Proof. reflexivity. Qed.
+
     Lemma make_access_size_good ranges size :
       make_access_size ranges = Some size ->
       (Z.of_nat (Memory.bytes_per

--- a/src/Bedrock/Field/Interface/Compilation.v
+++ b/src/Bedrock/Field/Interface/Compilation.v
@@ -56,8 +56,8 @@ Section Compile.
           and-functions functions)) ->
       (let head := v in
        find (cmd.seq
-               (cmd.call [] mul [expr.var x_var; expr.var y_var;
-                                   expr.var out_var])
+               (cmd.call [] mul [expr.var out_var; expr.var x_var;
+                                   expr.var y_var])
                k_impl)
        implementing (pred (dlet head k))
        and-returning retvars
@@ -96,8 +96,8 @@ Section Compile.
           and-functions functions)) ->
       (let head := v in
        find (cmd.seq
-               (cmd.call [] add [expr.var x_var; expr.var y_var;
-                                   expr.var out_var])
+               (cmd.call [] add [expr.var out_var; expr.var x_var;
+                                   expr.var y_var])
                k_impl)
        implementing (pred (dlet head k))
        and-returning retvars
@@ -136,8 +136,8 @@ Section Compile.
           and-functions functions)) ->
       (let head := v in
        find (cmd.seq
-               (cmd.call [] sub [expr.var x_var; expr.var y_var;
-                                   expr.var out_var])
+               (cmd.call [] sub [expr.var out_var; expr.var x_var;
+                                   expr.var y_var])
                k_impl)
        implementing (pred (dlet head k))
        and-returning retvars
@@ -172,7 +172,7 @@ Section Compile.
           and-functions functions)) ->
       (let head := v in
        find (cmd.seq
-               (cmd.call [] square [expr.var x_var; expr.var out_var])
+               (cmd.call [] square [expr.var out_var; expr.var x_var])
                k_impl)
        implementing (pred (dlet head k))
        and-returning retvars
@@ -211,7 +211,7 @@ Section Compile.
           and-functions functions)) ->
       (let head := v in
        find (cmd.seq
-               (cmd.call [] scmula24 [expr.var x_var; expr.var out_var])
+               (cmd.call [] scmula24 [expr.var out_var; expr.var x_var])
                k_impl)
        implementing (pred (dlet head k))
        and-returning retvars
@@ -246,7 +246,7 @@ Section Compile.
           and-functions functions)) ->
       (let head := v in
        find (cmd.seq
-               (cmd.call [] inv [expr.var x_var; expr.var out_var])
+               (cmd.call [] inv [expr.var out_var; expr.var x_var])
                k_impl)
        implementing (pred (dlet head k))
        and-returning retvars
@@ -278,7 +278,7 @@ Section Compile.
           and-functions functions)) ->
       (let head := v in
        find (cmd.seq
-               (cmd.call [] felem_copy [expr.var x_var; expr.var out_var])
+               (cmd.call [] felem_copy [expr.var out_var; expr.var x_var])
                k_impl)
        implementing (pred (dlet head k))
        and-returning retvars
@@ -311,7 +311,7 @@ Section Compile.
       (let head := v in
        find (cmd.seq
                (cmd.call [] felem_small_literal
-                         [expr.literal x; expr.var out_var])
+                         [expr.var out_var; expr.literal x])
                k_impl)
        implementing (pred (dlet head k))
        and-returning retvars

--- a/src/Bedrock/Group/ScalarMult/LadderStep.v
+++ b/src/Bedrock/Group/ScalarMult/LadderStep.v
@@ -243,24 +243,24 @@ Print ladderstep_body.
 *)
 (* ladderstep_body =
  * fun field_parameters : FieldParameters =>
- *  (cmd.call [] add [expr.var "X2"; expr.var "Z2"; expr.var "A"];;
- *  cmd.call [] square [expr.var "A"; expr.var "AA"];;
- *  cmd.call [] sub [expr.var "X2"; expr.var "Z2"; expr.var "B"];;
- *  cmd.call [] square [expr.var "B"; expr.var "BB"];;
- *  cmd.call [] sub [expr.var "AA"; expr.var "BB"; expr.var "E"];;
- *  cmd.call [] add [expr.var "X3"; expr.var "Z3"; expr.var "C"];;
- *  cmd.call [] sub [expr.var "X3"; expr.var "Z3"; expr.var "D"];;
- *  cmd.call [] mul [expr.var "D"; expr.var "A"; expr.var "DA"];;
- *  cmd.call [] mul [expr.var "C"; expr.var "B"; expr.var "CB"];;
- *  cmd.call [] add [expr.var "DA"; expr.var "CB"; expr.var "X3"];;
+ * (cmd.call [] add [expr.var "A"; expr.var "X2"; expr.var "Z2"];;
+ *  cmd.call [] square [expr.var "AA"; expr.var "A"];;
+ *  cmd.call [] sub [expr.var "B"; expr.var "X2"; expr.var "Z2"];;
+ *  cmd.call [] square [expr.var "BB"; expr.var "B"];;
+ *  cmd.call [] sub [expr.var "E"; expr.var "AA"; expr.var "BB"];;
+ *  cmd.call [] add [expr.var "C"; expr.var "X3"; expr.var "Z3"];;
+ *  cmd.call [] sub [expr.var "D"; expr.var "X3"; expr.var "Z3"];;
+ *  cmd.call [] mul [expr.var "DA"; expr.var "D"; expr.var "A"];;
+ *  cmd.call [] mul [expr.var "CB"; expr.var "C"; expr.var "B"];;
+ *  cmd.call [] add [expr.var "X3"; expr.var "DA"; expr.var "CB"];;
  *  cmd.call [] square [expr.var "X3"; expr.var "X3"];;
- *  cmd.call [] sub [expr.var "DA"; expr.var "CB"; expr.var "Z3"];;
+ *  cmd.call [] sub [expr.var "Z3"; expr.var "DA"; expr.var "CB"];;
  *  cmd.call [] square [expr.var "Z3"; expr.var "Z3"];;
- *  cmd.call [] mul [expr.var "X1"; expr.var "Z3"; expr.var "Z3"];;
- *  cmd.call [] mul [expr.var "AA"; expr.var "BB"; expr.var "X2"];;
- *  cmd.call [] scmula24 [expr.var "E"; expr.var "Z2"];;
- *  cmd.call [] add [expr.var "AA"; expr.var "Z2"; expr.var "Z2"];;
- *  cmd.call [] mul [expr.var "E"; expr.var "Z2"; expr.var "Z2"];;
+ *  cmd.call [] mul [expr.var "Z3"; expr.var "X1"; expr.var "Z3"];;
+ *  cmd.call [] mul [expr.var "X2"; expr.var "AA"; expr.var "BB"];;
+ *  cmd.call [] scmula24 [expr.var "Z2"; expr.var "E"];;
+ *  cmd.call [] add [expr.var "Z2"; expr.var "AA"; expr.var "Z2"];;
+ *  cmd.call [] mul [expr.var "Z2"; expr.var "E"; expr.var "Z2"];;
  *  /*skip*/)%bedrock_cmd
  *      : FieldParameters -> cmd
  *)

--- a/src/Bedrock/Group/ScalarMult/LadderStep.v
+++ b/src/Bedrock/Group/ScalarMult/LadderStep.v
@@ -236,31 +236,10 @@ Section __.
   Qed.
 End __.
 
-(*
+
 Require Import bedrock2.NotationsCustomEntry.
 Require Import bedrock2.NotationsInConstr.
-Print ladderstep_body.
-*)
-(* ladderstep_body =
- * fun field_parameters : FieldParameters =>
- * (cmd.call [] add [expr.var "A"; expr.var "X2"; expr.var "Z2"];;
- *  cmd.call [] square [expr.var "AA"; expr.var "A"];;
- *  cmd.call [] sub [expr.var "B"; expr.var "X2"; expr.var "Z2"];;
- *  cmd.call [] square [expr.var "BB"; expr.var "B"];;
- *  cmd.call [] sub [expr.var "E"; expr.var "AA"; expr.var "BB"];;
- *  cmd.call [] add [expr.var "C"; expr.var "X3"; expr.var "Z3"];;
- *  cmd.call [] sub [expr.var "D"; expr.var "X3"; expr.var "Z3"];;
- *  cmd.call [] mul [expr.var "DA"; expr.var "D"; expr.var "A"];;
- *  cmd.call [] mul [expr.var "CB"; expr.var "C"; expr.var "B"];;
- *  cmd.call [] add [expr.var "X3"; expr.var "DA"; expr.var "CB"];;
- *  cmd.call [] square [expr.var "X3"; expr.var "X3"];;
- *  cmd.call [] sub [expr.var "Z3"; expr.var "DA"; expr.var "CB"];;
- *  cmd.call [] square [expr.var "Z3"; expr.var "Z3"];;
- *  cmd.call [] mul [expr.var "Z3"; expr.var "X1"; expr.var "Z3"];;
- *  cmd.call [] mul [expr.var "X2"; expr.var "AA"; expr.var "BB"];;
- *  cmd.call [] scmula24 [expr.var "Z2"; expr.var "E"];;
- *  cmd.call [] add [expr.var "Z2"; expr.var "AA"; expr.var "Z2"];;
- *  cmd.call [] mul [expr.var "Z2"; expr.var "E"; expr.var "Z2"];;
- *  /*skip*/)%bedrock_cmd
- *      : FieldParameters -> cmd
- *)
+Local Coercion expr.var : string >-> Syntax.expr.
+Local Unset Printing Coercions.
+Local Open Scope bedrock_expr.
+Redirect "Crypto.Bedrock.Group.ScalarMult.LadderStep.ladderstep_body" Print ladderstep_body.

--- a/src/Bedrock/Group/ScalarMult/LadderStep.v
+++ b/src/Bedrock/Group/ScalarMult/LadderStep.v
@@ -236,10 +236,6 @@ Section __.
   Qed.
 End __.
 
-
-Require Import bedrock2.NotationsCustomEntry.
-Require Import bedrock2.NotationsInConstr.
 Local Coercion expr.var : string >-> Syntax.expr.
 Local Unset Printing Coercions.
-Local Open Scope bedrock_expr.
 Redirect "Crypto.Bedrock.Group.ScalarMult.LadderStep.ladderstep_body" Print ladderstep_body.

--- a/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
+++ b/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
@@ -487,60 +487,10 @@ Section __.
   End MontLadder.
 End __.
 
-(*
+
 Require Import bedrock2.NotationsCustomEntry.
 Require Import bedrock2.NotationsInConstr.
-Coercion expr.var : string >-> Syntax.expr.
-Unset Printing Coercions.
+Local Coercion expr.var : string >-> Syntax.expr.
+Local Unset Printing Coercions.
 Local Open Scope bedrock_expr.
-Print montladder_body.
-*)
-(* fun (field_parameters : FieldParameters)
- *   (scalar_field_parameters : ScalarFieldParameters) =>
- * (cmd.call [] felem_small_literal [(uintptr_t)1ULL; "X1"];;
- *  cmd.call [] felem_small_literal [(uintptr_t)0ULL; "Z1"];;
- *  cmd.call [] felem_copy ["U"; "X2"];;
- *  cmd.call [] felem_small_literal [(uintptr_t)1ULL; "Z2"];;
- *  "v6" = (uintptr_t)0ULL;;
- *  "v7" = (uintptr_t)scalarbitsULL;;
- *  (while ((uintptr_t)0ULL < "v7") {{
- *     "v7" = "v7" - (uintptr_t)1ULL;;
- *     cmd.call ["v8"] sctestbit ["K"; "v7"];;
- *     "v9" = "v6" .^ "v8";;
- *     (if ("v9") {{
- *        (("tmp" = "X1";;
- *          "X1" = "X2");;
- *         "X2" = "tmp");;
- *        cmd.unset "tmp"
- *      }});;
- *     (if ("v9") {{
- *        (("tmp" = "Z1";;
- *          "Z1" = "Z2");;
- *         "Z2" = "tmp");;
- *        cmd.unset "tmp"
- *      }});;
- *     cmd.call [] "ladderstep"
- *       ["U"; "X1"; "Z1"; "X2"; "Z2"; "A"; "AA"; "B"; "BB"; "E"; "C"; "D";
- *       "DA"; "CB"];;
- *     "v6" = "v8";;
- *     cmd.unset "v9";;
- *     cmd.unset "v8";;
- *     /*skip*/
- *   }});;
- *  (if ("v6") {{
- *     (("tmp" = "X1";;
- *       "X1" = "X2");;
- *      "X2" = "tmp");;
- *     cmd.unset "tmp"
- *   }});;
- *  (if ("v6") {{
- *     (("tmp" = "Z1";;
- *       "Z1" = "Z2");;
- *      "Z2" = "tmp");;
- *     cmd.unset "tmp"
- *   }});;
- *  cmd.call [] inv ["Z1"; "A"];;
- *  cmd.call [] mul ["X1"; "A"; "OUT"];;
- *  /*skip*/)%bedrock_cmd
- *      : FieldParameters -> ScalarFieldParameters -> cmd
- *)
+Redirect "Crypto.Bedrock.Group.ScalarMult.MontgomeryLadder.montladder_body" Print montladder_body.

--- a/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
+++ b/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
@@ -6,6 +6,7 @@ Require Import Crypto.Arithmetic.PrimeFieldTheorems.
 Require Import Crypto.Bedrock.Field.Interface.Compilation.
 Require Import Crypto.Bedrock.Group.Point.
 Require Import Crypto.Bedrock.Group.ScalarMult.LadderStep.
+Require Import Crypto.Bedrock.ScalarField.Interface.Compilation.
 Require Import Crypto.Bedrock.Specs.Field.
 Require Import Crypto.Bedrock.Specs.ScalarField.
 Require Import Crypto.Util.NumTheoryUtil.

--- a/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
+++ b/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
@@ -487,10 +487,6 @@ Section __.
   End MontLadder.
 End __.
 
-
-Require Import bedrock2.NotationsCustomEntry.
-Require Import bedrock2.NotationsInConstr.
 Local Coercion expr.var : string >-> Syntax.expr.
 Local Unset Printing Coercions.
-Local Open Scope bedrock_expr.
 Redirect "Crypto.Bedrock.Group.ScalarMult.MontgomeryLadder.montladder_body" Print montladder_body.

--- a/src/Bedrock/Group/ScalarMult/ScalarMult.v
+++ b/src/Bedrock/Group/ScalarMult/ScalarMult.v
@@ -123,14 +123,14 @@ Module M.
                    felem_size_in_bytes
                    ["X1"; "Z1"; "X2"; "Z2"; "A"; "AA"; "B"; "BB"; "E"; "C"; "D"; "DA"; "CB"; "x"; "r"]
                    (cmd.seq
-                      (cmd.call [] from_bytes [expr.var "x_bytes"; expr.var "x"])
+                      (cmd.call [] from_bytes [expr.var "x"; expr.var "x_bytes"])
                       (cmd.seq
                          (cmd.call [] "montladder"
                                    [expr.var "r"; expr.var "k"; expr.var "x"; expr.var "X1";
                                       expr.var "Z1"; expr.var "X2"; expr.var "Z2"; expr.var "A";
                                         expr.var "AA"; expr.var "B"; expr.var "BB"; expr.var "E";
                                           expr.var "C"; expr.var "D"; expr.var "DA"; expr.var "CB"])
-                         (cmd.call [] to_bytes [expr.var "r"; expr.var "out"]))))).
+                         (cmd.call [] to_bytes [expr.var "out"; expr.var "r"]))))).
 
       Lemma and_iff1_l (X : Prop) (P : Semantics.mem -> Prop) :
         X ->

--- a/src/Bedrock/ScalarField/Interface/Compilation.v
+++ b/src/Bedrock/ScalarField/Interface/Compilation.v
@@ -1,0 +1,57 @@
+Require Import Rupicola.Lib.Api.
+Require Import Crypto.Bedrock.Specs.ScalarField.
+Require Import Crypto.Arithmetic.PrimeFieldTheorems.
+Local Open Scope Z_scope.
+
+Section Compile.
+  Context {semantics : Semantics.parameters}
+          {semantics_ok : Semantics.parameters_ok semantics}.
+  Context {scalar_field_parameters : ScalarFieldParameters}.
+  Context {scalar_representaton : ScalarRepresentation}.
+  Existing Instance spec_of_sctestbit.
+
+  Lemma compile_sctestbit :
+    forall (locals: Semantics.locals) (mem: Semantics.mem)
+           (locals_ok : Semantics.locals -> Prop)
+           tr retvars R R' functions
+           T (pred: T -> list word -> Semantics.mem -> Prop)
+      x x_ptr x_var i wi i_var k k_impl var,
+      spec_of_sctestbit functions ->
+      (Scalar x_ptr x * R')%sep mem ->
+      map.get locals x_var = Some x_ptr ->
+      map.get locals i_var = Some wi ->
+      word.unsigned wi = Z.of_nat i ->
+      let v := Z.testbit (F.to_Z (sceval x)) (Z.of_nat i) in
+      (let head := v in
+       forall m,
+         (Scalar x_ptr x * R')%sep m ->
+         (find k_impl
+          implementing (pred (k head))
+          and-returning retvars
+          and-locals-post locals_ok
+          with-locals (map.put locals var (word.of_Z (Z.b2z head)))
+          and-memory m and-trace tr and-rest R
+          and-functions functions)) ->
+      (let head := v in
+       find (cmd.seq
+               (cmd.call [var] sctestbit [expr.var x_var; expr.var i_var])
+               k_impl)
+       implementing (pred (dlet head k))
+       and-returning retvars
+       and-locals-post locals_ok
+       with-locals locals and-memory mem and-trace tr and-rest R
+       and-functions functions).
+  Proof.
+    repeat straightline'.
+    handle_call; [ solve [eauto] ..
+                 | cbv [dlet.dlet] in *|-; sepsimpl ].
+    cbn [length] in *. destruct_lists_of_known_length.
+    subst_lets_in_goal. subst.
+    match goal with H : word.unsigned _ = Z.of_nat _ |- _ =>
+                    rewrite H in *
+    end.
+    repeat straightline'; eauto.
+  Qed.
+End Compile.
+
+Ltac scfield_compile_step := simple eapply compile_sctestbit.

--- a/src/Bedrock/Specs/Field.v
+++ b/src/Bedrock/Specs/Field.v
@@ -28,9 +28,6 @@ Class FieldParameters :=
     felem_small_literal : string;
   }.
 
-Lemma M_nonzero {fp : FieldParameters} : M <> 0.
-Proof. cbv [M]. congruence. Qed.
-
 Class FieldParameters_ok {field_parameters : FieldParameters} :=
   { M_prime : Znumtheory.prime M;
     (* TODO: a24_ok *)
@@ -77,22 +74,7 @@ Class FieldRepresentation_ok
                         -> bounded_by loose_bounds X;
   }.
 
-Section Proofs.
-  Context {semantics : Semantics.parameters}
-          {semantics_ok : Semantics.parameters_ok semantics}.
-  Context {field_parameters : FieldParameters}
-          {field_representaton : FieldRepresentation}
-          {field_representation_ok : FieldRepresentation_ok}.
-
-  Lemma FElem_to_bytes px x :
-    Lift1Prop.impl1 (FElem px x) (Placeholder px).
-  Proof.
-    rewrite FElem_from_bytes.
-    repeat intro; eexists; eauto.
-  Qed.
-End Proofs.
-
-Section Specs.
+Section FunctionSpecs.
   Context {semantics : Semantics.parameters}
           {semantics_ok : Semantics.parameters_ok semantics}.
   Context {field_parameters : FieldParameters}
@@ -177,4 +159,22 @@ Section Specs.
            (emp (F.to_Z (feval X) = word.unsigned x
                  /\ bounded_by tight_bounds X)
             * FElem pout X)%sep).
-End Specs.
+End FunctionSpecs.
+
+Section SpecProperties.
+  Context {semantics : Semantics.parameters}
+          {semantics_ok : Semantics.parameters_ok semantics}.
+  Context {field_parameters : FieldParameters}
+          {field_representaton : FieldRepresentation}
+          {field_representation_ok : FieldRepresentation_ok}.
+
+  Lemma FElem_to_bytes px x :
+    Lift1Prop.impl1 (FElem px x) (Placeholder px).
+  Proof.
+    rewrite FElem_from_bytes.
+    repeat intro; eexists; eauto.
+  Qed.
+
+  Lemma M_nonzero : M <> 0.
+  Proof. cbv [M]. congruence. Qed.
+End SpecProperties.

--- a/src/Bedrock/Specs/Field.v
+++ b/src/Bedrock/Specs/Field.v
@@ -74,39 +74,40 @@ Class FieldRepresentation_ok
                         -> bounded_by loose_bounds X;
   }.
 
+Notation unop_spec name op xbounds outbounds :=
+  (forall! (x : felem) (px pout : word),
+      (fun Rr mem =>
+         bounded_by xbounds x
+         /\ (exists Ra, (FElem px x * Ra)%sep mem)
+         /\ (Placeholder pout * Rr)%sep mem)
+        ===> name @ [pout; px] ===>
+        (fun _ =>
+           liftexists out,
+           (emp (feval out = op (feval x)
+                 /\ bounded_by outbounds out)
+            * FElem pout out)%sep))
+    (only parsing).
+
+Notation binop_spec name op xbounds ybounds outbounds :=
+  (forall! (x y : felem) (px py pout : word),
+      (fun Rr mem =>
+         bounded_by xbounds x
+         /\ bounded_by ybounds y
+         /\ (exists Ra, (FElem px x * Ra)%sep mem)
+         /\ (exists Ra, (FElem py y * Ra)%sep mem)
+         /\ (Placeholder pout * Rr)%sep mem)
+        ===> name @ [pout; px; py] ===>
+        (fun _ =>
+           liftexists out,
+           (emp ((feval out = op (feval x) (feval y))
+                 /\ bounded_by outbounds out)
+            * FElem pout out)%sep)) (only parsing).
+
 Section FunctionSpecs.
   Context {semantics : Semantics.parameters}
           {semantics_ok : Semantics.parameters_ok semantics}.
   Context {field_parameters : FieldParameters}
           {field_representaton : FieldRepresentation}.
-
-  Local Notation unop_spec name op xbounds outbounds :=
-    (forall! (x : felem) (px pout : word),
-        (fun Rr mem =>
-           bounded_by xbounds x
-           /\ (exists Ra, (FElem px x * Ra)%sep mem)
-           /\ (Placeholder pout * Rr)%sep mem)
-          ===> name @ [pout; px] ===>
-          (fun _ =>
-           liftexists out,
-           (emp (feval out = op (feval x)
-                 /\ bounded_by outbounds out)
-            * FElem pout out)%sep))
-      (only parsing).
-
-  Local Notation binop_spec name op xbounds ybounds outbounds :=
-    (forall! (x y : felem) (px py pout : word),
-        (fun Rr mem =>
-           bounded_by xbounds x
-           /\ bounded_by ybounds y
-           /\ (exists Ra, (FElem px x * FElem py y * Ra)%sep mem)
-           /\ (Placeholder pout * Rr)%sep mem)
-          ===> name @ [pout; px; py] ===>
-          (fun _ =>
-           liftexists out,
-           (emp ((feval out = op (feval x) (feval y))
-                 /\ bounded_by outbounds out)
-            * FElem pout out)%sep)) (only parsing).
 
   Instance spec_of_mul : spec_of mul :=
     binop_spec mul F.mul loose_bounds loose_bounds tight_bounds.

--- a/src/Bedrock/Specs/Field.v
+++ b/src/Bedrock/Specs/Field.v
@@ -86,7 +86,7 @@ Section FunctionSpecs.
            bounded_by xbounds x
            /\ (exists Ra, (FElem px x * Ra)%sep mem)
            /\ (Placeholder pout * Rr)%sep mem)
-          ===> name @ [px; pout] ===>
+          ===> name @ [pout; px] ===>
           (fun _ =>
            liftexists out,
            (emp (feval out = op (feval x)
@@ -101,7 +101,7 @@ Section FunctionSpecs.
            /\ bounded_by ybounds y
            /\ (exists Ra, (FElem px x * FElem py y * Ra)%sep mem)
            /\ (Placeholder pout * Rr)%sep mem)
-          ===> name @ [px; py; pout] ===>
+          ===> name @ [pout; px; py] ===>
           (fun _ =>
            liftexists out,
            (emp ((feval out = op (feval x) (feval y))
@@ -127,7 +127,7 @@ Section FunctionSpecs.
       (fun Rr mem =>
          (exists Ra, (FElemBytes px bs * Ra)%sep mem)
          /\ (Placeholder pout * Rr)%sep mem)
-        ===> from_bytes @ [px; pout] ===>
+        ===> from_bytes @ [pout; px] ===>
         (fun _ =>
            liftexists X,
            (emp (feval X = feval_bytes bs /\ bounded_by tight_bounds X)
@@ -139,7 +139,7 @@ Section FunctionSpecs.
          bounded_by tight_bounds x
          /\ (exists Ra, (FElem px x * Ra)%sep mem)
          /\ (FElemBytes pout old_out * Rr)%sep mem)
-        ===> to_bytes @ [px; pout] ===>
+        ===> to_bytes @ [pout; px] ===>
         (fun _ =>
            liftexists bs,
            (emp (feval_bytes bs = feval x) * FElemBytes pout bs)%sep).
@@ -147,13 +147,13 @@ Section FunctionSpecs.
   Definition spec_of_felem_copy : spec_of felem_copy :=
     forall! (x : felem) (px pout : word),
       (sep (FElem px x * Placeholder pout)%sep)
-        ===> felem_copy @ [px; pout] ===>
+        ===> felem_copy @ [pout; px] ===>
         (fun _ => FElem px x * FElem pout x)%sep.
 
   Definition spec_of_felem_small_literal : spec_of felem_small_literal :=
     forall! (x pout : word),
       (sep (Placeholder pout))
-        ===> felem_small_literal @ [x; pout] ===>
+        ===> felem_small_literal @ [pout; x] ===>
         (fun _ =>
            liftexists X,
            (emp (F.to_Z (feval X) = word.unsigned x

--- a/src/Bedrock/Specs/Group.v
+++ b/src/Bedrock/Specs/Group.v
@@ -30,7 +30,7 @@ Class GroupRepresentation {G : Type} {semantics : Semantics.parameters} :=
     GElem : word -> gelem -> Semantics.mem -> Prop;
   }.
 
-Section Specs.
+Section FunctionSpecs.
   Context {semantics : Semantics.parameters}
           {scalar_field_parameters : ScalarFieldParameters}
           {scalar_representaton : ScalarRepresentation}.
@@ -53,6 +53,4 @@ Section Specs.
              liftexists (xk : gelem),
              (emp (grepresents xk (scalarmult (F.to_Z (sceval k)) X))
               * GElem pout xk * GElem px x * Scalar pk k)%sep)).
-End Specs.
-
-
+End FunctionSpecs.

--- a/src/Bedrock/Specs/ScalarField.v
+++ b/src/Bedrock/Specs/ScalarField.v
@@ -27,7 +27,7 @@ Class ScalarRepresentation
     Scalar : word -> scalar -> Semantics.mem -> Prop;
   }.
 
-Section Specs.
+Section FunctionSpecs.
   Context {semantics : Semantics.parameters}
           {semantics_ok : Semantics.parameters_ok semantics}.
   Context {scalar_field_parameters : ScalarFieldParameters}.
@@ -45,9 +45,9 @@ Section Specs.
           (liftexists r,
            emp (rets = [r]
                 /\ r = word.of_Z (Z.b2z b)))).
-End Specs.
+End FunctionSpecs.
 
-Section Proofs.
+Section SpecProperties.
   Context {semantics : Semantics.parameters}
           {semantics_ok : Semantics.parameters_ok semantics}.
   Context {scalar_field_parameters : ScalarFieldParameters}
@@ -68,57 +68,4 @@ Section Proofs.
     rewrite scalarbits_eq. apply Z.log2_up_pos.
     apply lt_1_p. apply L_prime.
   Qed.
-End Proofs.
-
-Section Compile.
-  Context {semantics : Semantics.parameters}
-          {semantics_ok : Semantics.parameters_ok semantics}.
-  Context {scalar_field_parameters : ScalarFieldParameters}.
-  Context {scalar_representaton : ScalarRepresentation}.
-  Existing Instance spec_of_sctestbit.
-
-  Lemma compile_sctestbit :
-    forall (locals: Semantics.locals) (mem: Semantics.mem)
-           (locals_ok : Semantics.locals -> Prop)
-           tr retvars R R' functions
-           T (pred: T -> list word -> Semantics.mem -> Prop)
-      x x_ptr x_var i wi i_var k k_impl var,
-      spec_of_sctestbit functions ->
-      (Scalar x_ptr x * R')%sep mem ->
-      map.get locals x_var = Some x_ptr ->
-      map.get locals i_var = Some wi ->
-      word.unsigned wi = Z.of_nat i ->
-      let v := Z.testbit (F.to_Z (sceval x)) (Z.of_nat i) in
-      (let head := v in
-       forall m,
-         (Scalar x_ptr x * R')%sep m ->
-         (find k_impl
-          implementing (pred (k head))
-          and-returning retvars
-          and-locals-post locals_ok
-          with-locals (map.put locals var (word.of_Z (Z.b2z head)))
-          and-memory m and-trace tr and-rest R
-          and-functions functions)) ->
-      (let head := v in
-       find (cmd.seq
-               (cmd.call [var] sctestbit [expr.var x_var; expr.var i_var])
-               k_impl)
-       implementing (pred (dlet head k))
-       and-returning retvars
-       and-locals-post locals_ok
-       with-locals locals and-memory mem and-trace tr and-rest R
-       and-functions functions).
-  Proof.
-    repeat straightline'.
-    handle_call; [ solve [eauto] ..
-                 | cbv [dlet.dlet] in *|-; sepsimpl ].
-    cbn [length] in *. destruct_lists_of_known_length.
-    subst_lets_in_goal. subst.
-    match goal with H : word.unsigned _ = Z.of_nat _ |- _ =>
-                    rewrite H in *
-    end.
-    repeat straightline'; eauto.
-  Qed.
-End Compile.
-
-Ltac scfield_compile_step := simple eapply compile_sctestbit.
+End SpecProperties.


### PR DESCRIPTION
This is part of my work-in-progress on connecting the bedrock2 backend to the new field specifications and scalarmult implementation. Mainly, this change:
- moves the scalar field compilation lemmas to a new `ScalarField/` directory, so that the structure matches `Field/` and `Group/` and doesn't clutter the spec with non-trusted code
- changes the argument order for field operations so that the output pointer comes first instead of last, to match BoringSSL and the existing bedrock2 backend implementations
- introduces a separate separation-logic frame for each input instead of one for all inputs, because it should be okay to call `add(out, x, x)` (see #828)