### PR TITLE
Add support for interaction with files

### DIFF
--- a/src/PushButtonSynthesis/BarrettReduction.v
+++ b/src/PushButtonSynthesis/BarrettReduction.v
@@ -65,6 +65,7 @@ Section rbarrett_red.
   Local Instance split_mul_to : split_mul_to_opt := None.
   Local Instance split_multiret_to : split_multiret_to_opt := None.
   Local Instance unfold_value_barrier : unfold_value_barrier_opt := true.
+  Local Instance assembly_hints_lines : assembly_hints_lines_opt := None.
   Local Instance low_level_rewriter_method : low_level_rewriter_method_opt := default_low_level_rewriter_method.
 
   Let fancy_args

--- a/src/PushButtonSynthesis/BaseConversion.v
+++ b/src/PushButtonSynthesis/BaseConversion.v
@@ -90,6 +90,7 @@ Section __.
           {should_split_mul : should_split_mul_opt}
           {should_split_multiret : should_split_multiret_opt}
           {unfold_value_barrier : unfold_value_barrier_opt}
+          {assembly_hints_lines : assembly_hints_lines_opt}
           {widen_carry : widen_carry_opt}
           {widen_bytes : widen_bytes_opt}
           (s : Z) (c : list (Z * Z))
@@ -342,7 +343,7 @@ Section __.
     (** Note: If you change the name or type signature of this
           function, you will need to update the code in CLI.v *)
     Definition Synthesize (comment_header : list string) (function_name_prefix : string) (requests : list string)
-      : list (string * Pipeline.ErrorT (list string))
+      : list (synthesis_output_kind * string * Pipeline.ErrorT (list string))
       := Primitives.Synthesize
            machine_wordsize valid_names known_functions (extra_special_synthesis function_name_prefix)
            check_args

--- a/src/PushButtonSynthesis/FancyMontgomeryReduction.v
+++ b/src/PushButtonSynthesis/FancyMontgomeryReduction.v
@@ -72,6 +72,7 @@ Section rmontred.
   Local Instance split_mul_to : split_mul_to_opt := None.
   Local Instance split_multiret_to : split_multiret_to_opt := None.
   Local Instance unfold_value_barrier : unfold_value_barrier_opt := true.
+  Local Instance assembly_hints_lines : assembly_hints_lines_opt := None.
   Local Instance low_level_rewriter_method : low_level_rewriter_method_opt := default_low_level_rewriter_method.
 
   Let fancy_args

--- a/src/PushButtonSynthesis/SaturatedSolinas.v
+++ b/src/PushButtonSynthesis/SaturatedSolinas.v
@@ -72,6 +72,7 @@ Section __.
           {should_split_mul : should_split_mul_opt}
           {should_split_multiret : should_split_multiret_opt}
           {unfold_value_barrier : unfold_value_barrier_opt}
