### PR TITLE
C Stringification: prepend __extension__ before the typedef with __int128

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -495,7 +495,7 @@ $(ALL_C_FILES) : $(C_DIR)%.c : $$($$($$*_BINARY_NAME))
 test-c-files: $(ALL_C_FILES) $(EXTRA_C_FILES)
 
 test-c-files only-test-c-files:
-	$(CC) -Wall -Wno-unused-function -Werror $(CFLAGS) -c $(ALL_C_FILES) $(EXTRA_C_FILES)
+	$(CC) -Wall -Wno-unused-function -Wpedantic -Werror $(CFLAGS) -c $(ALL_C_FILES) $(EXTRA_C_FILES)
 
 $(ALL_BEDROCK2_FILES) : $(BEDROCK2_DIR)%.c : $$(BEDROCK2_$$($$*_BINARY_NAME))
 	$(SHOW)'SYNTHESIZE > $@'

--- a/fiat-c/src/curve25519_64.c
+++ b/fiat-c/src/curve25519_64.c
@@ -15,7 +15,7 @@
 #include <stdint.h>
 typedef unsigned char fiat_25519_uint1;
 typedef signed char fiat_25519_int1;
-#ifdef GNUC
+#ifdef __GNUC__
 #  define FIAT_EXTENSION __extension__
 #else
 #  define FIAT_EXTENSION

--- a/fiat-c/src/curve25519_64.c
+++ b/fiat-c/src/curve25519_64.c
@@ -15,8 +15,14 @@
 #include <stdint.h>
 typedef unsigned char fiat_25519_uint1;
 typedef signed char fiat_25519_int1;
-typedef signed __int128 fiat_25519_int128;
-typedef unsigned __int128 fiat_25519_uint128;
+#ifdef GNUC
+#  define FIAT_EXTENSION __extension__
+#else
+#  define FIAT_EXTENSION
+#endif
+
+FIAT_EXTENSION typedef signed __int128 fiat_25519_int128;
+FIAT_EXTENSION typedef unsigned __int128 fiat_25519_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/fiat-c/src/curve25519_64.c
+++ b/fiat-c/src/curve25519_64.c
@@ -16,13 +16,13 @@
 typedef unsigned char fiat_25519_uint1;
 typedef signed char fiat_25519_int1;
 #ifdef __GNUC__
-#  define FIAT_EXTENSION __extension__
+#  define FIAT_25519_FIAT_EXTENSION __extension__
 #else
-#  define FIAT_EXTENSION
+#  define FIAT_25519_FIAT_EXTENSION
 #endif
 
-FIAT_EXTENSION typedef signed __int128 fiat_25519_int128;
-FIAT_EXTENSION typedef unsigned __int128 fiat_25519_uint128;
+FIAT_25519_FIAT_EXTENSION typedef signed __int128 fiat_25519_int128;
+FIAT_25519_FIAT_EXTENSION typedef unsigned __int128 fiat_25519_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/fiat-c/src/p224_64.c
+++ b/fiat-c/src/p224_64.c
@@ -18,7 +18,7 @@
 #include <stdint.h>
 typedef unsigned char fiat_p224_uint1;
 typedef signed char fiat_p224_int1;
-#ifdef GNUC
+#ifdef __GNUC__
 #  define FIAT_EXTENSION __extension__
 #else
 #  define FIAT_EXTENSION

--- a/fiat-c/src/p224_64.c
+++ b/fiat-c/src/p224_64.c
@@ -19,13 +19,13 @@
 typedef unsigned char fiat_p224_uint1;
 typedef signed char fiat_p224_int1;
 #ifdef __GNUC__
-#  define FIAT_EXTENSION __extension__
+#  define FIAT_P224_FIAT_EXTENSION __extension__
 #else
-#  define FIAT_EXTENSION
+#  define FIAT_P224_FIAT_EXTENSION
 #endif
 
