### PR TITLE
Replace `Wf3` with `Wf` in most places

### DIFF
--- a/src/AbstractInterpretation/AbstractInterpretation.v
+++ b/src/AbstractInterpretation/AbstractInterpretation.v
@@ -511,11 +511,8 @@ Module Compilers.
            (@partial.ident.eval_with_bound)
              var abstract_domain' (annotate_expr default_relax_zrange) bottom' (abstract_interp_ident assume_cast_truncates) extract_list_state extract_option_state (is_annotated_for default_relax_zrange) (strip_annotation assume_cast_truncates strip_preexisting_annotations) skip_annotations_under annotate_with_state t e bound.
 
-      (* N.B. We insert [GeneralizeVar] so that we can assume [Wf e]
-              and get [Wf3 (GeneralizeVar e)], rather than needing to
-              assume [Wf3 e] *)
       Definition StripAnnotations (assume_cast_truncates : bool) {t} (e : Expr t) (bound : type.for_each_lhs_of_arrow abstract_domain t) : Expr t
-        := fun var => strip_annotations assume_cast_truncates (GeneralizeVar.GeneralizeVar (e _) _) bound.
+        := fun var => strip_annotations assume_cast_truncates (e _) bound.
 
       Definition eval {var} {t} (e : @expr _ t) : expr t
         := let assume_cast_truncates := false in

--- a/src/AbstractInterpretation/Proofs.v
+++ b/src/AbstractInterpretation/Proofs.v
@@ -1290,8 +1290,7 @@ Module Compilers.
               {skip_annotations_under : forall t, ident t -> bool}
               {strip_preexisting_annotations : bool}
               {t} (e : Expr t)
-              (Hwf : expr.Wf3 e)
-              (Hwf' : expr.Wf e)
+              (Hwf : expr.Wf e)
               (Ht : type.is_not_higher_order t = true)
               (st : type.for_each_lhs_of_arrow abstract_domain t)
               (Hst : Proper (type.and_for_each_lhs_of_arrow (@abstract_domain_R)) st)
@@ -1306,7 +1305,7 @@ Module Compilers.
                    abstraction_relation'
                      (Extract assume_cast_truncates e st)
                      (type.app_curried (expr.Interp (@ident.interp) (EvalWithBound relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations e st)) arg1)).
-        Proof using Hrelax. cbv [Extract EvalWithBound]; apply interp_eval_with_bound; auto. Qed.
+        Proof using Hrelax. cbv [Extract EvalWithBound]; apply interp_eval_with_bound; try apply expr.Wf3_of_Wf; auto. Qed.
 
         Lemma Interp_EtaExpandWithBound
               {t} (E : Expr t)
@@ -1402,14 +1401,7 @@ Module Compilers.
           type.app_curried (expr.Interp (@ident.interp) (StripAnnotations assume_cast_truncates E b_in)) arg1
           = type.app_curried (expr.Interp (@ident.interp) E) arg2.
       Proof using Type.
-        cbv [StripAnnotations].
-        intros *; rewrite <- (GeneralizeVar.Interp_gen1_GeneralizeVar E) by assumption.
-        apply (let E := GeneralizeVar.GeneralizeVar (E _) in
-               @interp_strip_annotations assume_cast_truncates t (E _) (E _) (E _));
-          try assumption;
-          try apply GeneralizeVar.Wf_GeneralizeVar;
-          try apply GeneralizeVar.Wf3_GeneralizeVar;
-          try apply Hwf.
+        apply (@interp_strip_annotations assume_cast_truncates t (E _) (E _) (E _)); try apply expr.Wf3_of_Wf; auto.
       Qed.
 
       Lemma Interp_StripAnnotations_bounded
@@ -1426,14 +1418,7 @@ Module Compilers.
             (type.app_curried (expr.Interp (@ident.interp) (StripAnnotations assume_cast_truncates E b_in)) arg1)
           = true.
       Proof using Type.
-        cbv [StripAnnotations].
-        intros; rewrite <- Extract_FromFlat_ToFlat by auto with wf typeclass_instances.
-        apply (let E := GeneralizeVar.GeneralizeVar (E _) in
-               @interp_strip_annotations assume_cast_truncates t (E _) (E _) (E _));
-          try assumption;
-          try apply GeneralizeVar.Wf_GeneralizeVar;
-          try apply GeneralizeVar.Wf3_GeneralizeVar;
-          try apply Hwf.
+        apply (@interp_strip_annotations assume_cast_truncates t (E _) (E _) (E _)); try apply expr.Wf3_of_Wf; auto.
       Qed.
 
       Lemma Interp_EtaExpandWithListInfoFromBound

--- a/src/AbstractInterpretation/Wf.v
+++ b/src/AbstractInterpretation/Wf.v
@@ -1154,7 +1154,7 @@ Module Compilers.
       Lemma Wf_StripAnnotations {assume_cast_truncates} {t} (e : Expr t) bound (Hwf : Wf e) (bound_valid : Proper (type.and_for_each_lhs_of_arrow (@abstract_domain_R)) bound)
         : Wf (StripAnnotations assume_cast_truncates e bound).
       Proof.
-        intros ??; eapply wf_strip_annotations with (G:=nil); cbn [List.In]; try tauto; apply GeneralizeVar.Wf_GeneralizeVar, Hwf.
+        intros ??; eapply wf_strip_annotations with (G:=nil); cbn [List.In]; try tauto; apply Hwf.
       Qed.
 
       Lemma Wf_EtaExpandWithBound {relax_zrange t} (e : Expr t) bound (Hwf : Wf e) (bound_valid : Proper (type.and_for_each_lhs_of_arrow (@abstract_domain_R)) bound)

--- a/src/Bedrock/Field/Synthesis/Generic/Operation.v
+++ b/src/Bedrock/Field/Synthesis/Generic/Operation.v
@@ -92,7 +92,7 @@ Section op.
              {name : string} (spec : spec_of name) : Prop :=
     (forall res : API.Expr t,
         start = ErrorT.Success res ->
-        expr.Wf3 res ->
+        expr.Wf res ->
         valid_func (res (fun _ : API.type => unit)) ->
         forall functions,
           spec (make_bedrock_func name op res :: functions)).

--- a/src/Bedrock/Field/Synthesis/Specialized/ReifiedOperation.v
+++ b/src/Bedrock/Field/Synthesis/Specialized/ReifiedOperation.v
@@ -31,7 +31,8 @@ Record reified_op {p t}
     computed_bedrock_func_eq :
       computed_bedrock_func = make_bedrock_func name op res;
     reified_eq : start = ErrorT.Success res;
-    reified_Wf3 : expr.Wf3 res;
+    reified_Wf_via_start : forall res, start = ErrorT.Success res -> expr.Wf res;
+    reified_Wf : expr.Wf res := reified_Wf_via_start _ reified_eq;
     reified_valid : Func.valid_func (p:=p) (res (fun _ => unit));
   }.
 Global Arguments reified_op {p t} name op start.
@@ -50,8 +51,12 @@ Ltac prove_reified_op :=
   [ match goal with
     | |- _ = make_bedrock_func _ _ _ =>
       vm_compute; reflexivity end | .. ];
