### PR TITLE
notypeclasses in transparent assert

### DIFF
--- a/src/Util/Tactics/TransparentAssert.v
+++ b/src/Util/Tactics/TransparentAssert.v
@@ -1,6 +1,6 @@
 (** [transparent assert (H : T)] is like [assert (H : T)], but leaves the body transparent. *)
 Tactic Notation "transparent" "assert" "(" ident(name) ":" constr(type) ")" :=
-  simple refine (let name := (_ : type) in _).
+  simple notypeclasses refine (let name := (_ : type) in _).
 
 (** [transparent eassert] is like [transparent assert], but allows holes in the type, which will be turned into evars. *)
 Tactic Notation "transparent" "assert" "(" ident(name) ":" constr(type) ")" "by" tactic3(tac) := transparent assert (name : type); [ solve [ tac ] | ].


### PR DESCRIPTION
Use `simple notypeclasses refine` in `transparent assert`.

See
https://github.com/mit-plv/rewriter/commit/ce996ca8e48022221dda7c092d5a05f193da2e96

The `notypeclasses` behavior is the one we want; even if the type is a
typeclass, we want to leave over the corresponding goal.