+          {assembly_hints_lines : assembly_hints_lines_opt}
           {widen_carry : widen_carry_opt}
           (widen_bytes : widen_bytes_opt := true) (* true, because we don't allow byte-sized things anyway, so we should not expect carries to be widened to byte-size when emitting C code *)
           (s : Z)
@@ -223,7 +224,7 @@ Section __.
     (** Note: If you change the name or type signature of this
           function, you will need to update the code in CLI.v *)
     Definition Synthesize (comment_header : list string) (function_name_prefix : string) (requests : list string)
-      : list (string * Pipeline.ErrorT (list string))
+      : list (synthesis_output_kind * string * Pipeline.ErrorT (list string))
       := Primitives.Synthesize
            machine_wordsize valid_names known_functions (fun _ => nil)
            check_args

--- a/src/PushButtonSynthesis/SmallExamples.v
+++ b/src/PushButtonSynthesis/SmallExamples.v
@@ -23,6 +23,7 @@ Import Associational Positional.
 Local Instance : split_mul_to_opt := None.
 Local Instance : split_multiret_to_opt := None.
 Local Instance : unfold_value_barrier_opt := true.
+Local Instance : assembly_hints_lines_opt := None.
 Local Instance : only_signed_opt := false.
 Local Instance : no_select_size_opt := None.
 Local Existing Instance default_low_level_rewriter_method.

--- a/src/PushButtonSynthesis/UnsaturatedSolinas.v
+++ b/src/PushButtonSynthesis/UnsaturatedSolinas.v
@@ -92,6 +92,7 @@ Section __.
           {should_split_mul : should_split_mul_opt}
           {should_split_multiret : should_split_multiret_opt}
           {unfold_value_barrier : unfold_value_barrier_opt}
+          {assembly_hints_lines : assembly_hints_lines_opt}
           {widen_carry : widen_carry_opt}
           {widen_bytes : widen_bytes_opt}
           {tight_upperbound_fraction : tight_upperbound_fraction_opt}
@@ -771,7 +772,7 @@ Section __.
     (** Note: If you change the name or type signature of this
           function, you will need to update the code in CLI.v *)
     Definition Synthesize (comment_header : list string) (function_name_prefix : string) (requests : list string)
-      : list (string * Pipeline.ErrorT (list string))
+      : list (synthesis_output_kind * string * Pipeline.ErrorT (list string))
       := Primitives.Synthesize
            machine_wordsize valid_names known_functions (extra_special_synthesis function_name_prefix)
            check_args

--- a/src/PushButtonSynthesis/WordByWordMontgomery.v
+++ b/src/PushButtonSynthesis/WordByWordMontgomery.v
@@ -107,6 +107,7 @@ Section __.
           {should_split_mul : should_split_mul_opt}
           {should_split_multiret : should_split_multiret_opt}
           {unfold_value_barrier : unfold_value_barrier_opt}
+          {assembly_hints_lines : assembly_hints_lines_opt}
           {widen_carry : widen_carry_opt}
           {widen_bytes : widen_bytes_opt}
           (m : Z)
@@ -1018,7 +1019,7 @@ Section __.
     (** Note: If you change the name or type signature of this
           function, you will need to update the code in CLI.v *)
     Definition Synthesize (comment_header : list string) (function_name_prefix : string) (requests : list string)
-      : list (string * Pipeline.ErrorT (list string))
+      : list (synthesis_output_kind * string * Pipeline.ErrorT (list string))
       := Primitives.Synthesize
            machine_wordsize valid_names known_functions (fun _ => nil)
            check_args

--- a/src/Rewriter/PerfTesting/Core.v
+++ b/src/Rewriter/PerfTesting/Core.v
@@ -56,6 +56,7 @@ Local Instance : no_select_opt := false.
 Local Instance : should_split_mul_opt := false.
 Local Instance : should_split_multiret_opt := false.
 Local Instance : unfold_value_barrier_opt := true.
+Local Instance : assembly_hints_lines_opt := None.
 Local Instance : widen_bytes_opt := false.
 Local Instance : widen_carry_opt := false.
 Local Instance : tight_upperbound_fraction_opt := default_tight_upperbound_fraction.

--- a/src/SlowPrimeSynthesisExamples.v
+++ b/src/SlowPrimeSynthesisExamples.v
@@ -38,6 +38,7 @@ Local Coercion Z.pos : positive >-> Z.
 
 Local Existing Instance default_low_level_rewriter_method.
 Local Instance : unfold_value_barrier_opt := true.
+Local Instance : assembly_hints_lines_opt := None.
 Local Instance : tight_upperbound_fraction_opt := default_tight_upperbound_fraction.
 Local Existing Instance default_language_naming_conventions.
 Local Instance : package_name_opt := None.


### PR DESCRIPTION
We now support the `--hints-file` and `--output-asm` arguments (both
unused) and the `--output` / `-o` argument.  The first two are initial
support for interacting with assembly hint files, though we don't
currently do anything with the arguments other than opening and reading
the files, and parsing the assembly.

cc @andres-erbsen, the relevant entry point is the function `Synthesize` at the bottom of `Primitives.v`.