### PR TITLE
Globalize Hints to suppress warning on Coq master

### DIFF
--- a/src/Algebra/Ring.v
+++ b/src/Algebra/Ring.v
@@ -479,6 +479,6 @@ Ltac ring_simplify_subterms_in_all :=
 Create HintDb ring_simplify discriminated.
 Create HintDb ring_simplify_subterms discriminated.
 Create HintDb ring_simplify_subterms_in_all discriminated.
-Hint Extern 1 => progress ring_simplify : ring_simplify.
-Hint Extern 1 => progress ring_simplify_subterms : ring_simplify_subterms.
-Hint Extern 1 => progress ring_simplify_subterms_in_all : ring_simplify_subterms_in_all.
+Global Hint Extern 1 => progress ring_simplify : ring_simplify.
+Global Hint Extern 1 => progress ring_simplify_subterms : ring_simplify_subterms.
+Global Hint Extern 1 => progress ring_simplify_subterms_in_all : ring_simplify_subterms_in_all.

--- a/src/Arithmetic/Core.v
+++ b/src/Arithmetic/Core.v
@@ -1076,8 +1076,8 @@ Record weight_properties {weight : nat -> Z} :=
     weight_multiples : forall i, weight (S i) mod weight i = 0;
     weight_divides : forall i : nat, 0 < weight (S i) / weight i;
   }.
-Hint Resolve weight_0 weight_positive weight_multiples weight_divides : core.
+Global Hint Resolve weight_0 weight_positive weight_multiples weight_divides : core.
 Lemma weight_nz {weight : nat -> Z} {wprops : @weight_properties weight}
   : forall i, weight i <> 0.
 Proof. intro i; pose proof (@weight_positive _ wprops i); lia. Qed.
-Hint Resolve weight_nz : core.
+Global Hint Resolve weight_nz : core.

--- a/src/Bedrock/Field/Translation/Proofs/EquivalenceProperties.v
+++ b/src/Bedrock/Field/Translation/Proofs/EquivalenceProperties.v
@@ -333,7 +333,7 @@ Section OnlyDiffer.
     Qed.
   End Generic.
 End OnlyDiffer.
-Hint Resolve
+Global Hint Resolve
      equiv_listZ_only_differ_undef_local
      equiv_listZ_only_differ_undef_mem
      equiv_listZ_only_differ_local

