### PR TITLE
 Adapt to fixing dropped implicit arguments in Context

### DIFF
--- a/src/Arithmetic/Core.v
+++ b/src/Arithmetic/Core.v
@@ -440,7 +440,7 @@ Module B.
     Qed. Hint Rewrite eval_negate_snd : push_basesystem_eval.
 
     Section Carries.
-      Context {modulo_cps div_cps:forall {R},Z->Z->(Z->R)->R}.
+      Context {modulo_cps div_cps:forall R,Z->Z->(Z->R)->R}.
       Let modulo x y := modulo_cps _ x y id.
       Let div x y := div_cps _ x y id.
       Context {modulo_cps_id : forall R x y f, modulo_cps R x y f = f (modulo x y)}
@@ -730,7 +730,7 @@ Module B.
       .
 
       Section Carries.
-        Context {modulo_cps div_cps:forall {R},Z->Z->(Z->R)->R}.
+        Context {modulo_cps div_cps:forall R,Z->Z->(Z->R)->R}.
         Let modulo x y := modulo_cps _ x y id.
         Let div x y := div_cps _ x y id.
         Context {modulo_cps_id : forall R x y f, modulo_cps R x y f = f (modulo x y)}
@@ -942,7 +942,7 @@ Module B.
       Section F.
         Context {sz:nat} {sz_nonzero : sz<>0%nat} {m :positive}.
         Context (weight_divides : forall i : nat, weight (S i) / weight i <> 0).
-        Context {modulo_cps div_cps:forall {R},Z->Z->(Z->R)->R}.
+        Context {modulo_cps div_cps:forall R,Z->Z->(Z->R)->R}.
         Let modulo x y := modulo_cps _ x y id.
         Let div x y := div_cps _ x y id.
         Context {modulo_cps_id : forall R x y f, modulo_cps R x y f = f (modulo x y)}

--- a/src/Arithmetic/MontgomeryReduction/WordByWord/Abstract/Dependent/Definition.v
+++ b/src/Arithmetic/MontgomeryReduction/WordByWord/Abstract/Dependent/Definition.v
@@ -29,6 +29,14 @@ Section WordByWordMontgomery.
     {sub_then_maybe_add : T R_numlimbs -> T R_numlimbs -> T R_numlimbs} (* computes [a - b + if (a - b) <? 0 then N else 0] *)
     (N : T R_numlimbs).
 