-FIAT_EXTENSION typedef signed __int128 fiat_p224_int128;
-FIAT_EXTENSION typedef unsigned __int128 fiat_p224_uint128;
+FIAT_P224_FIAT_EXTENSION typedef signed __int128 fiat_p224_int128;
+FIAT_P224_FIAT_EXTENSION typedef unsigned __int128 fiat_p224_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/fiat-c/src/p224_64.c
+++ b/fiat-c/src/p224_64.c
@@ -18,8 +18,14 @@
 #include <stdint.h>
 typedef unsigned char fiat_p224_uint1;
 typedef signed char fiat_p224_int1;
-typedef signed __int128 fiat_p224_int128;
-typedef unsigned __int128 fiat_p224_uint128;
+#ifdef GNUC
+#  define FIAT_EXTENSION __extension__
+#else
+#  define FIAT_EXTENSION
+#endif
+
+FIAT_EXTENSION typedef signed __int128 fiat_p224_int128;
+FIAT_EXTENSION typedef unsigned __int128 fiat_p224_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/fiat-c/src/p256_64.c
+++ b/fiat-c/src/p256_64.c
@@ -19,13 +19,13 @@
 typedef unsigned char fiat_p256_uint1;
 typedef signed char fiat_p256_int1;
 #ifdef __GNUC__
-#  define FIAT_EXTENSION __extension__
+#  define FIAT_P256_FIAT_EXTENSION __extension__
 #else
-#  define FIAT_EXTENSION
+#  define FIAT_P256_FIAT_EXTENSION
 #endif
 
-FIAT_EXTENSION typedef signed __int128 fiat_p256_int128;
-FIAT_EXTENSION typedef unsigned __int128 fiat_p256_uint128;
+FIAT_P256_FIAT_EXTENSION typedef signed __int128 fiat_p256_int128;
+FIAT_P256_FIAT_EXTENSION typedef unsigned __int128 fiat_p256_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/fiat-c/src/p256_64.c
+++ b/fiat-c/src/p256_64.c
@@ -18,7 +18,7 @@
 #include <stdint.h>
 typedef unsigned char fiat_p256_uint1;
 typedef signed char fiat_p256_int1;
-#ifdef GNUC
+#ifdef __GNUC__
 #  define FIAT_EXTENSION __extension__
 #else
 #  define FIAT_EXTENSION

--- a/fiat-c/src/p256_64.c
+++ b/fiat-c/src/p256_64.c
@@ -18,8 +18,14 @@
 #include <stdint.h>
 typedef unsigned char fiat_p256_uint1;
 typedef signed char fiat_p256_int1;
-typedef signed __int128 fiat_p256_int128;
-typedef unsigned __int128 fiat_p256_uint128;
+#ifdef GNUC
+#  define FIAT_EXTENSION __extension__
+#else
+#  define FIAT_EXTENSION
+#endif
+
+FIAT_EXTENSION typedef signed __int128 fiat_p256_int128;
+FIAT_EXTENSION typedef unsigned __int128 fiat_p256_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/fiat-c/src/p384_64.c
+++ b/fiat-c/src/p384_64.c
@@ -18,7 +18,7 @@
 #include <stdint.h>
 typedef unsigned char fiat_p384_uint1;
 typedef signed char fiat_p384_int1;
-#ifdef GNUC
+#ifdef __GNUC__
 #  define FIAT_EXTENSION __extension__
 #else
 #  define FIAT_EXTENSION

--- a/fiat-c/src/p384_64.c
+++ b/fiat-c/src/p384_64.c
@@ -18,8 +18,14 @@
 #include <stdint.h>
 typedef unsigned char fiat_p384_uint1;
 typedef signed char fiat_p384_int1;
-typedef signed __int128 fiat_p384_int128;
-typedef unsigned __int128 fiat_p384_uint128;
+#ifdef GNUC
+#  define FIAT_EXTENSION __extension__
+#else
+#  define FIAT_EXTENSION
+#endif
+
+FIAT_EXTENSION typedef signed __int128 fiat_p384_int128;
+FIAT_EXTENSION typedef unsigned __int128 fiat_p384_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/fiat-c/src/p384_64.c
+++ b/fiat-c/src/p384_64.c
@@ -19,13 +19,13 @@
 typedef unsigned char fiat_p384_uint1;
 typedef signed char fiat_p384_int1;
 #ifdef __GNUC__