--- a/src/PushButtonSynthesis/Primitives.v
+++ b/src/PushButtonSynthesis/Primitives.v
@@ -71,7 +71,7 @@ for (op, opmod) in (('id', '(@id (list Z))'), ('selectznz', 'Positional.select')
        SuchThat (is_reification_of reified_%s_gen %s)
        As reified_%s_gen_correct.
 Proof. Time cache_reify (). Time Qed.
-Hint Extern 1 (_ = _) => apply_cached_reification %s (proj1 reified_%s_gen_correct) : reify_cache_gen.
+Global Hint Extern 1 (_ = _) => apply_cached_reification %s (proj1 reified_%s_gen_correct) : reify_cache_gen.
 Hint Immediate (proj2 reified_%s_gen_correct) : wf_gen_cache.
 Hint Rewrite (proj1 reified_%s_gen_correct) : interp_gen_cache.
 Local Opaque reified_%s_gen. (* needed for making [autorewrite] not take a very long time *)''' % (indent, op, op, opmod, op, opmod, op, op, op, op)).replace('\n', '\n%s' % indent) + '\n')
@@ -83,7 +83,7 @@ Derive reified_id_gen
        SuchThat (is_reification_of reified_id_gen (@id (list Z)))
        As reified_id_gen_correct.
 Proof. Time cache_reify (). Time Qed.
-Hint Extern 1 (_ = _) => apply_cached_reification (@id (list Z)) (proj1 reified_id_gen_correct) : reify_cache_gen.
+Global Hint Extern 1 (_ = _) => apply_cached_reification (@id (list Z)) (proj1 reified_id_gen_correct) : reify_cache_gen.
 Hint Immediate (proj2 reified_id_gen_correct) : wf_gen_cache.
 Hint Rewrite (proj1 reified_id_gen_correct) : interp_gen_cache.
 Local Opaque reified_id_gen. (* needed for making [autorewrite] not take a very long time *)
@@ -92,7 +92,7 @@ Derive reified_selectznz_gen
        SuchThat (is_reification_of reified_selectznz_gen Positional.select)
        As reified_selectznz_gen_correct.
 Proof. Time cache_reify (). Time Qed.
-Hint Extern 1 (_ = _) => apply_cached_reification Positional.select (proj1 reified_selectznz_gen_correct) : reify_cache_gen.
+Global Hint Extern 1 (_ = _) => apply_cached_reification Positional.select (proj1 reified_selectznz_gen_correct) : reify_cache_gen.
 Hint Immediate (proj2 reified_selectznz_gen_correct) : wf_gen_cache.
 Hint Rewrite (proj1 reified_selectznz_gen_correct) : interp_gen_cache.
 Local Opaque reified_selectznz_gen. (* needed for making [autorewrite] not take a very long time *)
@@ -101,7 +101,7 @@ Derive reified_mulx_gen
        SuchThat (is_reification_of reified_mulx_gen mulx)
        As reified_mulx_gen_correct.
 Proof. Time cache_reify (). Time Qed.
-Hint Extern 1 (_ = _) => apply_cached_reification mulx (proj1 reified_mulx_gen_correct) : reify_cache_gen.
+Global Hint Extern 1 (_ = _) => apply_cached_reification mulx (proj1 reified_mulx_gen_correct) : reify_cache_gen.
 Hint Immediate (proj2 reified_mulx_gen_correct) : wf_gen_cache.
 Hint Rewrite (proj1 reified_mulx_gen_correct) : interp_gen_cache.
 Local Opaque reified_mulx_gen. (* needed for making [autorewrite] not take a very long time *)
@@ -110,7 +110,7 @@ Derive reified_addcarryx_gen
        SuchThat (is_reification_of reified_addcarryx_gen addcarryx)
        As reified_addcarryx_gen_correct.
 Proof. Time cache_reify (). Time Qed.
-Hint Extern 1 (_ = _) => apply_cached_reification addcarryx (proj1 reified_addcarryx_gen_correct) : reify_cache_gen.
+Global Hint Extern 1 (_ = _) => apply_cached_reification addcarryx (proj1 reified_addcarryx_gen_correct) : reify_cache_gen.
 Hint Immediate (proj2 reified_addcarryx_gen_correct) : wf_gen_cache.
 Hint Rewrite (proj1 reified_addcarryx_gen_correct) : interp_gen_cache.
 Local Opaque reified_addcarryx_gen. (* needed for making [autorewrite] not take a very long time *)
@@ -119,7 +119,7 @@ Derive reified_subborrowx_gen
        SuchThat (is_reification_of reified_subborrowx_gen subborrowx)
        As reified_subborrowx_gen_correct.
 Proof. Time cache_reify (). Time Qed.
-Hint Extern 1 (_ = _) => apply_cached_reification subborrowx (proj1 reified_subborrowx_gen_correct) : reify_cache_gen.
+Global Hint Extern 1 (_ = _) => apply_cached_reification subborrowx (proj1 reified_subborrowx_gen_correct) : reify_cache_gen.
 Hint Immediate (proj2 reified_subborrowx_gen_correct) : wf_gen_cache.
 Hint Rewrite (proj1 reified_subborrowx_gen_correct) : interp_gen_cache.
 Local Opaque reified_subborrowx_gen. (* needed for making [autorewrite] not take a very long time *)
@@ -128,7 +128,7 @@ Derive reified_value_barrier_gen
        SuchThat (is_reification_of reified_value_barrier_gen Z.value_barrier)
        As reified_value_barrier_gen_correct.
 Proof. Time cache_reify (). Time Qed.
-Hint Extern 1 (_ = _) => apply_cached_reification Z.value_barrier (proj1 reified_value_barrier_gen_correct) : reify_cache_gen.
+Global Hint Extern 1 (_ = _) => apply_cached_reification Z.value_barrier (proj1 reified_value_barrier_gen_correct) : reify_cache_gen.
 Hint Immediate (proj2 reified_value_barrier_gen_correct) : wf_gen_cache.
 Hint Rewrite (proj1 reified_value_barrier_gen_correct) : interp_gen_cache.
 Local Opaque reified_value_barrier_gen. (* needed for making [autorewrite] not take a very long time *)
@@ -137,7 +137,7 @@ Derive reified_cmovznz_gen
        SuchThat (is_reification_of reified_cmovznz_gen cmovznz)
        As reified_cmovznz_gen_correct.
 Proof. Time cache_reify (). Time Qed.
-Hint Extern 1 (_ = _) => apply_cached_reification cmovznz (proj1 reified_cmovznz_gen_correct) : reify_cache_gen.
+Global Hint Extern 1 (_ = _) => apply_cached_reification cmovznz (proj1 reified_cmovznz_gen_correct) : reify_cache_gen.
 Hint Immediate (proj2 reified_cmovznz_gen_correct) : wf_gen_cache.
 Hint Rewrite (proj1 reified_cmovznz_gen_correct) : interp_gen_cache.
 Local Opaque reified_cmovznz_gen. (* needed for making [autorewrite] not take a very long time *)
@@ -146,7 +146,7 @@ Derive reified_cmovznz_by_mul_gen
        SuchThat (is_reification_of reified_cmovznz_by_mul_gen cmovznz_by_mul)
        As reified_cmovznz_by_mul_gen_correct.
 Proof. Time cache_reify (). Time Qed.
-Hint Extern 1 (_ = _) => apply_cached_reification cmovznz_by_mul (proj1 reified_cmovznz_by_mul_gen_correct) : reify_cache_gen.
+Global Hint Extern 1 (_ = _) => apply_cached_reification cmovznz_by_mul (proj1 reified_cmovznz_by_mul_gen_correct) : reify_cache_gen.
 Hint Immediate (proj2 reified_cmovznz_by_mul_gen_correct) : wf_gen_cache.
 Hint Rewrite (proj1 reified_cmovznz_by_mul_gen_correct) : interp_gen_cache.
 Local Opaque reified_cmovznz_by_mul_gen. (* needed for making [autorewrite] not take a very long time *)

--- a/src/PushButtonSynthesis/UnsaturatedSolinasReificationCache.v
+++ b/src/PushButtonSynthesis/UnsaturatedSolinasReificationCache.v
@@ -35,7 +35,7 @@ for i in ('carry_mul', 'carry_square', 'carry_scmul', 'carry', 'encode', 'add', 
        SuchThat (is_reification_of reified_%s_gen %smod)
        As reified_%s_gen_correct.
 Proof. Time cache_reify (). Time Qed.
-Hint Extern 1 (_ = _) => apply_cached_reification %smod (proj1 reified_%s_gen_correct) : reify_cache_gen.
+Global Hint Extern 1 (_ = _) => apply_cached_reification %smod (proj1 reified_%s_gen_correct) : reify_cache_gen.
 Hint Immediate (proj2 reified_%s_gen_correct) : wf_gen_cache.
 Hint Rewrite (proj1 reified_%s_gen_correct) : interp_gen_cache.
 Local Opaque reified_%s_gen. (* needed for making [autorewrite] not take a very long time *)''' % (indent, i, i, i, i, i, i, i, i, i)).replace('\n', '\n%s' % indent) + '\n')
@@ -45,7 +45,7 @@ for (op, opmod) in (('to_bytes', 'freeze_to_bytesmod'), ('from_bytes', 'from_byt
        SuchThat (is_reification_of reified_%s_gen %s)
        As reified_%s_gen_correct.
 Proof. Time cache_reify (). Time Qed.
-Hint Extern 1 (_ = _) => apply_cached_reification %s (proj1 reified_%s_gen_correct) : reify_cache_gen.
+Global Hint Extern 1 (_ = _) => apply_cached_reification %s (proj1 reified_%s_gen_correct) : reify_cache_gen.
 Hint Immediate (proj2 reified_%s_gen_correct) : wf_gen_cache.
 Hint Rewrite (proj1 reified_%s_gen_correct) : interp_gen_cache.
 Local Opaque reified_%s_gen. (* needed for making [autorewrite] not take a very long time *)''' % (indent, op, op, opmod, op, opmod, op, op, op, op)).replace('\n', '\n%s' % indent) + '\n')

--- a/src/PushButtonSynthesis/WordByWordMontgomeryReificationCache.v
+++ b/src/PushButtonSynthesis/WordByWordMontgomeryReificationCache.v
@@ -87,7 +87,7 @@ for i in ('mul', 'add', 'sub', 'opp', 'to_bytes', 'from_bytes', 'nonzero', 'eval
        SuchThat (is_reification_of reified_%s_gen %smod)
        As reified_%s_gen_correct.
 Proof. Time cache_reify (). Time Qed.
-Hint Extern 1 (_ = _) => apply_cached_reification %smod (proj1 reified_%s_gen_correct) : reify_cache_gen.
+Global Hint Extern 1 (_ = _) => apply_cached_reification %smod (proj1 reified_%s_gen_correct) : reify_cache_gen.
 Hint Immediate (proj2 reified_%s_gen_correct) : wf_gen_cache.
 Hint Rewrite (proj1 reified_%s_gen_correct) : interp_gen_cache.
 Local Opaque reified_%s_gen. (* needed for making [autorewrite] not take a very long time *)''' % (indent, i, i, i, i, i, i, i, i, i)).replace('\n', '\n%s' % indent) + '\n')