-  match goal with
-  | |- expr.Wf3 _ => abstract (prove_Wf3 ())
+  lazymatch goal with
+  | |- forall res, ?e = _ -> expr.Wf _ =>
+    (* Kludge around auto being bad (COQBUG(https://github.com/coq/coq/issues/14190)) and eauto not respecting Hint Opaque *)
+    typeclasses eauto with wf_op_cache;
+    idtac "Warning: Falling back to manually proving pipeline well-formedness for" e;
+    PipelineTactics.prove_pipeline_wf ()
   | |- valid_func_bool ?x = true =>
     abstract vm_cast_no_check (eq_refl true)
   end.

--- a/src/Bedrock/Field/Synthesis/Specialized/UnsaturatedSolinas.v
+++ b/src/Bedrock/Field/Synthesis/Specialized/UnsaturatedSolinas.v
@@ -330,7 +330,7 @@ Ltac handle_easy_preconditions :=
     abstract vm_cast_no_check (eq_refl true)
   | |- Types.ok => solve [typeclasses eauto]
   | |- _ = ErrorT.Success _ => solve [apply reified_eq]
-  | |- Wf.Compilers.expr.Wf3 _ => solve [apply reified_Wf3]
+  | |- Wf.Compilers.expr.Wf _ => solve [apply reified_Wf]
   | |- Func.valid_func _ => solve [apply reified_valid]
   | _ => first [ apply inname_gen_varname_gen_disjoint
                | apply outname_gen_varname_gen_disjoint

--- a/src/Bedrock/Field/Synthesis/Specialized/WordByWordMontgomery.v
+++ b/src/Bedrock/Field/Synthesis/Specialized/WordByWordMontgomery.v
@@ -329,7 +329,7 @@ Ltac handle_easy_preconditions :=
     abstract vm_cast_no_check (eq_refl true)
   | |- Types.ok => solve [typeclasses eauto]
   | |- _ = ErrorT.Success _ => solve [apply reified_eq]
-  | |- Wf.Compilers.expr.Wf3 _ => solve [apply reified_Wf3]
+  | |- Wf.Compilers.expr.Wf _ => solve [apply reified_Wf]
   | |- Func.valid_func _ => solve [apply reified_valid]
   | _ => first [ apply inname_gen_varname_gen_disjoint
                | apply outname_gen_varname_gen_disjoint

--- a/src/Bedrock/Field/Translation/Proofs/Func.v
+++ b/src/Bedrock/Field/Translation/Proofs/Func.v
@@ -486,7 +486,7 @@ Section Func.
         (e : API.Expr t)
         (* expressions are valid input to translate_func *)
         (e_valid : valid_func (e _)) :
-    Wf3 e ->
+    Wf e ->
     forall (fname : string)
            (retnames : base_ltype (type.final_codomain t))
            (retsizes : base_access_sizes (type.final_codomain t))
@@ -557,7 +557,7 @@ Section Func.
                          rets out_ptrs retsizes))
                  R mem').
   Proof.
-    cbv [translate_func Wf3]; intros. subst.
+    cbv [translate_func]; intros. subst.
     cbn [fst snd
              WeakestPrecondition.call
              WeakestPrecondition.call_body WeakestPrecondition.func].
@@ -598,7 +598,7 @@ Section Func.
     cbv beta in *. cleanup; subst.
     eapply Proper_cmd; [ solve [apply Proper_call] | repeat intro | ].
     2 : { eapply translate_func'_correct with (args0:=args);
-          cbv [context_equiv]; intros; eauto; [ ].
+          cbv [context_equiv]; intros; try apply Wf3_of_Wf; eauto; [ ].
           eapply only_differ_disjoint_undef_on; eauto;
             [ eapply used_varnames_disjoint; lia | ].
           eapply putmany_of_list_zip_undef_on

--- a/src/Language/WfExtra.v
+++ b/src/Language/WfExtra.v
@@ -22,10 +22,17 @@ Module Compilers.
     Global Hint Resolve Wf_APP : wf_extra.
     Global Hint Opaque expr.APP : wf_extra interp_extra.
     Hint Rewrite @expr.Interp_APP : interp_extra.
-    Global Hint Resolve Wf_of_Wf3 : wf_extra.
+    Global Hint Immediate Wf_of_Wf3 : wf_extra.
+    Global Hint Resolve Wf3_of_Wf : wf_extra.
+
+    Definition Wf_base_Reify_as {t} v
+      := @Wf_base_Reify_as base.type.base base.base_interp base.type.base_beq ident ident.buildIdent base.reflect_base_beq t v.
 
     Definition Wf_Reify_as {t} v
       := @Wf_Reify_as base.type.base base.base_interp base.type.base_beq ident ident.buildIdent base.reflect_base_beq t v.
+
+    Definition Wf_base_reify {t} v
+      := @Wf_base_reify base.type.base base.base_interp base.type.base_beq ident ident.buildIdent base.reflect_base_beq t v.
 
     Definition Wf_reify {t} v
       := @Wf_reify base.type.base base.base_interp base.type.base_beq ident ident.buildIdent base.reflect_base_beq t v.
@@ -50,11 +57,13 @@ Module Compilers.
   End expr.
 
   Hint Constructors expr.wf : wf_extra.
-  Hint Resolve expr.Wf_APP expr.Wf_Reify_as expr.Wf_reify : wf_extra.
+  Hint Resolve expr.Wf_APP expr.Wf_Reify_as expr.Wf_base_Reify_as expr.Wf_reify expr.Wf_base_reify : wf_extra.
   (** Work around COQBUG(https://github.com/coq/coq/issues/11536) *)
-  Hint Extern 0 (expr.Wf (GallinaReify.base.Reify_as _ _)) => simple apply (@expr.Wf_Reify) : wf_extra.
+  Hint Extern 0 (expr.Wf (GallinaReify.base.Reify_as _ _)) => simple apply (@expr.Wf_base_Reify) : wf_extra.
+  Hint Extern 0 (expr.Wf (GallinaReify.Reify_as _ _)) => simple apply (@expr.Wf_Reify) : wf_extra.
   (** Work around COQBUG(https://github.com/coq/coq/issues/11536) *)
-  Hint Extern 0 (expr.Wf (fun var => GallinaReify.base.reify _)) => simple apply (@expr.Wf_reify) : wf_extra.
+  Hint Extern 0 (expr.Wf (fun var => GallinaReify.base.reify _)) => simple apply (@expr.Wf_base_reify) : wf_extra.
+  Hint Extern 0 (expr.Wf (fun var => GallinaReify.reify _)) => simple apply (@expr.Wf_reify) : wf_extra.
   Hint Opaque expr.APP GallinaReify.Reify_as GallinaReify.base.reify : wf_extra interp_extra.
   Hint Rewrite @expr.Interp_Reify_as @expr.interp_reify @expr.interp_reify_list @expr.interp_reify_option @expr.Interp_reify @expr.Interp_APP : interp_extra.
 
@@ -67,12 +76,6 @@ Module Compilers.
     Definition Wf_GeneralizeVar {t} e Hwf
       := @Wf_GeneralizeVar _ ident (@base.try_make_transport_cps _ base.try_make_base_transport_cps) (base.type.type_beq _ base.type.base_beq) base.reflect_type_beq base.try_make_transport_cps_correct _ t e Hwf.
 
-    Definition Wf3_FromFlat_ToFlat {t} e Hwf
-      := @Wf3_FromFlat_ToFlat _ ident (@base.try_make_transport_cps _ base.try_make_base_transport_cps) (base.type.type_beq _ base.type.base_beq) base.reflect_type_beq base.try_make_transport_cps_correct _ t e Hwf.
-
-    Definition Wf3_GeneralizeVar {t} e Hwf
-      := @Wf3_GeneralizeVar _ ident (@base.try_make_transport_cps _ base.try_make_base_transport_cps) (base.type.type_beq _ base.type.base_beq) base.reflect_type_beq base.try_make_transport_cps_correct _ t e Hwf.
-
     Definition Interp_FromFlat_ToFlat {t} e Hwf
       := @Interp_gen1_FromFlat_ToFlat _ ident (@base.try_make_transport_cps _ base.try_make_base_transport_cps) (base.type.type_beq _ base.type.base_beq) base.reflect_type_beq base.try_make_transport_cps_correct _ _ (@ident.interp) _ (@ident.interp_Proper) t e Hwf.
 
@@ -83,6 +86,5 @@ Module Compilers.
   Global Hint Extern 0 (?x == ?x) => apply expr.Wf_Interp_Proper_gen : wf_extra interp_extra.
   Hint Resolve GeneralizeVar.Wf_FromFlat_ToFlat GeneralizeVar.Wf_GeneralizeVar : wf_extra.
   Hint Opaque GeneralizeVar.FromFlat GeneralizeVar.ToFlat GeneralizeVar.GeneralizeVar : wf_extra interp_extra.
-  Hint Resolve GeneralizeVar.Wf3_FromFlat_ToFlat GeneralizeVar.Wf3_GeneralizeVar : wf_extra.
   Hint Rewrite @GeneralizeVar.Interp_GeneralizeVar @GeneralizeVar.Interp_FromFlat_ToFlat : interp_extra.
 End Compilers.

--- a/src/PushButtonSynthesis/BarrettReduction.v
+++ b/src/PushButtonSynthesis/BarrettReduction.v
@@ -28,6 +28,7 @@ Local Open Scope Z_scope. Local Open Scope list_scope. Local Open Scope bool_sco
 
 Import
   Language.Compilers
+  Language.Wf.Compilers
   Stringification.Language.Compilers.
 Import Compilers.API.
 
@@ -215,4 +216,16 @@ Section rbarrett_red.
     { cbv [ZRange.type.base.option.is_bounded_by ZRange.type.base.is_bounded_by bound is_bounded_by_bool value_range upper lower]. rewrite Bool.andb_true_iff, !Z.leb_le. lia. }
     { cbv [ZRange.type.base.option.is_bounded_by ZRange.type.base.is_bounded_by bound is_bounded_by_bool value_range upper lower]. rewrite Bool.andb_true_iff, !Z.leb_le. lia. }
   Qed.
+
+  Lemma Wf_barrett_red res (Hres : barrett_red = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). apply fancy_args_good. Qed.
 End rbarrett_red.
+
+Module Export Hints.
+  Hint Opaque
+       barrett_red
+  : wf_op_cache.
+  Hint Immediate
+       Wf_barrett_red
+  : wf_op_cache.
+End Hints.

--- a/src/PushButtonSynthesis/BaseConversion.v
+++ b/src/PushButtonSynthesis/BaseConversion.v
@@ -326,6 +326,9 @@ Section __.
                       | destruct_head'_and; eapply Z.le_lt_trans; eassumption ].
   Qed.
 
+  Lemma Wf_convert_bases res (Hres : convert_bases = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
+
   Section for_stringification.
     Local Open Scope string_scope.
     Local Open Scope list_scope.
@@ -355,3 +358,12 @@ Section __.
            function_name_prefix requests.
   End for_stringification.
 End __.
+
+Module Export Hints.
+  Hint Opaque
+       convert_bases
+  : wf_op_cache.
+  Hint Immediate
+       Wf_convert_bases
+  : wf_op_cache.
+End Hints.

--- a/src/PushButtonSynthesis/FancyMontgomeryReduction.v
+++ b/src/PushButtonSynthesis/FancyMontgomeryReduction.v
@@ -29,6 +29,7 @@ Local Open Scope Z_scope. Local Open Scope list_scope. Local Open Scope bool_sco
 
 Import
   Language.Compilers
+  Language.Wf.Compilers
   Stringification.Language.Compilers.
 Import Compilers.API.
 
@@ -198,4 +199,16 @@ Section rmontred.
     { cbv [ZRange.type.base.option.is_bounded_by ZRange.type.base.is_bounded_by bound is_bounded_by_bool value_range upper lower].
       rewrite Bool.andb_true_iff, !Z.leb_le. lia. }
   Qed.
+
+  Lemma Wf_montred res (Hres : montred = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). apply fancy_args_good. Qed.
 End rmontred.
+
+Module Export Hints.
+  Hint Opaque
+       montred
+  : wf_op_cache.
+  Hint Immediate
+       Wf_montred
+  : wf_op_cache.
+End Hints.

--- a/src/PushButtonSynthesis/Primitives.v
+++ b/src/PushButtonSynthesis/Primitives.v
@@ -198,6 +198,7 @@ Ltac prove_correctness' should_not_clear use_curve_good :=
   | .. ].
 
 Ltac prove_correctness use_curve_good := prove_correctness' ltac:(fun _ => fail) use_curve_good.
+Ltac prove_pipeline_wf _ := PipelineTactics.prove_pipeline_wf ().
 
 Module CorrectnessStringification.
   Module dyn_context.
@@ -931,11 +932,17 @@ Section __.
     : mulx_correct s' (Interp res).
   Proof using Type. prove_correctness I. Qed.
 
+  Lemma Wf_mulx s' res (Hres : mulx s' = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
+
   Strategy -1000 [addcarryx]. (* if we don't tell the kernel to unfold this early, then [Qed] seems to run off into the weeds *)
   Lemma addcarryx_correct s' res
         (Hres : addcarryx s' = Success res)
     : addcarryx_correct s' (Interp res).
   Proof using Type. prove_correctness I. Qed.
+
+  Lemma Wf_addcarryx s' res (Hres : addcarryx s' = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
 
   Strategy -1000 [subborrowx]. (* if we don't tell the kernel to unfold this early, then [Qed] seems to run off into the weeds *)
   Lemma subborrowx_correct s' res
@@ -943,11 +950,17 @@ Section __.
     : subborrowx_correct s' (Interp res).
   Proof using Type. prove_correctness I. Qed.
 
+  Lemma Wf_subborrowx s' res (Hres : subborrowx s' = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
+
   Strategy -1000 [value_barrier]. (* if we don't tell the kernel to unfold this early, then [Qed] seems to run off into the weeds *)
   Lemma value_barrier_correct s' res
         (Hres : value_barrier s' = Success res)
     : value_barrier_correct (int.is_signed s') (int.bitwidth_of s') (Interp res).
   Proof using Type. prove_correctness I. Qed.
+
+  Lemma Wf_value_barrier s' res (Hres : value_barrier s' = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
 
   Strategy -1000 [cmovznz]. (* if we don't tell the kernel to unfold this early, then [Qed] seems to run off into the weeds *)
   Lemma cmovznz_correct s' res
@@ -955,16 +968,25 @@ Section __.
     : cmovznz_correct false s' (Interp res).
   Proof using Type. prove_correctness I. Qed.
 
+  Lemma Wf_cmovznz s' res (Hres : cmovznz s' = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
+
   Strategy -1000 [cmovznz_by_mul]. (* if we don't tell the kernel to unfold this early, then [Qed] seems to run off into the weeds *)
   Lemma cmovznz_by_mul_correct s' res
         (Hres : cmovznz_by_mul s' = Success res)
     : COperationSpecifications.Primitives.cmovznz_correct false s' (Interp res).
   Proof using Type. prove_correctness I. Qed.
 
+  Lemma Wf_cmovznz_by_mul s' res (Hres : cmovznz_by_mul s' = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
+
   Lemma selectznz_correct limbwidth res
         (Hres : selectznz = Success res)
     : selectznz_correct (weight (Qnum limbwidth) (QDen limbwidth)) n saturated_bounds_list (Interp res).
   Proof using Type. prove_correctness I. Qed.
+
+  Lemma Wf_selectznz res (Hres : selectznz = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
 
   Section for_stringification.
     Context (valid_names : string)
@@ -1093,3 +1115,24 @@ Section __.
               end.
   End for_stringification.
 End __.
+
+Module Export Hints.
+  Hint Opaque
+       mulx
+       addcarryx
+       subborrowx
+       value_barrier
+       cmovznz
+       cmovznz_by_mul
+       selectznz
+  : wf_op_cache.
+  Hint Immediate
+       Wf_mulx
+       Wf_addcarryx
+       Wf_subborrowx
+       Wf_value_barrier
+       Wf_cmovznz
+       Wf_cmovznz_by_mul
+       Wf_selectznz
+  : wf_op_cache.
+End Hints.

--- a/src/PushButtonSynthesis/SaturatedSolinas.v
+++ b/src/PushButtonSynthesis/SaturatedSolinas.v
@@ -212,6 +212,9 @@ Section __.
     : mul_correct (weight machine_wordsize 1) n m boundsn (Interp res).
   Proof using curve_good. prove_correctness (). Qed.
 
+  Lemma Wf_mul res (Hres : mul = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
+
   Section for_stringification.
     Local Open Scope string_scope.
     Local Open Scope list_scope.
@@ -236,3 +239,12 @@ Section __.
            function_name_prefix requests.
   End for_stringification.
 End __.
+
+Module Export Hints.
+  Hint Opaque
+       mul
+  : wf_op_cache.
+  Hint Immediate
+       Wf_mul
+  : wf_op_cache.
+End Hints.

--- a/src/PushButtonSynthesis/UnsaturatedSolinas.v
+++ b/src/PushButtonSynthesis/UnsaturatedSolinas.v
@@ -618,40 +618,64 @@ Section __.
     : carry_mul_correct (weight (Qnum limbwidth) (QDen limbwidth)) n m tight_bounds loose_bounds (Interp res).
   Proof using curve_good. prove_correctness (). Qed.
 
+  Lemma Wf_carry_mul res (Hres : carry_mul = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
+
   Lemma carry_square_correct res
         (Hres : carry_square = Success res)
     : carry_square_correct (weight (Qnum limbwidth) (QDen limbwidth)) n m tight_bounds loose_bounds (Interp res).
   Proof using curve_good. prove_correctness (). Qed.
+
+  Lemma Wf_carry_square res (Hres : carry_square = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
 
   Lemma carry_scmul_const_correct a res
         (Hres : carry_scmul_const a = Success res)
     : carry_scmul_const_correct (weight (Qnum limbwidth) (QDen limbwidth)) n m tight_bounds loose_bounds a (Interp res).
   Proof using curve_good. prove_correctness (). Qed.
 
+  Lemma Wf_carry_scmul_const a res (Hres : carry_scmul_const a = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
+
   Lemma carry_correct res
         (Hres : carry = Success res)
     : carry_correct (weight (Qnum limbwidth) (QDen limbwidth)) n m tight_bounds loose_bounds (Interp res).
   Proof using curve_good. prove_correctness (). Qed.
+
+  Lemma Wf_carry res (Hres : carry = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
 
   Lemma add_correct res
         (Hres : add = Success res)
     : add_correct (weight (Qnum limbwidth) (QDen limbwidth)) n m tight_bounds loose_bounds (Interp res).
   Proof using curve_good. prove_correctness (). Qed.
 
+  Lemma Wf_add res (Hres : add = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
+
   Lemma sub_correct res
         (Hres : sub = Success res)
     : sub_correct (weight (Qnum limbwidth) (QDen limbwidth)) n m tight_bounds loose_bounds (Interp res).
   Proof using curve_good. prove_correctness (). Qed.
+
+  Lemma Wf_sub res (Hres : sub = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
 
   Lemma opp_correct res
         (Hres : opp = Success res)
     : opp_correct (weight (Qnum limbwidth) (QDen limbwidth)) n m tight_bounds loose_bounds (Interp res).
   Proof using curve_good. prove_correctness (). Qed.
 
+  Lemma Wf_opp res (Hres : opp = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
+
   Lemma from_bytes_correct res
         (Hres : from_bytes = Success res)
     : from_bytes_correct (weight (Qnum limbwidth) (QDen limbwidth)) n n_bytes m s tight_bounds (Interp res).
   Proof using curve_good. prove_correctness (). Qed.
+
+  Lemma Wf_from_bytes res (Hres : from_bytes = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
 
   Lemma relax_correct
     : forall x, list_Z_bounded_by tight_bounds x -> list_Z_bounded_by loose_bounds x.
@@ -684,11 +708,17 @@ Section __.
                       | progress cbv [tight_upperbounds] in * ].
   Qed.
 
+  Lemma Wf_to_bytes res (Hres : to_bytes = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
+
   Strategy -1000 [encode]. (* if we don't tell the kernel to unfold this early, then [Qed] seems to run off into the weeds *)
   Lemma encode_correct res
         (Hres : encode = Success res)
     : encode_correct (weight (Qnum limbwidth) (QDen limbwidth)) n m tight_bounds (Interp res).
   Proof using curve_good. prove_correctness (). Qed.
+
+  Lemma Wf_encode res (Hres : encode = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
 
   Strategy -1000 [zero]. (* if we don't tell the kernel to unfold this early, then [Qed] seems to run off into the weeds *)
   Lemma zero_correct res
@@ -696,11 +726,17 @@ Section __.
     : zero_correct (weight (Qnum limbwidth) (QDen limbwidth)) n m tight_bounds (Interp res).
   Proof using curve_good. prove_correctness (). Qed.
 
+  Lemma Wf_zero res (Hres : zero = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
+
   Strategy -1000 [one]. (* if we don't tell the kernel to unfold this early, then [Qed] seems to run off into the weeds *)
   Lemma one_correct res
         (Hres : one = Success res)
     : one_correct (weight (Qnum limbwidth) (QDen limbwidth)) n m tight_bounds (Interp res).
   Proof using curve_good. prove_correctness (). Qed.
+
+  Lemma Wf_one res (Hres : one = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
 
   Section ring.
     Context carry_mul_res (Hcarry_mul : carry_mul = Success carry_mul_res)
@@ -788,3 +824,34 @@ Section __.
            function_name_prefix requests.
   End for_stringification.
 End __.
+
+Module Export Hints.
+  Hint Opaque
+       carry_mul
+       carry_square
+       carry_scmul_const
+       carry
+       add
+       sub
+       opp
+       from_bytes
+       to_bytes
+       encode
+       zero
+       one
+  : wf_op_cache.
+  Hint Immediate
+       Wf_carry_mul
+       Wf_carry_square
+       Wf_carry_scmul_const
+       Wf_carry
+       Wf_add
+       Wf_sub
+       Wf_opp
+       Wf_from_bytes
+       Wf_to_bytes
+       Wf_encode
+       Wf_zero
+       Wf_one
+  : wf_op_cache.
+End Hints.

--- a/src/PushButtonSynthesis/WordByWordMontgomery.v
+++ b/src/PushButtonSynthesis/WordByWordMontgomery.v
@@ -880,50 +880,80 @@ Section __.
     : mul_correct machine_wordsize n m valid from_montgomery_res (Interp res).
   Proof using curve_good. prove_correctness mulmod_correct. Qed.
 
+  Lemma Wf_mul res (Hres : mul = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
+
   Lemma square_correct res
         (Hres : square = Success res)
     : square_correct machine_wordsize n m valid from_montgomery_res (Interp res).
   Proof using curve_good. prove_correctness squaremod_correct. Qed.
+
+  Lemma Wf_square res (Hres : square = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
 
   Lemma add_correct res
         (Hres : add = Success res)
     : add_correct machine_wordsize n m valid from_montgomery_res (Interp res).
   Proof using curve_good. prove_correctness addmod_correct. Qed.
 
+  Lemma Wf_add res (Hres : add = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
+
   Lemma sub_correct res
         (Hres : sub = Success res)
     : sub_correct machine_wordsize n m valid from_montgomery_res (Interp res).
   Proof using curve_good. prove_correctness submod_correct. Qed.
+
+  Lemma Wf_sub res (Hres : sub = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
 
   Lemma opp_correct res
         (Hres : opp = Success res)
     : opp_correct machine_wordsize n m valid from_montgomery_res (Interp res).
   Proof using curve_good. prove_correctness oppmod_correct. Qed.
 
+  Lemma Wf_opp res (Hres : opp = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
+
   Lemma from_montgomery_correct res
         (Hres : from_montgomery = Success res)
     : from_montgomery_correct machine_wordsize n m r' valid (Interp res).
   Proof using curve_good. prove_correctness from_montgomerymod_correct. Qed.
+
+  Lemma Wf_from_montgomery res (Hres : from_montgomery = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
 
   Lemma to_montgomery_correct res
         (Hres : to_montgomery = Success res)
     : to_montgomery_correct machine_wordsize n m valid from_montgomery_res (Interp res).
   Proof using curve_good. prove_correctness to_montgomerymod_correct. Qed.
 
+  Lemma Wf_to_montgomery res (Hres : to_montgomery = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
+
   Lemma nonzero_correct res
         (Hres : nonzero = Success res)
     : nonzero_correct machine_wordsize n m valid from_montgomery_res (Interp res).
   Proof using curve_good. prove_correctness nonzeromod_correct. Qed.
+
+  Lemma Wf_nonzero res (Hres : nonzero = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
 
   Lemma to_bytes_correct res
         (Hres : to_bytes = Success res)
     : to_bytes_correct machine_wordsize n n_bytes m valid (Interp res).
   Proof using curve_good. prove_correctness to_bytesmod_correct. Qed.
 
+  Lemma Wf_to_bytes res (Hres : to_bytes = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
+
   Lemma from_bytes_correct res
         (Hres : from_bytes = Success res)
     : from_bytes_correct machine_wordsize n n_bytes m valid bytes_valid (Interp res).
   Proof using curve_good. prove_correctness eval_from_bytesmod_and_partitions. Qed.
+
+  Lemma Wf_from_bytes res (Hres : from_bytes = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
 
   Strategy -1000 [encode]. (* if we don't tell the kernel to unfold this early, then [Qed] seems to run off into the weeds *)
   Lemma encode_correct res
@@ -931,11 +961,17 @@ Section __.
     : encode_correct machine_wordsize n m valid from_montgomery_res (Interp res).
   Proof using curve_good. prove_correctness encodemod_correct. Qed.
 
+  Lemma Wf_encode res (Hres : encode = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
+
   Strategy -1000 [zero]. (* if we don't tell the kernel to unfold this early, then [Qed] seems to run off into the weeds *)
   Lemma zero_correct res
         (Hres : zero = Success res)
     : zero_correct machine_wordsize n m valid from_montgomery_res (Interp res).
   Proof using curve_good. prove_correctness encodemod_correct. Qed.
+
+  Lemma Wf_zero res (Hres : zero = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
 
   Strategy -1000 [one]. (* if we don't tell the kernel to unfold this early, then [Qed] seems to run off into the weeds *)
   Lemma one_correct res
@@ -943,11 +979,17 @@ Section __.
     : one_correct machine_wordsize n m valid from_montgomery_res (Interp res).
   Proof using curve_good. prove_correctness encodemod_correct. Qed.
 
+  Lemma Wf_one res (Hres : one = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
+
   Local Opaque Pipeline.BoundsPipeline. (* need this or else [eapply Pipeline.BoundsPipeline_correct in Hres] takes forever *)
   Lemma selectznz_correct res
         (Hres : selectznz = Success res)
     : selectznz_correct machine_wordsize n saturated_bounds_list (Interp res).
   Proof using curve_good. Primitives.prove_correctness use_curve_good. Qed.
+
+  Lemma Wf_selectznz res (Hres : selectznz = Success res) : Wf res.
+  Proof using Type. prove_pipeline_wf (). Qed.
 
   Section ring.
     Context from_montgomery_res (Hfrom_montgomery : from_montgomery = Success from_montgomery_res)
@@ -1033,3 +1075,38 @@ Section __.
            function_name_prefix requests.
   End for_stringification.
 End __.
+
+Module Export Hints.
+  Hint Opaque
+       mul
+       square
+       add
+       sub
+       opp
+       from_montgomery
+       to_montgomery
+       nonzero
+       to_bytes
+       from_bytes
+       encode
+       zero
+       one
+       selectznz
+  : wf_op_cache.
+  Hint Immediate
+       Wf_mul
+       Wf_square
+       Wf_add
+       Wf_sub
+       Wf_opp
+       Wf_from_montgomery
+       Wf_to_montgomery
+       Wf_nonzero
+       Wf_to_bytes
+       Wf_from_bytes
+       Wf_encode
+       Wf_zero
+       Wf_one
+       Wf_selectznz
+  : wf_op_cache.
+End Hints.


### PR DESCRIPTION
Now that I've managed to prove `Wf3 <-> Wf`, we can make use of it to
hide `Wf3` requirements from APIs of PHOAS passes.  Moreover, now that
we're just using `Wf`, we expose the `Wf` proofs of the various
synthesized operations, so that we can use them in the Bedrock2 backend
without having to re-prove `Wf3` from scratch.

Timing info coming soon.

Unfortunately my pushes to the rewriter broke fiat-crypto on Coq's CI, so I'm going to merge this as soon as the timing info is in and the CI passes.  @jadephilipoom , please take a look at the changes to the Bedrock files here, and let me know what you think.  If you want me to make the necessary changes to #944, I'm happy to take point on doing that.

<details><summary>Timing Diff</summary>
<p>

```
     After |   Peak Mem | File Name                                                                                                         |     Before |   Peak Mem ||    Change || Change (mem) | % Change | % Change (mem)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
174m39.36s | 2328800 ko | Total Time / Peak Mem                                                                                             | 176m18.93s | 2328268 ko || -1m39.57s ||       532 ko |   -0.94% |         +0.02%
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  6m39.65s |  972768 ko | fiat-java/src/FiatP384.java                                                                                       |   6m59.64s |  972516 ko || -0m19.99s ||       252 ko |   -4.76% |         +0.02%
  1m09.35s | 1404760 ko | Bedrock/Field/Synthesis/Examples/p256_64.vo                                                                       |   1m29.16s | 1659832 ko || -0m19.81s ||   -255072 ko |  -22.21% |        -15.36%
  1m11.37s | 1450824 ko | Bedrock/Field/Synthesis/Examples/p224_64.vo                                                                       |   1m29.64s | 1630972 ko || -0m18.26s ||   -180148 ko |  -20.38% |        -11.04%
  2m06.35s | 1105932 ko | Bedrock/Field/Synthesis/Examples/X25519_64.vo                                                                     |   2m21.46s | 1253120 ko || -0m15.11s ||   -147188 ko |  -10.68% |        -11.74%
  4m31.76s | 1390812 ko | PushButtonSynthesis/WordByWordMontgomeryReificationCache.vo                                                       |   4m42.07s | 1423064 ko || -0m10.31s ||    -32252 ko |   -3.65% |         -2.26%
  7m34.20s | 1014288 ko | fiat-bedrock2/src/p384_32.c                                                                                       |   7m42.67s | 1014176 ko || -0m08.47s ||       112 ko |   -1.83% |         +0.01%
  0m21.26s |  885252 ko | Bedrock/Field/Synthesis/Examples/X1305_32.vo                                                                      |   0m29.33s |  966940 ko || -0m08.06s ||    -81688 ko |  -27.51% |         -8.44%
  7m54.95s |  982860 ko | fiat-json/src/p384_32.json                                                                                        |   8m02.26s |  982716 ko || -0m07.31s ||       144 ko |   -1.51% |         +0.01%
  7m27.36s | 1060928 ko | fiat-zig/src/p384_32.zig                                                                                          |   7m21.04s | 1061004 ko || +0m06.31s ||       -76 ko |   +1.43% |         -0.00%
  0m27.66s |  764424 ko | Rewriter/Language/Wf.vo                                                                                           |   0m22.62s |  624592 ko || +0m05.03s ||    139832 ko |  +22.28% |        +22.38%
  2m18.41s | 2183128 ko | Fancy/Barrett256.vo                                                                                               |   2m23.31s | 2155516 ko || -0m04.90s ||     27612 ko |   -3.41% |         +1.28%
  0m33.66s |  231600 ko | fiat-bedrock2/src/secp256k1_32.c                                                                                  |   0m38.24s |  231740 ko || -0m04.58s ||      -140 ko |  -11.97% |         -0.06%
  7m58.70s |  967460 ko | fiat-rust/src/p384_32.rs                                                                                          |   8m01.91s |  967684 ko || -0m03.21s ||      -224 ko |   -0.66% |         -0.02%
  7m57.65s | 2140684 ko | Curves/Weierstrass/AffineProofs.vo                                                                                |   7m54.20s | 2138364 ko || +0m03.44s ||      2320 ko |   +0.72% |         +0.10%
  0m30.87s |  211584 ko | fiat-json/src/p256_32.json                                                                                        |   0m27.78s |  211324 ko || +0m03.08s ||       260 ko |  +11.12% |         +0.12%
  0m27.80s |  186960 ko | fiat-java/src/FiatP256.java                                                                                       |   0m30.89s |  186532 ko || -0m03.08s ||       428 ko |  -10.00% |         +0.22%
  1m21.16s | 1687176 ko | Fancy/Montgomery256.vo                                                                                            |   1m23.94s | 1672140 ko || -0m02.78s ||     15036 ko |   -3.31% |         +0.89%
  1m02.31s | 1113208 ko | Rewriter/Passes/MultiRetSplit.vo                                                                                  |   1m04.61s | 1113416 ko || -0m02.29s ||      -208 ko |   -3.55% |         -0.01%
  0m31.84s |  211500 ko | fiat-zig/src/secp256k1_32.zig                                                                                     |   0m28.99s |  211316 ko || +0m02.85s ||       184 ko |   +9.83% |         +0.08%
  0m28.07s |  209788 ko | fiat-c/src/secp256k1_32.c                                                                                         |   0m30.65s |  209684 ko || -0m02.57s ||       104 ko |   -8.41% |         +0.04%
  0m27.33s |  200716 ko | fiat-c/src/p256_32.c                                                                                              |   0m29.68s |  200608 ko || -0m02.35s ||       108 ko |   -7.91% |         +0.05%
  0m22.93s |  147004 ko | fiat-zig/src/p434_64.zig                                                                                          |   0m20.89s |  146948 ko || +0m02.03s ||        56 ko |   +9.76% |         +0.03%
  8m03.17s |  973004 ko | fiat-c/src/p384_32.c                                                                                              |   8m04.64s |  973048 ko || -0m01.46s ||       -44 ko |   -0.30% |         -0.00%
  8m02.65s | 1094728 ko | fiat-go/32/p384/p384.go                                                                                           |   8m03.88s | 1094992 ko || -0m01.23s ||      -264 ko |   -0.25% |         -0.02%
  1m00.63s |  826272 ko | Rewriter/Rewriter/InterpProofs.vo                                                                                 |   0m58.81s |  981028 ko || +0m01.82s ||   -154756 ko |   +3.09% |        -15.77%
  0m53.67s | 2141824 ko | ExtractionOCaml/bedrock2_word_by_word_montgomery                                                                  |   0m52.30s | 2141740 ko || +0m01.37s ||        84 ko |   +2.61% |         +0.00%
  0m36.45s | 2328800 ko | ExtractionOCaml/bedrock2_word_by_word_montgomery.ml                                                               |   0m38.01s | 2328268 ko || -0m01.55s ||       532 ko |   -4.10% |         +0.02%
  0m35.74s | 2054544 ko | ExtractionOCaml/word_by_word_montgomery.ml                                                                        |   0m36.93s | 2052764 ko || -0m01.18s ||      1780 ko |   -3.22% |         +0.08%
  0m33.75s |  196068 ko | fiat-bedrock2/src/p256_32.c                                                                                       |   0m34.85s |  196348 ko || -0m01.10s ||      -280 ko |   -3.15% |         -0.14%
  0m32.03s | 1476384 ko | ExtractionOCaml/bedrock2_unsaturated_solinas                                                                      |   0m33.08s | 1487020 ko || -0m01.04s ||    -10636 ko |   -3.17% |         -0.71%
  0m31.52s | 1232236 ko | ExtractionOCaml/perf_word_by_word_montgomery                                                                      |   0m29.93s | 1272128 ko || +0m01.58s ||    -39892 ko |   +5.31% |         -3.13%
  0m31.44s | 1282544 ko | ExtractionOCaml/bedrock2_saturated_solinas                                                                        |   0m30.26s | 1282544 ko || +0m01.17s ||         0 ko |   +3.89% |         +0.00%
  0m30.82s | 1414792 ko | ExtractionOCaml/unsaturated_solinas                                                                               |   0m32.10s | 1414688 ko || -0m01.28s ||       104 ko |   -3.98% |         +0.00%
  0m29.78s | 1416744 ko | ExtractionOCaml/saturated_solinas                                                                                 |   0m28.74s | 1416400 ko || +0m01.04s ||       344 ko |   +3.61% |         +0.02%
  0m29.59s | 1232620 ko | ExtractionOCaml/base_conversion                                                                                   |   0m27.61s | 1416496 ko || +0m01.98s ||   -183876 ko |   +7.17% |        -12.98%
  0m19.03s | 1656648 ko | ExtractionOCaml/bedrock2_base_conversion.ml                                                                       |   0m20.09s | 1657912 ko || -0m01.05s ||     -1264 ko |   -5.27% |         -0.07%
  0m18.83s |  625740 ko | Stringification/IR.vo                                                                                             |   0m16.94s |  626860 ko || +0m01.88s ||     -1120 ko |  +11.15% |         -0.17%
  0m16.27s |  132200 ko | fiat-bedrock2/src/p224_32.c                                                                                       |   0m14.97s |  132164 ko || +0m01.29s ||        36 ko |   +8.68% |         +0.02%
  0m13.98s |  129276 ko | fiat-zig/src/p224_32.zig                                                                                          |   0m12.80s |  129544 ko || +0m01.17s ||      -268 ko |   +9.21% |         -0.20%
  3m51.27s | 2168712 ko | Rewriter/Passes/ArithWithCasts.vo                                                                                 |   3m51.63s | 2167000 ko || -0m00.35s ||      1712 ko |   -0.15% |         +0.07%
  3m30.09s | 1702592 ko | Curves/Montgomery/XZProofs.vo                                                                                     |   3m29.65s | 1702320 ko || +0m00.43s ||       272 ko |   +0.20% |         +0.01%
  3m17.44s | 1465016 ko | Curves/Weierstrass/Projective.vo                                                                                  |   3m17.62s | 1433268 ko || -0m00.18s ||     31748 ko |   -0.09% |         +2.21%
  3m11.74s | 2062708 ko | Rewriter/Passes/NBE.vo                                                                                            |   3m11.43s | 2062748 ko || +0m00.31s ||       -40 ko |   +0.16% |         -0.00%
  3m05.28s | 1236768 ko | Fancy/Compiler.vo                                                                                                 |   3m04.51s | 1250224 ko || +0m00.77s ||    -13456 ko |   +0.41% |         -1.07%
  2m53.62s | 1435876 ko | Curves/Montgomery/AffineProofs.vo                                                                                 |   2m53.27s | 1436104 ko || +0m00.34s ||      -228 ko |   +0.20% |         -0.01%
  2m36.03s | 1601812 ko | Rewriter/Passes/ToFancyWithCasts.vo                                                                               |   2m35.21s | 1860012 ko || +0m00.81s ||   -258200 ko |   +0.52% |        -13.88%
  2m24.24s | 1015020 ko | AbstractInterpretation/Wf.vo                                                                                      |   2m24.75s | 1006060 ko || -0m00.50s ||      8960 ko |   -0.35% |         +0.89%
  1m46.94s | 1029696 ko | Rewriter/Rewriter/Wf.vo                                                                                           |   1m47.02s | 1039540 ko || -0m00.08s ||     -9844 ko |   -0.07% |         -0.94%
  1m40.91s |  460776 ko | Spec/Test/X25519.vo                                                                                               |   1m41.16s |  460420 ko || -0m00.25s ||       356 ko |   -0.24% |         +0.07%
  1m24.30s | 1538012 ko | SlowPrimeSynthesisExamples.vo                                                                                     |   1m24.08s | 1536568 ko || +0m00.21s ||      1444 ko |   +0.26% |         +0.09%
  1m18.08s | 1448380 ko | Bedrock/Field/Synthesis/Generic/WordByWordMontgomery.vo                                                           |   1m18.21s | 1446376 ko || -0m00.13s ||      2004 ko |   -0.16% |         +0.13%
  1m17.50s | 1161468 ko | UnsaturatedSolinasHeuristics/Tests.vo                                                                             |   1m18.09s | 1161080 ko || -0m00.59s ||       388 ko |   -0.75% |         +0.03%
  1m15.03s |  835104 ko | AbstractInterpretation/Proofs.vo                                                                                  |   1m14.75s |  829116 ko || +0m00.28s ||      5988 ko |   +0.37% |         +0.72%
  1m14.89s | 1420472 ko | Bedrock/Field/Synthesis/Generic/UnsaturatedSolinas.vo                                                             |   1m14.80s | 1416224 ko || +0m00.09s ||      4248 ko |   +0.12% |         +0.29%
  1m13.16s | 1173404 ko | Bedrock/Group/ScalarMult/MontgomeryLadder.vo                                                                      |   1m12.78s | 1172960 ko || +0m00.37s ||       444 ko |   +0.52% |         +0.03%
  1m12.18s |  896392 ko | AbstractInterpretation/ZRangeProofs.vo                                                                            |   1m12.21s |  897708 ko || -0m00.03s ||     -1316 ko |   -0.04% |         -0.14%
  1m11.71s |  846624 ko | Curves/Weierstrass/Jacobian.vo                                                                                    |   1m11.72s |  846408 ko || -0m00.00s ||       216 ko |   -0.01% |         +0.02%
  1m10.10s |  802424 ko | Rewriter/Language/UnderLetsProofs.vo                                                                              |   1m10.66s |  800856 ko || -0m00.56s ||      1568 ko |   -0.79% |         +0.19%
  1m04.22s | 1225496 ko | Bedrock/Field/Translation/Proofs/ValidComputable/Expr.vo                                                          |   1m03.89s | 1225612 ko || +0m00.32s ||      -116 ko |   +0.51% |         -0.00%
  0m57.69s |  802644 ko | Rewriter/RulesProofs.vo                                                                                           |   0m57.69s |  802076 ko || +0m00.00s ||       568 ko |   +0.00% |         +0.07%
  0m57.51s | 1285028 ko | Rewriter/Passes/Arith.vo                                                                                          |   0m57.55s | 1285144 ko || -0m00.03s ||      -116 ko |   -0.06% |         -0.00%
  0m53.97s |  830300 ko | Rewriter/Rewriter/ProofsCommon.vo                                                                                 |   0m53.97s |  818748 ko || +0m00.00s ||     11552 ko |   +0.00% |         +1.41%
  0m52.19s |  658124 ko | Demo.vo                                                                                                           |   0m52.24s |  657524 ko || -0m00.05s ||       600 ko |   -0.09% |         +0.09%
  0m50.12s | 2141840 ko | ExtractionOCaml/word_by_word_montgomery                                                                           |   0m50.28s | 2141740 ko || -0m00.16s ||       100 ko |   -0.31% |         +0.00%
  0m50.03s |  989112 ko | PushButtonSynthesis/UnsaturatedSolinasReificationCache.vo                                                         |   0m50.23s |  968876 ko || -0m00.19s ||     20236 ko |   -0.39% |         +2.08%
  0m48.53s |  853660 ko | Rewriter/Rewriter/Examples/PerfTesting/LiftLetsMap.vo                                                             |   0m49.33s |  853736 ko || -0m00.79s ||       -76 ko |   -1.62% |         -0.00%
  0m46.87s |  913040 ko | Bedrock/Field/Synthesis/Examples/LadderStep.vo                                                                    |   0m46.37s |  911008 ko || +0m00.50s ||      2032 ko |   +1.07% |         +0.22%
  0m38.89s |  921224 ko | Rewriter/Passes/MulSplit.vo                                                                                       |   0m38.67s |  920620 ko || +0m00.21s ||       604 ko |   +0.56% |         +0.06%
  0m38.07s | 1080640 ko | Rewriter/Rewriter/Examples/PerfTesting/SieveOfEratosthenes.vo                                                     |   0m38.40s | 1083876 ko || -0m00.32s ||     -3236 ko |   -0.85% |         -0.29%
  0m34.22s |  903088 ko | PushButtonSynthesis/BarrettReductionReificationCache.vo                                                           |   0m34.24s |  903100 ko || -0m00.02s ||       -12 ko |   -0.05% |         -0.00%
  0m32.94s |  564144 ko | Arithmetic/Saturated.vo                                                                                           |   0m32.91s |  563824 ko || +0m00.03s ||       320 ko |   +0.09% |         +0.05%
  0m32.51s |  979620 ko | PushButtonSynthesis/BYInversionReificationCache.vo                                                                |   0m32.58s |  979816 ko || -0m00.07s ||      -196 ko |   -0.21% |         -0.02%
  0m31.70s |  886824 ko | Rewriter/Rewriter/Examples.vo                                                                                     |   0m31.77s |  928644 ko || -0m00.07s ||    -41820 ko |   -0.22% |         -4.50%
  0m31.64s |  225324 ko | fiat-java/src/FiatSecp256K1.java                                                                                  |   0m31.67s |  225316 ko || -0m00.03s ||         8 ko |   -0.09% |         +0.00%
  0m31.48s |  203520 ko | fiat-json/src/secp256k1_32.json                                                                                   |   0m31.06s |  203328 ko || +0m00.42s ||       192 ko |   +1.35% |         +0.09%
  0m31.29s |  189900 ko | fiat-go/32/secp256k1/secp256k1.go                                                                                 |   0m31.25s |  189736 ko || +0m00.03s ||       164 ko |   +0.12% |         +0.08%
  0m31.16s | 1422108 ko | ExtractionOCaml/bedrock2_base_conversion                                                                          |   0m30.46s | 1462128 ko || +0m00.69s ||    -40020 ko |   +2.29% |         -2.73%
  0m31.04s |  178128 ko | fiat-rust/src/secp256k1_32.rs                                                                                     |   0m30.98s |  177876 ko || +0m00.05s ||       252 ko |   +0.19% |         +0.14%
  0m30.79s |  200560 ko | fiat-zig/src/p256_32.zig                                                                                          |   0m31.09s |  200620 ko || -0m00.30s ||       -60 ko |   -0.96% |         -0.02%
  0m30.73s |  201452 ko | fiat-go/32/p256/p256.go                                                                                           |   0m30.62s |  201500 ko || +0m00.10s ||       -48 ko |   +0.35% |         -0.02%
  0m30.24s |  201112 ko | fiat-rust/src/p256_32.rs                                                                                          |   0m30.50s |  201388 ko || -0m00.26s ||      -276 ko |   -0.85% |         -0.13%
  0m29.90s |  910248 ko | Rewriter/Rewriter/Examples/PrefixSums.vo                                                                          |   0m29.66s |  935076 ko || +0m00.23s ||    -24828 ko |   +0.80% |         -2.65%
  0m29.11s | 1237024 ko | ExtractionOCaml/perf_unsaturated_solinas                                                                          |   0m28.50s | 1237052 ko || +0m00.60s ||       -28 ko |   +2.14% |         -0.00%
  0m27.04s | 1192544 ko | Assembly/Parse/TestAsm.vo                                                                                         |   0m27.52s | 1192648 ko || -0m00.48s ||      -104 ko |   -1.74% |         -0.00%
  0m25.98s |  138656 ko | fiat-bedrock2/src/p434_64.c                                                                                       |   0m26.57s |  138692 ko || -0m00.58s ||       -36 ko |   -2.22% |         -0.02%
  0m25.23s |  776184 ko | Bedrock/Group/ScalarMult/LadderStep.vo                                                                            |   0m25.31s |  776148 ko || -0m00.07s ||        36 ko |   -0.31% |         +0.00%
  0m23.44s |  117300 ko | fiat-json/src/p434_64.json                                                                                        |   0m22.87s |  117488 ko || +0m00.57s ||      -188 ko |   +2.49% |         -0.16%
  0m23.42s |  152732 ko | fiat-go/64/p434/p434.go                                                                                           |   0m23.58s |  152460 ko || -0m00.15s ||       272 ko |   -0.67% |         +0.17%
  0m23.32s |  869940 ko | Bedrock/Group/ScalarMult/ScalarMult.vo                                                                            |   0m23.22s |  869952 ko || +0m00.10s ||       -12 ko |   +0.43% |         -0.00%
  0m23.16s |  629656 ko | Rewriter/Language/Inversion.vo                                                                                    |   0m22.98s |  629956 ko || +0m00.17s ||      -300 ko |   +0.78% |         -0.04%
  0m22.78s |  148156 ko | fiat-rust/src/p434_64.rs                                                                                          |   0m22.87s |  148356 ko || -0m00.08s ||      -200 ko |   -0.39% |         -0.13%
  0m22.71s |  859016 ko | Bedrock/Field/Translation/Proofs/Expr.vo                                                                          |   0m22.66s |  858084 ko || +0m00.05s ||       932 ko |   +0.22% |         +0.10%
  0m22.62s |  130644 ko | fiat-c/src/p434_64.c                                                                                              |   0m22.90s |  130652 ko || -0m00.27s ||        -8 ko |   -1.22% |         -0.00%
  0m22.37s |  815460 ko | Rewriter/Rewriter/Examples/PerfTesting/Plus0Tree.vo                                                               |   0m22.28s |  811856 ko || +0m00.08s ||      3604 ko |   +0.40% |         +0.44%
  0m22.12s |  849840 ko | PushButtonSynthesis/WordByWordMontgomery.vo                                                                       |   0m22.06s |  849424 ko || +0m00.06s ||       416 ko |   +0.27% |         +0.04%
  0m21.98s | 1741024 ko | ExtractionOCaml/bedrock2_unsaturated_solinas.ml                                                                   |   0m22.59s | 1742636 ko || -0m00.60s ||     -1612 ko |   -2.70% |         -0.09%
  0m21.21s | 1646016 ko | ExtractionOCaml/unsaturated_solinas.ml                                                                            |   0m20.54s | 1646488 ko || +0m00.67s ||      -472 ko |   +3.26% |         -0.02%
  0m20.64s |  811976 ko | PushButtonSynthesis/UnsaturatedSolinas.vo                                                                         |   0m20.19s |  810548 ko || +0m00.44s ||      1428 ko |   +2.22% |         +0.17%
  0m19.82s | 1658004 ko | ExtractionOCaml/bedrock2_saturated_solinas.ml                                                                     |   0m19.78s | 1656348 ko || +0m00.03s ||      1656 ko |   +0.20% |         +0.09%
  0m19.29s | 1908392 ko | ExtractionOCaml/perf_word_by_word_montgomery.ml                                                                   |   0m18.71s | 1899400 ko || +0m00.57s ||      8992 ko |   +3.09% |         +0.47%
  0m18.89s |  620456 ko | Arithmetic/WordByWordMontgomery.vo                                                                                |   0m18.91s |  620940 ko || -0m00.01s ||      -484 ko |   -0.10% |         -0.07%
  0m18.77s |  585024 ko | Arithmetic/BarrettReduction.vo                                                                                    |   0m18.42s |  584092 ko || +0m00.34s ||       932 ko |   +1.90% |         +0.15%
  0m18.59s | 1560584 ko | ExtractionOCaml/saturated_solinas.ml                                                                              |   0m18.38s | 1559476 ko || +0m00.21s ||      1108 ko |   +1.14% |         +0.07%
  0m18.58s |  884024 ko | Curves/Edwards/XYZT/Basic.vo                                                                                      |   0m17.88s |  884160 ko || +0m00.69s ||      -136 ko |   +3.91% |         -0.01%
  0m18.46s | 1556216 ko | ExtractionOCaml/base_conversion.ml                                                                                |   0m18.44s | 1554340 ko || +0m00.01s ||      1876 ko |   +0.10% |         +0.12%
  0m18.42s |  846416 ko | PushButtonSynthesis/FancyMontgomeryReductionReificationCache.vo                                                   |   0m18.36s |  846340 ko || +0m00.06s ||        76 ko |   +0.32% |         +0.00%
  0m18.36s |  687468 ko | Util/ZUtil/ArithmeticShiftr.vo                                                                                    |   0m18.31s |  678640 ko || +0m00.05s ||      8828 ko |   +0.27% |         +1.30%
  0m18.30s |  552324 ko | Arithmetic/Core.vo                                                                                                |   0m17.83s |  552684 ko || +0m00.47s ||      -360 ko |   +2.63% |         -0.06%
  0m17.98s | 1795048 ko | ExtractionOCaml/perf_unsaturated_solinas.ml                                                                       |   0m17.70s | 1780472 ko || +0m00.28s ||     14576 ko |   +1.58% |         +0.81%
  0m17.89s |  769776 ko | Bedrock/Field/Translation/Proofs/LoadStoreList.vo                                                                 |   0m18.42s |  770032 ko || -0m00.53s ||      -256 ko |   -2.87% |         -0.03%
  0m17.72s | 1765520 ko | ExtractionHaskell/word_by_word_montgomery.hs                                                                      |   0m16.80s | 1767272 ko || +0m00.91s ||     -1752 ko |   +5.47% |         -0.09%
  0m17.68s |  824888 ko | Language/IdentifiersGENERATED.vo                                                                                  |   0m17.60s |  825564 ko || +0m00.07s ||      -676 ko |   +0.45% |         -0.08%
  0m17.61s |  741960 ko | Curves/Edwards/AffineProofs.vo                                                                                    |   0m17.54s |  741688 ko || +0m00.07s ||       272 ko |   +0.39% |         +0.03%
  0m17.56s |  687284 ko | Bedrock/Field/Common/Util.vo                                                                                      |   0m17.55s |  686808 ko || +0m00.00s ||       476 ko |   +0.05% |         +0.06%
  0m17.40s |  457144 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Map/TestGoals.vo              |   0m17.73s |  457200 ko || -0m00.33s ||       -56 ko |   -1.86% |         -0.01%
  0m16.92s | 1802964 ko | ExtractionHaskell/bedrock2_word_by_word_montgomery.hs                                                             |   0m17.88s | 1803940 ko || -0m00.95s ||      -976 ko |   -5.36% |         -0.05%
  0m16.55s |  487236 ko | Algebra/Field.vo                                                                                                  |   0m16.50s |  487300 ko || +0m00.05s ||       -64 ko |   +0.30% |         -0.01%
  0m15.28s |  751116 ko | Rewriter/Rewriter/Examples/PerfTesting/UnderLetsPlus0.vo                                                          |   0m15.33s |  751348 ko || -0m00.05s ||      -232 ko |   -0.32% |         -0.03%
  0m14.89s |  629776 ko | Language/IdentifiersGENERATEDProofs.vo                                                                            |   0m14.90s |  629556 ko || -0m00.00s ||       220 ko |   -0.06% |         +0.03%
  0m14.39s |  821360 ko | Bedrock/Field/Translation/Proofs/Cmd.vo                                                                           |   0m14.88s |  822000 ko || -0m00.49s ||      -640 ko |   -3.29% |         -0.07%
  0m14.32s |  114404 ko | fiat-java/src/FiatP224.java                                                                                       |   0m14.26s |  114476 ko || +0m00.06s ||       -72 ko |   +0.42% |         -0.06%
  0m14.13s |  128512 ko | fiat-go/32/p224/p224.go                                                                                           |   0m14.23s |  128588 ko || -0m00.09s ||       -76 ko |   -0.70% |         -0.05%
  0m14.04s |  125784 ko | fiat-json/src/p224_32.json                                                                                        |   0m14.03s |  125816 ko || +0m00.00s ||       -32 ko |   +0.07% |         -0.02%
  0m14.03s |  113952 ko | fiat-rust/src/p224_32.rs                                                                                          |   0m13.86s |  114292 ko || +0m00.16s ||      -340 ko |   +1.22% |         -0.29%
  0m13.87s |  116152 ko | fiat-c/src/p224_32.c                                                                                              |   0m13.83s |  115984 ko || +0m00.03s ||       168 ko |   +0.28% |         +0.14%
  0m13.37s |  706376 ko | Rewriter/Demo.vo                                                                                                  |   0m13.35s |  708556 ko || +0m00.01s ||     -2180 ko |   +0.14% |         -0.30%
  0m13.05s | 1500584 ko | ExtractionHaskell/bedrock2_unsaturated_solinas.hs                                                                 |   0m12.43s | 1495668 ko || +0m00.62s ||      4916 ko |   +4.98% |         +0.32%
  0m12.98s |  732316 ko | Bedrock/Field/Translation/Proofs/ValidComputable/Cmd.vo                                                           |   0m13.03s |  732048 ko || -0m00.04s ||       268 ko |   -0.38% |         +0.03%
  0m12.89s |  642864 ko | Util/ZRange/LandLorBounds.vo                                                                                      |   0m13.40s |  638636 ko || -0m00.50s ||      4228 ko |   -3.80% |         +0.66%
  0m12.80s |   87940 ko | fiat-bedrock2/src/p384_64.c                                                                                       |   0m12.85s |   88020 ko || -0m00.04s ||       -80 ko |   -0.38% |         -0.09%
  0m12.57s | 1400004 ko | ExtractionHaskell/unsaturated_solinas.hs                                                                          |   0m11.85s | 1399776 ko || +0m00.72s ||       228 ko |   +6.07% |         +0.01%
  0m12.24s |  514728 ko | Primitives/MxDHRepChange.vo                                                                                       |   0m12.21s |  514452 ko || +0m00.02s ||       276 ko |   +0.24% |         +0.05%
  0m12.05s |  615600 ko | Rewriter/Language/IdentifiersLibraryProofs.vo                                                                     |   0m11.64s |  615208 ko || +0m00.41s ||       392 ko |   +3.52% |         +0.06%
  0m12.03s | 1414420 ko | ExtractionHaskell/bedrock2_base_conversion.hs                                                                     |   0m12.21s | 1412704 ko || -0m00.18s ||      1716 ko |   -1.47% |         +0.12%
  0m11.69s | 1365548 ko | ExtractionHaskell/saturated_solinas.hs                                                                            |   0m11.75s | 1364604 ko || -0m00.06s ||       944 ko |   -0.51% |         +0.06%
  0m11.42s | 1414936 ko | ExtractionHaskell/bedrock2_saturated_solinas.hs                                                                   |   0m12.10s | 1415772 ko || -0m00.67s ||      -836 ko |   -5.61% |         -0.05%
  0m11.00s |  515076 ko | Algebra/Ring.vo                                                                                                   |   0m10.98s |  505464 ko || +0m00.01s ||      9612 ko |   +0.18% |         +1.90%
  0m10.82s | 1372900 ko | ExtractionHaskell/base_conversion.hs                                                                              |   0m11.75s | 1371292 ko || -0m00.92s ||      1608 ko |   -7.91% |         +0.11%
  0m10.81s |   86780 ko | fiat-go/64/p384/p384.go                                                                                           |   0m10.92s |   86000 ko || -0m00.10s ||       780 ko |   -1.00% |         +0.90%
  0m10.64s |   86676 ko | fiat-json/src/p384_64.json                                                                                        |   0m10.76s |   86480 ko || -0m00.11s ||       196 ko |   -1.11% |         +0.22%
  0m10.52s |   85832 ko | fiat-rust/src/p384_64.rs                                                                                          |   0m10.52s |   85656 ko || +0m00.00s ||       176 ko |   +0.00% |         +0.20%
  0m10.52s |   78400 ko | fiat-zig/src/p384_64.zig                                                                                          |   0m10.58s |   78216 ko || -0m00.06s ||       184 ko |   -0.56% |         +0.23%
  0m10.50s |   77180 ko | fiat-c/src/p384_64.c                                                                                              |   0m10.30s |   77328 ko || +0m00.19s ||      -148 ko |   +1.94% |         -0.19%
  0m10.47s |  888140 ko | Assembly/Parse/Examples/fiat_p256_mul_optimised_seed12.vo                                                         |   0m10.48s |  888544 ko || -0m00.00s ||      -404 ko |   -0.09% |         -0.04%
  0m10.07s | 1183224 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/WeakestPreconditionProperties.vo |   0m10.99s | 1183060 ko || -0m00.92s ||       164 ko |   -8.37% |         +0.01%
  0m10.06s |  792324 ko | Bedrock/Field/Translation/Proofs/Func.vo                                                                          |   0m10.05s |  792188 ko || +0m00.00s ||       136 ko |   +0.09% |         +0.01%
  0m10.03s |  538312 ko | Arithmetic/FancyMontgomeryReduction.vo                                                                            |   0m10.04s |  538352 ko || -0m00.00s ||       -40 ko |   -0.09% |         -0.00%
  0m09.43s |  645276 ko | Language/IdentifiersBasicGENERATED.vo                                                                             |   0m09.36s |  645112 ko || +0m00.07s ||       164 ko |   +0.74% |         +0.02%
  0m09.24s |  795560 ko | Assembly/Parse/Examples/fiat_p256_square_optimised_seed6.vo                                                       |   0m09.21s |  795504 ko || +0m00.02s ||        56 ko |   +0.32% |         +0.00%
  0m09.23s |  803476 ko | PushButtonSynthesis/SmallExamples.vo                                                                              |   0m08.98s |  803256 ko || +0m00.25s ||       220 ko |   +2.78% |         +0.02%
  0m09.11s |  970844 ko | Bedrock/Field/Translation/Proofs/EquivalenceProperties.vo                                                         |   0m09.06s |  970752 ko || +0m00.04s ||        92 ko |   +0.55% |         +0.00%
  0m09.05s |  692308 ko | Bedrock/Field/Translation/Proofs/Flatten.vo                                                                       |   0m08.95s |  692720 ko || +0m00.10s ||      -412 ko |   +1.11% |         -0.05%
  0m08.59s |  523608 ko | Util/ZRange/CornersMonotoneBounds.vo                                                                              |   0m08.59s |  514148 ko || +0m00.00s ||      9460 ko |   +0.00% |         +1.83%
  0m07.76s |  611676 ko | Rewriter/Passes/NoSelect.vo                                                                                       |   0m07.38s |  611588 ko || +0m00.37s ||        88 ko |   +5.14% |         +0.01%
  0m07.75s |   39276 ko | fiat-zig/src/p448_solinas_32.zig                                                                                  |   0m07.68s |   39320 ko || +0m00.07s ||       -44 ko |   +0.91% |         -0.11%
  0m07.67s |   45136 ko | fiat-json/src/p448_solinas_32.json                                                                                |   0m07.97s |   45452 ko || -0m00.29s ||      -316 ko |   -3.76% |         -0.69%
  0m07.67s |   39304 ko | fiat-rust/src/p448_solinas_32.rs                                                                                  |   0m07.54s |   39492 ko || +0m00.12s ||      -188 ko |   +1.72% |         -0.47%
  0m07.51s |   39100 ko | fiat-c/src/p448_solinas_32.c                                                                                      |   0m07.54s |   39168 ko || -0m00.03s ||       -68 ko |   -0.39% |         -0.17%
  0m07.44s |  987344 ko | Bedrock/Field/Translation/Proofs/UsedVarnames.vo                                                                  |   0m07.43s |  987632 ko || +0m00.01s ||      -288 ko |   +0.13% |         -0.02%
  0m07.42s |  522520 ko | Util/ListUtil.vo                                                                                                  |   0m07.35s |  513308 ko || +0m00.07s ||      9212 ko |   +0.95% |         +1.79%
  0m07.39s |  650420 ko | PushButtonSynthesis/SaturatedSolinasReificationCache.vo                                                           |   0m06.99s |  650124 ko || +0m00.39s ||       296 ko |   +5.72% |         +0.04%
  0m07.33s |  717584 ko | Assembly/Parse/Examples/fiat_p256_mul_optimised_seed4.vo                                                          |   0m07.64s |  717504 ko || -0m00.30s ||        80 ko |   -4.05% |         +0.01%
  0m07.05s |  736060 ko | PushButtonSynthesis/BaseConversion.vo                                                                             |   0m07.00s |  734864 ko || +0m00.04s ||      1196 ko |   +0.71% |         +0.16%
  0m07.00s |  692168 ko | Assembly/Parse/Examples/fiat_p256_mul_optimised_seed11.vo                                                         |   0m06.67s |  692016 ko || +0m00.33s ||       152 ko |   +4.94% |         +0.02%
  0m06.86s |  683072 ko | Assembly/Parse/Examples/fiat_p256_square_optimised_seed103.vo                                                     |   0m06.83s |  683804 ko || +0m00.03s ||      -732 ko |   +0.43% |         -0.10%
  0m06.76s |  486736 ko | Util/MSets/Sum.vo                                                                                                 |   0m06.71s |  486876 ko || +0m00.04s ||      -140 ko |   +0.74% |         -0.02%
  0m06.53s |  485964 ko | Rewriter/Util/ListUtil.vo                                                                                         |   0m06.48s |  486028 ko || +0m00.04s ||       -64 ko |   +0.77% |         -0.01%
  0m06.50s |  589040 ko | Arithmetic/BYInv.vo                                                                                               |   0m06.45s |  588432 ko || +0m00.04s ||       608 ko |   +0.77% |         +0.10%
  0m06.41s |  796268 ko | Bedrock/Field/Synthesis/Examples/EncodeDecode.vo                                                                  |   0m06.20s |  795376 ko || +0m00.20s ||       892 ko |   +3.38% |         +0.11%
  0m06.28s |  526332 ko | Util/ZUtil/Modulo.vo                                                                                              |   0m06.22s |  516812 ko || +0m00.06s ||      9520 ko |   +0.96% |         +1.84%
  0m06.25s |  751600 ko | PushButtonSynthesis/Primitives.vo                                                                                 |   0m06.07s |  749820 ko || +0m00.17s ||      1780 ko |   +2.96% |         +0.23%
  0m06.10s |  666876 ko | BoundsPipeline.vo                                                                                                 |   0m06.07s |  667472 ko || +0m00.02s ||      -596 ko |   +0.49% |         -0.08%
  0m06.01s |  572380 ko | COperationSpecifications.vo                                                                                       |   0m05.98s |  572396 ko || +0m00.02s ||       -16 ko |   +0.50% |         -0.00%
  0m06.00s |  608052 ko | Fancy/Prod.vo                                                                                                     |   0m05.76s |  608268 ko || +0m00.24s ||      -216 ko |   +4.16% |         -0.03%
  0m05.94s |  586824 ko | Language/InversionExtra.vo                                                                                        |   0m05.96s |  586844 ko || -0m00.01s ||       -20 ko |   -0.33% |         -0.00%
  0m05.73s |  505064 ko | Util/FsatzAutoLemmas.vo                                                                                           |   0m05.79s |  505016 ko || -0m00.05s ||        48 ko |   -1.03% |         +0.00%
  0m05.57s |  541652 ko | Curves/Edwards/Pre.vo                                                                                             |   0m05.54s |  541576 ko || +0m00.03s ||        76 ko |   +0.54% |         +0.01%
  0m05.43s |  745544 ko | PushButtonSynthesis/BarrettReduction.vo                                                                           |   0m05.33s |  745212 ko || +0m00.09s ||       332 ko |   +1.87% |         +0.04%
  0m05.27s |  491964 ko | Util/ZUtil/ZSimplify/Autogenerated.vo                                                                             |   0m05.34s |  484684 ko || -0m00.07s ||      7280 ko |   -1.31% |         +1.50%
  0m05.25s |  501896 ko | Arithmetic/MontgomeryReduction/Proofs.vo                                                                          |   0m05.18s |  492856 ko || +0m00.07s ||      9040 ko |   +1.35% |         +1.83%
  0m05.14s |  667532 ko | Assembly/Syntax.vo                                                                                                |   0m05.11s |  667364 ko || +0m00.02s ||       168 ko |   +0.58% |         +0.02%
  0m05.07s |  534296 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Word/Properties.vo            |   0m05.28s |  534208 ko || -0m00.20s ||        88 ko |   -3.97% |         +0.01%
  0m05.04s |  528100 ko | UnsaturatedSolinasHeuristics.vo                                                                                   |   0m05.00s |  527924 ko || +0m00.04s ||       176 ko |   +0.80% |         +0.03%
  0m04.80s |  514556 ko | Algebra/Field_test.vo                                                                                             |   0m04.80s |  514564 ko || +0m00.00s ||        -8 ko |   +0.00% |         -0.00%
  0m04.72s |  526716 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Map/Properties.vo             |   0m04.71s |  526784 ko || +0m00.00s ||       -68 ko |   +0.21% |         -0.01%
  0m04.72s |  514500 ko | Rewriter/Language/IdentifiersBasicLibrary.vo                                                                      |   0m04.64s |  514480 ko || +0m00.08s ||        20 ko |   +1.72% |         +0.00%
  0m04.71s |  519756 ko | Util/ZRange/BasicLemmas.vo                                                                                        |   0m04.77s |  510000 ko || -0m00.05s ||      9756 ko |   -1.25% |         +1.91%
  0m04.45s |  759600 ko | Bedrock/Field/Synthesis/Examples/MulTwice.vo                                                                      |   0m04.15s |  759820 ko || +0m00.29s ||      -220 ko |   +7.22% |         -0.02%
  0m04.43s |  517932 ko | Curves/Montgomery/Affine.vo                                                                                       |   0m04.14s |  517408 ko || +0m00.29s ||       524 ko |   +7.00% |         +0.10%
  0m04.30s |  578452 ko | Assembly/Parse/Examples/fiat_p256_square_optimised_seed46.vo                                                      |   0m04.11s |  578356 ko || +0m00.18s ||        96 ko |   +4.62% |         +0.01%
  0m04.26s |  520816 ko | Arithmetic/UniformWeight.vo                                                                                       |   0m04.28s |  520224 ko || -0m00.02s ||       592 ko |   -0.46% |         +0.11%
  0m04.16s |  530268 ko | Bedrock/Field/Interface/Compilation.vo                                                                            |   0m04.12s |  530412 ko || +0m00.04s ||      -144 ko |   +0.97% |         -0.02%
  0m04.12s |  503936 ko | Arithmetic/BarrettReduction/Generalized.vo                                                                        |   0m04.05s |  494292 ko || +0m00.07s ||      9644 ko |   +1.72% |         +1.95%
  0m04.12s |  599776 ko | PushButtonSynthesis/BaseConversionReificationCache.vo                                                             |   0m04.11s |  600144 ko || +0m00.00s ||      -368 ko |   +0.24% |         -0.06%
  0m04.09s |  445144 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Map/SlowGoals.vo              |   0m04.06s |  445160 ko || +0m00.03s ||       -16 ko |   +0.73% |         -0.00%
  0m03.99s |  749328 ko | PushButtonSynthesis/FancyMontgomeryReduction.vo                                                                   |   0m03.93s |  749096 ko || +0m00.06s ||       232 ko |   +1.52% |         +0.03%
  0m03.97s |  516160 ko | CastLemmas.vo                                                                                                     |   0m04.06s |  507152 ko || -0m00.08s ||      9008 ko |   -2.21% |         +1.77%
  0m03.84s |  583812 ko | Rewriter/Passes/AddAssocLeft.vo                                                                                   |   0m03.64s |  584120 ko || +0m00.19s ||      -308 ko |   +5.49% |         -0.05%
  0m03.80s |  745796 ko | PushButtonSynthesis/SaturatedSolinas.vo                                                                           |   0m03.83s |  744528 ko || -0m00.03s ||      1268 ko |   -0.78% |         +0.17%
  0m03.79s |  566296 ko | Rewriter/Passes/Test.vo                                                                                           |   0m03.77s |  566472 ko || +0m00.02s ||      -176 ko |   +0.53% |         -0.03%
  0m03.78s |   32868 ko | fiat-bedrock2/src/p521_64.c                                                                                       |   0m03.86s |   32868 ko || -0m00.08s ||         0 ko |   -2.07% |         +0.00%
  0m03.62s |  507384 ko | Util/ZUtil/LandLorBounds.vo                                                                                       |   0m03.54s |  497956 ko || +0m00.08s ||      9428 ko |   +2.25% |         +1.89%
  0m03.59s |  411968 ko | Algebra/Group.vo                                                                                                  |   0m03.56s |  411804 ko || +0m00.02s ||       164 ko |   +0.84% |         +0.03%
  0m03.55s |  529856 ko | Assembly/Semantics.vo                                                                                             |   0m03.52s |  529656 ko || +0m00.02s ||       200 ko |   +0.85% |         +0.03%
  0m03.48s |  500364 ko | Arithmetic/BarrettReduction/HAC.vo                                                                                |   0m03.44s |  490328 ko || +0m00.04s ||     10036 ko |   +1.16% |         +2.04%
  0m03.46s |  499708 ko | Util/ZUtil/LandLorShiftBounds.vo                                                                                  |   0m03.42s |  489744 ko || +0m00.04s ||      9964 ko |   +1.16% |         +2.03%
  0m03.36s |  687716 ko | Bedrock/Field/Common/Arrays/MakeAccessSizes.vo                                                                    |   0m03.32s |  688252 ko || +0m00.04s ||      -536 ko |   +1.20% |         -0.07%
  0m03.24s |   24580 ko | fiat-go/64/p521/p521.go                                                                                           |   0m03.18s |   24776 ko || +0m00.06s ||      -196 ko |   +1.88% |         -0.79%
  0m03.23s |  510188 ko | MiscCompilerPassesProofs.vo                                                                                       |   0m03.21s |  509976 ko || +0m00.02s ||       212 ko |   +0.62% |         +0.04%
  0m03.18s |  480540 ko | Util/MSets/Iso.vo                                                                                                 |   0m03.21s |  480360 ko || -0m00.02s ||       180 ko |   -0.93% |         +0.03%
  0m03.10s |   39588 ko | fiat-bedrock2/src/secp256k1_64.c                                                                                  |   0m03.17s |   39880 ko || -0m00.06s ||      -292 ko |   -2.20% |         -0.73%
  0m03.05s |   21344 ko | fiat-zig/src/p521_64.zig                                                                                          |   0m02.97s |   21444 ko || +0m00.07s ||      -100 ko |   +2.69% |         -0.46%
  0m02.97s |  494196 ko | Arithmetic/Primitives.vo                                                                                          |   0m02.99s |  484908 ko || -0m00.02s ||      9288 ko |   -0.66% |         +1.91%
  0m02.96s |   21412 ko | fiat-rust/src/p521_64.rs                                                                                          |   0m02.72s |   21472 ko || +0m00.23s ||       -60 ko |   +8.82% |         -0.27%
  0m02.90s |  742636 ko | CLI.vo                                                                                                            |   0m02.95s |  741940 ko || -0m00.05s ||       696 ko |   -1.69% |         +0.09%
  0m02.86s |  574612 ko | Bedrock/Field/Translation/Expr.vo                                                                                 |   0m02.85s |  574560 ko || +0m00.00s ||        52 ko |   +0.35% |         +0.00%
  0m02.86s |  525096 ko | Util/ZUtil/Morphisms.vo                                                                                           |   0m02.92s |  517584 ko || -0m00.06s ||      7512 ko |   -2.05% |         +1.45%
  0m02.83s |   36204 ko | fiat-bedrock2/src/p448_solinas_64.c                                                                               |   0m02.83s |   36264 ko || +0m00.00s ||       -60 ko |   +0.00% |         -0.16%
  0m02.78s |  521488 ko | Arithmetic/Freeze.vo                                                                                              |   0m02.68s |  520872 ko || +0m00.09s ||       616 ko |   +3.73% |         +0.11%
  0m02.78s |   25564 ko | fiat-json/src/p521_64.json                                                                                        |   0m03.08s |   25660 ko || -0m00.30s ||       -96 ko |   -9.74% |         -0.37%
  0m02.74s |   33556 ko | fiat-bedrock2/src/curve25519_32.c                                                                                 |   0m02.85s |   33444 ko || -0m00.10s ||       112 ko |   -3.85% |         +0.33%
  0m02.73s |  582696 ko | Rewriter/Passes/UnfoldValueBarrier.vo                                                                             |   0m02.58s |  582736 ko || +0m00.14s ||       -40 ko |   +5.81% |         -0.00%
  0m02.71s |  497688 ko | Util/ZUtil/TwosComplement.vo                                                                                      |   0m02.70s |  488752 ko || +0m00.00s ||      8936 ko |   +0.37% |         +1.82%
  0m02.70s |  579724 ko | Rewriter/Passes/StripLiteralCasts.vo                                                                              |   0m02.73s |  579140 ko || -0m00.02s ||       584 ko |   -1.09% |         +0.10%
  0m02.69s |  477468 ko | Spec/MontgomeryCurve.vo                                                                                           |   0m02.72s |  477636 ko || -0m00.03s ||      -168 ko |   -1.10% |         -0.03%
  0m02.66s |   34668 ko | fiat-go/64/secp256k1/secp256k1.go                                                                                 |   0m02.68s |   34676 ko || -0m00.02s ||        -8 ko |   -0.74% |         -0.02%
  0m02.63s |   22376 ko | fiat-c/src/p521_64.c                                                                                              |   0m02.95s |   22220 ko || -0m00.32s ||       156 ko |  -10.84% |         +0.70%
  0m02.60s |   36676 ko | fiat-json/src/secp256k1_64.json                                                                                   |   0m02.59s |   36628 ko || +0m00.01s ||        48 ko |   +0.38% |         +0.13%
  0m02.58s |   34560 ko | fiat-zig/src/secp256k1_64.zig                                                                                     |   0m02.50s |   34728 ko || +0m00.08s ||      -168 ko |   +3.20% |         -0.48%
  0m02.57s |  687424 ko | Bedrock/Field/Common/Names/MakeNames.vo                                                                           |   0m02.45s |  687536 ko || +0m00.11s ||      -112 ko |   +4.89% |         -0.01%
  0m02.53s |  517108 ko | Arithmetic/BaseConversion.vo                                                                                      |   0m02.52s |  517008 ko || +0m00.00s ||       100 ko |   +0.39% |         +0.01%
  0m02.51s |  496036 ko | Util/ZUtil/Shift.vo                                                                                               |   0m02.51s |  486808 ko || +0m00.00s ||      9228 ko |   +0.00% |         +1.89%
  0m02.51s |   39372 ko | fiat-bedrock2/src/p224_64.c                                                                                       |   0m02.49s |   39104 ko || +0m00.01s ||       268 ko |   +0.80% |         +0.68%
  0m02.51s |   35548 ko | fiat-c/src/secp256k1_64.c                                                                                         |   0m02.53s |   35448 ko || -0m00.02s ||       100 ko |   -0.79% |         +0.28%
  0m02.50s |  687628 ko | Bedrock/Field/Synthesis/Generic/Bignum.vo                                                                         |   0m02.49s |  687412 ko || +0m00.00s ||       216 ko |   +0.40% |         +0.03%
  0m02.45s |   33220 ko | fiat-rust/src/secp256k1_64.rs                                                                                     |   0m02.48s |   33048 ko || -0m00.02s ||       172 ko |   -1.20% |         +0.52%
  0m02.43s |  579900 ko | Rewriter/Passes/ToFancy.vo                                                                                        |   0m02.40s |  580044 ko || +0m00.03s ||      -144 ko |   +1.25% |         -0.02%
  0m02.41s |  634488 ko | CompilersTestCases.vo                                                                                             |   0m02.32s |  638268 ko || +0m00.09s ||     -3780 ko |   +3.87% |         -0.59%
  0m02.34s |  765408 ko | Rewriter/PerfTesting/Core.vo                                                                                      |   0m02.37s |  764772 ko || -0m00.03s ||       636 ko |   -1.26% |         +0.08%
  0m02.32s |   39520 ko | fiat-bedrock2/src/p256_64.c                                                                                       |   0m02.34s |   39268 ko || -0m00.02s ||       252 ko |   -0.85% |         +0.64%
  0m02.27s |  585796 ko | Bedrock/Group/ScalarMult/MontgomeryEquivalence.vo                                                                 |   0m02.29s |  585964 ko || -0m00.02s ||      -168 ko |   -0.87% |         -0.02%
  0m02.27s |  615364 ko | Stringification/Language.vo                                                                                       |   0m02.12s |  614972 ko || +0m00.14s ||       392 ko |   +7.07% |         +0.06%
  0m02.26s |  489584 ko | Util/ZUtil/Testbit.vo                                                                                             |   0m02.29s |  480320 ko || -0m00.03s ||      9264 ko |   -1.31% |         +1.92%
  0m02.25s |  561972 ko | AbstractInterpretation/AbstractInterpretation.vo                                                                  |   0m02.27s |  561360 ko || -0m00.02s ||       612 ko |   -0.88% |         +0.10%
  0m02.25s |  696212 ko | Bedrock/Field/Interface/Representation.vo                                                                         |   0m02.17s |  695888 ko || +0m00.08s ||       324 ko |   +3.68% |         +0.04%
  0m02.23s |  741424 ko | Bedrock/Field/Stringification/Stringification.vo                                                                  |   0m02.19s |  741308 ko || +0m00.04s ||       116 ko |   +1.82% |         +0.01%
  0m02.21s |  443060 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/AbsintWordToZ.vo                 |   0m02.27s |  442908 ko || -0m00.06s ||       152 ko |   -2.64% |         +0.03%
  0m02.21s |  488576 ko | Arithmetic/BarrettReduction/RidiculousFish.vo                                                                     |   0m02.09s |  478860 ko || +0m00.12s ||      9716 ko |   +5.74% |         +2.02%
  0m02.21s |  510620 ko | Arithmetic/ModularArithmeticTheorems.vo                                                                           |   0m02.26s |  508212 ko || -0m00.04s ||      2408 ko |   -2.21% |         +0.47%
  0m02.21s |  681472 ko | Bedrock/Field/Common/Arrays/ByteBounds.vo                                                                         |   0m02.22s |  680984 ko || -0m00.01s ||       488 ko |   -0.45% |         +0.07%
  0m02.21s |  687584 ko | Bedrock/Field/Common/Arrays/MaxBounds.vo                                                                          |   0m02.02s |  687388 ko || +0m00.18s ||       196 ko |   +9.40% |         +0.02%
  0m02.19s |  756496 ko | Bedrock/Field/Synthesis/Specialized/WordByWordMontgomery.vo                                                       |   0m02.04s |  756248 ko || +0m00.14s ||       248 ko |   +7.35% |         +0.03%
  0m02.18s |  595768 ko | AbstractInterpretation/ZRange.vo                                                                                  |   0m02.16s |  595728 ko || +0m00.02s ||        40 ko |   +0.92% |         +0.00%
  0m02.17s |  491324 ko | Util/Tuple.vo                                                                                                     |   0m02.11s |  481916 ko || +0m00.06s ||      9408 ko |   +2.84% |         +1.95%
  0m02.17s |  496688 ko | Util/ZUtil/Div.vo                                                                                                 |   0m02.14s |  487016 ko || +0m00.02s ||      9672 ko |   +1.40% |         +1.98%
  0m02.17s |   25956 ko | fiat-go/64/p448solinas/p448solinas.go                                                                             |   0m02.11s |   26276 ko || +0m00.06s ||      -320 ko |   +2.84% |         -1.21%
  0m02.16s |  459152 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/Scalars.vo                       |   0m02.13s |  459092 ko || +0m00.03s ||        60 ko |   +1.40% |         +0.01%
  0m02.16s |  735152 ko | Bedrock/Field/Synthesis/Specialized/Tactics.vo                                                                    |   0m02.07s |  734864 ko || +0m00.09s ||       288 ko |   +4.34% |         +0.03%
  0m02.11s |  736612 ko | Bedrock/Field/Synthesis/Generic/Operation.vo                                                                      |   0m01.90s |  736828 ko || +0m00.20s ||      -216 ko |  +11.05% |         -0.02%
  0m02.11s |  762084 ko | Bedrock/Standalone/StandaloneHaskellMain.vo                                                                       |   0m02.11s |  761668 ko || +0m00.00s ||       416 ko |   +0.00% |         +0.05%
  0m02.10s |  729548 ko | Bedrock/Field/Translation/Proofs/ValidComputable/Func.vo                                                          |   0m02.12s |  729244 ko || -0m00.02s ||       304 ko |   -0.94% |         +0.04%
  0m02.09s |  749728 ko | Bedrock/Field/Synthesis/Specialized/UnsaturatedSolinas.vo                                                         |   0m02.07s |  749384 ko || +0m00.02s ||       344 ko |   +0.96% |         +0.04%
  0m02.08s |  524232 ko | Arithmetic/ModOps.vo                                                                                              |   0m02.05s |  524132 ko || +0m00.03s ||       100 ko |   +1.46% |         +0.01%
  0m02.07s |  762532 ko | Bedrock/Standalone/StandaloneOCamlMain.vo                                                                         |   0m01.98s |  761568 ko || +0m00.08s ||       964 ko |   +4.54% |         +0.12%
  0m02.05s |  732044 ko | Bedrock/Field/Synthesis/Generic/Tactics.vo                                                                        |   0m01.88s |  731812 ko || +0m00.16s ||       232 ko |   +9.04% |         +0.03%
  0m02.04s |  466516 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/TailRecursion.vo                 |   0m02.05s |  466412 ko || -0m00.00s ||       104 ko |   -0.48% |         +0.02%
  0m02.00s |  457484 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/FE310CSemantics.vo               |   0m01.97s |  457888 ko || +0m00.03s ||      -404 ko |   +1.52% |         -0.08%
  0m02.00s |   34796 ko | fiat-go/64/p256/p256.go                                                                                           |   0m02.00s |   34844 ko || +0m00.00s ||       -48 ko |   +0.00% |         -0.13%
  0m01.98s |  734376 ko | Bedrock/Field/Synthesis/Specialized/ReifiedOperation.vo                                                           |   0m01.81s |  734412 ko || +0m00.16s ||       -36 ko |   +9.39% |         -0.00%
  0m01.97s |   36848 ko | fiat-json/src/p224_64.json                                                                                        |   0m01.88s |   36604 ko || +0m00.09s ||       244 ko |   +4.78% |         +0.66%
  0m01.95s |   35112 ko | fiat-rust/src/p224_64.rs                                                                                          |   0m01.96s |   34968 ko || -0m00.01s ||       144 ko |   -0.51% |         +0.41%
  0m01.94s |   33628 ko | fiat-c/src/p224_64.c                                                                                              |   0m01.91s |   33568 ko || +0m00.03s ||        60 ko |   +1.57% |         +0.17%
  0m01.94s |   37416 ko | fiat-json/src/p256_64.json                                                                                        |   0m01.92s |   37352 ko || +0m00.02s ||        64 ko |   +1.04% |         +0.17%
  0m01.93s |   34572 ko | fiat-go/64/p224/p224.go                                                                                           |   0m02.05s |   34780 ko || -0m00.11s ||      -208 ko |   -5.85% |         -0.59%
  0m01.93s |   36384 ko | fiat-zig/src/p256_64.zig                                                                                          |   0m01.94s |   36336 ko || -0m00.01s ||        48 ko |   -0.51% |         +0.13%
  0m01.92s |   34736 ko | fiat-zig/src/p224_64.zig                                                                                          |   0m01.94s |   34708 ko || -0m00.02s ||        28 ko |   -1.03% |         +0.08%
  0m01.91s |  747636 ko | Rewriter/PerfTesting/StandaloneOCamlMain.vo                                                                       |   0m01.92s |  747364 ko || -0m00.01s ||       272 ko |   -0.52% |         +0.03%
  0m01.90s |   21440 ko | fiat-zig/src/p448_solinas_64.zig                                                                                  |   0m01.85s |   21424 ko || +0m00.04s ||        16 ko |   +2.70% |         +0.07%
  0m01.89s |   34852 ko | fiat-rust/src/p256_64.rs                                                                                          |   0m01.88s |   34776 ko || +0m00.01s ||        76 ko |   +0.53% |         +0.21%
  0m01.87s |   25112 ko | fiat-json/src/p448_solinas_64.json                                                                                |   0m01.93s |   24932 ko || -0m00.05s ||       180 ko |   -3.10% |         +0.72%
  0m01.83s |   25752 ko | fiat-json/src/curve25519_32.json                                                                                  |   0m01.80s |   25424 ko || +0m00.03s ||       328 ko |   +1.66% |         +1.29%
  0m01.82s |   21432 ko | fiat-c/src/p448_solinas_64.c                                                                                      |   0m01.83s |   21264 ko || -0m00.01s ||       168 ko |   -0.54% |         +0.79%
  0m01.82s |   21416 ko | fiat-rust/src/p448_solinas_64.rs                                                                                  |   0m01.85s |   21248 ko || -0m00.03s ||       168 ko |   -1.62% |         +0.79%
  0m01.81s |  661916 ko | Bedrock/Field/Translation/Cmd.vo                                                                                  |   0m01.83s |  662064 ko || -0m00.02s ||      -148 ko |   -1.09% |         -0.02%
  0m01.80s |  472620 ko | Assembly/Parse/Examples/fiat_25519_carry_square_optimised.vo                                                      |   0m01.78s |  472576 ko || +0m00.02s ||        44 ko |   +1.12% |         +0.00%
  0m01.79s |   21272 ko | fiat-java/src/FiatCurve25519.java                                                                                 |   0m01.80s |   21308 ko || -0m00.01s ||       -36 ko |   -0.55% |         -0.16%
  0m01.78s |  640052 ko | Bedrock/Field/Common/Tactics.vo                                                                                   |   0m01.76s |  640668 ko || +0m00.02s ||      -616 ko |   +1.13% |         -0.09%
  0m01.78s |   21516 ko | fiat-go/32/curve25519/curve25519.go                                                                               |   0m01.73s |   21160 ko || +0m00.05s ||       356 ko |   +2.89% |         +1.68%
  0m01.77s |  550840 ko | Arithmetic/PrimeFieldTheorems.vo                                                                                  |   0m01.81s |  550476 ko || -0m00.04s ||       364 ko |   -2.20% |         +0.06%
  0m01.75s |  489028 ko | Util/ZUtil/Pow2Mod.vo                                                                                             |   0m01.78s |  479536 ko || -0m00.03s ||      9492 ko |   -1.68% |         +1.97%
  0m01.75s |   35624 ko | fiat-c/src/p256_64.c                                                                                              |   0m01.88s |   35448 ko || -0m00.12s ||       176 ko |   -6.91% |         +0.49%
  0m01.74s |  472688 ko | Assembly/Parse/Examples/fiat_25519_carry_square_optimised_seed10.vo                                               |   0m01.79s |  472860 ko || -0m00.05s ||      -172 ko |   -2.79% |         -0.03%
  0m01.74s |   21336 ko | fiat-zig/src/curve25519_32.zig                                                                                    |   0m01.75s |   21272 ko || -0m00.01s ||        64 ko |   -0.57% |         +0.30%
  0m01.73s |  478016 ko | Algebra/ScalarMult.vo                                                                                             |   0m01.71s |  469176 ko || +0m00.02s ||      8840 ko |   +1.16% |         +1.88%
  0m01.73s |  492752 ko | Assembly/Parse.vo                                                                                                 |   0m01.71s |  493124 ko || +0m00.02s ||      -372 ko |   +1.16% |         -0.07%
  0m01.73s |  515188 ko | Util/ZRange/SplitRangeBounds.vo                                                                                   |   0m01.69s |  505960 ko || +0m00.04s ||      9228 ko |   +2.36% |         +1.82%
  0m01.72s |  471000 ko | Assembly/Parse/Examples/fiat_25519_carry_square_optimised_seed20.vo                                               |   0m01.76s |  470976 ko || -0m00.04s ||        24 ko |   -2.27% |         +0.00%
  0m01.72s |  511000 ko | Rewriter/Language/IdentifiersLibrary.vo                                                                           |   0m01.70s |  511288 ko || +0m00.02s ||      -288 ko |   +1.17% |         -0.05%
  0m01.72s |   21368 ko | fiat-c/src/curve25519_32.c                                                                                        |   0m01.73s |   21256 ko || -0m00.01s ||       112 ko |   -0.57% |         +0.52%
  0m01.71s |  464480 ko | Spec/WeierstrassCurve.vo                                                                                          |   0m01.78s |  464152 ko || -0m00.07s ||       328 ko |   -3.93% |         +0.07%
  0m01.71s |   21380 ko | fiat-rust/src/curve25519_32.rs                                                                                    |   0m01.69s |   21496 ko || +0m00.02s ||      -116 ko |   +1.18% |         -0.53%
  0m01.68s |  738132 ko | StandaloneHaskellMain.vo                                                                                          |   0m01.74s |  737148 ko || -0m00.06s ||       984 ko |   -3.44% |         +0.13%
  0m01.68s |  494924 ko | Util/ZUtil/Bitwise.vo                                                                                             |   0m01.72s |  487840 ko || -0m00.04s ||      7084 ko |   -2.32% |         +1.45%
  0m01.67s |  679052 ko | Bedrock/Field/Translation/Parameters/SelectParameters.vo                                                          |   0m01.55s |  679636 ko || +0m00.11s ||      -584 ko |   +7.74% |         -0.08%
  0m01.67s |  738924 ko | StandaloneOCamlMain.vo                                                                                            |   0m01.78s |  737892 ko || -0m00.11s ||      1032 ko |   -6.17% |         +0.13%
  0m01.63s |  679644 ko | Bedrock/Field/Translation/Parameters/Defaults64.vo                                                                |   0m01.59s |  679232 ko || +0m00.03s ||       412 ko |   +2.51% |         +0.06%
  0m01.61s |  675236 ko | Bedrock/Field/Translation/Parameters/Defaults.vo                                                                  |   0m01.63s |  675448 ko || -0m00.01s ||      -212 ko |   -1.22% |         -0.03%
  0m01.61s |  679272 ko | Bedrock/Field/Translation/Parameters/Defaults32.vo                                                                |   0m01.64s |  679676 ko || -0m00.02s ||      -404 ko |   -1.82% |         -0.05%
  0m01.60s |  443004 ko | Rewriter/Rewriter/Examples/PerfTesting/Harness.vo                                                                 |   0m01.55s |  443440 ko || +0m00.05s ||      -436 ko |   +3.22% |         -0.09%
  0m01.58s |  502068 ko | Util/ZUtil/Quot.vo                                                                                                |   0m01.53s |  492812 ko || +0m00.05s ||      9256 ko |   +3.26% |         +1.87%
  0m01.56s |  508152 ko | Arithmetic/Partition.vo                                                                                           |   0m01.61s |  508216 ko || -0m00.05s ||       -64 ko |   -3.10% |         -0.01%
  0m01.53s |  446584 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/Map/SeparationLogic.vo           |   0m01.47s |  446444 ko || +0m00.06s ||       140 ko |   +4.08% |         +0.03%
  0m01.50s |  482456 ko | Util/ZUtil/Rshi.vo                                                                                                |   0m01.49s |  473012 ko || +0m00.01s ||      9444 ko |   +0.67% |         +1.99%
  0m01.48s |  570700 ko | Stringification/Go.vo                                                                                             |   0m01.56s |  570704 ko || -0m00.08s ||        -4 ko |   -5.12% |         -0.00%
  0m01.47s |  569408 ko | Bedrock/Field/Common/Types.vo                                                                                     |   0m01.42s |  568868 ko || +0m00.05s ||       540 ko |   +3.52% |         +0.09%
  0m01.46s |  567984 ko | Stringification/JSON.vo                                                                                           |   0m01.49s |  568032 ko || -0m00.03s ||       -48 ko |   -2.01% |         -0.00%
  0m01.46s |  505900 ko | Util/ZRange/SplitBounds.vo                                                                                        |   0m01.44s |  496020 ko || +0m00.02s ||      9880 ko |   +1.38% |         +1.99%
  0m01.45s |  561976 ko | Bedrock/Field/Translation/Proofs/Equivalence.vo                                                                   |   0m01.46s |  561504 ko || -0m00.01s ||       472 ko |   -0.68% |         +0.08%
  0m01.45s |  482040 ko | Curves/Edwards/XYZT/Precomputed.vo                                                                                |   0m01.40s |  482100 ko || +0m00.05s ||       -60 ko |   +3.57% |         -0.01%
  0m01.44s |  661332 ko | Bedrock/Field/Translation/Func.vo                                                                                 |   0m01.44s |  661656 ko || +0m00.00s ||      -324 ko |   +0.00% |         -0.04%
  0m01.44s |  526520 ko | Bedrock/ScalarField/Interface/Compilation.vo                                                                      |   0m01.34s |  526356 ko || +0m00.09s ||       164 ko |   +7.46% |         +0.03%
  0m01.44s |  508296 ko | Rewriter/Rewriter/Rewriter.vo                                                                                     |   0m01.47s |  508448 ko || -0m00.03s ||      -152 ko |   -2.04% |         -0.02%
  0m01.43s |  566156 ko | Stringification/Java.vo                                                                                           |   0m01.34s |  566276 ko || +0m00.08s ||      -120 ko |   +6.71% |         -0.02%
  0m01.42s |  471396 ko | Util/ListUtil/Forall.vo                                                                                           |   0m01.37s |  460924 ko || +0m00.04s ||     10472 ko |   +3.64% |         +2.27%
  0m01.40s |  572228 ko | Bedrock/Field/Translation/LoadStoreList.vo                                                                        |   0m01.39s |  572084 ko || +0m00.01s ||       144 ko |   +0.71% |         +0.02%
  0m01.39s |  488332 ko | Fancy/Spec.vo                                                                                                     |   0m01.44s |  488468 ko || -0m00.05s ||      -136 ko |   -3.47% |         -0.02%
  0m01.39s |  509868 ko | Rewriter/Rewriter/Reify.vo                                                                                        |   0m01.33s |  509892 ko || +0m00.05s ||       -24 ko |   +4.51% |         -0.00%
  0m01.38s |  565812 ko | Stringification/C.vo                                                                                              |   0m01.54s |  565052 ko || -0m00.16s ||       760 ko |  -10.38% |         +0.13%
  0m01.36s |  566848 ko | Stringification/Rust.vo                                                                                           |   0m01.34s |  566996 ko || +0m00.02s ||      -148 ko |   +1.49% |         -0.02%
  0m01.36s |  488576 ko | Util/ZUtil/Ones.vo                                                                                                |   0m01.33s |  479204 ko || +0m00.03s ||      9372 ko |   +2.25% |         +1.95%
  0m01.35s |  440128 ko | Coqprime/PrimalityTest/EGroup                                                                                     |   0m01.35s |  439784 ko || +0m00.00s ||       344 ko |   +0.00% |         +0.07%
  0m01.35s |  484200 ko | Util/NatUtil.vo                                                                                                   |   0m01.39s |  473384 ko || -0m00.03s ||     10816 ko |   -2.87% |         +2.28%
  0m01.35s |  454540 ko | Util/ZUtil/OnesFrom.vo                                                                                            |   0m01.35s |  454444 ko || +0m00.00s ||        96 ko |   +0.00% |         +0.02%
  0m01.33s |  570200 ko | Bedrock/Field/Common/Arrays/MakeListLengths.vo                                                                    |   0m01.27s |  570256 ko || +0m00.06s ||       -56 ko |   +4.72% |         -0.00%
  0m01.33s |  436048 ko | Rewriter/Util/ListUtil/Forall.vo                                                                                  |   0m01.32s |  436124 ko || +0m00.01s ||       -76 ko |   +0.75% |         -0.01%
  0m01.33s |  482976 ko | Util/ZUtil/AddGetCarry.vo                                                                                         |   0m01.36s |  473152 ko || -0m00.03s ||      9824 ko |   -2.20% |         +2.07%
  0m01.32s |  567004 ko | Stringification/Zig.vo                                                                                            |   0m01.36s |  566972 ko || -0m00.04s ||        32 ko |   -2.94% |         +0.00%
  0m01.31s |  561516 ko | Bedrock/Field/Translation/Proofs/VarnameSet.vo                                                                    |   0m01.26s |  561592 ko || +0m00.05s ||       -76 ko |   +3.96% |         -0.01%
  0m01.30s |  579924 ko | Bedrock/Field/Stringification/LoadStoreListVarData.vo                                                             |   0m01.27s |  580424 ko || +0m00.03s ||      -500 ko |   +2.36% |         -0.08%
  0m01.30s |  570080 ko | Bedrock/Field/Translation/Flatten.vo                                                                              |   0m01.33s |  570164 ko || -0m00.03s ||       -84 ko |   -2.25% |         -0.01%
  0m01.29s |  554356 ko | Language/APINotations.vo                                                                                          |   0m01.27s |  554440 ko || +0m00.02s ||       -84 ko |   +1.57% |         -0.01%
  0m01.28s |  584944 ko | Bedrock/Field/Stringification/FlattenVarData.vo                                                                   |   0m01.24s |  584884 ko || +0m00.04s ||        60 ko |   +3.22% |         +0.01%
  0m01.27s |  600008 ko | Rewriter/All.vo                                                                                                   |   0m01.23s |  599772 ko || +0m00.04s ||       236 ko |   +3.25% |         +0.03%
  0m01.26s |  459724 ko | Curves/Montgomery/AffineInstances.vo                                                                              |   0m01.23s |  459812 ko || +0m00.03s ||       -88 ko |   +2.43% |         -0.01%
  0m01.25s |  430668 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Datatypes/PropSet.vo          |   0m01.24s |  430440 ko || +0m00.01s ||       228 ko |   +0.80% |         +0.05%
  0m01.23s |  539592 ko | Rewriter/Rewriter/AllTactics.vo                                                                                   |   0m01.24s |  539480 ko || -0m00.01s ||       112 ko |   -0.80% |         +0.02%
  0m01.22s |  457732 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/ptsto_bytes.vo                   |   0m01.19s |  457536 ko || +0m00.03s ||       196 ko |   +2.52% |         +0.04%
  0m01.22s |  465712 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/src/Rupicola/Lib/Compiler.vo                                    |   0m01.20s |  465556 ko || +0m00.02s ||       156 ko |   +1.66% |         +0.03%
  0m01.22s |  481608 ko | Rewriter/Language/Language.vo                                                                                     |   0m01.26s |  483188 ko || -0m00.04s ||     -1580 ko |   -3.17% |         -0.32%
  0m01.21s |  456736 ko | Util/Bool/Reflect.vo                                                                                              |   0m01.20s |  456620 ko || +0m00.01s ||       116 ko |   +0.83% |         +0.02%
  0m01.17s |  531624 ko | Bedrock/Specs/Field.vo                                                                                            |   0m01.20s |  531584 ko || -0m00.03s ||        40 ko |   -2.50% |         +0.00%
  0m01.17s |  435276 ko | Coqprime/Z/ZCAux                                                                                                  |   0m01.18s |  435120 ko || -0m00.01s ||       156 ko |   -0.84% |         +0.03%
  0m01.15s |  550472 ko | MiscCompilerPassesProofsExtra.vo                                                                                  |   0m01.14s |  550532 ko || +0m00.01s ||       -60 ko |   +0.87% |         -0.01%
  0m01.14s |  442696 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Datatypes/List.vo             |   0m01.07s |  442644 ko || +0m00.06s ||        52 ko |   +6.54% |         +0.01%
  0m01.14s |  462576 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/src/Rupicola/Lib/ControlFlow/DownTo.vo                          |   0m01.15s |  462652 ko || -0m00.01s ||       -76 ko |   -0.86% |         -0.01%
  0m01.14s |  553084 ko | AbstractInterpretation/WfExtra.vo                                                                                 |   0m01.15s |  553316 ko || -0m00.01s ||      -232 ko |   -0.86% |         -0.04%
  0m01.14s |  550412 ko | Rewriter/AllTacticsExtra.vo                                                                                       |   0m01.11s |  550544 ko || +0m00.02s ||      -132 ko |   +2.70% |         -0.02%
  0m01.13s |  549672 ko | PushButtonSynthesis/ReificationCache.vo                                                                           |   0m01.11s |  550016 ko || +0m00.01s ||      -344 ko |   +1.80% |         -0.06%
  0m01.13s |  489200 ko | Util/ZUtil/TruncatingShiftl.vo                                                                                    |   0m01.09s |  479960 ko || +0m00.03s ||      9240 ko |   +3.66% |         +1.92%
  0m01.12s |  560036 ko | Bedrock/Specs/ScalarField.vo                                                                                      |   0m01.05s |  559804 ko || +0m00.07s ||       232 ko |   +6.66% |         +0.04%
  0m01.12s |  546628 ko | Language/UnderLetsProofsExtra.vo                                                                                  |   0m01.19s |  546792 ko || -0m00.06s ||      -164 ko |   -5.88% |         -0.02%
  0m01.11s |  444880 ko | Util/Strings/String_as_OT.vo                                                                                      |   0m01.06s |  444836 ko || +0m00.05s ||        44 ko |   +4.71% |         +0.00%
  0m01.09s |  543336 ko | Language/API.vo                                                                                                   |   0m01.13s |  543236 ko || -0m00.03s ||       100 ko |   -3.53% |         +0.01%
  0m01.08s |  526036 ko | Bedrock/Group/Point.vo                                                                                            |   0m01.04s |  525908 ko || +0m00.04s ||       128 ko |   +3.84% |         +0.02%
  0m01.07s |  524500 ko | Bedrock/Specs/Group.vo                                                                                            |   0m01.07s |  524568 ko || +0m00.00s ||       -68 ko |   +0.00% |         -0.01%
  0m01.07s |  444436 ko | Rewriter/Util/NatUtil.vo                                                                                          |   0m01.06s |  444584 ko || +0m00.01s ||      -148 ko |   +0.94% |         -0.03%
  0m01.06s |  471460 ko | Rewriter/Rules.vo                                                                                                 |   0m01.02s |  471656 ko || +0m00.04s ||      -196 ko |   +3.92% |         -0.04%
  0m01.04s |  546264 ko | Language/WfExtra.vo                                                                                               |   0m01.13s |  547096 ko || -0m00.08s ||      -832 ko |   -7.96% |         -0.15%
  0m01.02s |  460968 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/src/Rupicola/Lib/ControlFlow/CondSwap.vo                        |   0m01.05s |  460860 ko || -0m00.03s ||       108 ko |   -2.85% |         +0.02%
  0m01.02s |  508580 ko | Bedrock/Group/Loops.vo                                                                                            |   0m00.98s |  499536 ko || +0m00.04s ||      9044 ko |   +4.08% |         +1.81%
  0m01.00s |  438932 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Map/TestLemmas.vo             |   0m01.00s |  438852 ko || +0m00.00s ||        80 ko |   +0.00% |         +0.01%
  0m00.99s |  487796 ko | Arithmetic/BarrettReduction/Wikipedia.vo                                                                          |   0m00.98s |  478532 ko || +0m00.01s ||      9264 ko |   +1.02% |         +1.93%
  0m00.99s |  435552 ko | Coqprime/PrimalityTest/Root                                                                                       |   0m01.01s |  435936 ko || -0m00.02s ||      -384 ko |   -1.98% |         -0.08%
  0m00.97s |  444608 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Word/BigEndian.vo             |   0m00.93s |  444812 ko || +0m00.03s ||      -204 ko |   +4.30% |         -0.04%
  0m00.96s |  517248 ko | Rewriter/Rewriter/ProofsCommonTactics.vo                                                                          |   0m00.97s |  517664 ko || -0m00.01s ||      -416 ko |   -1.03% |         -0.08%
  0m00.95s |  451244 ko | Algebra/IntegralDomain.vo                                                                                         |   0m00.95s |  451276 ko || +0m00.00s ||       -32 ko |   +0.00% |         -0.00%
  0m00.94s |  441828 ko | Algebra/NsatzTactic.vo                                                                                            |   0m00.98s |  441576 ko || -0m00.04s ||       252 ko |   -4.08% |         +0.05%
  0m00.93s |  454256 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/Array.vo                         |   0m00.85s |  453760 ko || +0m00.08s ||       496 ko |   +9.41% |         +0.10%
  0m00.93s |  441668 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Word/LittleEndian.vo          |   0m00.92s |  441816 ko || +0m00.01s ||      -148 ko |   +1.08% |         -0.03%
  0m00.93s |  499416 ko | MiscCompilerPasses.vo                                                                                             |   0m00.89s |  499364 ko || +0m00.04s ||        52 ko |   +4.49% |         +0.01%
  0m00.92s |  523436 ko | Rewriter/Rewriter/Examples/PerfTesting/Settings.vo                                                                |   0m00.94s |  523920 ko || -0m00.01s ||      -484 ko |   -2.12% |         -0.09%
  0m00.90s |  437792 ko | Coqprime/PrimalityTest/Cyclic                                                                                     |   0m00.84s |  437656 ko || +0m00.06s ||       136 ko |   +7.14% |         +0.03%
  0m00.89s |  488652 ko | ArithmeticCPS/WordByWordMontgomery.vo                                                                             |   0m00.82s |  488760 ko || +0m00.07s ||      -108 ko |   +8.53% |         -0.02%
  0m00.88s |  500520 ko | Rewriter/Language/IdentifiersGenerate.vo                                                                          |   0m00.91s |  500276 ko || -0m00.03s ||       244 ko |   -3.29% |         +0.04%
  0m00.87s |  530116 ko | Rewriter/Util/plugins/RewriterBuild.vo                                                                            |   0m00.93s |  529660 ko || -0m00.06s ||       456 ko |   -6.45% |         +0.08%
  0m00.87s |  529892 ko | Rewriter/Util/plugins/RewriterBuildRegistry.vo                                                                    |   0m00.84s |  529800 ko || +0m00.03s ||        92 ko |   +3.57% |         +0.01%
  0m00.87s |  493876 ko | Util/NumTheoryUtil.vo                                                                                             |   0m00.88s |  484488 ko || -0m00.01s ||      9388 ko |   -1.13% |         +1.93%
  0m00.85s |  508924 ko | Rewriter/Language/IdentifiersGenerateProofs.vo                                                                    |   0m00.87s |  508992 ko || -0m00.02s ||       -68 ko |   -2.29% |         -0.01%
  0m00.85s |  525320 ko | Rewriter/Util/plugins/RewriterBuildRegistryImports.vo                                                             |   0m00.85s |  525276 ko || +0m00.00s ||        44 ko |   +0.00% |         +0.00%
  0m00.85s |  457176 ko | Util/CPSUtil.vo                                                                                                   |   0m00.82s |  457236 ko || +0m00.03s ||       -60 ko |   +3.65% |         -0.01%
  0m00.85s |  448480 ko | Util/Strings/ParseArithmetic.vo                                                                                   |   0m00.81s |  447940 ko || +0m00.03s ||       540 ko |   +4.93% |         +0.12%
  0m00.84s |  458404 ko | Util/Arg.vo                                                                                                       |   0m00.86s |  458208 ko || -0m00.02s ||       196 ko |   -2.32% |         +0.04%
  0m00.84s |  463132 ko | Util/ZRange/OperationsBounds.vo                                                                                   |   0m00.88s |  463152 ko || -0m00.04s ||       -20 ko |   -4.54% |         -0.00%
  0m00.83s |  469192 ko | Assembly/Equality.vo                                                                                              |   0m00.82s |  469028 ko || +0m00.01s ||       164 ko |   +1.21% |         +0.03%
  0m00.83s |  438828 ko | Rewriter/Rewriter/Examples/PerfTesting/Sample.vo                                                                  |   0m00.84s |  438620 ko || -0m00.01s ||       208 ko |   -1.19% |         +0.04%
  0m00.83s |  455248 ko | Rewriter/Util/Bool/Reflect.vo                                                                                     |   0m00.83s |  455312 ko || +0m00.00s ||       -64 ko |   +0.00% |         -0.01%
  0m00.82s |  442656 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Z/BitOps.vo                   |   0m00.83s |  442736 ko || -0m00.01s ||       -80 ko |   -1.20% |         -0.01%
  0m00.82s |  459260 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/src/Rupicola/Lib/SepLocals.vo                                   |   0m00.79s |  459016 ko || +0m00.02s ||       244 ko |   +3.79% |         +0.05%
  0m00.82s |  501836 ko | Util/QUtil.vo                                                                                                     |   0m00.82s |  492312 ko || +0m00.00s ||      9524 ko |   +0.00% |         +1.93%
  0m00.80s |  450300 ko | Algebra/SubsetoidRing.vo                                                                                          |   0m00.89s |  450364 ko || -0m00.08s ||       -64 ko |  -10.11% |         -0.01%
  0m00.80s |  486188 ko | ArithmeticCPS/Freeze.vo                                                                                           |   0m00.80s |  486544 ko || +0m00.00s ||      -356 ko |   +0.00% |         -0.07%
  0m00.80s |  436328 ko | Coqprime/Z/ZSum                                                                                                   |   0m00.85s |  436772 ko || -0m00.04s ||      -444 ko |   -5.88% |         -0.10%
  0m00.80s |  468236 ko | Util/OptionList.vo                                                                                                |   0m00.85s |  458700 ko || -0m00.04s ||      9536 ko |   -5.88% |         +2.07%
  0m00.80s |  492424 ko | Util/ZUtil/CC.vo                                                                                                  |   0m00.78s |  482596 ko || +0m00.02s ||      9828 ko |   +2.56% |         +2.03%
  0m00.79s |  330692 ko | Util/PartiallyReifiedProp.vo                                                                                      |   0m00.81s |  330568 ko || -0m00.02s ||       124 ko |   -2.46% |         +0.03%
  0m00.78s |  484608 ko | Util/Decidable/Decidable2Bool.vo                                                                                  |   0m00.70s |  474652 ko || +0m00.08s ||      9956 ko |  +11.42% |         +2.09%
  0m00.77s |  438640 ko | Coqprime/PrimalityTest/Zp                                                                                         |   0m00.78s |  438964 ko || -0m00.01s ||      -324 ko |   -1.28% |         -0.07%
  0m00.77s |  488008 ko | Util/ZUtil/Stabilization.vo                                                                                       |   0m00.74s |  478344 ko || +0m00.03s ||      9664 ko |   +4.05% |         +2.02%
  0m00.76s |  475988 ko | ArithmeticCPS/Core.vo                                                                                             |   0m00.73s |  475860 ko || +0m00.03s ||       128 ko |   +4.10% |         +0.02%
  0m00.75s |  465324 ko | Util/Loops.vo                                                                                                     |   0m00.76s |  455860 ko || -0m00.01s ||      9464 ko |   -1.31% |         +2.07%
  0m00.75s |  442888 ko | Util/Strings/ParseArithmeticToTaps.vo                                                                             |   0m00.73s |  443256 ko || +0m00.02s ||      -368 ko |   +2.73% |         -0.08%
  0m00.74s |  483824 ko | ArithmeticCPS/BaseConversion.vo                                                                                   |   0m00.74s |  483728 ko || +0m00.00s ||        96 ko |   +0.00% |         +0.01%
  0m00.74s |  401732 ko | Util/Structures/Orders/Sum.vo                                                                                     |   0m00.75s |  401532 ko || -0m00.01s ||       200 ko |   -1.33% |         +0.04%
  0m00.74s |  467980 ko | Util/ZUtil/Modulo/PullPush.vo                                                                                     |   0m00.74s |  458932 ko || +0m00.00s ||      9048 ko |   +0.00% |         +1.97%
  0m00.71s |  439156 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Map/SortedList.vo             |   0m00.77s |  439392 ko || -0m00.06s ||      -236 ko |   -7.79% |         -0.05%
  0m00.71s |  467596 ko | Rewriter/Language/IdentifiersBasicGenerate.vo                                                                     |   0m00.73s |  467524 ko || -0m00.02s ||        72 ko |   -2.73% |         +0.01%
  0m00.70s |  446520 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Map/OfListWord.vo             |   0m00.72s |  446360 ko || -0m00.02s ||       160 ko |   -2.77% |         +0.03%
  0m00.70s |  481024 ko | ArithmeticCPS/ModOps.vo                                                                                           |   0m00.71s |  481100 ko || -0m00.01s ||       -76 ko |   -1.40% |         -0.01%
  0m00.70s |  482968 ko | Util/ZUtil/Log2.vo                                                                                                |   0m00.67s |  473332 ko || +0m00.02s ||      9636 ko |   +4.47% |         +2.03%
  0m00.69s |  478364 ko | ArithmeticCPS/Saturated.vo                                                                                        |   0m00.72s |  478236 ko || -0m00.03s ||       128 ko |   -4.16% |         +0.02%
  0m00.68s |   22856 ko | fiat-bedrock2/src/curve25519_64.c                                                                                 |   0m00.67s |   23032 ko || +0m00.01s ||      -176 ko |   +1.49% |         -0.76%
  0m00.67s |  441132 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Word/ZifyLittleEndian.vo      |   0m00.66s |  441360 ko || +0m00.01s ||      -228 ko |   +1.51% |         -0.05%
  0m00.67s |  457672 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/src/Rupicola/Lib/Core.vo                                        |   0m00.70s |  457328 ko || -0m00.02s ||       344 ko |   -4.28% |         +0.07%
  0m00.67s |  457304 ko | Util/Strings/NamingConventions.vo                                                                                 |   0m00.70s |  457464 ko || -0m00.02s ||      -160 ko |   -4.28% |         -0.03%
  0m00.66s |  437628 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Datatypes/ListSet.vo          |   0m00.66s |  437328 ko || +0m00.00s ||       300 ko |   +0.00% |         +0.06%
  0m00.65s |  447420 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/Memory.vo                        |   0m00.68s |  447948 ko || -0m00.03s ||      -528 ko |   -4.41% |         -0.11%
  0m00.65s |  439604 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Z/bitblast.vo                 |   0m00.70s |  439216 ko || -0m00.04s ||       388 ko |   -7.14% |         +0.08%
  0m00.65s |  459768 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/src/Rupicola/Lib/Notations.vo                                   |   0m00.63s |  460228 ko || +0m00.02s ||      -460 ko |   +3.17% |         -0.09%
  0m00.64s |  462560 ko | Language/IdentifierParameters.vo                                                                                  |   0m00.60s |  462432 ko || +0m00.04s ||       128 ko |   +6.66% |         +0.02%
  0m00.63s |  439576 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/Semantics.vo                     |   0m00.61s |  439488 ko || +0m00.02s ||        88 ko |   +3.27% |         +0.02%
  0m00.63s |  397528 ko | Rewriter/Util/Decidable.vo                                                                                        |   0m00.61s |  397476 ko || +0m00.02s ||        52 ko |   +3.27% |         +0.01%
  0m00.63s |  470032 ko | Util/ZUtil/Ltz.vo                                                                                                 |   0m00.60s |  460880 ko || +0m00.03s ||      9152 ko |   +5.00% |         +1.98%
  0m00.62s |  456908 ko | Arithmetic/ModularArithmeticPre.vo                                                                                |   0m00.66s |  456552 ko || -0m00.04s ||       356 ko |   -6.06% |         +0.07%
  0m00.62s |  467964 ko | Util/Listable.vo                                                                                                  |   0m00.54s |  458836 ko || +0m00.07s ||      9128 ko |  +14.81% |         +1.98%
  0m00.62s |  451952 ko | Util/MSetPositive/Show.vo                                                                                         |   0m00.63s |  452636 ko || -0m00.01s ||      -684 ko |   -1.58% |         -0.15%
  0m00.61s |  438604 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Word/Naive.vo                 |   0m00.60s |  438108 ko || +0m00.01s ||       496 ko |   +1.66% |         +0.11%
  0m00.61s |  463628 ko | Language/PreExtra.vo                                                                                              |   0m00.64s |  463616 ko || -0m00.03s ||        12 ko |   -4.68% |         +0.00%
  0m00.61s |  462136 ko | Rewriter/TestRules.vo                                                                                             |   0m00.64s |  462236 ko || -0m00.03s ||      -100 ko |   -4.68% |         -0.02%
  0m00.61s |  458496 ko | Util/Strings/String.vo                                                                                            |   0m00.59s |  449256 ko || +0m00.02s ||      9240 ko |   +3.38% |         +2.05%
  0m00.61s |  486524 ko | Util/ZUtil/Land.vo                                                                                                |   0m00.64s |  476892 ko || -0m00.03s ||      9632 ko |   -4.68% |         +2.01%
  0m00.61s |  490520 ko | Util/ZUtil/SignBit.vo                                                                                             |   0m00.64s |  481244 ko || -0m00.03s ||      9276 ko |   -4.68% |         +1.92%
  0m00.60s |  437772 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Z/ZLib.vo                     |   0m00.63s |  438032 ko || -0m00.03s ||      -260 ko |   -4.76% |         -0.05%
  0m00.60s |  460800 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/src/Rupicola/Lib/LegacyCompiler.vo                              |   0m00.60s |  461136 ko || +0m00.00s ||      -336 ko |   +0.00% |         -0.07%
  0m00.60s |  475636 ko | Util/ZUtil/Divide.vo                                                                                              |   0m00.55s |  466112 ko || +0m00.04s ||      9524 ko |   +9.09% |         +2.04%
  0m00.60s |  467080 ko | Util/ZUtil/Pow.vo                                                                                                 |   0m00.62s |  457860 ko || -0m00.02s ||      9220 ko |   -3.22% |         +2.01%
  0m00.59s |  456220 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/src/Rupicola/Lib/Gensym.vo                                      |   0m00.55s |  456084 ko || +0m00.03s ||       136 ko |   +7.27% |         +0.02%
  0m00.59s |  460116 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/src/Rupicola/Lib/Tactics.vo                                     |   0m00.59s |  460500 ko || +0m00.00s ||      -384 ko |   +0.00% |         -0.08%
  0m00.59s |  441184 ko | Curves/Weierstrass/Affine.vo                                                                                      |   0m00.63s |  441068 ko || -0m00.04s ||       116 ko |   -6.34% |         +0.02%
  0m00.59s |  398104 ko | Util/Decidable.vo                                                                                                 |   0m00.60s |  398044 ko || -0m00.01s ||        60 ko |   -1.66% |         +0.01%
  0m00.59s |  450756 ko | Util/HList.vo                                                                                                     |   0m00.59s |  450316 ko || +0m00.00s ||       440 ko |   +0.00% |         +0.09%
  0m00.59s |  436924 ko | Util/MSetPositive/Facts.vo                                                                                        |   0m00.55s |  436900 ko || +0m00.03s ||        24 ko |   +7.27% |         +0.00%
  0m00.59s |  438840 ko | Util/ZBounded.vo                                                                                                  |   0m00.61s |  438580 ko || -0m00.02s ||       260 ko |   -3.27% |         +0.05%
  0m00.58s |  434588 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Z/prove_Zeq_bitwise.vo        |   0m00.58s |  434632 ko || +0m00.00s ||       -44 ko |   +0.00% |         -0.01%
  0m00.58s |  449932 ko | Rewriter/Language/UnderLets.vo                                                                                    |   0m00.58s |  449908 ko || +0m00.00s ||        24 ko |   +0.00% |         +0.00%
  0m00.58s |  460756 ko | Util/ZUtil.vo                                                                                                     |   0m00.59s |  461368 ko || -0m00.01s ||      -612 ko |   -1.69% |         -0.13%
  0m00.58s |  436600 ko | Util/ZUtil/CPS.vo                                                                                                 |   0m00.61s |  436608 ko || -0m00.03s ||        -8 ko |   -4.91% |         -0.00%
  0m00.57s |  440680 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/WeakestPrecondition.vo           |   0m00.51s |  440940 ko || +0m00.05s ||      -260 ko |  +11.76% |         -0.05%
  0m00.57s |  460232 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/src/Rupicola/Lib/Api.vo                                         |   0m00.57s |  460352 ko || +0m00.00s ||      -120 ko |   +0.00% |         -0.02%
  0m00.57s |  429792 ko | Coqprime/PrimalityTest/IGroup                                                                                     |   0m00.57s |  429800 ko || +0m00.00s ||        -8 ko |   +0.00% |         -0.00%
  0m00.57s |  435152 ko | Coqprime/PrimalityTest/Lagrange                                                                                   |   0m00.61s |  435188 ko || -0m00.04s ||       -36 ko |   -6.55% |         -0.00%
  0m00.57s |  464572 ko | Rewriter/TestRulesProofs.vo                                                                                       |   0m00.57s |  464520 ko || +0m00.00s ||        52 ko |   +0.00% |         +0.01%
  0m00.57s |  442408 ko | Spec/CompleteEdwardsCurve.vo                                                                                      |   0m00.57s |  442368 ko || +0m00.00s ||        40 ko |   +0.00% |         +0.00%
  0m00.57s |  438624 ko | Util/ZRange.vo                                                                                                    |   0m00.59s |  438240 ko || -0m00.02s ||       384 ko |   -3.38% |         +0.08%
  0m00.57s |  468504 ko | Util/ZUtil/Combine.vo                                                                                             |   0m00.56s |  459292 ko || +0m00.00s ||      9212 ko |   +1.78% |         +2.00%
  0m00.57s |  471628 ko | Util/ZUtil/EquivModulo.vo                                                                                         |   0m00.56s |  462392 ko || +0m00.00s ||      9236 ko |   +1.78% |         +1.99%
  0m00.56s |  437828 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/ZnWords.vo                       |   0m00.55s |  437724 ko || +0m00.01s ||       104 ko |   +1.81% |         +0.02%
  0m00.56s |  433228 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Map/OfFunc.vo                 |   0m00.54s |  433080 ko || +0m00.02s ||       148 ko |   +3.70% |         +0.03%
  0m00.56s |  438216 ko | Rewriter/Util/MSetPositive/Facts.vo                                                                               |   0m00.52s |  438356 ko || +0m00.04s ||      -140 ko |   +7.69% |         -0.03%
  0m00.55s |  440668 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/BasicC32Semantics.vo             |   0m00.51s |  440604 ko || +0m00.04s ||        64 ko |   +7.84% |         +0.01%
  0m00.55s |  439760 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/footpr.vo                        |   0m00.55s |  439720 ko || +0m00.00s ||        40 ko |   +0.00% |         +0.00%
  0m00.55s |  439500 ko | Util/ZRange/Operations.vo                                                                                         |   0m00.52s |  439384 ko || +0m00.03s ||       116 ko |   +5.76% |         +0.02%
  0m00.55s |  459876 ko | Util/ZUtil/Le.vo                                                                                                  |   0m00.52s |  450564 ko || +0m00.03s ||      9312 ko |   +5.76% |         +2.06%
  0m00.55s |  459360 ko | Util/ZUtil/Tactics/LtbToLt.vo                                                                                     |   0m00.49s |  450240 ko || +0m00.06s ||      9120 ko |  +12.24% |         +2.02%
  0m00.55s |  453628 ko | Util/ZUtil/Tactics/SolveRange.vo                                                                                  |   0m00.53s |  453012 ko || +0m00.02s ||       616 ko |   +3.77% |         +0.13%
  0m00.55s |   19508 ko | fiat-go/64/curve25519/curve25519.go                                                                               |   0m00.54s |   19760 ko || +0m00.01s ||      -252 ko |   +1.85% |         -1.27%
  0m00.54s |  440400 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/BasicC64Semantics.vo             |   0m00.55s |  440588 ko || -0m00.01s ||      -188 ko |   -1.81% |         -0.04%
  0m00.54s |  444636 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/SepLogAddrArith.vo               |   0m00.51s |  444264 ko || +0m00.03s ||       372 ko |   +5.88% |         +0.08%
  0m00.54s |  446536 ko | Curves/Montgomery/XZ.vo                                                                                           |   0m00.56s |  446548 ko || -0m00.02s ||       -12 ko |   -3.57% |         -0.00%
  0m00.54s |  430144 ko | Rewriter/Util/Strings/ParseArithmetic.vo                                                                          |   0m00.58s |  430200 ko || -0m00.03s ||       -56 ko |   -6.89% |         -0.01%
  0m00.54s |  459148 ko | Spec/ModularArithmetic.vo                                                                                         |   0m00.59s |  459272 ko || -0m00.04s ||      -124 ko |   -8.47% |         -0.02%
  0m00.54s |   20312 ko | fiat-json/src/curve25519_64.json                                                                                  |   0m00.51s |   20252 ko || +0m00.03s ||        60 ko |   +5.88% |         +0.29%
  0m00.53s |  433036 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Map/SortedListWord.vo         |   0m00.48s |  433104 ko || +0m00.05s ||       -68 ko |  +10.41% |         -0.01%
  0m00.53s |  402152 ko | Coqprime/List/Permutation                                                                                         |   0m00.50s |  402172 ko || +0m00.03s ||       -20 ko |   +6.00% |         -0.00%
  0m00.53s |  429428 ko | Coqprime/PrimalityTest/Euler                                                                                      |   0m00.51s |  429464 ko || +0m00.02s ||       -36 ko |   +3.92% |         -0.00%
  0m00.53s |  441060 ko | Util/AdditionChainExponentiation.vo                                                                               |   0m00.50s |  440880 ko || +0m00.03s ||       180 ko |   +6.00% |         +0.04%
  0m00.53s |  415216 ko | Util/Strings/String_as_OT_old.vo                                                                                  |   0m00.53s |  415196 ko || +0m00.00s ||        20 ko |   +0.00% |         +0.00%
  0m00.53s |  438856 ko | Util/ZUtil/Tactics/SimplifyFractionsLe.vo                                                                         |   0m00.49s |  438412 ko || +0m00.04s ||       444 ko |   +8.16% |         +0.10%
  0m00.53s |  450512 ko | Util/ZUtil/Tactics/Ztestbit.vo                                                                                    |   0m00.52s |  450448 ko || +0m00.01s ||        64 ko |   +1.92% |         +0.01%
  0m00.52s |  432836 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Word/DebugWordEq.vo           |   0m00.47s |  432220 ko || +0m00.05s ||       616 ko |  +10.63% |         +0.14%
  0m00.52s |  430336 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Z/PushPullMod.vo              |   0m00.48s |  430160 ko || +0m00.04s ||       176 ko |   +8.33% |         +0.04%
  0m00.52s |  430516 ko | Coqprime/List/ZProgression                                                                                        |   0m00.49s |  430216 ko || +0m00.03s ||       300 ko |   +6.12% |         +0.06%
  0m00.52s |  398852 ko | Util/Sum.vo                                                                                                       |   0m00.50s |  398820 ko || +0m00.02s ||        32 ko |   +4.00% |         +0.00%
  0m00.52s |  445292 ko | Util/ZRange/Show.vo                                                                                               |   0m00.50s |  445240 ko || +0m00.02s ||        52 ko |   +4.00% |         +0.01%
  0m00.52s |  451092 ko | Util/ZUtil/Tactics.vo                                                                                             |   0m00.51s |  450920 ko || +0m00.01s ||       172 ko |   +1.96% |         +0.03%
  0m00.51s |  391148 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/ProgramLogic.vo                  |   0m00.54s |  391192 ko || -0m00.03s ||       -44 ko |   -5.55% |         -0.01%
  0m00.51s |  434876 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Word/SimplWordExpr.vo         |   0m00.53s |  435176 ko || -0m00.02s ||      -300 ko |   -3.77% |         -0.06%
  0m00.51s |  434280 ko | Rewriter/Util/FMapPositive/Equality.vo                                                                            |   0m00.47s |  434428 ko || +0m00.04s ||      -148 ko |   +8.51% |         -0.03%
  0m00.51s |  450960 ko | Util/ZUtil/Lor.vo                                                                                                 |   0m00.51s |  451272 ko || +0m00.00s ||      -312 ko |   +0.00% |         -0.06%
  0m00.51s |  458572 ko | Util/ZUtil/Odd.vo                                                                                                 |   0m00.45s |  449356 ko || +0m00.06s ||      9216 ko |  +13.33% |         +2.05%
  0m00.51s |  458904 ko | Util/ZUtil/Peano.vo                                                                                               |   0m00.54s |  449556 ko || -0m00.03s ||      9348 ko |   -5.55% |         +2.07%
  0m00.51s |  459044 ko | Util/ZUtil/Tactics/LinearSubstitute.vo                                                                            |   0m00.50s |  449736 ko || +0m00.01s ||      9308 ko |   +2.00% |         +2.06%
  0m00.51s |  465896 ko | Util/ZUtil/Tactics/RewriteModSmall.vo                                                                             |   0m00.49s |  456368 ko || +0m00.02s ||      9528 ko |   +4.08% |         +2.08%
  0m00.50s |  441648 ko | Rewriter/Language/PreLemmas.vo                                                                                    |   0m00.54s |  441784 ko || -0m00.04s ||      -136 ko |   -7.40% |         -0.03%
  0m00.50s |  433200 ko | Util/FMapPositive/Equality.vo                                                                                     |   0m00.48s |  433636 ko || +0m00.02s ||      -436 ko |   +4.16% |         -0.10%
  0m00.50s |  430824 ko | Util/Strings/Sorting.vo                                                                                           |   0m00.50s |  430664 ko || +0m00.00s ||       160 ko |   +0.00% |         +0.03%
  0m00.50s |  429792 ko | Util/ZUtil/AddModulo.vo                                                                                           |   0m00.45s |  430072 ko || +0m00.04s ||      -280 ko |  +11.11% |         -0.06%
  0m00.50s |  430776 ko | Util/ZUtil/MulSplit.vo                                                                                            |   0m00.48s |  430552 ko || +0m00.02s ||       224 ko |   +4.16% |         +0.05%
  0m00.50s |  459324 ko | Util/ZUtil/Opp.vo                                                                                                 |   0m00.44s |  450220 ko || +0m00.06s ||      9104 ko |  +13.63% |         +2.02%
  0m00.50s |  451164 ko | Util/ZUtil/Tactics/SolveTestbit.vo                                                                                |   0m00.56s |  451072 ko || -0m00.06s ||        92 ko |  -10.71% |         +0.02%
  0m00.49s |  431784 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Map/MapKeys.vo                |   0m00.51s |  431772 ko || -0m00.02s ||        12 ko |   -3.92% |         +0.00%
  0m00.49s |  432184 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Map/Z_keyed_SortedListMap.vo  |   0m00.42s |  432520 ko || +0m00.07s ||      -336 ko |  +16.66% |         -0.07%
  0m00.49s |  439880 ko | Arithmetic/MontgomeryReduction/Definition.vo                                                                      |   0m00.53s |  439984 ko || -0m00.04s ||      -104 ko |   -7.54% |         -0.02%
  0m00.49s |  427868 ko | Util/ZUtil/Modulo/Bootstrap.vo                                                                                    |   0m00.44s |  428096 ko || +0m00.04s ||      -228 ko |  +11.36% |         -0.05%
  0m00.49s |  427812 ko | Util/ZUtil/Z2Nat.vo                                                                                               |   0m00.49s |  427308 ko || +0m00.00s ||       504 ko |   +0.00% |         +0.11%
  0m00.48s |  431056 ko | Bedrock/Field/Common/Names/VarnameGenerator.vo                                                                    |   0m00.53s |  431184 ko || -0m00.05s ||      -128 ko |   -9.43% |         -0.02%
  0m00.48s |  430412 ko | Coqprime/PrimalityTest/FGroup                                                                                     |   0m00.51s |  430472 ko || -0m00.03s ||       -60 ko |   -5.88% |         -0.01%
  0m00.48s |  439368 ko | Util/MSets/Show.vo                                                                                                |   0m00.50s |  439456 ko || -0m00.02s ||       -88 ko |   -4.00% |         -0.02%
  0m00.48s |  428224 ko | Util/ZUtil/DistrIf.vo                                                                                             |   0m00.46s |  428120 ko || +0m00.01s ||       104 ko |   +4.34% |         +0.02%
  0m00.48s |  427440 ko | Util/ZUtil/Ge.vo                                                                                                  |   0m00.47s |  427768 ko || +0m00.01s ||      -328 ko |   +2.12% |         -0.07%
  0m00.48s |  438580 ko | Util/ZUtil/Tactics/ZeroBounds.vo                                                                                  |   0m00.50s |  438432 ko || -0m00.02s ||       148 ko |   -4.00% |         +0.03%
  0m00.47s |  427900 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/div10.vo                         |   0m00.46s |  427660 ko || +0m00.00s ||       240 ko |   +2.17% |         +0.05%
  0m00.47s |  401836 ko | Coqprime/List/UList                                                                                               |   0m00.48s |  401852 ko || -0m00.01s ||       -16 ko |   -2.08% |         -0.00%
  0m00.47s |  438416 ko | Util/IdfunWithAlt.vo                                                                                              |   0m00.48s |  438424 ko || -0m00.01s ||        -8 ko |   -2.08% |         -0.00%
  0m00.47s |  420964 ko | Util/MSetPositive/Equality.vo                                                                                     |   0m00.51s |  420792 ko || -0m00.04s ||       172 ko |   -7.84% |         +0.04%
  0m00.47s |  430172 ko | Util/NUtil/WithoutReferenceToZ.vo                                                                                 |   0m00.49s |  430600 ko || -0m00.02s ||      -428 ko |   -4.08% |         -0.09%
  0m00.47s |  429088 ko | Util/Strings/Parse/Common.vo                                                                                      |   0m00.45s |  429292 ko || +0m00.01s ||      -204 ko |   +4.44% |         -0.04%
  0m00.47s |  428340 ko | Util/Strings/Show.vo                                                                                              |   0m00.52s |  428776 ko || -0m00.05s ||      -436 ko |   -9.61% |         -0.10%
  0m00.47s |  429624 ko | Util/ZUtil/Definitions.vo                                                                                         |   0m00.50s |  429764 ko || -0m00.03s ||      -140 ko |   -6.00% |         -0.03%
  0m00.47s |   17856 ko | fiat-rust/src/curve25519_64.rs                                                                                    |   0m00.47s |   17892 ko || +0m00.00s ||       -36 ko |   +0.00% |         -0.20%
  0m00.47s |   18460 ko | fiat-zig/src/curve25519_64.zig                                                                                    |   0m00.48s |   18104 ko || -0m00.01s ||       356 ko |   -2.08% |         +1.96%
  0m00.46s |  432416 ko | Algebra/Nsatz.vo                                                                                                  |   0m00.50s |  432484 ko || -0m00.03s ||       -68 ko |   -7.99% |         -0.01%
  0m00.46s |  427568 ko | PushButtonSynthesis/InvertHighLow.vo                                                                              |   0m00.47s |  427708 ko || -0m00.00s ||      -140 ko |   -2.12% |         -0.03%
  0m00.46s |  436104 ko | Util/ErrorT/Show.vo                                                                                               |   0m00.45s |  436152 ko || +0m00.01s ||       -48 ko |   +2.22% |         -0.01%
  0m00.46s |  428388 ko | Util/SideConditions/RingPackage.vo                                                                                |   0m00.43s |  428268 ko || +0m00.03s ||       120 ko |   +6.97% |         +0.02%
  0m00.46s |  419860 ko | Util/Strings/StringMap.vo                                                                                         |   0m00.45s |  419644 ko || +0m00.01s ||       216 ko |   +2.22% |         +0.05%
  0m00.46s |  427952 ko | Util/ZUtil/Hints/Core.vo                                                                                          |   0m00.42s |  427984 ko || +0m00.04s ||       -32 ko |   +9.52% |         -0.00%
  0m00.46s |  427864 ko | Util/ZUtil/ModInv.vo                                                                                              |   0m00.43s |  427872 ko || +0m00.03s ||        -8 ko |   +6.97% |         -0.00%
  0m00.46s |  427432 ko | Util/ZUtil/Pow2.vo                                                                                                |   0m00.45s |  427692 ko || +0m00.01s ||      -260 ko |   +2.22% |         -0.06%
  0m00.46s |  427860 ko | Util/ZUtil/Tactics/PeelLe.vo                                                                                      |   0m00.43s |  428156 ko || +0m00.03s ||      -296 ko |   +6.97% |         -0.06%
  0m00.46s |  429976 ko | Util/ZUtil/Zselect.vo                                                                                             |   0m00.51s |  429892 ko || -0m00.04s ||        84 ko |   -9.80% |         +0.01%
  0m00.46s |   18276 ko | fiat-c/src/curve25519_64.c                                                                                        |   0m00.47s |   18260 ko || -0m00.00s ||        16 ko |   -2.12% |         +0.08%
  0m00.45s |  431548 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Map/Funext.vo                 |   0m00.43s |  431684 ko || +0m00.02s ||      -136 ko |   +4.65% |         -0.03%
  0m00.45s |  430188 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Tactics/rewr.vo               |   0m00.40s |  430040 ko || +0m00.04s ||       148 ko |  +12.49% |         +0.03%
  0m00.45s |  427164 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Z/Lia.vo                      |   0m00.41s |  427256 ko || +0m00.04s ||       -92 ko |   +9.75% |         -0.02%
  0m00.45s |  422708 ko | Rewriter/Util/MSetPositive/Equality.vo                                                                            |   0m00.47s |  422976 ko || -0m00.01s ||      -268 ko |   -4.25% |         -0.06%
  0m00.45s |  428788 ko | Rewriter/Util/Strings/Parse/Common.vo                                                                             |   0m00.45s |  429260 ko || +0m00.00s ||      -472 ko |   +0.00% |         -0.10%
  0m00.45s |  428000 ko | Rewriter/Util/Strings/String.vo                                                                                   |   0m00.45s |  427944 ko || +0m00.00s ||        56 ko |   +0.00% |         +0.01%
  0m00.45s |  427860 ko | Util/Factorize.vo                                                                                                 |   0m00.43s |  427888 ko || +0m00.02s ||       -28 ko |   +4.65% |         -0.00%
  0m00.45s |  428168 ko | Util/ZUtil/Hints/PullPush.vo                                                                                      |   0m00.44s |  428060 ko || +0m00.01s ||       108 ko |   +2.27% |         +0.02%
  0m00.45s |  427240 ko | Util/ZUtil/Mul.vo                                                                                                 |   0m00.43s |  427408 ko || +0m00.02s ||      -168 ko |   +4.65% |         -0.03%
  0m00.45s |  428496 ko | Util/ZUtil/Tactics/DivModToQuotRem.vo                                                                             |   0m00.43s |  428348 ko || +0m00.02s ||       148 ko |   +4.65% |         +0.03%
  0m00.45s |  427760 ko | Util/ZUtil/Tactics/DivideExistsMul.vo                                                                             |   0m00.41s |  427036 ko || +0m00.04s ||       724 ko |   +9.75% |         +0.16%
  0m00.45s |  429084 ko | Util/ZUtil/Tactics/PullPush/Modulo.vo                                                                             |   0m00.40s |  428864 ko || +0m00.04s ||       220 ko |  +12.49% |         +0.05%
  0m00.45s |  428396 ko | Util/ZUtil/ZSimplify/Simple.vo                                                                                    |   0m00.47s |  428448 ko || -0m00.01s ||       -52 ko |   -4.25% |         -0.01%
  0m00.44s |  432056 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Map/SortedListString_test.vo  |   0m00.45s |  431932 ko || -0m00.01s ||       124 ko |   -2.22% |         +0.02%
  0m00.44s |  399836 ko | Algebra/Monoid.vo                                                                                                 |   0m00.38s |  399980 ko || +0m00.06s ||      -144 ko |  +15.78% |         -0.03%
  0m00.44s |  431604 ko | Rewriter/Util/Strings/Decimal.vo                                                                                  |   0m00.45s |  431660 ko || -0m00.01s ||       -56 ko |   -2.22% |         -0.01%
  0m00.44s |  428512 ko | Util/SideConditions/ModInvPackage.vo                                                                              |   0m00.44s |  428676 ko || +0m00.00s ||      -164 ko |   +0.00% |         -0.03%
  0m00.44s |  427856 ko | Util/ZUtil/Div/Bootstrap.vo                                                                                       |   0m00.47s |  428100 ko || -0m00.02s ||      -244 ko |   -6.38% |         -0.05%
  0m00.44s |  427740 ko | Util/ZUtil/Hints/ZArith.vo                                                                                        |   0m00.44s |  427816 ko || +0m00.00s ||       -76 ko |   +0.00% |         -0.01%
  0m00.44s |  427300 ko | Util/ZUtil/Lnot.vo                                                                                                |   0m00.43s |  427488 ko || +0m00.01s ||      -188 ko |   +2.32% |         -0.04%
  0m00.44s |  429708 ko | Util/ZUtil/LnotModulo.vo                                                                                          |   0m00.46s |  429976 ko || -0m00.02s ||      -268 ko |   -4.34% |         -0.06%
  0m00.44s |  427672 ko | Util/ZUtil/ModExp.vo                                                                                              |   0m00.42s |  427276 ko || +0m00.02s ||       396 ko |   +4.76% |         +0.09%
  0m00.44s |  428296 ko | Util/ZUtil/N2Z.vo                                                                                                 |   0m00.49s |  428388 ko || -0m00.04s ||       -92 ko |  -10.20% |         -0.02%
  0m00.44s |  428856 ko | Util/ZUtil/Sorting.vo                                                                                             |   0m00.45s |  428896 ko || -0m00.01s ||       -40 ko |   -2.22% |         -0.00%
  0m00.44s |  427612 ko | Util/ZUtil/Tactics/CompareToSgn.vo                                                                                |   0m00.46s |  427440 ko || -0m00.02s ||       172 ko |   -4.34% |         +0.04%
  0m00.44s |  427440 ko | Util/ZUtil/Tactics/ReplaceNegWithPos.vo                                                                           |   0m00.43s |  427496 ko || +0m00.01s ||       -56 ko |   +2.32% |         -0.01%
  0m00.43s |  431092 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/Map/Separation.vo                |   0m00.43s |  430900 ko || +0m00.00s ||       192 ko |   +0.00% |         +0.04%
  0m00.43s |  429536 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Byte.vo                       |   0m00.44s |  429100 ko || -0m00.01s ||       436 ko |   -2.27% |         +0.10%
  0m00.43s |  433876 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Map/Solver.vo                 |   0m00.44s |  433900 ko || -0m00.01s ||       -24 ko |   -2.27% |         -0.00%
  0m00.43s |  430364 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Tactics/SafeSimpl.vo          |   0m00.45s |  430352 ko || -0m00.02s ||        12 ko |   -4.44% |         +0.00%
  0m00.43s |  399272 ko | Coqprime/List/ListAux                                                                                             |   0m00.46s |  399248 ko || -0m00.03s ||        24 ko |   -6.52% |         +0.00%
  0m00.43s |  428684 ko | TAPSort.vo                                                                                                        |   0m00.44s |  428688 ko || -0m00.01s ||        -4 ko |   -2.27% |         -0.00%
  0m00.43s |  427924 ko | Util/ZUtil/Hints/Ztestbit.vo                                                                                      |   0m00.42s |  428016 ko || +0m00.01s ||       -92 ko |   +2.38% |         -0.02%
  0m00.43s |  427928 ko | Util/ZUtil/Sgn.vo                                                                                                 |   0m00.46s |  428308 ko || -0m00.03s ||      -380 ko |   -6.52% |         -0.08%
  0m00.43s |  427308 ko | Util/ZUtil/Tactics/SplitMinMax.vo                                                                                 |   0m00.43s |  427512 ko || +0m00.00s ||      -204 ko |   +0.00% |         -0.04%
  0m00.42s |  428616 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/MetricLogging.vo                 |   0m00.42s |  428892 ko || +0m00.00s ||      -276 ko |   +0.00% |         -0.06%
  0m00.42s |  427188 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Tactics/Simp.vo               |   0m00.41s |  427372 ko || +0m00.01s ||      -184 ko |   +2.43% |         -0.04%
  0m00.42s |  427860 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Tactics/Tactics.vo            |   0m00.42s |  427824 ko || +0m00.00s ||        36 ko |   +0.00% |         +0.00%
  0m00.42s |  432628 ko | Util/SideConditions/Autosolve.vo                                                                                  |   0m00.42s |  432348 ko || +0m00.00s ||       280 ko |   +0.00% |         +0.06%
  0m00.42s |  431848 ko | Util/Strings/Decimal.vo                                                                                           |   0m00.45s |  432080 ko || -0m00.03s ||      -232 ko |   -6.66% |         -0.05%
  0m00.42s |  428148 ko | Util/ZUtil/ZSimplify/Core.vo                                                                                      |   0m00.43s |  427852 ko || -0m00.01s ||       296 ko |   -2.32% |         +0.06%
  0m00.41s |  406576 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Datatypes/String.vo           |   0m00.38s |  406636 ko || +0m00.02s ||       -60 ko |   +7.89% |         -0.01%
  0m00.41s |  431508 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Map/SortedListString.vo       |   0m00.39s |  431620 ko || +0m00.01s ||      -112 ko |   +5.12% |         -0.02%
  0m00.41s |  427464 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Z/HexNotation.vo              |   0m00.40s |  427440 ko || +0m00.00s ||        24 ko |   +2.49% |         +0.00%
  0m00.41s |  427244 ko | Util/Decidable/Bool2Prop.vo                                                                                       |   0m00.42s |  427400 ko || -0m00.01s ||      -156 ko |   -2.38% |         -0.03%
  0m00.40s |  431112 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Map/Empty_set_keyed_map.vo    |   0m00.41s |  431116 ko || -0m00.00s ||        -4 ko |   -2.43% |         -0.00%
  0m00.40s |  432220 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Map/Interface.vo              |   0m00.45s |  432244 ko || -0m00.04s ||       -24 ko |  -11.11% |         -0.00%
  0m00.40s |  428940 ko | Util/ZUtil/Hints.vo                                                                                               |   0m00.40s |  428836 ko || +0m00.00s ||       104 ko |   +0.00% |         +0.02%
  0m00.40s |  426020 ko | Util/ZUtil/Tactics/PrimeBound.vo                                                                                  |   0m00.36s |  426100 ko || +0m00.04s ||       -80 ko |  +11.11% |         -0.01%
  0m00.40s |  429244 ko | Util/ZUtil/Tactics/PullPush.vo                                                                                    |   0m00.47s |  429468 ko || -0m00.06s ||      -224 ko |  -14.89% |         -0.05%
  0m00.38s |  400196 ko | Coqprime/List/Iterator                                                                                            |   0m00.39s |  400180 ko || -0m00.01s ||        16 ko |   -2.56% |         +0.00%
  0m00.38s |  429840 ko | Util/ZUtil/ZSimplify.vo                                                                                           |   0m00.39s |  429976 ko || -0m00.01s ||      -136 ko |   -2.56% |         -0.03%
  0m00.38s |   21716 ko | fiat-bedrock2/src/poly1305_32.c                                                                                   |   0m00.37s |   21460 ko || +0m00.01s ||       256 ko |   +2.70% |         +1.19%
  0m00.37s |  356752 ko | Util/ListUtil/SetoidList.vo                                                                                       |   0m00.34s |  356756 ko || +0m00.02s ||        -4 ko |   +8.82% |         -0.00%
  0m00.33s |  402468 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/ToCString.vo                     |   0m00.32s |  402316 ko || +0m00.01s ||       152 ko |   +3.12% |         +0.03%
  0m00.33s |  386660 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Decidable.vo                  |   0m00.32s |  386560 ko || +0m00.01s ||       100 ko |   +3.12% |         +0.02%
  0m00.33s |  373084 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/src/Rupicola/Lib/IdentParsing.vo                                |   0m00.29s |  373316 ko || +0m00.04s ||      -232 ko |  +13.79% |         -0.06%
  0m00.32s |  383824 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/Structs.vo                       |   0m00.31s |  383552 ko || +0m00.01s ||       272 ko |   +3.22% |         +0.07%
  0m00.32s |  386908 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Word/Interface.vo             |   0m00.34s |  386856 ko || -0m00.02s ||        52 ko |   -5.88% |         +0.01%
  0m00.32s |  374812 ko | Algebra/Hierarchy.vo                                                                                              |   0m00.29s |  374756 ko || +0m00.03s ||        56 ko |  +10.34% |         +0.01%
  0m00.31s |  395496 ko | Rewriter/Util/Sum.vo                                                                                              |   0m00.35s |  395460 ko || -0m00.03s ||        36 ko |  -11.42% |         +0.00%
  0m00.31s |  315140 ko | Util/Option.vo                                                                                                    |   0m00.27s |  315132 ko || +0m00.03s ||         8 ko |  +14.81% |         +0.00%
  0m00.31s |  396756 ko | Util/Structures/Equalities/Sum.vo                                                                                 |   0m00.30s |  396720 ko || +0m00.01s ||        36 ko |   +3.33% |         +0.00%
  0m00.30s |  350032 ko | Util/ListUtil/NthExt.vo                                                                                           |   0m00.26s |  350400 ko || +0m00.03s ||      -368 ko |  +15.38% |         -0.10%
  0m00.29s |  353320 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/TracePredicate.vo                |   0m00.24s |  353476 ko || +0m00.04s ||      -156 ko |  +20.83% |         -0.04%
  0m00.29s |  377900 ko | Coqprime/N/NatAux                                                                                                 |   0m00.31s |  377972 ko || -0m00.02s ||       -72 ko |   -6.45% |         -0.01%
  0m00.29s |  314724 ko | Rewriter/Util/Option.vo                                                                                           |   0m00.27s |  314696 ko || +0m00.01s ||        28 ko |   +7.40% |         +0.00%
  0m00.29s |  350704 ko | Rewriter/Util/Strings/Ascii.vo                                                                                    |   0m00.27s |  350932 ko || +0m00.01s ||      -228 ko |   +7.40% |         -0.06%
  0m00.28s |  320408 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/Variables.vo                     |   0m00.26s |  320328 ko || +0m00.02s ||        80 ko |   +7.69% |         +0.02%
  0m00.28s |  332804 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Tactics/destr.vo              |   0m00.28s |  332924 ko || +0m00.00s ||      -120 ko |   +0.00% |         -0.03%
  0m00.28s |  355352 ko | Rewriter/Util/OptionList.vo                                                                                       |   0m00.28s |  355200 ko || +0m00.00s ||       152 ko |   +0.00% |         +0.04%
  0m00.28s |  355356 ko | Util/ListUtil/FoldBool.vo                                                                                         |   0m00.27s |  355260 ko || +0m00.01s ||        96 ko |   +3.70% |         +0.02%
  0m00.28s |  366380 ko | Util/Strings/Ascii.vo                                                                                             |   0m00.27s |  366508 ko || +0m00.01s ||      -128 ko |   +3.70% |         -0.03%
  0m00.27s |  346924 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/NotationsCustomEntry.vo          |   0m00.26s |  346800 ko || +0m00.01s ||       124 ko |   +3.84% |         +0.03%
  0m00.27s |  350988 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/StructNotations.vo               |   0m00.29s |  351084 ko || -0m00.01s ||       -96 ko |   -6.89% |         -0.02%
  0m00.26s |  350368 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/Bytedump.vo                      |   0m00.30s |  350188 ko || -0m00.03s ||       180 ko |  -13.33% |         +0.05%
  0m00.26s |  322164 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/NotationsInConstr.vo             |   0m00.25s |  322140 ko || +0m00.01s ||        24 ko |   +4.00% |         +0.00%
  0m00.26s |  347940 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/Syntax.vo                        |   0m00.27s |  348108 ko || -0m00.01s ||      -168 ko |   -3.70% |         -0.04%
  0m00.26s |  346052 ko | Spec/MxDH.vo                                                                                                      |   0m00.27s |  345960 ko || -0m00.01s ||        92 ko |   -3.70% |         +0.02%
  0m00.26s |  314508 ko | Util/PointedProp.vo                                                                                               |   0m00.25s |  314340 ko || +0m00.01s ||       168 ko |   +4.00% |         +0.05%
  0m00.25s |  321680 ko | Util/SideConditions/ReductionPackages.vo                                                                          |   0m00.22s |  321900 ko || +0m00.03s ||      -220 ko |  +13.63% |         -0.06%
  0m00.25s |   19096 ko | fiat-json/src/poly1305_32.json                                                                                    |   0m00.24s |   19384 ko || +0m00.01s ||      -288 ko |   +4.16% |         -1.48%
  0m00.24s |   18044 ko | fiat-java/src/FiatPoly1305.java                                                                                   |   0m00.22s |   17748 ko || +0m00.01s ||       296 ko |   +9.09% |         +1.66%
  0m00.23s |  319100 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/string2ident.vo                  |   0m00.24s |  319024 ko || -0m00.00s ||        76 ko |   -4.16% |         +0.02%
  0m00.23s |  355624 ko | Util/LetInMonad.vo                                                                                                |   0m00.30s |  355504 ko || -0m00.06s ||       120 ko |  -23.33% |         +0.03%
  0m00.22s |  285192 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Z/div_mod_to_equations.vo     |   0m00.22s |  285300 ko || +0m00.00s ||      -108 ko |   +0.00% |         -0.03%
  0m00.22s |  309160 ko | Util/ParseTaps.vo                                                                                                 |   0m00.23s |  309248 ko || -0m00.01s ||       -88 ko |   -4.34% |         -0.02%
  0m00.22s |  296660 ko | Util/ZUtil/Notations.vo                                                                                           |   0m00.23s |  296740 ko || -0m00.01s ||       -80 ko |   -4.34% |         -0.02%
  0m00.22s |   17812 ko | fiat-c/src/poly1305_32.c                                                                                          |   0m00.22s |   17752 ko || +0m00.00s ||        60 ko |   +0.00% |         +0.33%
  0m00.22s |   17904 ko | fiat-go/32/poly1305/poly1305.go                                                                                   |   0m00.23s |   17608 ko || -0m00.01s ||       296 ko |   -4.34% |         +1.68%
  0m00.22s |   17528 ko | fiat-rust/src/poly1305_32.rs                                                                                      |   0m00.23s |   17600 ko || -0m00.01s ||       -72 ko |   -4.34% |         -0.40%
  0m00.22s |   17612 ko | fiat-zig/src/poly1305_32.zig                                                                                      |   0m00.23s |   17624 ko || -0m00.01s ||       -12 ko |   -4.34% |         -0.06%
  0m00.19s |  277872 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Z/div_to_equations.vo         |   0m00.22s |  277756 ko || -0m00.03s ||       116 ko |  -13.63% |         +0.04%
  0m00.19s |  263904 ko | Util/Sigma.vo                                                                                                     |   0m00.19s |  263864 ko || +0m00.00s ||        40 ko |   +0.00% |         +0.01%
  0m00.18s |  233444 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Datatypes/HList.vo            |   0m00.17s |  233488 ko || +0m00.00s ||       -44 ko |   +5.88% |         -0.01%
  0m00.18s |  250832 ko | Rewriter/Util/ListUtil/SetoidList.vo                                                                              |   0m00.20s |  251000 ko || -0m00.02s ||      -168 ko |  -10.00% |         -0.06%
  0m00.18s |  275008 ko | Util/ListUtil/ForallIn.vo                                                                                         |   0m00.19s |  274968 ko || -0m00.01s ||        40 ko |   -5.26% |         +0.01%
  0m00.18s |   19560 ko | fiat-bedrock2/src/poly1305_64.c                                                                                   |   0m00.17s |   19784 ko || +0m00.00s ||      -224 ko |   +5.88% |         -1.13%
  0m00.16s |  250080 ko | Rewriter/Util/Sigma.vo                                                                                            |   0m00.20s |  250140 ko || -0m00.04s ||       -60 ko |  -20.00% |         -0.02%
  0m00.16s |  223860 ko | Util/Prod.vo                                                                                                      |   0m00.16s |  223796 ko || +0m00.00s ||        64 ko |   +0.00% |         +0.02%
  0m00.15s |  182896 ko | Util/Bool.vo                                                                                                      |   0m00.14s |  182988 ko || +0m00.00s ||       -92 ko |   +7.14% |         -0.05%
  0m00.15s |  212124 ko | Util/TagList.vo                                                                                                   |   0m00.16s |  212012 ko || -0m00.01s ||       112 ko |   -6.25% |         +0.05%
  0m00.15s |   17300 ko | fiat-go/64/poly1305/poly1305.go                                                                                   |   0m00.15s |   17604 ko || +0m00.00s ||      -304 ko |   +0.00% |         -1.72%
  0m00.15s |   18360 ko | fiat-json/src/poly1305_64.json                                                                                    |   0m00.15s |   18360 ko || +0m00.00s ||         0 ko |   +0.00% |         +0.00%
  0m00.14s |  206624 ko | Rewriter/Language/Pre.vo                                                                                          |   0m00.17s |  206656 ko || -0m00.03s ||       -32 ko |  -17.64% |         -0.01%
  0m00.14s |  200196 ko | Rewriter/Language/PreCommon.vo                                                                                    |   0m00.16s |  200352 ko || -0m00.01s ||      -156 ko |  -12.49% |         -0.07%
  0m00.14s |  215096 ko | Rewriter/Rewriter/Examples/PerfTesting/ListRectInstances.vo                                                       |   0m00.14s |  215192 ko || +0m00.00s ||       -96 ko |   +0.00% |         -0.04%
  0m00.14s |  211028 ko | Rewriter/Util/Prod.vo                                                                                             |   0m00.14s |  211168 ko || +0m00.00s ||      -140 ko |   +0.00% |         -0.06%
  0m00.14s |  210772 ko | Util/PrimitiveHList.vo                                                                                            |   0m00.14s |  210708 ko || +0m00.00s ||        64 ko |   +0.00% |         +0.03%
  0m00.13s |  213296 ko | Rewriter/Util/PrimitiveProd.vo                                                                                    |   0m00.14s |  213432 ko || -0m00.01s ||      -136 ko |   -7.14% |         -0.06%
  0m00.13s |  171572 ko | Util/Equality.vo                                                                                                  |   0m00.12s |  171656 ko || +0m00.01s ||       -84 ko |   +8.33% |         -0.04%
  0m00.13s |  226784 ko | Util/PrimitiveProd.vo                                                                                             |   0m00.15s |  226812 ko || -0m00.01s ||       -28 ko |  -13.33% |         -0.01%
  0m00.13s |   17016 ko | fiat-zig/src/poly1305_64.zig                                                                                      |   0m00.12s |   16668 ko || +0m00.01s ||       348 ko |   +8.33% |         +2.08%
  0m00.12s |  184220 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/ReversedListNotations.vo         |   0m00.12s |  183956 ko || +0m00.00s ||       264 ko |   +0.00% |         +0.14%
  0m00.12s |  149268 ko | Rewriter/Util/Bool.vo                                                                                             |   0m00.10s |  149232 ko || +0m00.01s ||        36 ko |  +19.99% |         +0.02%
  0m00.12s |  155956 ko | Rewriter/Util/Equality.vo                                                                                         |   0m00.11s |  155972 ko || +0m00.00s ||       -16 ko |   +9.09% |         -0.01%
  0m00.12s |  198568 ko | Rewriter/Util/PrimitiveHList.vo                                                                                   |   0m00.14s |  198516 ko || -0m00.02s ||        52 ko |  -14.28% |         +0.02%
  0m00.12s |  213200 ko | Util/Relations.vo                                                                                                 |   0m00.11s |  213132 ko || +0m00.00s ||        68 ko |   +9.09% |         +0.03%
  0m00.12s |  144572 ko | Util/Structures/Equalities/Iso.vo                                                                                 |   0m00.07s |  144512 ko || +0m00.04s ||        60 ko |  +71.42% |         +0.04%
  0m00.12s |   16584 ko | fiat-c/src/poly1305_64.c                                                                                          |   0m00.13s |   16952 ko || -0m00.01s ||      -368 ko |   -7.69% |         -2.17%
  0m00.11s |  189188 ko | Util/PrimitiveSigma.vo                                                                                            |   0m00.13s |  188988 ko || -0m00.02s ||       200 ko |  -15.38% |         +0.10%
  0m00.11s |  137212 ko | Util/Structures/Orders/Iso.vo                                                                                     |   0m00.11s |  137304 ko || +0m00.00s ||       -92 ko |   +0.00% |         -0.06%
  0m00.11s |   17100 ko | fiat-rust/src/poly1305_64.rs                                                                                      |   0m00.14s |   16948 ko || -0m00.03s ||       152 ko |  -21.42% |         +0.89%
  0m00.10s |  124272 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Datatypes/Option.vo           |   0m00.09s |  124332 ko || +0m00.01s ||       -60 ko |  +11.11% |         -0.04%
  0m00.10s |   28408 ko | Rewriter/Util/plugins/rewriter_build.cmx                                                                          |   0m00.09s |   28480 ko || +0m00.01s ||       -72 ko |  +11.11% |         -0.25%
  0m00.10s |  123868 ko | Util/LetIn.vo                                                                                                     |   0m00.10s |  123948 ko || +0m00.00s ||       -80 ko |   +0.00% |         -0.06%
  0m00.10s |  128568 ko | Util/Logic/ExistsEqAnd.vo                                                                                         |   0m00.08s |  128516 ko || +0m00.02s ||        52 ko |  +25.00% |         +0.04%
  0m00.10s |  146276 ko | Util/Sigma/Related.vo                                                                                             |   0m00.12s |  146240 ko || -0m00.01s ||        36 ko |  -16.66% |         +0.02%
  0m00.10s |  100488 ko | Util/Unit.vo                                                                                                      |   0m00.08s |  100336 ko || +0m00.02s ||       152 ko |  +25.00% |         +0.15%
  0m00.09s |  135512 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/Lift1Prop.vo                     |   0m00.08s |  135572 ko || +0m00.00s ||       -60 ko |  +12.49% |         -0.04%
  0m00.09s |   94208 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Tactics/ParamRecords.vo       |   0m00.06s |   94236 ko || +0m00.03s ||       -28 ko |  +50.00% |         -0.02%
  0m00.09s |  113524 ko | Rewriter/Util/LetIn.vo                                                                                            |   0m00.07s |  113516 ko || +0m00.01s ||         8 ko |  +28.57% |         +0.00%
  0m00.09s |  129432 ko | Rewriter/Util/Sigma/Related.vo                                                                                    |   0m00.09s |  129568 ko || +0m00.00s ||      -136 ko |   +0.00% |         -0.10%
  0m00.09s |  110480 ko | Util/AutoRewrite.vo                                                                                               |   0m00.06s |  110612 ko || +0m00.03s ||      -132 ko |  +50.00% |         -0.11%
  0m00.09s |  126784 ko | Util/Compose.vo                                                                                                   |   0m00.07s |  126888 ko || +0m00.01s ||      -104 ko |  +28.57% |         -0.08%
  0m00.09s |  121292 ko | Util/HProp.vo                                                                                                     |   0m00.09s |  121360 ko || +0m00.00s ||       -68 ko |   +0.00% |         -0.05%
  0m00.09s |  114468 ko | Util/IffT.vo                                                                                                      |   0m00.08s |  114372 ko || +0m00.00s ||        96 ko |  +12.49% |         +0.08%
  0m00.09s |  113348 ko | Util/Logic/ProdForall.vo                                                                                          |   0m00.10s |  113288 ko || -0m00.01s ||        60 ko |  -10.00% |         +0.05%
  0m00.09s |  100032 ko | Util/SideConditions/CorePackages.vo                                                                               |   0m00.06s |   99996 ko || +0m00.03s ||        36 ko |  +50.00% |         +0.03%
  0m00.09s |  109728 ko | Util/Sigma/Lift.vo                                                                                                |   0m00.08s |  109644 ko || +0m00.00s ||        84 ko |  +12.49% |         +0.07%
  0m00.09s |   92776 ko | Util/Sigma/MapProjections.vo                                                                                      |   0m00.07s |   92740 ko || +0m00.01s ||        36 ko |  +28.57% |         +0.03%
  0m00.09s |  123364 ko | Util/Structures/Orders.vo                                                                                         |   0m00.10s |  123284 ko || -0m00.01s ||        80 ko |  -10.00% |         +0.06%
  0m00.09s |  115376 ko | Util/Tactics.vo                                                                                                   |   0m00.10s |  115368 ko || -0m00.01s ||         8 ko |  -10.00% |         +0.00%
  0m00.09s |  101128 ko | Util/Tactics/DestructHyps.vo                                                                                      |   0m00.06s |  101076 ko || +0m00.03s ||        52 ko |  +50.00% |         +0.05%
  0m00.09s |   91256 ko | Util/Tactics/SideConditionsBeforeToAfter.vo                                                                       |   0m00.04s |   91148 ko || +0m00.05s ||       108 ko | +124.99% |         +0.11%
  0m00.09s |  112272 ko | Util/Tower.vo                                                                                                     |   0m00.07s |  112376 ko || +0m00.01s ||      -104 ko |  +28.57% |         -0.09%
  0m00.08s |  114932 ko | Rewriter/Util/Logic/ExistsEqAnd.vo                                                                                |   0m00.06s |  114892 ko || +0m00.02s ||        40 ko |  +33.33% |         +0.03%
  0m00.08s |   97908 ko | Rewriter/Util/Logic/ProdForall.vo                                                                                 |   0m00.06s |   98064 ko || +0m00.02s ||      -156 ko |  +33.33% |         -0.15%
  0m00.08s |   95428 ko | Rewriter/Util/Notations.vo                                                                                        |   0m00.07s |   95512 ko || +0m00.00s ||       -84 ko |  +14.28% |         -0.08%
  0m00.08s |  176724 ko | Rewriter/Util/PrimitiveSigma.vo                                                                                   |   0m00.14s |  176628 ko || -0m00.06s ||        96 ko |  -42.85% |         +0.05%
  0m00.08s |   88824 ko | Rewriter/Util/Tactics/BreakMatch.vo                                                                               |   0m00.08s |   88804 ko || +0m00.00s ||        20 ko |   +0.00% |         +0.02%
  0m00.08s |   84104 ko | Rewriter/Util/Tactics/HeadUnderBinders.vo                                                                         |   0m00.06s |   84312 ko || +0m00.02s ||      -208 ko |  +33.33% |         -0.24%
  0m00.08s |  105268 ko | Rewriter/Util/Tactics/RewriteHyp.vo                                                                               |   0m00.07s |  105080 ko || +0m00.00s ||       188 ko |  +14.28% |         +0.17%
  0m00.08s |  106296 ko | Util/CPSNotations.vo                                                                                              |   0m00.08s |  106380 ko || +0m00.00s ||       -84 ko |   +0.00% |         -0.07%
  0m00.08s |   90852 ko | Util/ChangeInAll.vo                                                                                               |   0m00.07s |   90752 ko || +0m00.00s ||       100 ko |  +14.28% |         +0.11%
  0m00.08s |  105680 ko | Util/ErrorT.vo                                                                                                    |   0m00.07s |  105552 ko || +0m00.00s ||       128 ko |  +14.28% |         +0.12%
  0m00.08s |  115372 ko | Util/Logic.vo                                                                                                     |   0m00.08s |  115464 ko || +0m00.00s ||       -92 ko |   +0.00% |         -0.07%
  0m00.08s |  102764 ko | Util/Logic/Exists.vo                                                                                              |   0m00.09s |  102780 ko || -0m00.00s ||       -16 ko |  -11.11% |         -0.01%
  0m00.08s |  104736 ko | Util/Logic/Forall.vo                                                                                              |   0m00.06s |  104900 ko || +0m00.02s ||      -164 ko |  +33.33% |         -0.15%
  0m00.08s |   92008 ko | Util/Tactics/ConvoyDestruct.vo                                                                                    |   0m00.07s |   91980 ko || +0m00.00s ||        28 ko |  +14.28% |         +0.03%
  0m00.08s |   98332 ko | Util/Tactics/DebugPrint.vo                                                                                        |   0m00.07s |   98384 ko || +0m00.00s ||       -52 ko |  +14.28% |         -0.05%
  0m00.08s |   90684 ko | Util/Tactics/ESpecialize.vo                                                                                       |   0m00.07s |   90736 ko || +0m00.00s ||       -52 ko |  +14.28% |         -0.05%
  0m00.08s |   91112 ko | Util/Tactics/EvarNormalize.vo                                                                                     |   0m00.08s |   90920 ko || +0m00.00s ||       192 ko |   +0.00% |         +0.21%
  0m00.08s |   91248 ko | Util/Tactics/NormalizeCommutativeIdentifier.vo                                                                    |   0m00.04s |   91264 ko || +0m00.04s ||       -16 ko | +100.00% |         -0.01%
  0m00.08s |   91104 ko | Util/Tactics/PoseTermWithName.vo                                                                                  |   0m00.09s |   90992 ko || -0m00.00s ||       112 ko |  -11.11% |         +0.12%
  0m00.08s |  118692 ko | Util/Tactics/RewriteHyp.vo                                                                                        |   0m00.08s |  118776 ko || +0m00.00s ||       -84 ko |   +0.00% |         -0.07%
  0m00.08s |   99440 ko | Util/Tactics/RunTacticAsConstr.vo                                                                                 |   0m00.06s |   99496 ko || +0m00.02s ||       -56 ko |  +33.33% |         -0.05%
  0m00.08s |   99464 ko | Util/Tactics/SpecializeAllWays.vo                                                                                 |   0m00.05s |   99256 ko || +0m00.03s ||       208 ko |  +60.00% |         +0.20%
  0m00.07s |   75368 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Datatypes/PrimitivePair.vo    |   0m00.05s |   75396 ko || +0m00.02s ||       -28 ko |  +40.00% |         -0.03%
  0m00.07s |  109652 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Datatypes/Prod.vo             |   0m00.06s |  109612 ko || +0m00.01s ||        40 ko |  +16.66% |         +0.03%
  0m00.07s |   91768 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Ltac2Lib/Constr.vo            |   0m00.07s |   91440 ko || +0m00.00s ||       328 ko |   +0.00% |         +0.35%
  0m00.07s |   90808 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Ltac2Lib/Msg.vo               |   0m00.06s |   90820 ko || +0m00.01s ||       -12 ko |  +16.66% |         -0.01%
  0m00.07s |   87908 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Macros/symmetry.vo            |   0m00.06s |   88096 ko || +0m00.01s ||      -188 ko |  +16.66% |         -0.21%
  0m00.07s |  104632 ko | Rewriter/Util/HProp.vo                                                                                            |   0m00.07s |  104516 ko || +0m00.00s ||       116 ko |   +0.00% |         +0.11%
  0m00.07s |   97668 ko | Rewriter/Util/IffT.vo                                                                                             |   0m00.06s |   97588 ko || +0m00.01s ||        80 ko |  +16.66% |         +0.08%
  0m00.07s |   97708 ko | Rewriter/Util/Pointed.vo                                                                                          |   0m00.08s |   97724 ko || -0m00.00s ||       -16 ko |  -12.49% |         -0.01%
  0m00.07s |   93476 ko | Rewriter/Util/Tactics/DestructHead.vo                                                                             |   0m00.07s |   93464 ko || +0m00.00s ||        12 ko |   +0.00% |         +0.01%
  0m00.07s |   85256 ko | Rewriter/Util/Tactics/DoWithHyp.vo                                                                                |   0m00.06s |   85284 ko || +0m00.01s ||       -28 ko |  +16.66% |         -0.03%
  0m00.07s |   83560 ko | Rewriter/Util/Tactics/Head.vo                                                                                     |   0m00.05s |   83624 ko || +0m00.02s ||       -64 ko |  +40.00% |         -0.07%
  0m00.07s |   74440 ko | Rewriter/Util/Tactics/PrintContext.vo                                                                             |   0m00.06s |   74436 ko || +0m00.01s ||         4 ko |  +16.66% |         +0.00%
  0m00.07s |   84604 ko | Rewriter/Util/Tactics/SpecializeBy.vo                                                                             |   0m00.06s |   84604 ko || +0m00.01s ||         0 ko |  +16.66% |         +0.00%
  0m00.07s |   85208 ko | Rewriter/Util/Tactics/SplitInContext.vo                                                                           |   0m00.08s |   85400 ko || -0m00.00s ||      -192 ko |  -12.49% |         -0.22%
  0m00.07s |   23648 ko | Rewriter/Util/plugins/rewriter_build_plugin.cmx                                                                   |   0m00.06s |   23728 ko || +0m00.01s ||       -80 ko |  +16.66% |         -0.33%
  0m00.07s |  102184 ko | Util/Bool/Equality.vo                                                                                             |   0m00.07s |  102248 ko || +0m00.00s ||       -64 ko |   +0.00% |         -0.06%
  0m00.07s |   94512 ko | Util/Curry.vo                                                                                                     |   0m00.06s |   94544 ko || +0m00.01s ||       -32 ko |  +16.66% |         -0.03%
  0m00.07s |   91116 ko | Util/DefaultedTypes.vo                                                                                            |   0m00.05s |   91044 ko || +0m00.02s ||        72 ko |  +40.00% |         +0.07%
  0m00.07s |  105848 ko | Util/FixCoqMistakes.vo                                                                                            |   0m00.07s |  105688 ko || +0m00.00s ||       160 ko |   +0.00% |         +0.15%
  0m00.07s |   91576 ko | Util/FueledLUB.vo                                                                                                 |   0m00.05s |   91656 ko || +0m00.02s ||       -80 ko |  +40.00% |         -0.08%
  0m00.07s |   98780 ko | Util/Logic/ImplAnd.vo                                                                                             |   0m00.06s |   98664 ko || +0m00.01s ||       116 ko |  +16.66% |         +0.11%
  0m00.07s |  103168 ko | Util/PER.vo                                                                                                       |   0m00.07s |  103300 ko || +0m00.00s ||      -132 ko |   +0.00% |         -0.12%
  0m00.07s |   93812 ko | Util/Pos.vo                                                                                                       |   0m00.05s |   93788 ko || +0m00.02s ||        24 ko |  +40.00% |         +0.02%
  0m00.07s |  103892 ko | Util/Tactics/BreakMatch.vo                                                                                        |   0m00.07s |  103628 ko || +0m00.00s ||       264 ko |   +0.00% |         +0.25%
  0m00.07s |   93364 ko | Util/Tactics/CPSId.vo                                                                                             |   0m00.07s |   93256 ko || +0m00.00s ||       108 ko |   +0.00% |         +0.11%
  0m00.07s |   94016 ko | Util/Tactics/CacheTerm.vo                                                                                         |   0m00.08s |   93988 ko || -0m00.00s ||        28 ko |  -12.49% |         +0.02%
  0m00.07s |   91048 ko | Util/Tactics/ChangeInAll.vo                                                                                       |   0m00.08s |   90924 ko || -0m00.00s ||       124 ko |  -12.49% |         +0.13%
  0m00.07s |   91076 ko | Util/Tactics/Contains.vo                                                                                          |   0m00.05s |   90956 ko || +0m00.02s ||       120 ko |  +40.00% |         +0.13%
  0m00.07s |  107760 ko | Util/Tactics/DestructHead.vo                                                                                      |   0m00.07s |  107744 ko || +0m00.00s ||        16 ko |   +0.00% |         +0.01%
  0m00.07s |   98028 ko | Util/Tactics/ETransitivity.vo                                                                                     |   0m00.07s |   98068 ko || +0m00.00s ||       -40 ko |   +0.00% |         -0.04%
  0m00.07s |   90912 ko | Util/Tactics/EvarExists.vo                                                                                        |   0m00.07s |   90792 ko || +0m00.00s ||       120 ko |   +0.00% |         +0.13%
  0m00.07s |   90712 ko | Util/Tactics/GetGoal.vo                                                                                           |   0m00.04s |   90796 ko || +0m00.03s ||       -84 ko |  +75.00% |         -0.09%
  0m00.07s |   99056 ko | Util/Tactics/Head.vo                                                                                              |   0m00.09s |   99212 ko || -0m00.01s ||      -156 ko |  -22.22% |         -0.15%
  0m00.07s |  105848 ko | Util/Tactics/MoveLetIn.vo                                                                                         |   0m00.09s |  105944 ko || -0m00.01s ||       -96 ko |  -22.22% |         -0.09%
  0m00.07s |   90968 ko | Util/Tactics/PrintContext.vo                                                                                      |   0m00.06s |   91044 ko || +0m00.01s ||       -76 ko |  +16.66% |         -0.08%
  0m00.07s |   90960 ko | Util/Tactics/Revert.vo                                                                                            |   0m00.06s |   90944 ko || +0m00.01s ||        16 ko |  +16.66% |         +0.01%
  0m00.07s |   92432 ko | Util/Tactics/SetoidSubst.vo                                                                                       |   0m00.06s |   92372 ko || +0m00.01s ||        60 ko |  +16.66% |         +0.06%
  0m00.07s |  100168 ko | Util/Tactics/SpecializeBy.vo                                                                                      |   0m00.06s |  100216 ko || +0m00.01s ||       -48 ko |  +16.66% |         -0.04%
  0m00.07s |   90760 ko | Util/Tactics/SubstEvars.vo                                                                                        |   0m00.05s |   90712 ko || +0m00.02s ||        48 ko |  +40.00% |         +0.05%
  0m00.07s |   91396 ko | Util/Tactics/UnfoldArg.vo                                                                                         |   0m00.06s |   91404 ko || +0m00.01s ||        -8 ko |  +16.66% |         -0.00%
  0m00.07s |   99740 ko | Util/Tactics/UniquePose.vo                                                                                        |   0m00.07s |  100000 ko || +0m00.00s ||      -260 ko |   +0.00% |         -0.26%
  0m00.06s |   94424 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/Hexdump.vo                       |   0m00.08s |   94520 ko || -0m00.02s ||       -96 ko |  -25.00% |         -0.10%
  0m00.06s |   76144 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/Notations.vo                     |   0m00.05s |   76156 ko || +0m00.00s ||       -12 ko |  +19.99% |         -0.01%
  0m00.06s |   91060 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Ltac2Lib/Log.vo               |   0m00.07s |   90944 ko || -0m00.01s ||       116 ko |  -14.28% |         +0.12%
  0m00.06s |   73304 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Macros/subst.vo               |   0m00.05s |   73300 ko || +0m00.00s ||         4 ko |  +19.99% |         +0.00%
  0m00.06s |   73800 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Tactics/autoforward.vo        |   0m00.05s |   73796 ko || +0m00.00s ||         4 ko |  +19.99% |         +0.00%
  0m00.06s |   74132 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Tactics/rdelta.vo             |   0m00.05s |   74112 ko || +0m00.00s ||        20 ko |  +19.99% |         +0.02%
  0m00.06s |   73832 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/dlet.vo                       |   0m00.05s |   73952 ko || +0m00.00s ||      -120 ko |  +19.99% |         -0.16%
  0m00.06s |   75612 ko | Coqprime/Tactic/Tactic                                                                                            |   0m00.07s |   75664 ko || -0m00.01s ||       -52 ko |  -14.28% |         -0.06%
  0m00.06s |   91440 ko | Rewriter/Util/CPSNotations.vo                                                                                     |   0m00.05s |   91324 ko || +0m00.00s ||       116 ko |  +19.99% |         +0.12%
  0m00.06s |   77700 ko | Rewriter/Util/InductiveHList.vo                                                                                   |   0m00.07s |   77680 ko || -0m00.01s ||        20 ko |  -14.28% |         +0.02%
  0m00.06s |   83812 ko | Rewriter/Util/Tactics/AssertSucceedsPreserveError.vo                                                              |   0m00.05s |   83648 ko || +0m00.00s ||       164 ko |  +19.99% |         +0.19%
  0m00.06s |   76680 ko | Rewriter/Util/Tactics/CPSId.vo                                                                                    |   0m00.05s |   76796 ko || +0m00.00s ||      -116 ko |  +19.99% |         -0.15%
  0m00.06s |   78804 ko | Rewriter/Util/Tactics/CacheTerm.vo                                                                                |   0m00.07s |   78768 ko || -0m00.01s ||        36 ko |  -14.28% |         +0.04%
  0m00.06s |   74284 ko | Rewriter/Util/Tactics/Contains.vo                                                                                 |   0m00.08s |   74320 ko || -0m00.02s ||       -36 ko |  -25.00% |         -0.04%
  0m00.06s |   82108 ko | Rewriter/Util/Tactics/DebugPrint.vo                                                                               |   0m00.07s |   82316 ko || -0m00.01s ||      -208 ko |  -14.28% |         -0.25%
  0m00.06s |   85632 ko | Rewriter/Util/Tactics/DestructHyps.vo                                                                             |   0m00.06s |   85468 ko || +0m00.00s ||       164 ko |   +0.00% |         +0.19%
  0m00.06s |   83936 ko | Rewriter/Util/Tactics/RunTacticAsConstr.vo                                                                        |   0m00.06s |   83904 ko || +0m00.00s ||        32 ko |   +0.00% |         +0.03%
  0m00.06s |   76508 ko | Rewriter/Util/Tactics/SetoidSubst.vo                                                                              |   0m00.06s |   76484 ko || +0m00.00s ||        24 ko |   +0.00% |         +0.03%
  0m00.06s |   75160 ko | Rewriter/Util/plugins/StrategyTactic.vo                                                                           |   0m00.05s |   75360 ko || +0m00.00s ||      -200 ko |  +19.99% |         -0.26%
  0m00.06s |   17720 ko | Rewriter/Util/plugins/rewriter_build_plugin.cmxs                                                                  |   0m00.05s |   17556 ko || +0m00.00s ||       164 ko |  +19.99% |         +0.93%
  0m00.06s |   93528 ko | Util/Bool/IsTrue.vo                                                                                               |   0m00.07s |   93460 ko || -0m00.01s ||        68 ko |  -14.28% |         +0.07%
  0m00.06s |  104496 ko | Util/Comparison.vo                                                                                                |   0m00.09s |  104612 ko || -0m00.03s ||      -116 ko |  -33.33% |         -0.11%
  0m00.06s |   90572 ko | Util/GlobalSettings.vo                                                                                            |   0m00.06s |   90496 ko || +0m00.00s ||        76 ko |   +0.00% |         +0.08%
  0m00.06s |   92052 ko | Util/Isomorphism.vo                                                                                               |   0m00.06s |   91988 ko || +0m00.00s ||        64 ko |   +0.00% |         +0.06%
  0m00.06s |  113188 ko | Util/Notations.vo                                                                                                 |   0m00.09s |  113344 ko || -0m00.03s ||      -156 ko |  -33.33% |         -0.13%
  0m00.06s |   93200 ko | Util/Sigma/Associativity.vo                                                                                       |   0m00.07s |   93284 ko || -0m00.01s ||       -84 ko |  -14.28% |         -0.09%
  0m00.06s |  115132 ko | Util/Sumbool.vo                                                                                                   |   0m00.09s |  115152 ko || -0m00.03s ||       -20 ko |  -33.33% |         -0.01%
  0m00.06s |   90724 ko | Util/Tactics/ClearAll.vo                                                                                          |   0m00.08s |   90916 ko || -0m00.02s ||      -192 ko |  -25.00% |         -0.21%
  0m00.06s |   90988 ko | Util/Tactics/ClearDuplicates.vo                                                                                   |   0m00.07s |   91004 ko || -0m00.01s ||       -16 ko |  -14.28% |         -0.01%
  0m00.06s |   99576 ko | Util/Tactics/DoWithHyp.vo                                                                                         |   0m00.08s |   99516 ko || -0m00.02s ||        60 ko |  -25.00% |         +0.06%
  0m00.06s |   91548 ko | Util/Tactics/Forward.vo                                                                                           |   0m00.07s |   91488 ko || -0m00.01s ||        60 ko |  -14.28% |         +0.06%
  0m00.06s |   99704 ko | Util/Tactics/HeadUnderBinders.vo                                                                                  |   0m00.08s |   99668 ko || -0m00.02s ||        36 ko |  -25.00% |         +0.03%
  0m00.06s |   90920 ko | Util/Tactics/Not.vo                                                                                               |   0m00.06s |   90992 ko || +0m00.00s ||       -72 ko |   +0.00% |         -0.07%
  0m00.06s |   90672 ko | Util/Tactics/OnSubterms.vo                                                                                        |   0m00.06s |   90900 ko || +0m00.00s ||      -228 ko |   +0.00% |         -0.25%
  0m00.06s |   91212 ko | Util/Tactics/PrintGoal.vo                                                                                         |   0m00.06s |   91264 ko || +0m00.00s ||       -52 ko |   +0.00% |         -0.05%
  0m00.06s |   91516 ko | Util/Tactics/SimplifyRepeatedIfs.vo                                                                               |   0m00.06s |   91408 ko || +0m00.00s ||       108 ko |   +0.00% |         +0.11%
  0m00.06s |  100872 ko | Util/Tactics/SplitInContext.vo                                                                                    |   0m00.09s |  101060 ko || -0m00.03s ||      -188 ko |  -33.33% |         -0.18%
  0m00.06s |   90864 ko | Util/Tactics/SubstLet.vo                                                                                          |   0m00.08s |   90756 ko || -0m00.02s ||       108 ko |  -25.00% |         +0.11%
  0m00.06s |   90784 ko | Util/Tactics/Test.vo                                                                                              |   0m00.06s |   90840 ko || +0m00.00s ||       -56 ko |   +0.00% |         -0.06%
  0m00.06s |   91660 ko | Util/Tactics/TransparentAssert.vo                                                                                 |   0m00.07s |   91760 ko || -0m00.01s ||      -100 ko |  -14.28% |         -0.10%
  0m00.06s |   92356 ko | Util/Tactics/UnifyAbstractReflexivity.vo                                                                          |   0m00.08s |   92352 ko || -0m00.02s ||         4 ko |  -25.00% |         +0.00%
  0m00.06s |   91976 ko | Util/Tactics/VM.vo                                                                                                |   0m00.08s |   91792 ko || -0m00.02s ||       184 ko |  -25.00% |         +0.20%
  0m00.05s |   73596 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Macros/unique.vo              |   0m00.06s |   73472 ko || -0m00.00s ||       124 ko |  -16.66% |         +0.16%
  0m00.05s |   74268 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Tactics/eabstract.vo          |   0m00.05s |   74152 ko || +0m00.00s ||       116 ko |   +0.00% |         +0.15%
  0m00.05s |   74420 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Tactics/letexists.vo          |   0m00.06s |   74536 ko || -0m00.00s ||      -116 ko |  -16.66% |         -0.15%
  0m00.05s |   75828 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Tactics/simpl_rewrite.vo      |   0m00.07s |   75660 ko || -0m00.02s ||       168 ko |  -28.57% |         +0.22%
  0m00.05s |   74044 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/sanity.vo                     |   0m00.05s |   74064 ko || +0m00.00s ||       -20 ko |   +0.00% |         -0.02%
  0m00.05s |   85608 ko | Rewriter/Util/Bool/Equality.vo                                                                                    |   0m00.07s |   85664 ko || -0m00.02s ||       -56 ko |  -28.57% |         -0.06%
  0m00.05s |   88020 ko | Rewriter/Util/Comparison.vo                                                                                       |   0m00.06s |   87832 ko || -0m00.00s ||       188 ko |  -16.66% |         +0.21%
  0m00.05s |   89828 ko | Rewriter/Util/FixCoqMistakes.vo                                                                                   |   0m00.08s |   89840 ko || -0m00.03s ||       -12 ko |  -37.50% |         -0.01%
  0m00.05s |   73556 ko | Rewriter/Util/GlobalSettings.vo                                                                                   |   0m00.05s |   73692 ko || +0m00.00s ||      -136 ko |   +0.00% |         -0.18%
  0m00.05s |   74084 ko | Rewriter/Util/Tactics/ConstrFail.vo                                                                               |   0m00.03s |   74288 ko || +0m00.02s ||      -204 ko |  +66.66% |         -0.27%
  0m00.05s |   74712 ko | Rewriter/Util/Tactics/Not.vo                                                                                      |   0m00.05s |   74768 ko || +0m00.00s ||       -56 ko |   +0.00% |         -0.07%
  0m00.05s |   75248 ko | Rewriter/Util/Tactics/PrintGoal.vo                                                                                |   0m00.04s |   75328 ko || +0m00.01s ||       -80 ko |  +25.00% |         -0.10%
  0m00.05s |   84264 ko | Rewriter/Util/Tactics/SpecializeAllWays.vo                                                                        |   0m00.07s |   84372 ko || -0m00.02s ||      -108 ko |  -28.57% |         -0.12%
  0m00.05s |   74012 ko | Rewriter/Util/Tactics/Test.vo                                                                                     |   0m00.05s |   74140 ko || +0m00.00s ||      -128 ko |   +0.00% |         -0.17%
  0m00.05s |   84132 ko | Rewriter/Util/Tactics/UniquePose.vo                                                                               |   0m00.06s |   84388 ko || -0m00.00s ||      -256 ko |  -16.66% |         -0.30%
  0m00.05s |   75532 ko | Rewriter/Util/Tactics/WarnIfGoalsRemain.vo                                                                        |   0m00.04s |   75568 ko || +0m00.01s ||       -36 ko |  +25.00% |         -0.04%
  0m00.05s |   76488 ko | Rewriter/Util/TypeList.vo                                                                                         |   0m00.06s |   76412 ko || -0m00.00s ||        76 ko |  -16.66% |         +0.09%
  0m00.05s |  114292 ko | Util/Pointed.vo                                                                                                   |   0m00.08s |  114436 ko || -0m00.03s ||      -144 ko |  -37.50% |         -0.12%
  0m00.05s |   90920 ko | Util/Tactics/ClearbodyAll.vo                                                                                      |   0m00.07s |   90704 ko || -0m00.02s ||       216 ko |  -28.57% |         +0.23%
  0m00.05s |   90848 ko | Util/Tactics/ConstrFail.vo                                                                                        |   0m00.07s |   91044 ko || -0m00.02s ||      -196 ko |  -28.57% |         -0.21%
  0m00.05s |   91044 ko | Util/Tactics/DestructTrivial.vo                                                                                   |   0m00.07s |   90940 ko || -0m00.02s ||       104 ko |  -28.57% |         +0.11%
  0m00.05s |   90740 ko | Util/Tactics/SetEvars.vo                                                                                          |   0m00.06s |   90908 ko || -0m00.00s ||      -168 ko |  -16.66% |         -0.18%
  0m00.05s |   91864 ko | Util/Tactics/SimplifyProjections.vo                                                                               |   0m00.06s |   91868 ko || -0m00.00s ||        -4 ko |  -16.66% |         -0.00%
  0m00.04s |   78640 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Tactics/forward.vo            |   0m00.05s |   78788 ko || -0m00.01s ||      -148 ko |  -20.00% |         -0.18%
  0m00.04s |   77016 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/deps/coqutil/src/coqutil/Tactics/syntactic_unify.vo    |   0m00.05s |   76960 ko || -0m00.01s ||        56 ko |  -20.00% |         +0.07%
  0m00.04s |   75328 ko | Rewriter/Util/Isomorphism.vo                                                                                      |   0m00.04s |   75232 ko || +0m00.00s ||        96 ko |   +0.00% |         +0.12%
  0m00.04s |   74072 ko | Rewriter/Util/Tactics/EvarNormalize.vo                                                                            |   0m00.05s |   74440 ko || -0m00.01s ||      -368 ko |  -20.00% |         -0.49%
  0m00.04s |   74276 ko | Rewriter/Util/Tactics/SetEvars.vo                                                                                 |   0m00.05s |   74212 ko || -0m00.01s ||        64 ko |  -20.00% |         +0.08%
  0m00.04s |   74284 ko | Rewriter/Util/Tactics/SubstEvars.vo                                                                               |   0m00.04s |   74080 ko || +0m00.00s ||       204 ko |   +0.00% |         +0.27%
  0m00.04s |   74896 ko | Rewriter/Util/Tactics/TransparentAssert.vo                                                                        |   0m00.05s |   74844 ko || -0m00.01s ||        52 ko |  -20.00% |         +0.06%
  0m00.04s |   90748 ko | Util/Tactics/HasBody.vo                                                                                           |   0m00.08s |   90756 ko || -0m00.04s ||        -8 ko |  -50.00% |         -0.00%
  0m00.03s |   76396 ko | /home/jgross/Documents/repos/fiat-crypto/rupicola/bedrock2/bedrock2/src/bedrock2/Markers.vo                       |   0m00.04s |   76432 ko || -0m00.01s ||       -36 ko |  -25.00% |         -0.04%
  0m00.03s |   73984 ko | Rewriter/Util/Tactics/GetGoal.vo                                                                                  |   0m00.05s |   74136 ko || -0m00.02s ||      -152 ko |  -40.00% |         -0.20%
  0m00.03s |   23180 ko | Rewriter/Util/plugins/definition_by_tactic.cmx                                                                    |   0m00.02s |   23316 ko || +0m00.00s ||      -136 ko |  +49.99% |         -0.58%
  0m00.03s |   15912 ko | Rewriter/Util/plugins/definition_by_tactic_plugin.cmxs                                                            |   0m00.02s |   15844 ko || +0m00.00s ||        68 ko |  +49.99% |         +0.42%
  0m00.03s |   15640 ko | Rewriter/Util/plugins/strategy_tactic_plugin.cmxs                                                                 |   0m00.02s |   15552 ko || +0m00.00s ||        88 ko |  +49.99% |         +0.56%
  0m00.02s |   22552 ko | Rewriter/Util/plugins/definition_by_tactic_plugin.cmx                                                             |   0m00.02s |   22492 ko || +0m00.00s ||        60 ko |   +0.00% |         +0.26%
  0m00.02s |   23576 ko | Rewriter/Util/plugins/inductive_from_elim.cmx                                                                     |   0m00.03s |   23512 ko || -0m00.00s ||        64 ko |  -33.33% |         +0.27%
  0m00.02s |   15640 ko | Rewriter/Util/plugins/inductive_from_elim_plugin.cmxs                                                             |   0m00.02s |   15548 ko || +0m00.00s ||        92 ko |   +0.00% |         +0.59%
  0m00.02s |   20584 ko | Rewriter/Util/plugins/strategy_tactic_plugin.cmx                                                                  |   0m00.02s |   20748 ko || +0m00.00s ||      -164 ko |   +0.00% |         -0.79%
  0m00.01s |   17700 ko | Rewriter/Util/plugins/definition_by_tactic.cmi                                                                    |   0m00.01s |   17652 ko || +0m00.00s ||        48 ko |   +0.00% |         +0.27%
  0m00.01s |   20252 ko | Rewriter/Util/plugins/inductive_from_elim_plugin.cmx                                                              |   0m00.01s |   20156 ko || +0m00.00s ||        96 ko |   +0.00% |         +0.47%
  0m00.01s |   15116 ko | Rewriter/Util/plugins/rewriter_build.cmi                                                                          |   0m00.01s |   15308 ko || +0m00.00s ||      -192 ko |   +0.00% |         -1.25%
  0m00.01s |   15488 ko | Rewriter/Util/plugins/rewriter_build_plugin.cmxa                                                                  |   0m00.01s |   15500 ko || +0m00.00s ||       -12 ko |   +0.00% |         -0.07%
  0m00.01s |   15364 ko | Rewriter/Util/plugins/strategy_tactic.cmi                                                                         |   0m00.01s |   15168 ko || +0m00.00s ||       196 ko |   +0.00% |         +1.29%
  0m00.01s |   19236 ko | Rewriter/Util/plugins/strategy_tactic.cmx                                                                         |   0m00.01s |   19356 ko || +0m00.00s ||      -120 ko |   +0.00% |         -0.61%
  0m00.01s |   15204 ko | Rewriter/Util/plugins/strategy_tactic_plugin.cmxa                                                                 |   0m00.01s |   15080 ko || +0m00.00s ||       124 ko |   +0.00% |         +0.82%
  0m00.00s |   15488 ko | Rewriter/Util/plugins/definition_by_tactic_plugin.cmxa                                                            |   0m00.01s |   15328 ko || -0m00.01s ||       160 ko | -100.00% |         +1.04%
  0m00.00s |   15900 ko | Rewriter/Util/plugins/inductive_from_elim.cmi                                                                     |   0m00.01s |   15832 ko || -0m00.01s ||        68 ko | -100.00% |         +0.42%
  0m00.00s |   15092 ko | Rewriter/Util/plugins/inductive_from_elim_plugin.cmxa                                                             |   0m00.02s |   15252 ko || -0m00.02s ||      -160 ko | -100.00% |         -1.04%
```
</p>
</details>