-#  define FIAT_EXTENSION __extension__
+#  define FIAT_P384_FIAT_EXTENSION __extension__
 #else
-#  define FIAT_EXTENSION
+#  define FIAT_P384_FIAT_EXTENSION
 #endif
 
-FIAT_EXTENSION typedef signed __int128 fiat_p384_int128;
-FIAT_EXTENSION typedef unsigned __int128 fiat_p384_uint128;
+FIAT_P384_FIAT_EXTENSION typedef signed __int128 fiat_p384_int128;
+FIAT_P384_FIAT_EXTENSION typedef unsigned __int128 fiat_p384_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/fiat-c/src/p434_64.c
+++ b/fiat-c/src/p434_64.c
@@ -18,8 +18,14 @@
 #include <stdint.h>
 typedef unsigned char fiat_p434_uint1;
 typedef signed char fiat_p434_int1;
-typedef signed __int128 fiat_p434_int128;
-typedef unsigned __int128 fiat_p434_uint128;
+#ifdef GNUC
+#  define FIAT_EXTENSION __extension__
+#else
+#  define FIAT_EXTENSION
+#endif
+
+FIAT_EXTENSION typedef signed __int128 fiat_p434_int128;
+FIAT_EXTENSION typedef unsigned __int128 fiat_p434_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/fiat-c/src/p434_64.c
+++ b/fiat-c/src/p434_64.c
@@ -19,13 +19,13 @@
 typedef unsigned char fiat_p434_uint1;
 typedef signed char fiat_p434_int1;
 #ifdef __GNUC__
-#  define FIAT_EXTENSION __extension__
+#  define FIAT_P434_FIAT_EXTENSION __extension__
 #else
-#  define FIAT_EXTENSION
+#  define FIAT_P434_FIAT_EXTENSION
 #endif
 
-FIAT_EXTENSION typedef signed __int128 fiat_p434_int128;
-FIAT_EXTENSION typedef unsigned __int128 fiat_p434_uint128;
+FIAT_P434_FIAT_EXTENSION typedef signed __int128 fiat_p434_int128;
+FIAT_P434_FIAT_EXTENSION typedef unsigned __int128 fiat_p434_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/fiat-c/src/p434_64.c
+++ b/fiat-c/src/p434_64.c
@@ -18,7 +18,7 @@
 #include <stdint.h>
 typedef unsigned char fiat_p434_uint1;
 typedef signed char fiat_p434_int1;
-#ifdef GNUC
+#ifdef __GNUC__
 #  define FIAT_EXTENSION __extension__
 #else
 #  define FIAT_EXTENSION

--- a/fiat-c/src/p448_solinas_32.c
+++ b/fiat-c/src/p448_solinas_32.c
@@ -15,8 +15,14 @@
 #include <stdint.h>
 typedef unsigned char fiat_p448_uint1;
 typedef signed char fiat_p448_int1;
-typedef signed __int128 fiat_p448_int128;
-typedef unsigned __int128 fiat_p448_uint128;
+#ifdef GNUC
+#  define FIAT_EXTENSION __extension__
+#else
+#  define FIAT_EXTENSION
+#endif
+
+FIAT_EXTENSION typedef signed __int128 fiat_p448_int128;
+FIAT_EXTENSION typedef unsigned __int128 fiat_p448_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/fiat-c/src/p448_solinas_32.c
+++ b/fiat-c/src/p448_solinas_32.c
@@ -16,13 +16,13 @@
 typedef unsigned char fiat_p448_uint1;
 typedef signed char fiat_p448_int1;
 #ifdef __GNUC__
-#  define FIAT_EXTENSION __extension__
+#  define FIAT_P448_FIAT_EXTENSION __extension__
 #else
-#  define FIAT_EXTENSION
+#  define FIAT_P448_FIAT_EXTENSION
 #endif
 