@@ -101,7 +101,7 @@ Proof.
   (* we would do something faster, but it breaks extraction COQBUG(https://github.com/coq/coq/issues/7954) *)
   (* Time cache_reify_faster_2arg (). *)
 Time Qed.
-Hint Extern 1 (_ = _) => apply_cached_reification %smod (proj1 reified_%s_gen_correct) : reify_cache_gen.
+Global Hint Extern 1 (_ = _) => apply_cached_reification %smod (proj1 reified_%s_gen_correct) : reify_cache_gen.
 Hint Immediate (proj2 reified_%s_gen_correct) : wf_gen_cache.
 Hint Rewrite (proj1 reified_%s_gen_correct) : interp_gen_cache.
 Local Opaque reified_%s_gen. (* needed for making [autorewrite] not take a very long time *)''' % (indent, i, i, i, i, i, i, i, i, i)).replace('\n', '\n%s' % indent) + '\n')
@@ -116,7 +116,7 @@ Proof.
   (* we do something faster *)
   Time cache_reify_faster_1arg ().
 Time Qed.
-Hint Extern 1 (_ = _) => apply_cached_reification %smod (proj1 reified_%s_gen_correct) : reify_cache_gen.
+Global Hint Extern 1 (_ = _) => apply_cached_reification %smod (proj1 reified_%s_gen_correct) : reify_cache_gen.
 Hint Immediate (proj2 reified_%s_gen_correct) : wf_gen_cache.
 Hint Rewrite (proj1 reified_%s_gen_correct) : interp_gen_cache.
 Local Opaque reified_%s_gen. (* needed for making [autorewrite] not take a very long time *)''' % (indent, i, i, i, i, i, i, i, i, i)).replace('\n', '\n%s' % indent) + '\n')

--- a/src/Util/Bool.v
+++ b/src/Util/Bool.v
@@ -9,10 +9,10 @@ Create HintDb bool_congr_setoid discriminated.
 (** For generic simplifications of things involving booleans, e.g., if-statements *)
 Create HintDb boolsimplify discriminated.
 
-Hint Extern 1 => progress autorewrite with boolsimplify in * : boolsimplify.
-Hint Extern 1 => progress autorewrite with bool_congr in * : bool_congr.
-Hint Extern 1 => progress autorewrite with bool_congr_setoid in * : bool_congr_setoid.
-Hint Extern 2 => progress rewrite_strat topdown hints bool_congr_setoid : bool_congr_setoid.
+Global Hint Extern 1 => progress autorewrite with boolsimplify in * : boolsimplify.
+Global Hint Extern 1 => progress autorewrite with bool_congr in * : bool_congr.
+Global Hint Extern 1 => progress autorewrite with bool_congr_setoid in * : bool_congr_setoid.
+Global Hint Extern 2 => progress rewrite_strat topdown hints bool_congr_setoid : bool_congr_setoid.
 
 Hint Rewrite Bool.andb_diag Bool.orb_diag Bool.eqb_reflx Bool.negb_involutive Bool.eqb_negb1 Bool.eqb_negb2 Bool.orb_true_r Bool.orb_true_l Bool.orb_false_r Bool.orb_false_l Bool.orb_negb_r Bool.andb_false_r Bool.andb_false_l Bool.andb_true_r Bool.andb_false_r Bool.andb_negb_r Bool.xorb_false_r Bool.xorb_false_l Bool.xorb_true_r Bool.xorb_true_l Bool.xorb_nilpotent : bool_congr.
 Hint Rewrite Bool.negb_if : boolsimplify.
@@ -25,12 +25,12 @@ Create HintDb push_andb discriminated.
 Create HintDb pull_andb discriminated.
 Create HintDb push_negb discriminated.
 Create HintDb pull_negb discriminated.
-Hint Extern 1 => progress autorewrite with push_orb in * : push_orb.
-Hint Extern 1 => progress autorewrite with pull_orb in * : pull_orb.
-Hint Extern 1 => progress autorewrite with push_andb in * : push_andb.
-Hint Extern 1 => progress autorewrite with pull_andb in * : pull_andb.
-Hint Extern 1 => progress autorewrite with push_negb in * : push_negb.
-Hint Extern 1 => progress autorewrite with pull_negb in * : pull_negb.
+Global Hint Extern 1 => progress autorewrite with push_orb in * : push_orb.
+Global Hint Extern 1 => progress autorewrite with pull_orb in * : pull_orb.
+Global Hint Extern 1 => progress autorewrite with push_andb in * : push_andb.
+Global Hint Extern 1 => progress autorewrite with pull_andb in * : pull_andb.
+Global Hint Extern 1 => progress autorewrite with push_negb in * : push_negb.
+Global Hint Extern 1 => progress autorewrite with pull_negb in * : pull_negb.
 Hint Rewrite Bool.negb_orb Bool.negb_andb : push_negb.
 Hint Rewrite Bool.xorb_negb_negb : pull_negb.
 Hint Rewrite <- Bool.negb_orb Bool.negb_andb Bool.negb_xorb_l Bool.negb_xorb_r : pull_negb.

