### PR TITLE
Make translate_cmd handle pairs

### DIFF
--- a/src/AbstractInterpretation/Wf.v
+++ b/src/AbstractInterpretation/Wf.v
@@ -550,7 +550,9 @@ Module Compilers.
                                 | [ H : ?x = ?x |- _ ] => clear H
                                 | [ H : length ?l1 = length ?l2, H' : context[length ?l1] |- _ ] => rewrite H in H'
                                 | [ H : context[invert_pair ?e] |- _ ]
-                                  => let lem := constr:(expr.invert_pair_ident_pair : invert_pair e = _) in
+                                  => let lem := lazymatch e with
+                                                | (?x, ?y)%expr => constr:(expr.invert_pair_ident_pair(v1:=x) (v2:=y) : invert_pair e = _)
+                                                end in
                                      rewrite lem in H
                                 end
                               | apply wf_annotate_with_expr

--- a/src/Bedrock/Field/Translation/Expr.v
+++ b/src/Bedrock/Field/Translation/Expr.v
@@ -183,25 +183,6 @@ Section Expr.
     | _ => false
     end.
 
-  Definition is_pair_ident {t} (idc : ident t) : bool :=
-    match idc with
-    | ident.pair _ _ => true
-    | _ => false
-    end.
-
-  Definition is_pair_ident_expr {var t}
-             (e : @API.expr var t) : bool :=
-    match e with
-    | expr.Ident _ i => is_pair_ident i
-    | _ => false
-    end.
-
-  Definition is_pair {var t} (e : @API.expr var t) : bool :=
-    match invert_expr.invert_AppIdent2 e with
-    | Some (existT _ (i, _, _)) => is_pair_ident i
-    | None => false
-    end.
-
   (* only require cast for the argument of (App f x) if:
      - f is not a cast
      - f is not mul_high (then, x = 2^width)
@@ -247,7 +228,6 @@ Section Expr.
     | ident.Z_mul_high => rmul_high
     | ident.Z_cast => fun _ x => x
     | ident.Z_cast2 => fun _ x => x
-    | ident.pair _ _ => pair
     | i => match translate_binop i with
            | Some x => x
            | None => make_error _
@@ -276,7 +256,7 @@ Section Expr.
            {t} (e : @API.expr ltype t) : rtype t :=
     if cast_exempt e
     then translate_cast_exempt require_cast e
-    else if (require_cast && negb (is_pair e))%bool
+    else if require_cast
          then
            match e in expr.expr t0 return rtype t0 with
            | expr.App _ _ f x =>

--- a/src/Bedrock/Field/Translation/Expr.v
+++ b/src/Bedrock/Field/Translation/Expr.v
@@ -183,6 +183,25 @@ Section Expr.
     | _ => false
     end.
 
+  Definition is_pair_ident {t} (idc : ident t) : bool :=
+    match idc with
+    | ident.pair _ _ => true
+    | _ => false
+    end.
+
+  Definition is_pair_ident_expr {var t}
+             (e : @API.expr var t) : bool :=
+    match e with
+    | expr.Ident _ i => is_pair_ident i
+    | _ => false
+    end.
+
+  Definition is_pair {var t} (e : @API.expr var t) : bool :=
+    match invert_expr.invert_AppIdent2 e with
+    | Some (existT _ (i, _, _)) => is_pair_ident i
+    | None => false
+    end.
+
   (* only require cast for the argument of (App f x) if:
      - f is not a cast
      - f is not mul_high (then, x = 2^width)
@@ -228,6 +247,7 @@ Section Expr.
     | ident.Z_mul_high => rmul_high
     | ident.Z_cast => fun _ x => x
     | ident.Z_cast2 => fun _ x => x
+    | ident.pair _ _ => pair
     | i => match translate_binop i with
            | Some x => x
            | None => make_error _
@@ -256,7 +276,7 @@ Section Expr.
            {t} (e : @API.expr ltype t) : rtype t :=
     if cast_exempt e
     then translate_cast_exempt require_cast e
-    else if require_cast
+    else if (require_cast && negb (is_pair e))%bool
          then
            match e in expr.expr t0 return rtype t0 with
            | expr.App _ _ f x =>

--- a/src/Bedrock/Field/Translation/Proofs/Cmd.v
+++ b/src/Bedrock/Field/Translation/Proofs/Cmd.v
@@ -295,8 +295,12 @@ Section Cmd.
     wf3 G e1 e2 e3 ->
     translate_cmd e3 nextn = assign nextn (translate_expr true e3).
   Proof.
-    inversion 1; cleanup_wf; try reflexivity;
-      inversion 1; cleanup_wf; try reflexivity.
+    inversion 1; cleanup_wf; try reflexivity; intros.
+    all: repeat first [ reflexivity
+                      | match goal with
+                        | [ H : wf3 _ ?x _ _ |- _ ]
+                          => assert_fails is_var x; inversion H; clear H; cleanup_wf
+                        end ].
   Qed.
 
   Local Ltac simplify :=
@@ -442,6 +446,7 @@ Section Cmd.
                         [ eapply Proper_call | repeat intro
                           | eapply assign_correct; eauto;
                             eapply translate_expr_correct; solve [eauto] ]
+               | _ => progress cbn [invert_expr.invert_pair_cps invert_expr.invert_AppIdent2_cps Option.bind invert_expr.invert_App2_cps invert_expr.invert_App_cps invert_expr.invert_Ident invert_expr.is_pair Compilers.invertIdent]
                end.
 
     { (* let-in (product of base types) *)

--- a/src/Bedrock/Field/Translation/Proofs/Cmd.v
+++ b/src/Bedrock/Field/Translation/Proofs/Cmd.v
@@ -446,7 +446,7 @@ Section Cmd.
                         [ eapply Proper_call | repeat intro
                           | eapply assign_correct; eauto;
                             eapply translate_expr_correct; solve [eauto] ]
-               | _ => progress cbn [invert_expr.invert_pair_cps invert_expr.invert_AppIdent2_cps Option.bind invert_expr.invert_App2_cps invert_expr.invert_App_cps invert_expr.invert_Ident invert_expr.is_pair Compilers.invertIdent]
+               | _ => progress cbn [invert_expr.invert_pair_cps invert_expr.invert_AppIdent2_cps Option.bind invert_expr.invert_App2_cps invert_expr.invert_App_cps invert_expr.invert_Ident invert_expr.is_pair Compilers.invertIdent Option.bind translate_ident2_for_cmd Crypto.Util.Option.bind]
                end.
 
     { (* let-in (product of base types) *)
@@ -496,7 +496,7 @@ Section Cmd.
         eapply only_differ_disjoint_undef_on; eauto with lia; [ ].
         match goal with H : PropSet.sameset _ _ |- _ =>
                         rewrite H end.
-        apply used_varnames_disjoint; cbn; lia. }
+        apply used_varnames_disjoint; lia. }
       { simplify; subst; eauto; [ | | ].
         { (* varnames subset *)
           rewrite varname_set_local.
@@ -509,7 +509,7 @@ Section Cmd.
           rewrite <-Nat.add_1_r.
           apply used_varnames_shift. }
         { (* only_differ *)
-          rewrite <-(Nat.add_1_r nextn) in *.
+          rewrite <-(Nat.add_comm nextn 1) in *.
           only_differ_ok. }
         { (* equivalence of output holds *)
           clear IHe1_valid.


### PR DESCRIPTION
This allows things like `fun (x y : Z) => (x, y)` and `fun (x y : Z) (z
: list Z) => (x, y, z)` to synthesize correctly.  This fixes #886 and is partial work towards making bedrock2 output handle divstep.