-FIAT_EXTENSION typedef signed __int128 fiat_p448_int128;
-FIAT_EXTENSION typedef unsigned __int128 fiat_p448_uint128;
+FIAT_P448_FIAT_EXTENSION typedef signed __int128 fiat_p448_int128;
+FIAT_P448_FIAT_EXTENSION typedef unsigned __int128 fiat_p448_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/fiat-c/src/p448_solinas_32.c
+++ b/fiat-c/src/p448_solinas_32.c
@@ -15,7 +15,7 @@
 #include <stdint.h>
 typedef unsigned char fiat_p448_uint1;
 typedef signed char fiat_p448_int1;
-#ifdef GNUC
+#ifdef __GNUC__
 #  define FIAT_EXTENSION __extension__
 #else
 #  define FIAT_EXTENSION

--- a/fiat-c/src/p448_solinas_64.c
+++ b/fiat-c/src/p448_solinas_64.c
@@ -15,8 +15,14 @@
 #include <stdint.h>
 typedef unsigned char fiat_p448_uint1;
 typedef signed char fiat_p448_int1;
-typedef signed __int128 fiat_p448_int128;
-typedef unsigned __int128 fiat_p448_uint128;
+#ifdef GNUC
+#  define FIAT_EXTENSION __extension__
+#else
+#  define FIAT_EXTENSION
+#endif
+
+FIAT_EXTENSION typedef signed __int128 fiat_p448_int128;
+FIAT_EXTENSION typedef unsigned __int128 fiat_p448_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/fiat-c/src/p448_solinas_64.c
+++ b/fiat-c/src/p448_solinas_64.c
@@ -16,13 +16,13 @@
 typedef unsigned char fiat_p448_uint1;
 typedef signed char fiat_p448_int1;
 #ifdef __GNUC__
-#  define FIAT_EXTENSION __extension__
+#  define FIAT_P448_FIAT_EXTENSION __extension__
 #else
-#  define FIAT_EXTENSION
+#  define FIAT_P448_FIAT_EXTENSION
 #endif
 
-FIAT_EXTENSION typedef signed __int128 fiat_p448_int128;
-FIAT_EXTENSION typedef unsigned __int128 fiat_p448_uint128;
+FIAT_P448_FIAT_EXTENSION typedef signed __int128 fiat_p448_int128;
+FIAT_P448_FIAT_EXTENSION typedef unsigned __int128 fiat_p448_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/fiat-c/src/p448_solinas_64.c
+++ b/fiat-c/src/p448_solinas_64.c
@@ -15,7 +15,7 @@
 #include <stdint.h>
 typedef unsigned char fiat_p448_uint1;
 typedef signed char fiat_p448_int1;
-#ifdef GNUC
+#ifdef __GNUC__
 #  define FIAT_EXTENSION __extension__
 #else
 #  define FIAT_EXTENSION

--- a/fiat-c/src/p521_64.c
+++ b/fiat-c/src/p521_64.c
@@ -15,7 +15,7 @@
 #include <stdint.h>
 typedef unsigned char fiat_p521_uint1;
 typedef signed char fiat_p521_int1;
-#ifdef GNUC
+#ifdef __GNUC__
 #  define FIAT_EXTENSION __extension__
 #else
 #  define FIAT_EXTENSION

--- a/fiat-c/src/p521_64.c
+++ b/fiat-c/src/p521_64.c
@@ -16,13 +16,13 @@
 typedef unsigned char fiat_p521_uint1;
 typedef signed char fiat_p521_int1;
 #ifdef __GNUC__
-#  define FIAT_EXTENSION __extension__
+#  define FIAT_P521_FIAT_EXTENSION __extension__
 #else
-#  define FIAT_EXTENSION
+#  define FIAT_P521_FIAT_EXTENSION
 #endif
 
-FIAT_EXTENSION typedef signed __int128 fiat_p521_int128;
-FIAT_EXTENSION typedef unsigned __int128 fiat_p521_uint128;
+FIAT_P521_FIAT_EXTENSION typedef signed __int128 fiat_p521_int128;
+FIAT_P521_FIAT_EXTENSION typedef unsigned __int128 fiat_p521_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/fiat-c/src/p521_64.c
+++ b/fiat-c/src/p521_64.c
@@ -15,8 +15,14 @@
 #include <stdint.h>
 typedef unsigned char fiat_p521_uint1;
 typedef signed char fiat_p521_int1;