--- a/src/Util/Bool/Reflect.v
+++ b/src/Util/Bool/Reflect.v
@@ -277,8 +277,8 @@ Lemma reflect_not {A a} `{reflect A a} : reflect (~A) (negb a).
 Proof. exact _. Qed.
 
 (** Disallow infinite loops of reflect_not *)
-Hint Extern 0 (reflect (~?A) _) => eapply (@reflect_not A) : typeclass_instances.
-Hint Extern 0 (reflect _ (negb ?b)) => eapply (@reflect_not _ b) : typeclass_instances.
+Global Hint Extern 0 (reflect (~?A) _) => eapply (@reflect_not A) : typeclass_instances.
+Global Hint Extern 0 (reflect _ (negb ?b)) => eapply (@reflect_not _ b) : typeclass_instances.
 
 Global Instance reflect_eq_unit : reflect_rel (@eq unit) (fun _ _ => true) | 10. exact _. Qed.
 Global Instance reflect_eq_bool : reflect_rel (@eq bool) Bool.eqb | 10. exact _. Qed.
@@ -376,9 +376,9 @@ Definition reflect_if_bool {x : bool} {A B a b} {HA : reflect A a} {HB : reflect
      then HA
      else HB.
 
-Hint Extern 1 (reflect _ (match ?x with true => ?a | false => ?b end))
+Global Hint Extern 1 (reflect _ (match ?x with true => ?a | false => ?b end))
 => eapply (@reflect_if_bool x _ _ a b) : typeclass_instances.
-Hint Extern 1 (reflect (match ?x with true => ?A | false => ?B end) _)
+Global Hint Extern 1 (reflect (match ?x with true => ?A | false => ?B end) _)
 => eapply (@reflect_if_bool x A B) : typeclass_instances.
 
 Global Instance reflect_ex_forall_not : forall T (P:T->Prop) (exPb:bool) {d:reflect (exists b, P b) exPb}, reflect (forall b, ~ P b) (negb exPb).
@@ -423,14 +423,14 @@ Lemma reflect_eq_pair {A B a1 a2 b1 b2 Aeqb Beqb}
        {HB : Bool.reflect (@eq B b1 b2) Beqb}
   : Bool.reflect ((a1, b1) = (a2, b2)) (andb Aeqb Beqb).
 Proof. apply reflect_f_equal2_inverts; now inversion 1. Defined.
-Hint Extern 2 (reflect (@pair ?A ?B _ _ = pair _ _) _) => simple eapply (@reflect_eq_pair A B) : typeclass_instances.
+Global Hint Extern 2 (reflect (@pair ?A ?B _ _ = pair _ _) _) => simple eapply (@reflect_eq_pair A B) : typeclass_instances.
 
 Lemma reflect_eq_cons {A x y xs ys eqb eqbs}
        {HA : Bool.reflect (@eq A x y) eqb}
        {HB : Bool.reflect (@eq (list A) xs ys) eqbs}
   : Bool.reflect (cons x xs = cons y ys) (andb eqb eqbs).
 Proof. apply reflect_f_equal2_inverts; now inversion 1. Defined.
-Hint Extern 2 (reflect (@cons ?T _ _ = cons _ _) _) => simple eapply (@reflect_eq_cons T) : typeclass_instances.
+Global Hint Extern 2 (reflect (@cons ?T _ _ = cons _ _) _) => simple eapply (@reflect_eq_cons T) : typeclass_instances.
 
 Lemma reflect_bool : forall {P b} {Preflect:reflect P b}, b = true -> P.
 Proof. intros P b Preflect; destruct Preflect; solve [ auto | discriminate ]. Qed.

--- a/src/Util/Decidable.v
+++ b/src/Util/Decidable.v
@@ -84,7 +84,7 @@ Global Instance dec_iff {A B} `{Decidable A, Decidable B} : Decidable (A <-> B) 
 Lemma dec_not {A} `{Decidable A} : Decidable (~A).
 Proof. solve_decidable_transparent. Defined.
 (** Disallow infinite loops of dec_not *)
-Hint Extern 0 (Decidable (~?A)) => apply (@dec_not A) : typeclass_instances.
+Global Hint Extern 0 (Decidable (~?A)) => apply (@dec_not A) : typeclass_instances.
 Global Instance dec_eq_unit : DecidableRel (@eq unit) | 10. exact _. Defined.
 Global Instance dec_eq_bool : DecidableRel (@eq bool) | 10. exact _. Defined.
 Global Instance dec_eq_Empty_set : DecidableRel (@eq Empty_set) | 10. exact _. Defined.
@@ -216,7 +216,7 @@ Ltac vm_decide := abstract vm_decide_no_check.
 Ltac lazy_decide := abstract lazy_decide_no_check.
 
 (** For dubious compatibility with [eauto using]. *)
-Hint Extern 2 (Decidable _) => progress unfold Decidable : typeclass_instances core.
+Global Hint Extern 2 (Decidable _) => progress unfold Decidable : typeclass_instances core.
 
 Definition cast_if_eq {T} `{DecidableRel (@eq T)} {P} (t t' : T) (v : P t) : option (P t')
   := match dec (t = t'), dec (t' = t') with

--- a/src/Util/Decidable/Bool2Prop.v
+++ b/src/Util/Decidable/Bool2Prop.v
@@ -1,61 +1,61 @@
 Require Coq.ZArith.ZArith.
 
 Lemma unit_eq (x y:unit) : x = y. destruct x, y; reflexivity. Qed.
-Hint Resolve unit_eq : core.
+Global Hint Resolve unit_eq : core.
 
-Hint Extern 0 (_ = _ :> bool) => (
+Global Hint Extern 0 (_ = _ :> bool) => (
   match goal with
   | [H:Bool.eqb ?a ?b = true |- ?a = ?b ] => apply (proj1 (Bool.eqb_true_iff _ _) H)
   | [H:Bool.eqb ?b ?a = true |- ?a = ?b ] => symmetry; apply (proj1 (Bool.eqb_true_iff _ _) H)
   end) : core.
 
-Hint Extern 0 (_ = _ :> nat) => (
+Global Hint Extern 0 (_ = _ :> nat) => (
   match goal with
   | [H:Nat.eqb ?a ?b = true |- ?a = ?b ] => apply (proj1 (PeanoNat.Nat.eqb_eq _ _) H)
   | [H:Nat.eqb ?b ?a = true |- ?a = ?b ] => symmetry; apply (proj1 (PeanoNat.Nat.eqb_eq _ _) H)
   end) : core.
 
-Hint Extern 0 (_ <= _) => (
+Global Hint Extern 0 (_ <= _) => (
   match goal with
   | [H:Nat.ltb ?a ?b = true |- ?a < ?b ] => apply (proj1 (PeanoNat.Nat.ltb_lt _ _) H)
   end) : core.
 
-Hint Extern 0 (_ <= _) => (
+Global Hint Extern 0 (_ <= _) => (
   match goal with
   | [H:Nat.leb ?a ?b = true |- ?a <= ?b ] => apply (proj1 (PeanoNat.Nat.leb_le _ _) H)
   end) : core.
 
-Hint Extern 0 (_ = _ :> BinNums.N) => (
+Global Hint Extern 0 (_ = _ :> BinNums.N) => (
   match goal with
   | [H:BinNat.N.eqb ?a ?b = true |- ?a = ?b ] => apply (proj1 (BinNat.N.eqb_eq _ _) H)
   | [H:BinNat.N.eqb ?b ?a = true |- ?a = ?b ] => symmetry; apply (proj1 (BinNat.N.eqb_eq _ _) H)
   end) : core.
-Hint Extern 0 (_ = _ :> BinInt.Z) => (
+Global Hint Extern 0 (_ = _ :> BinInt.Z) => (
   match goal with
   | [H:BinInt.Z.eqb ?a ?b = true |- ?a = ?b ] => apply (proj1 (BinInt.Z.eqb_eq _ _) H)
   | [H:BinInt.Z.eqb ?a ?b = true |- ?b = ?a ] => symmetry; apply (proj1 (BinInt.Z.eqb_eq _ _) H)
   end) : core.
-Hint Extern 0 (BinInt.Z.lt _ _) => (
+Global Hint Extern 0 (BinInt.Z.lt _ _) => (
   match goal with
   | [H:BinInt.Z.ltb ?a ?b = true |- BinInt.Z.lt ?a ?b ] => apply (proj1 (BinInt.Z.ltb_lt _ _) H)
   | [H:BinInt.Z.gtb ?b ?a = true |- BinInt.Z.lt ?a ?b ] => apply (proj1 (BinInt.Z.gtb_lt _ _) H)
   end) : core.
-Hint Extern 0 (BinInt.Z.le _ _) => (
+Global Hint Extern 0 (BinInt.Z.le _ _) => (
   match goal with
   | [H:BinInt.Z.leb ?a ?b = true |- BinInt.Z.le ?a ?b ] => apply (proj1 (BinInt.Z.leb_le _ _) H)
   | [H:BinInt.Z.geb ?b ?a = true |- BinInt.Z.le ?a ?b ] => apply (proj1 (BinInt.Z.geb_le _ _) H)
   end) : core.
 
-Hint Extern 0 (_ = _ :> BinPos.positive) => (
+Global Hint Extern 0 (_ = _ :> BinPos.positive) => (
   match goal with
   | [H:BinPos.Pos.eqb ?a ?b = true |- ?a = ?b ] => apply (proj1 (BinPos.Pos.eqb_eq _ _) H)
   | [H:BinPos.Pos.eqb ?a ?b = true |- ?b = ?a ] => symmetry; apply (proj1 (BinPos.Pos.eqb_eq _ _) H)
   end) : core.
-Hint Extern 0 (BinPos.Pos.lt _ _) => (
+Global Hint Extern 0 (BinPos.Pos.lt _ _) => (
   match goal with
   | [H:BinPos.Pos.ltb ?a ?b = true |- BinPos.Pos.lt ?a ?b ] => apply (proj1 (BinPos.Pos.ltb_lt _ _) H)
   end) : core.
-Hint Extern 0 (BinPos.Pos.le _ _) => (
+Global Hint Extern 0 (BinPos.Pos.le _ _) => (
   match goal with
   | [H:BinPos.Pos.leb ?a ?b = true |- BinPos.Pos.le ?a ?b ] => apply (proj1 (BinPos.Pos.leb_le _ _) H)
   end) : core.

--- a/src/Util/FixCoqMistakes.v
+++ b/src/Util/FixCoqMistakes.v
@@ -85,4 +85,4 @@ Ltac solve_Proper_eq :=
       unify R R';
       apply (@reflexive_proper A R')
   end.
-Hint Extern 0 (Proper _ _) => solve_Proper_eq : typeclass_instances.
+Global Hint Extern 0 (Proper _ _) => solve_Proper_eq : typeclass_instances.

--- a/src/Util/LetIn.v
+++ b/src/Util/LetIn.v
@@ -55,7 +55,7 @@ Ltac let_in_to_Let_In e :=
     with fun x => @?C x => C end (* match drops the type cast *)
   | ?x => x
   end.
-Hint Extern 0 (_call_let_in_to_Let_In ?e) => (
+Global Hint Extern 0 (_call_let_in_to_Let_In ?e) => (
   let e := let_in_to_Let_In e in eexact e
 ) : typeclass_instances.
 Ltac change_let_in_with_Let_In :=

--- a/src/Util/LetInMonad.v
+++ b/src/Util/LetInMonad.v
@@ -35,7 +35,7 @@ Definition lift2 {A B C} (f : A -> B -> C) : LetInM A -> LetInM B -> LetInM C
   := fun x y => under_lets x (fun x' => under_lets y (fun y' => ret (f x' y'))).
 
 Create HintDb push_denote discriminated.
-Hint Extern 1 => progress autorewrite with push_denote in * : push_denote.
+Global Hint Extern 1 => progress autorewrite with push_denote in * : push_denote.
 
 Ltac push_denote_step :=
   first [ progress simpl @denote in *

--- a/src/Util/ListUtil.v
+++ b/src/Util/ListUtil.v
@@ -111,7 +111,7 @@ Hint Rewrite
   @prod_length
   : distr_length.
 
-Hint Extern 1 => progress autorewrite with distr_length in * : distr_length.
+Global Hint Extern 1 => progress autorewrite with distr_length in * : distr_length.
 Ltac distr_length := autorewrite with distr_length in *;
   try solve [simpl in *; intros; (idtac + exfalso); lia].
 
@@ -451,7 +451,7 @@ Lemma nth_error_length_error : forall A i (xs:list A),
 Proof.
   induction i as [|? IHi]; destruct xs; nth_tac'; rewrite IHi by lia; auto.
 Qed.
-Hint Resolve nth_error_length_error : core.
+Global Hint Resolve nth_error_length_error : core.
 Hint Rewrite @nth_error_length_error using lia : simpl_nth_error.
 
 Lemma map_nth_default : forall (A B : Type) (f : A -> B) n x y l,
@@ -1214,7 +1214,7 @@ Proof.
   assumption.
 Qed.
 
-Hint Resolve nth_default_in_bounds : simpl_nth_default.
+Global Hint Resolve nth_default_in_bounds : simpl_nth_default.
 
 Lemma cons_eq_head : forall {T} (x y:T) xs ys, x::xs = y::ys -> x=y.
 Proof.
@@ -1541,7 +1541,7 @@ Proof.
       intuition auto with zarith. }
 Qed.
 
-Hint Resolve sum_firstn_nonnegative : znonzero.
+Global Hint Resolve sum_firstn_nonnegative : znonzero.
 
 Lemma sum_firstn_app : forall xs ys n,
   sum_firstn (xs ++ ys) n = (sum_firstn xs n + sum_firstn ys (n - length xs))%Z.

--- a/src/Util/NatUtil.v
+++ b/src/Util/NatUtil.v
@@ -11,7 +11,7 @@ Scheme Equality for nat.
 
 Create HintDb natsimplify discriminated.
 
-Hint Resolve mod_bound_pos plus_le_compat : arith.
+Global Hint Resolve mod_bound_pos plus_le_compat : arith.
 Hint Rewrite @mod_small @mod_mod @mod_1_l @mod_1_r succ_pred using lia : natsimplify.
 
 Hint Rewrite sub_diag add_0_l add_0_r sub_0_r sub_succ : natsimplify.
@@ -26,7 +26,7 @@ Qed.
 Lemma mod_bound_lt x y : 0 < y -> x mod y < y.
 Proof. apply Nat.mod_bound_pos; lia. Qed.
 
-Hint Resolve mod_bound_nonneg mod_bound_lt : arith.
+Global Hint Resolve mod_bound_nonneg mod_bound_lt : arith.
 
 Lemma min_def {x y} : min x y = x - (x - y).
 Proof. apply Min.min_case_strong; lia. Qed.
@@ -236,7 +236,7 @@ Proof.
   intro; induction k; simpl; nia.
 Qed.
 
-Hint Resolve pow_nonzero : arith.
+Global Hint Resolve pow_nonzero : arith.
 
 Lemma S_pred_nonzero : forall a, (a > 0 -> S (pred a) = a)%nat.
 Proof.
@@ -249,7 +249,7 @@ Lemma mod_same_eq a b : a <> 0 -> a = b -> b mod a = 0.
 Proof. intros; subst; apply mod_same; assumption. Qed.
 
 Hint Rewrite @mod_same_eq using lia : natsimplify.
-Hint Resolve mod_same_eq : arith.
+Global Hint Resolve mod_same_eq : arith.
 
 Lemma mod_mod_eq a b c : a <> 0 -> b = c mod a -> b mod a = b.
 Proof. intros; subst; autorewrite with natsimplify; reflexivity. Qed.

--- a/src/Util/PER.v
+++ b/src/Util/PER.v
@@ -4,5 +4,5 @@ Lemma PER_valid_l {A} {R : relation A} {HS : Symmetric R} {HT : Transitive R} x 
 Proof. hnf; etransitivity; eassumption || symmetry; eassumption. Qed.
 Lemma PER_valid_r {A} {R : relation A} {HS : Symmetric R} {HT : Transitive R} x y (H : R x y) : Proper R y.
 Proof. hnf; etransitivity; eassumption || symmetry; eassumption. Qed.
-Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_l _ R); [ | | solve [ auto with nocore ] ] : typeclass_instances.
-Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [ auto with nocore ] ] : typeclass_instances.
+Global Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_l _ R); [ | | solve [ auto with nocore ] ] : typeclass_instances.
+Global Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [ auto with nocore ] ] : typeclass_instances.

--- a/src/Util/PointedProp.v
+++ b/src/Util/PointedProp.v
@@ -98,10 +98,10 @@ Create HintDb push_prop_of_option discriminated.
 Create HintDb push_to_prop discriminated.
 Create HintDb push_eq_trivial discriminated.
 Create HintDb push_eq_Some_trivial discriminated.
-Hint Extern 1 => progress autorewrite with push_prop_of_option in * : push_prop_of_option.
-Hint Extern 1 => progress autorewrite with push_to_prop in * : push_to_prop.
-Hint Extern 1 => progress autorewrite with push_eq_trivial in * : push_eq_trivial.
-Hint Extern 1 => progress autorewrite with push_eq_Some_trivial in * : push_eq_Some_trivial.
+Global Hint Extern 1 => progress autorewrite with push_prop_of_option in * : push_prop_of_option.
+Global Hint Extern 1 => progress autorewrite with push_to_prop in * : push_to_prop.
+Global Hint Extern 1 => progress autorewrite with push_eq_trivial in * : push_eq_trivial.
+Global Hint Extern 1 => progress autorewrite with push_eq_Some_trivial in * : push_eq_Some_trivial.
 
 Lemma to_prop_and P Q : to_prop (P /\ Q)%pointed_prop
                         <-> (to_prop P /\ to_prop Q).

--- a/src/Util/PrimitiveProd.v
+++ b/src/Util/PrimitiveProd.v
@@ -151,9 +151,9 @@ Global Instance iffTp_iffTp_prod_Proper
 Proof.
   intros ?? [?] ?? [?]; constructor; tauto.
 Defined.
-Hint Extern 2 (Proper _ prod) => apply iffTp_iffTp_prod_Proper : typeclass_instances.
-Hint Extern 2 (Proper _ (fun A => prod A)) => refine iff_iffTp_prod_Proper : typeclass_instances.
-Hint Extern 2 (Proper _ (fun A B => prod A B)) => refine iff_prod_Proper : typeclass_instances.
+Global Hint Extern 2 (Proper _ prod) => apply iffTp_iffTp_prod_Proper : typeclass_instances.
+Global Hint Extern 2 (Proper _ (fun A => prod A)) => refine iff_iffTp_prod_Proper : typeclass_instances.
+Global Hint Extern 2 (Proper _ (fun A B => prod A B)) => refine iff_prod_Proper : typeclass_instances.
 
 (** ** Useful Tactics *)
 (** *** [inversion_prod] *)

--- a/src/Util/Prod.v
+++ b/src/Util/Prod.v
@@ -95,9 +95,9 @@ Global Instance iffTp_iffTp_prod_Proper
 Proof.
   intros ?? [?] ?? [?]; constructor; tauto.
 Defined.
-Hint Extern 2 (Proper _ prod) => apply iffTp_iffTp_prod_Proper : typeclass_instances.
-Hint Extern 2 (Proper _ (fun A => prod A)) => refine iff_iffTp_prod_Proper : typeclass_instances.
-Hint Extern 2 (Proper _ (fun A B => prod A B)) => refine iff_prod_Proper : typeclass_instances.
+Global Hint Extern 2 (Proper _ prod) => apply iffTp_iffTp_prod_Proper : typeclass_instances.
+Global Hint Extern 2 (Proper _ (fun A => prod A)) => refine iff_iffTp_prod_Proper : typeclass_instances.
+Global Hint Extern 2 (Proper _ (fun A B => prod A B)) => refine iff_prod_Proper : typeclass_instances.
 
 (** ** Useful Tactics *)
 (** *** [inversion_prod] *)

--- a/src/Util/Tactics/DebugPrint.v
+++ b/src/Util/Tactics/DebugPrint.v
@@ -13,21 +13,21 @@ Ltac solve_debugfail tac :=
 
 (** constr-based [idtac] *)
 Class cidtac {T} (msg : T) := Build_cidtac : True.
-Hint Extern 0 (cidtac ?msg) => idtac msg; exact I : typeclass_instances.
+Global Hint Extern 0 (cidtac ?msg) => idtac msg; exact I : typeclass_instances.
 (** constr-based [idtac] *)
 Class cidtac2 {T1 T2} (msg1 : T1) (msg2 : T2) := Build_cidtac2 : True.
-Hint Extern 0 (cidtac2 ?msg1 ?msg2) => idtac msg1 msg2; exact I : typeclass_instances.
+Global Hint Extern 0 (cidtac2 ?msg1 ?msg2) => idtac msg1 msg2; exact I : typeclass_instances.
 Class cidtac3 {T1 T2 T3} (msg1 : T1) (msg2 : T2) (msg3 : T3) := Build_cidtac3 : True.
-Hint Extern 0 (cidtac3 ?msg1 ?msg2 ?msg3) => idtac msg1 msg2 msg3; exact I : typeclass_instances.
+Global Hint Extern 0 (cidtac3 ?msg1 ?msg2 ?msg3) => idtac msg1 msg2 msg3; exact I : typeclass_instances.
 Class cidtac4 {T1 T2 T3 T4} (msg1 : T1) (msg2 : T2) (msg3 : T3) (msg4 : T4) := Build_cidtac4 : True.
-Hint Extern 0 (cidtac4 ?msg1 ?msg2 ?msg3 ?msg4) => idtac msg1 msg2 msg3 msg4; exact I : typeclass_instances.
+Global Hint Extern 0 (cidtac4 ?msg1 ?msg2 ?msg3 ?msg4) => idtac msg1 msg2 msg3 msg4; exact I : typeclass_instances.
 
 Class cfail {T} (msg : T) := Build_cfail : True.
-Hint Extern 0 (cfail ?msg) => idtac "Error:" msg; exact I : typeclass_instances.
+Global Hint Extern 0 (cfail ?msg) => idtac "Error:" msg; exact I : typeclass_instances.
 Class cfail2 {T1 T2} (msg1 : T1) (msg2 : T2) := Build_cfail2 : True.
-Hint Extern 0 (cfail2 ?msg1 ?msg2) => idtac "Error:" msg1 msg2; exact I : typeclass_instances.
+Global Hint Extern 0 (cfail2 ?msg1 ?msg2) => idtac "Error:" msg1 msg2; exact I : typeclass_instances.
 Class cfail3 {T1 T2 T3} (msg1 : T1) (msg2 : T2) (msg3 : T3) := Build_cfail3 : True.
-Hint Extern 0 (cfail3 ?msg1 ?msg2 ?msg3) => idtac "Error:" msg1 msg2 msg3; exact I : typeclass_instances.
+Global Hint Extern 0 (cfail3 ?msg1 ?msg2 ?msg3) => idtac "Error:" msg1 msg2 msg3; exact I : typeclass_instances.
 
 Ltac constr_run_tac tac :=
   let dummy := match goal with

--- a/src/Util/ZUtil/Hints.v
+++ b/src/Util/ZUtil/Hints.v
@@ -6,8 +6,8 @@ Require Export Crypto.Util.ZUtil.Hints.Ztestbit.
 Require Export Crypto.Util.ZUtil.Hints.PullPush.
 Require Export Crypto.Util.ZUtil.ZSimplify.Core.
 
-Hint Resolve -> Z.log2_lt_pow2 Z.log2_le_pow2 : concl_log2.
-Hint Resolve <- Z.log2_lt_pow2 Z.log2_le_pow2 : hyp_log2.
+Global Hint Resolve -> Z.log2_lt_pow2 Z.log2_le_pow2 : concl_log2.
+Global Hint Resolve <- Z.log2_lt_pow2 Z.log2_le_pow2 : hyp_log2.
 
 (** For the occasional lemma that can remove the use of [Z.div] *)
 Hint Rewrite Z.div_small_iff using zutil_arith : zstrip_div.

--- a/src/Util/ZUtil/Hints/Core.v
+++ b/src/Util/ZUtil/Hints/Core.v
@@ -3,9 +3,9 @@ Require Import Coq.micromega.Lia Coq.micromega.Lqa.
 Require Import Coq.ZArith.ZArith.
 (* Should we [Require Import Coq.ZArith.Zhints.]? *)
 
-Hint Extern 1 => lia : lia.
-Hint Extern 1 => lra : lra.
-Hint Extern 1 => nia : nia.
+Global Hint Extern 1 => lia : lia.
+Global Hint Extern 1 => lra : lra.
+Global Hint Extern 1 => nia : nia.
 
 Ltac zutil_arith := solve [ lia | auto with nocore ].
 Ltac zutil_arith_more_inequalities := solve [ zutil_arith | auto with zarith ].
@@ -58,32 +58,32 @@ Create HintDb Zshift_to_pow discriminated.
 Create HintDb Zpow_to_shift discriminated.
 Create HintDb pull_Zmax discriminated.
 Create HintDb push_Zmax discriminated.
-Hint Extern 1 => progress autorewrite with push_Zopp in * : push_Zopp.
-Hint Extern 1 => progress autorewrite with pull_Zopp in * : pull_Zopp.
-Hint Extern 1 => progress autorewrite with push_Zpow in * : push_Zpow.
-Hint Extern 1 => progress autorewrite with pull_Zpow in * : pull_Zpow.
-Hint Extern 1 => progress autorewrite with push_Zmul in * : push_Zmul.
-Hint Extern 1 => progress autorewrite with pull_Zmul in * : pull_Zmul.
-Hint Extern 1 => progress autorewrite with push_Zadd in * : push_Zadd.
-Hint Extern 1 => progress autorewrite with pull_Zadd in * : pull_Zadd.
-Hint Extern 1 => progress autorewrite with push_Zsub in * : push_Zsub.
-Hint Extern 1 => progress autorewrite with pull_Zsub in * : pull_Zsub.
-Hint Extern 1 => progress autorewrite with push_Zdiv in * : push_Zmul.
-Hint Extern 1 => progress autorewrite with pull_Zdiv in * : pull_Zmul.
-Hint Extern 1 => progress autorewrite with pull_Zmod in * : pull_Zmod.
-Hint Extern 1 => progress autorewrite with push_Zmod in * : push_Zmod.
-Hint Extern 1 => progress autorewrite with pull_Zof_nat in * : pull_Zof_nat.
-Hint Extern 1 => progress autorewrite with push_Zof_nat in * : push_Zof_nat.
-Hint Extern 1 => progress autorewrite with pull_Zshift in * : pull_Zshift.
-Hint Extern 1 => progress autorewrite with push_Zshift in * : push_Zshift.
-Hint Extern 1 => progress autorewrite with Zshift_to_pow in * : Zshift_to_pow.
-Hint Extern 1 => progress autorewrite with Zpow_to_shift in * : Zpow_to_shift.
-Hint Extern 1 => progress autorewrite with pull_Zof_N in * : pull_Zof_N.
-Hint Extern 1 => progress autorewrite with push_Zof_N in * : push_Zof_N.
-Hint Extern 1 => progress autorewrite with pull_Zto_N in * : pull_Zto_N.
-Hint Extern 1 => progress autorewrite with push_Zto_N in * : push_Zto_N.
-Hint Extern 1 => progress autorewrite with push_Zmax in * : push_Zmax.
-Hint Extern 1 => progress autorewrite with pull_Zmax in * : pull_Zmax.
+Global Hint Extern 1 => progress autorewrite with push_Zopp in * : push_Zopp.
+Global Hint Extern 1 => progress autorewrite with pull_Zopp in * : pull_Zopp.
+Global Hint Extern 1 => progress autorewrite with push_Zpow in * : push_Zpow.
+Global Hint Extern 1 => progress autorewrite with pull_Zpow in * : pull_Zpow.
+Global Hint Extern 1 => progress autorewrite with push_Zmul in * : push_Zmul.
+Global Hint Extern 1 => progress autorewrite with pull_Zmul in * : pull_Zmul.
+Global Hint Extern 1 => progress autorewrite with push_Zadd in * : push_Zadd.
+Global Hint Extern 1 => progress autorewrite with pull_Zadd in * : pull_Zadd.
+Global Hint Extern 1 => progress autorewrite with push_Zsub in * : push_Zsub.
+Global Hint Extern 1 => progress autorewrite with pull_Zsub in * : pull_Zsub.
+Global Hint Extern 1 => progress autorewrite with push_Zdiv in * : push_Zmul.
+Global Hint Extern 1 => progress autorewrite with pull_Zdiv in * : pull_Zmul.
+Global Hint Extern 1 => progress autorewrite with pull_Zmod in * : pull_Zmod.
+Global Hint Extern 1 => progress autorewrite with push_Zmod in * : push_Zmod.
+Global Hint Extern 1 => progress autorewrite with pull_Zof_nat in * : pull_Zof_nat.
+Global Hint Extern 1 => progress autorewrite with push_Zof_nat in * : push_Zof_nat.
+Global Hint Extern 1 => progress autorewrite with pull_Zshift in * : pull_Zshift.
+Global Hint Extern 1 => progress autorewrite with push_Zshift in * : push_Zshift.
+Global Hint Extern 1 => progress autorewrite with Zshift_to_pow in * : Zshift_to_pow.
+Global Hint Extern 1 => progress autorewrite with Zpow_to_shift in * : Zpow_to_shift.
+Global Hint Extern 1 => progress autorewrite with pull_Zof_N in * : pull_Zof_N.
+Global Hint Extern 1 => progress autorewrite with push_Zof_N in * : push_Zof_N.
+Global Hint Extern 1 => progress autorewrite with pull_Zto_N in * : pull_Zto_N.
+Global Hint Extern 1 => progress autorewrite with push_Zto_N in * : push_Zto_N.
+Global Hint Extern 1 => progress autorewrite with push_Zmax in * : push_Zmax.
+Global Hint Extern 1 => progress autorewrite with pull_Zmax in * : pull_Zmax.
 
 (** For the occasional lemma that can remove the use of [Z.div] *)
 Create HintDb zstrip_div.

--- a/src/Util/ZUtil/Hints/ZArith.v
+++ b/src/Util/ZUtil/Hints/ZArith.v
@@ -1,11 +1,11 @@
 Require Import Coq.ZArith.ZArith.
 Require Export Crypto.Util.ZUtil.Hints.Core.
 
-Hint Resolve Z.log2_nonneg Z.log2_up_nonneg Z.div_small Z.mod_small Z.pow_neg_r Z.pow_0_l Z.pow_pos_nonneg Z.lt_le_incl Z.pow_nonzero Z.div_le_upper_bound Z_div_exact_full_2 Z.div_same Z.div_lt_upper_bound Z.div_le_lower_bound Zplus_minus Zplus_gt_compat_l Zplus_gt_compat_r Zmult_gt_compat_l Zmult_gt_compat_r Z.pow_lt_mono_r Z.pow_lt_mono_l Z.pow_lt_mono Z.mul_lt_mono_nonneg Z.div_lt_upper_bound Z.div_pos Zmult_lt_compat_r Z.pow_le_mono_r Z.pow_le_mono_l Z.div_lt Z.div_le_compat_l Z.div_le_mono Z.max_le_compat Z.min_le_compat Z.log2_up_le_mono Z.pow_nonneg : zarith.
-Hint Resolve (fun a b H => proj1 (Z.mod_pos_bound a b H)) (fun a b H => proj2 (Z.mod_pos_bound a b H)) : zarith.
-Hint Resolve -> Z.pow_gt_1 Z.opp_le_mono Z.pred_le_mono : zarith.
-Hint Resolve <- Z.lor_nonneg : zarith.
+Global Hint Resolve Z.log2_nonneg Z.log2_up_nonneg Z.div_small Z.mod_small Z.pow_neg_r Z.pow_0_l Z.pow_pos_nonneg Z.lt_le_incl Z.pow_nonzero Z.div_le_upper_bound Z_div_exact_full_2 Z.div_same Z.div_lt_upper_bound Z.div_le_lower_bound Zplus_minus Zplus_gt_compat_l Zplus_gt_compat_r Zmult_gt_compat_l Zmult_gt_compat_r Z.pow_lt_mono_r Z.pow_lt_mono_l Z.pow_lt_mono Z.mul_lt_mono_nonneg Z.div_lt_upper_bound Z.div_pos Zmult_lt_compat_r Z.pow_le_mono_r Z.pow_le_mono_l Z.div_lt Z.div_le_compat_l Z.div_le_mono Z.max_le_compat Z.min_le_compat Z.log2_up_le_mono Z.pow_nonneg : zarith.
+Global Hint Resolve (fun a b H => proj1 (Z.mod_pos_bound a b H)) (fun a b H => proj2 (Z.mod_pos_bound a b H)) : zarith.
+Global Hint Resolve -> Z.pow_gt_1 Z.opp_le_mono Z.pred_le_mono : zarith.
+Global Hint Resolve <- Z.lor_nonneg : zarith.
 
-Hint Resolve Zmult_le_compat_r Zmult_le_compat_l Z_div_le Z.add_le_mono Z.sub_le_mono : zarith.
-Hint Resolve Z.lt_gt Z.lt_le_incl : zarith.
-Hint Resolve Nat2Z.is_nonneg : zarith.
+Global Hint Resolve Zmult_le_compat_r Zmult_le_compat_l Z_div_le Z.add_le_mono Z.sub_le_mono : zarith.
+Global Hint Resolve Z.lt_gt Z.lt_le_incl : zarith.
+Global Hint Resolve Nat2Z.is_nonneg : zarith.

--- a/src/Util/ZUtil/Stabilization.v
+++ b/src/Util/ZUtil/Stabilization.v
@@ -31,7 +31,7 @@ Module Z.
   Proof. apply Z.log2_up_nonneg. Qed.
   Hint Resolve Z.stabilization_time_weaker_nonneg : zarith.
 End Z.
-Hint Resolve Z.stabilization_time_nonneg Z.stabilization_time_weaker_nonneg : zarith.
+Global Hint Resolve Z.stabilization_time_nonneg Z.stabilization_time_weaker_nonneg : zarith.
 
 Lemma stabilization_time (x:Z) : stabilizes_after x (Z.stabilization_time x).
 Proof.


### PR DESCRIPTION
Starting off from
```
git grep --name-only '^Hint \(Resolve\|Extern\)' | xargs sed -i 's/^Hint \(Resolve\|Extern\)/Global Hint \1/g'
```