+  (* Coq bug #9412 *)
+  Local Arguments eval {n}.
+  Local Arguments zero {n}.
+  Local Arguments divmod {n}.
+  Local Arguments scmul {n}.
+  Local Arguments addT {n}.
+  Local Arguments addT' {n}.
+
   (* Recurse for a as many iterations as A has limbs, varying A := A, S := 0, r, bounds *)
   Section Iteration.
     Context (pred_A_numlimbs : nat)
@@ -36,12 +44,12 @@ Section WordByWordMontgomery.
             (A : T (S pred_A_numlimbs))
             (S : T (S R_numlimbs)).
     (* Given A, B < R, we want to compute A * B / R mod N. R = bound 0 * ... * bound (n-1) *)
-    Local Definition A_a := dlet p := divmod _ A in p. Local Definition A' := fst A_a. Local Definition a := snd A_a.
-    Local Definition S1 := addT _ S (scmul _ a B).
-    Local Definition s := snd (divmod _ S1).
+    Local Definition A_a := dlet p := divmod A in p. Local Definition A' := fst A_a. Local Definition a := snd A_a.
+    Local Definition S1 := addT S (scmul a B).
+    Local Definition s := snd (divmod S1).
     Local Definition q := fst (Z.mul_split r s k).
-    Local Definition S2 := addT' _ S1 (scmul _ q N).
-    Local Definition S3 := fst (divmod _ S2).
+    Local Definition S2 := addT' S1 (scmul q N).
+    Local Definition S3 := fst (divmod S2).
     Local Definition S4 := drop_high S3.
   End Iteration.
 
@@ -63,18 +71,18 @@ Section WordByWordMontgomery.
          end.
 
     Definition pre_redc : T (S R_numlimbs)
-      := snd (redc_loop A_numlimbs (A, zero (1 + R_numlimbs))).
+      := snd (redc_loop A_numlimbs (A, zero (n := 1 + R_numlimbs))).
 
     Definition redc : T R_numlimbs
       := conditional_sub pre_redc.
   End loop.
 
   Definition add (A B : T R_numlimbs) : T R_numlimbs
-    := conditional_sub (addT _ A B).
+    := conditional_sub (addT A B).
   Definition sub (A B : T R_numlimbs) : T R_numlimbs
     := sub_then_maybe_add A B.
   Definition opp (A : T R_numlimbs) : T R_numlimbs
-    := sub (zero _) A.
+    := sub zero A.
 End WordByWordMontgomery.
 
 Create HintDb word_by_word_montgomery.

--- a/src/Arithmetic/MontgomeryReduction/WordByWord/Abstract/Dependent/Proofs.v
+++ b/src/Arithmetic/MontgomeryReduction/WordByWord/Abstract/Dependent/Proofs.v
@@ -28,7 +28,7 @@ Section WordByWordMontgomery.
   Context
     {T : nat -> Type}
     {eval : forall {n}, T n -> Z}
-    {zero : forall {n}, T n}
+    {zero : forall n, T n}
     {divmod : forall {n}, T (S n) -> T n * Z} (* returns lowest limb and all-but-lowest-limb *)
     {r : positive}
     {r_big : r > 1}
@@ -41,13 +41,13 @@ Section WordByWordMontgomery.
     {eval_div : forall n v, small v -> eval (fst (@divmod n v)) = eval v / r}
     {eval_mod : forall n v, small v -> snd (@divmod n v) = eval v mod r}
     {small_div : forall n v, small v -> small (fst (@divmod n v))}
-    {scmul : forall {n}, Z -> T n -> T (S n)} (* uses double-output multiply *)
+    {scmul : forall n, Z -> T n -> T (S n)} (* uses double-output multiply *)
     {eval_scmul: forall n a v, small v -> 0 <= a < r -> 0 <= eval v < R -> eval (@scmul n a v) = a * eval v}
     {small_scmul : forall n a v, small v -> 0 <= a < r -> 0 <= eval v < R -> small (@scmul n a v)}
-    {addT : forall {n}, T n -> T n -> T (S n)} (* joins carry *)
+    {addT : forall n, T n -> T n -> T (S n)} (* joins carry *)
     {eval_addT : forall n a b, eval (@addT n a b) = eval a + eval b}
     {small_addT : forall n a b, small a -> small b -> small (@addT n a b)}
-    {addT' : forall {n}, T (S n) -> T n -> T (S (S n))} (* joins carry *)
+    {addT' : forall n, T (S n) -> T n -> T (S (S n))} (* joins carry *)
     {eval_addT' : forall n a b, eval (@addT' n a b) = eval a + eval b}
     {small_addT' : forall n a b, small a -> small b -> small (@addT' n a b)}
     {drop_high : T (S (S R_numlimbs)) -> T (S R_numlimbs)} (* drops the highest limb *)
@@ -101,6 +101,7 @@ Section WordByWordMontgomery.
        using (repeat autounfold with word_by_word_montgomery; t_small)
     : push_eval.
 
+  (* Coq bug #9412 *)
   Local Arguments eval {_} _.
   Local Arguments small {_} _.
   Local Arguments divmod {_} _.

--- a/src/Arithmetic/Saturated/AddSub.v
+++ b/src/Arithmetic/Saturated/AddSub.v
@@ -19,8 +19,8 @@ Module B.
       Let small {n} := @small s n.
       Section GenericOp.
         Context {op : Z -> Z -> Z}
-                {op_get_carry_cps : forall {T}, Z -> Z -> (Z * Z -> T) -> T} (* no carry in, carry out *)
-                {op_with_carry_cps : forall {T}, Z -> Z -> Z -> (Z * Z -> T) -> T}. (* carry in, carry out  *)
+                {op_get_carry_cps : forall T, Z -> Z -> (Z * Z -> T) -> T} (* no carry in, carry out *)
+                {op_with_carry_cps : forall T, Z -> Z -> Z -> (Z * Z -> T) -> T}. (* carry in, carry out  *)
         Let op_get_carry x y := op_get_carry_cps _ x y id.
         Let op_with_carry x y z := op_with_carry_cps _ x y z id.
         Context {op_get_carry_id : forall {T} x y f,

--- a/src/Arithmetic/Saturated/Core.v
+++ b/src/Arithmetic/Saturated/Core.v
@@ -117,20 +117,20 @@ Module Columns.
             {weight_multiples : forall i, weight (S i) mod weight i = 0}
             {weight_divides : forall i : nat, weight (S i) / weight i > 0}
             (* add_get_carry takes in a number at which to split output *)
-            {add_get_carry_cps: forall {T}, Z ->Z -> Z -> (Z * Z -> T) -> T}
-            {div_cps modulo_cps : forall {T}, Z -> Z -> (Z -> T) -> T}.
+            {add_get_carry_cps: forall T, Z ->Z -> Z -> (Z * Z -> T) -> T}
+            {div_cps modulo_cps : forall T, Z -> Z -> (Z -> T) -> T}.
     Let add_get_carry s x y := add_get_carry_cps _ s x y id.
     Let div x y := div_cps _ x y id.
     Let modulo x y := modulo_cps _ x y id.
-    Context {add_get_carry_cps_id : forall {T} s x y f,
+    Context {add_get_carry_cps_id : forall T s x y f,
                 @add_get_carry_cps T s x y f = f (add_get_carry s x y)}
             {add_get_carry_mod : forall s x y,
                 fst (add_get_carry s x y)  = (x + y) mod s}
             {add_get_carry_div : forall s x y,
                 snd (add_get_carry s x y)  = (x + y) / s}
-            {div_cps_id : forall {T} x y f,
+            {div_cps_id : forall T x y f,
                 @div_cps T x y f = f (div x y)}
-            {modulo_cps_id : forall {T} x y f,
+            {modulo_cps_id : forall T x y f,
                 @modulo_cps T x y f = f (modulo x y)}
             {div_correct : forall a b, div a b = a / b}
             {modulo_correct : forall a b, modulo a b = a mod b}

--- a/src/Arithmetic/Saturated/MulSplit.v
+++ b/src/Arithmetic/Saturated/MulSplit.v
@@ -18,6 +18,10 @@ Module B.
                   snd (mul_split_cps s x y id)  = (x * y) / s}
       .
 
+      (* Coq bug #9412 *)
+      Local Arguments mul_split_cps {T}.
+      Local Arguments mul_split_cps_id {T}.
+
       Local Lemma mul_split_cps_correct {T} s x y f
         : @mul_split_cps T s x y f = f ((x * y) mod s, (x * y) / s).
       Proof.
@@ -26,7 +30,7 @@ Module B.
       Hint Rewrite @mul_split_cps_correct : uncps.
 
       Definition sat_multerm_cps s (t t' : B.limb) {T} (f:list B.limb ->T) :=
-      mul_split_cps _ s (snd t) (snd t') (fun xy =>
+      mul_split_cps s (snd t) (snd t') (fun xy =>
       dlet xy := xy in
       f ((fst t * fst t', fst xy) :: (fst t * fst t' * s, snd xy) :: nil)).
 

--- a/src/Compilers/Eta.v
+++ b/src/Compilers/Eta.v
@@ -12,13 +12,14 @@ Section language.
 
     Section gen_flat_type.
       Context (eta : forall {A B}, A * B -> A * B).
+      Local Arguments eta {A B}. (* Coq bug #9412 *)
       Fixpoint interp_flat_type_eta_gen {t T} : (interp_flat_type var t -> T) -> interp_flat_type var t -> T
         := match t return (interp_flat_type var t -> T) -> interp_flat_type var t -> T with
            | Tbase T => fun f => f
            | Unit => fun f => f
            | Prod A B
              => fun f x
-                => let '(a, b) := eta _ _ x in
+                => let '(a, b) := eta x in
                    @interp_flat_type_eta_gen
                      A _
                      (fun a' => @interp_flat_type_eta_gen B _ (fun b' => f (a', b')) b)
@@ -27,8 +28,9 @@ Section language.
 
       Section gen_type.
         Context (exprf_eta : forall {t} (e : exprf t), exprf t).
+        Local Arguments exprf_eta {t}. (* Coq bug #9412 *)
         Definition expr_eta_gen {t} (e : expr t) : expr (Arrow (domain t) (codomain t))
-          := Abs (interp_flat_type_eta_gen (fun x => exprf_eta _ (invert_Abs e x))).
+          := Abs (interp_flat_type_eta_gen (fun x => exprf_eta (invert_Abs e x))).
       End gen_type.
 
       Fixpoint exprf_eta_gen {t} (e : exprf t) : exprf t

--- a/src/Compilers/EtaInterp.v
+++ b/src/Compilers/EtaInterp.v
@@ -29,7 +29,7 @@ Section language.
   Local Ltac t := repeat t_step.
 
   Section gen_flat_type.
-    Context (eta : forall {A B}, A * B -> A * B)
+    Context (eta : forall A B, A * B -> A * B)
             (eq_eta : forall A B x, @eta A B x = x).
     Lemma eq_interp_flat_type_eta_gen {var t T f} x
       : @interp_flat_type_eta_gen base_type_code var eta t T f x = f x.
@@ -38,7 +38,7 @@ Section language.
     (* Local *) Hint Rewrite @eq_interp_flat_type_eta_gen.
 
     Section gen_type.
-      Context (exprf_eta : forall {t} (e : exprf t), exprf t)
+      Context (exprf_eta : forall t (e : exprf t), exprf t)
               (eq_interp_exprf_eta : forall t e, interpf (@interp_op) (@exprf_eta t e) = interpf (@interp_op) e).
       Lemma interp_expr_eta_gen {t e}
         : forall x,

--- a/src/Compilers/EtaWf.v
+++ b/src/Compilers/EtaWf.v
@@ -42,11 +42,11 @@ Section language.
   Section with_var.
     Context {var1 var2 : base_type_code -> Type}.
     Section gen_flat_type.
-      Context (eta : forall {A B}, A * B -> A * B)
+      Context (eta : forall A B, A * B -> A * B)
               (eq_eta : forall A B x, @eta A B x = x).
       Section gen_type.
-        Context (exprf_eta1 : forall {t} (e : exprf t), exprf t)
-                (exprf_eta2 : forall {t} (e : exprf t), exprf t)
+        Context (exprf_eta1 : forall t (e : exprf t), exprf t)
+                (exprf_eta2 : forall t (e : exprf t), exprf t)
                 (wff_exprf_eta : forall G t e1 e2, @wff _ _ var1 var2 G t e1 e2
                                                    <-> @wff _ _ var1 var2 G t (@exprf_eta1 t e1) (@exprf_eta2 t e2)).
         Lemma wf_expr_eta_gen {t e1 e2}

--- a/src/Compilers/Inline.v
+++ b/src/Compilers/Inline.v
@@ -38,11 +38,12 @@ Section language.
          end.
 
     Context (postprocess : forall {t}, @exprf var t -> inline_directive t).
+    Local Arguments postprocess {t}.
 
     Fixpoint inline_const_genf {t} (e : @exprf (@exprf var) t) : @exprf var t
       := match e in Syntax.exprf _ _ t return @exprf var t with
          | LetIn tx ex tC eC
-           => match postprocess _ (@inline_const_genf _ ex) in inline_directive t' return (interp_flat_type _ t' -> @exprf var tC) -> @exprf var tC with
+           => match postprocess (@inline_const_genf _ ex) in inline_directive t' return (interp_flat_type _ t' -> @exprf var tC) -> @exprf var tC with
               | default_inline _ ex
                 => match ex in Syntax.exprf _ _ t' return (interp_flat_type _ t' -> @exprf var tC) -> @exprf var tC with
                    | TT => fun eC => eC tt

--- a/src/Experiments/PartialEvaluationWithLetIn.v
+++ b/src/Experiments/PartialEvaluationWithLetIn.v
@@ -526,7 +526,7 @@ Module partial.
                      cells'
            end.
 
-      Context (half_interp : forall {t} (idc : pident t),
+      Context (half_interp : forall t (idc : pident t),
                   parametric.half_interp UnderLets pbase_value value t
                   + parametric.half_interp2 UnderLets pbase_value value t).
 

--- a/src/Util/Loops.v
+++ b/src/Util/Loops.v
@@ -50,7 +50,7 @@ Module Import core.
                end.
     Qed.
 
-    Context (body_cps2 : A -> forall {R}, (A -> R) -> (B -> R) -> R).
+    Context (body_cps2 : A -> forall R, (A -> R) -> (B -> R) -> R).
     Fixpoint loop_cps2 (fuel : nat) (s : A) {R} (timeout:A->R) (ret:B->R) {struct fuel} : R :=
       body_cps2 s R
                 (fun a =>


### PR DESCRIPTION
Implicit arguments in `Context` were discarded. Coq PR [#11390](https://github.com/coq/coq/pull/11390) preserves them. The present PR adapts fiat-crypto to the new semantics.

There were several places in fiat-crypto using implicit arguments in `Context`. Depending on whether it looked intended or not that they were there, or depending on how easy it was to adapt to a change, I sometimes removed the implicit arguments and sometimes preserve them.

As a result, the PR is backward-incompatible and has to merged synchronously with coq/coq#11390. If you'd prefer a backward-compatible change, the implicit arguments should instead be removed in the few places where it has an impact.
