### PR TITLE
run Dalek-crypto backend tests more directly

### DIFF
--- a/etc/ci/test-fiat-rust-curve25519-dalek.sh
+++ b/etc/ci/test-fiat-rust-curve25519-dalek.sh
@@ -5,7 +5,7 @@ set -ex
 ################################################################################
 # Tests for calibra/curve25519-dalek
 ################################################################################
-git clone https://github.com/calibra/curve25519-dalek.git --branch=fiat2 curve25519-dalek || exit $?
+git clone https://github.com/dalek-cryptography/curve25519-dalek curve25519-dalek || exit $?
 
 pushd curve25519-dalek >/dev/null || exit $?
 
@@ -15,5 +15,6 @@ fiat-crypto = { path = "../fiat-rust" }
 EOF
 
 cargo test --features="std fiat_u64_backend" --no-default-features || exit $?
+cargo test --features="std fiat_u32_backend" --no-default-features || exit $?
 
 popd >/dev/null


### PR DESCRIPTION
- this uses the Dalek upstream repository to run backend tests, rather than the Novi fork used previously.
- this tests the 32-bit backend as well as the 64 bit backend.

/cc @isislovecruft for awareness of extent of backend tests running here.