### PR TITLE
Bump bedrock2 via rupicola again

### DIFF
--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -15,12 +15,12 @@ jobs:
       matrix:
         env:
         - { COQ_VERSION: "8.12.0", COQ_PACKAGE: "coq-8.12.0 libcoq-8.12.0-ocaml-dev", SKIP_BEDROCK2: "" , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
-        - { COQ_VERSION: "8.11.1", COQ_PACKAGE: "coq-8.11.1 libcoq-8.11.1-ocaml-dev", SKIP_BEDROCK2: "" , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
+        - { COQ_VERSION: "8.11.1", COQ_PACKAGE: "coq-8.11.1 libcoq-8.11.1-ocaml-dev", SKIP_BEDROCK2: "1", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
         - { COQ_VERSION: "8.10.2", COQ_PACKAGE: "coq-8.10.2 libcoq-8.10.2-ocaml-dev", SKIP_BEDROCK2: "1", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
         - { COQ_VERSION: "8.9.1" , COQ_PACKAGE: "coq-8.9.1 libcoq-8.9.1-ocaml-dev"  , SKIP_BEDROCK2: "1", SKIP_VALIDATE: "1", PPA: "ppa:jgross-h/many-coq-versions" }
         - { COQ_VERSION: "master", COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_BEDROCK2: "" , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-master-daily" }
         - { COQ_VERSION: "v8.12" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_BEDROCK2: "" , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.12-daily" }
-        - { COQ_VERSION: "v8.11" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_BEDROCK2: "" , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.11-daily" }
+        - { COQ_VERSION: "v8.11" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_BEDROCK2: "1", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.11-daily" }
         - { COQ_VERSION: "v8.10" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_BEDROCK2: "1", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.10-daily" }
         - { COQ_VERSION: "v8.9"  , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_BEDROCK2: "1", SKIP_VALIDATE: "1", PPA: "ppa:jgross-h/coq-8.9-daily" }
         ghc: [ '8.8.1' ]

--- a/src/Bedrock/Field/Translation/Parameters/Defaults.v
+++ b/src/Bedrock/Field/Translation/Parameters/Defaults.v
@@ -48,6 +48,7 @@ Section Defs.
     | expr.var x => negb (String.eqb x ERROR)
     | expr.load _ a => error_free_expr a
     | expr.op _ x y => (error_free_expr x && error_free_expr y)%bool
+    | expr.inlinetable _ _ index => error_free_expr index
     end.
   Fixpoint error_free_cmd (x : cmd.cmd) : bool :=
     match x with


### PR DESCRIPTION
There were still some uses of `omega`.  This should hopefully actually
eliminate all uses of omega, making fiat-crypto compatible with
https://github.com/coq/coq/pull/13741