### PR TITLE
Use a more flexible encoding for tight upperbounds

### DIFF
--- a/src/UnsaturatedSolinasHeuristics.v
+++ b/src/UnsaturatedSolinasHeuristics.v
@@ -180,7 +180,7 @@ else:
   Definition default_tight_upperbound_fraction : Q := 1%Q.
   Definition coef := 2. (* for balance in sub *)
   Definition prime_upperbound_list : list Z
-    := Partition.partition weight n (s-1).
+    := Partition.partition weight n (2 ^ Z.log2_up (s - Associational.eval c) - 1).
   (** We take the absolute value mostly to make proofs easy *)
   Definition tight_upperbounds : list Z
     := List.map


### PR DESCRIPTION
We encode `2^Z.log2_up(s-c)-1` rather than `s-1` for cases when `c` is
negative.  We can't actually handle `c < 0` due to the preconditions for
`freeze`, but this brings us a step closer.

See #960