-typedef signed __int128 fiat_p521_int128;
-typedef unsigned __int128 fiat_p521_uint128;
+#ifdef GNUC
+#  define FIAT_EXTENSION __extension__
+#else
+#  define FIAT_EXTENSION
+#endif
+
+FIAT_EXTENSION typedef signed __int128 fiat_p521_int128;
+FIAT_EXTENSION typedef unsigned __int128 fiat_p521_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/fiat-c/src/poly1305_64.c
+++ b/fiat-c/src/poly1305_64.c
@@ -16,13 +16,13 @@
 typedef unsigned char fiat_poly1305_uint1;
 typedef signed char fiat_poly1305_int1;
 #ifdef __GNUC__
-#  define FIAT_EXTENSION __extension__
+#  define FIAT_POLY1305_FIAT_EXTENSION __extension__
 #else
-#  define FIAT_EXTENSION
+#  define FIAT_POLY1305_FIAT_EXTENSION
 #endif
 
-FIAT_EXTENSION typedef signed __int128 fiat_poly1305_int128;
-FIAT_EXTENSION typedef unsigned __int128 fiat_poly1305_uint128;
+FIAT_POLY1305_FIAT_EXTENSION typedef signed __int128 fiat_poly1305_int128;
+FIAT_POLY1305_FIAT_EXTENSION typedef unsigned __int128 fiat_poly1305_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/fiat-c/src/poly1305_64.c
+++ b/fiat-c/src/poly1305_64.c
@@ -15,7 +15,7 @@
 #include <stdint.h>
 typedef unsigned char fiat_poly1305_uint1;
 typedef signed char fiat_poly1305_int1;
-#ifdef GNUC
+#ifdef __GNUC__
 #  define FIAT_EXTENSION __extension__
 #else
 #  define FIAT_EXTENSION

--- a/fiat-c/src/poly1305_64.c
+++ b/fiat-c/src/poly1305_64.c
@@ -15,8 +15,14 @@
 #include <stdint.h>
 typedef unsigned char fiat_poly1305_uint1;
 typedef signed char fiat_poly1305_int1;
-typedef signed __int128 fiat_poly1305_int128;
-typedef unsigned __int128 fiat_poly1305_uint128;
+#ifdef GNUC
+#  define FIAT_EXTENSION __extension__
+#else
+#  define FIAT_EXTENSION
+#endif
+
+FIAT_EXTENSION typedef signed __int128 fiat_poly1305_int128;
+FIAT_EXTENSION typedef unsigned __int128 fiat_poly1305_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/fiat-c/src/secp256k1_64.c
+++ b/fiat-c/src/secp256k1_64.c
@@ -19,13 +19,13 @@
 typedef unsigned char fiat_secp256k1_uint1;
 typedef signed char fiat_secp256k1_int1;
 #ifdef __GNUC__
-#  define FIAT_EXTENSION __extension__
+#  define FIAT_SECP256K1_FIAT_EXTENSION __extension__
 #else
-#  define FIAT_EXTENSION
+#  define FIAT_SECP256K1_FIAT_EXTENSION
 #endif
 
-FIAT_EXTENSION typedef signed __int128 fiat_secp256k1_int128;
-FIAT_EXTENSION typedef unsigned __int128 fiat_secp256k1_uint128;
+FIAT_SECP256K1_FIAT_EXTENSION typedef signed __int128 fiat_secp256k1_int128;
+FIAT_SECP256K1_FIAT_EXTENSION typedef unsigned __int128 fiat_secp256k1_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/fiat-c/src/secp256k1_64.c
+++ b/fiat-c/src/secp256k1_64.c
@@ -18,7 +18,7 @@
 #include <stdint.h>
 typedef unsigned char fiat_secp256k1_uint1;
 typedef signed char fiat_secp256k1_int1;
-#ifdef GNUC
+#ifdef __GNUC__
 #  define FIAT_EXTENSION __extension__
 #else
 #  define FIAT_EXTENSION

--- a/fiat-c/src/secp256k1_64.c
+++ b/fiat-c/src/secp256k1_64.c
@@ -18,8 +18,14 @@
 #include <stdint.h>
 typedef unsigned char fiat_secp256k1_uint1;
 typedef signed char fiat_secp256k1_int1;
-typedef signed __int128 fiat_secp256k1_int128;
-typedef unsigned __int128 fiat_secp256k1_uint128;
+#ifdef GNUC
+#  define FIAT_EXTENSION __extension__
+#else
+#  define FIAT_EXTENSION
+#endif
+
+FIAT_EXTENSION typedef signed __int128 fiat_secp256k1_int128;
+FIAT_EXTENSION typedef unsigned __int128 fiat_secp256k1_uint128;
 
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"

--- a/src/Stringification/C.v
+++ b/src/Stringification/C.v
@@ -104,8 +104,14 @@ Module Compilers.
                             "typedef signed char " ++ prefix ++ "int1;"]%string
                     else [])
                 ++ (if IntSet.mem uint128 bitwidths_used || IntSet.mem int128 bitwidths_used
-                    then ["typedef signed __int128 " ++ prefix ++ "int128;";
-                            "typedef unsigned __int128 " ++ prefix ++ "uint128;"]%string
+                    then ["#ifdef GNUC";
+                          "#  define FIAT_EXTENSION __extension__";
+                          "#else";
+                          "#  define FIAT_EXTENSION";
+                          "#endif";
+                          "";
+                          "FIAT_EXTENSION typedef signed __int128 " ++ prefix ++ "int128;";
+                          "FIAT_EXTENSION typedef unsigned __int128 " ++ prefix ++ "uint128;"]%string
                     else [])
                 ++ [""
                     ; "#if (-1 & 3) != 3"

--- a/src/Stringification/C.v
+++ b/src/Stringification/C.v
@@ -104,14 +104,15 @@ Module Compilers.
                             "typedef signed char " ++ prefix ++ "int1;"]%string
                     else [])
                 ++ (if IntSet.mem uint128 bitwidths_used || IntSet.mem int128 bitwidths_used
-                    then ["#ifdef __GNUC__";
-                          "#  define FIAT_EXTENSION __extension__";
+                    then let FIAT_EXTENSION := (String.to_upper prefix ++ "FIAT_EXTENSION")%string in
+                         ["#ifdef __GNUC__";
+                          "#  define " ++ FIAT_EXTENSION ++ " __extension__";
                           "#else";
-                          "#  define FIAT_EXTENSION";
+                          "#  define " ++ FIAT_EXTENSION;
                           "#endif";
                           "";
-                          "FIAT_EXTENSION typedef signed __int128 " ++ prefix ++ "int128;";
-                          "FIAT_EXTENSION typedef unsigned __int128 " ++ prefix ++ "uint128;"]%string
+                          FIAT_EXTENSION ++ " typedef signed __int128 " ++ prefix ++ "int128;";
+                          FIAT_EXTENSION ++ " typedef unsigned __int128 " ++ prefix ++ "uint128;"]%string
                     else [])
                 ++ [""
                     ; "#if (-1 & 3) != 3"

--- a/src/Stringification/C.v
+++ b/src/Stringification/C.v
@@ -104,7 +104,7 @@ Module Compilers.
                             "typedef signed char " ++ prefix ++ "int1;"]%string
                     else [])
                 ++ (if IntSet.mem uint128 bitwidths_used || IntSet.mem int128 bitwidths_used
-                    then ["#ifdef GNUC";
+                    then ["#ifdef __GNUC__";
                           "#  define FIAT_EXTENSION __extension__";
                           "#else";
                           "#  define FIAT_EXTENSION";


### PR DESCRIPTION
This allows the generated C code to compile with gcc and -Wpedantic.

Suggested in #820 by @chjj 