### PR TITLE
Add `ShowLevel`, rip out `with_parens` from `Show`

### DIFF
--- a/Makefile-coq.local
+++ b/Makefile-coq.local
@@ -1,6 +1,6 @@
 PROFILE?=
 # Remove -undeclared-scope once we stop supporting 8.9
-OTHERFLAGS += -w -notation-overridden,-undeclared-scope,-deprecated-hint-rewrite-without-locality,-deprecated-hint-constr,-fragile-hint-constr,-native-compiler-disabled
+OTHERFLAGS += -w -notation-overridden,-undeclared-scope,-deprecated-hint-rewrite-without-locality,-deprecated-hint-constr,-fragile-hint-constr,-native-compiler-disabled,-ambiguous-paths
 ifneq ($(PROFILE),)
 OTHERFLAGS += -profile-ltac
 endif

--- a/_CoqProject.in
+++ b/_CoqProject.in
@@ -245,6 +245,7 @@ src/Util/IffT.v
 src/Util/Isomorphism.v
 src/Util/LetIn.v
 src/Util/LetInMonad.v
+src/Util/Level.v
 src/Util/ListUtil.v
 src/Util/Listable.v
 src/Util/Logic.v

--- a/src/Assembly/Equivalence.v
+++ b/src/Assembly/Equivalence.v
@@ -56,23 +56,23 @@ Inductive EquivalenceCheckingError :=
 .
 
 Global Instance show_lines_BoundsDataError : ShowLines BoundsDataError
-  := fun parens err => match err with
-                       | Unknown_array_length t => ["Unknown array length of type " ++ show false t ++ "."]%string
-                       | Invalid_arrow_type t => ["Invalid higher order function involving the type " ++ show false t ++ "."]%string
-                       end%list.
+  := fun err => match err with
+                | Unknown_array_length t => ["Unknown array length of type " ++ show t ++ "."]%string
+                | Invalid_arrow_type t => ["Invalid higher order function involving the type " ++ show t ++ "."]%string
+                end%list.
 Global Instance show_BoundsDataError : Show BoundsDataError
-  := fun parens err => String.concat String.NewLine (show_lines parens err).
+  := fun err => String.concat String.NewLine (show_lines err).
 Global Instance show_lines_EquivalenceCheckingError : ShowLines EquivalenceCheckingError
-  := fun parens err => match err with
-                       | Could_not_prove_equivalence
-                         => ["Could not prove equivalence of assembly and AST."]
-                       | Not_enough_registers num_given num_extra_needed
-                         => ["Not enough registers available for storing input and output (given " ++ show false num_given ++ ", needed an additional " ++ show false num_extra_needed ++ "."]%string
-                       | Invalid_bounds_data err
-                         => show_lines parens err
-                       end%list.
+  := fun err => match err with
+                | Could_not_prove_equivalence
+                  => ["Could not prove equivalence of assembly and AST."]
+                | Not_enough_registers num_given num_extra_needed
+                  => ["Not enough registers available for storing input and output (given " ++ show num_given ++ ", needed an additional " ++ show num_extra_needed ++ "."]%string
+                | Invalid_bounds_data err
+                  => show_lines err
+                end%list.
 Global Instance show_EquivalenceCheckingError : Show EquivalenceCheckingError
-  := fun parens err => String.concat String.NewLine (show_lines parens err).
+  := fun err => String.concat String.NewLine (show_lines err).
 
 (* stores information about registers and array lengths associated to variables *)
 Fixpoint base_reg_data (t : base.type) : Set

--- a/src/Bedrock/Field/Interface/Compilation.v
+++ b/src/Bedrock/Field/Interface/Compilation.v
@@ -408,7 +408,7 @@ Section Compile.
       map.get locals y_var = Some y_ptr ->
       let v := (overwrite1 op) x Y in
       let v' := op x Y in
-      (let __ := 0 in (* placeholder *)
+      (let _ := 0 in (* placeholder *)
        forall m,
          sep (FElem y_ptr y) Rin m ->
          sep (Placeholder y_ptr) Rin m ->
@@ -445,7 +445,7 @@ Section Compile.
       map.get locals x_var = Some x_ptr ->
       let v := (overwrite2 op) X y in
       let v' := op X y in
-      (let __ := 0 in (* placeholder *)
+      (let _ := 0 in (* placeholder *)
        forall m,
          sep (FElem x_ptr x) Rin m ->
          sep (Placeholder x_ptr) Rin m ->

--- a/src/Bedrock/Field/Stringification/FlattenVarData.v
+++ b/src/Bedrock/Field/Stringification/FlattenVarData.v
@@ -22,10 +22,10 @@ Import C.Compilers.ToString IR.Compilers.ToString.
 Notation name_with_type := (string * option int.type)%type (only parsing).
 Definition print_name (n : name_with_type) : string := fst n.
 Definition print_type (n : name_with_type) : string
-  := let __ := Compilers.Options.default_language_naming_conventions in
+  := let _ := Compilers.Options.default_language_naming_conventions in
      C.String.type.primitive.to_string "" IR.type.Z (snd n).
 Definition print_ptr_type (n : name_with_type) : string
-  := let __ := Compilers.Options.default_language_naming_conventions in
+  := let _ := Compilers.Options.default_language_naming_conventions in
      C.String.type.primitive.to_string "" IR.type.Zptr (snd n).
 Definition print_cast (n : name_with_type) : string
   := ("(" ++ print_type n ++ ")")%string.

--- a/src/Bedrock/Group/Point.v
+++ b/src/Bedrock/Group/Point.v
@@ -19,7 +19,7 @@ Section Compile.
       tr retvars R functions T (pred: T -> _ -> _ -> Prop)
       (x y : F M_pos) k k_impl,
       let v := (x, y) in
-      (let __ := 0 in (* placeholder *)
+      (let _ := 0 in (* placeholder *)
        find k_impl
        implementing (pred (dlet x
                                 (fun x => dlet y

--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -362,8 +362,8 @@ Module Pipeline.
     Definition show_lines_Expr {t} (arg_bounds : type.for_each_lhs_of_arrow ZRange.type.option.interp t) (include_input_bounds : bool)
       : ShowLines (Expr t)
       := fun with_parens syntax_tree
-         => let __ := default_language_naming_conventions in
-            let __ := default_documentation_options in
+         => let _ := default_language_naming_conventions in
+            let _ := default_documentation_options in
             match ToString.ToFunctionLines
                     (relax_zrange := fun r => r)
                     machine_wordsize
@@ -381,8 +381,8 @@ Module Pipeline.
 
     Global Instance show_lines_ErrorMessage : ShowLines ErrorMessage
       := fun parens e
-         => let __ := default_language_naming_conventions in
-            let __ := default_documentation_options in
+         => let _ := default_language_naming_conventions in
+            let _ := default_documentation_options in
             maybe_wrap_parens_lines
               parens
               match e with

--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -271,11 +271,11 @@ Module Pipeline.
             {output_api : ToString.OutputLanguageAPI}.
     Local Open Scope string_scope.
     Global Instance show_low_level_rewriter_method_opt : Show low_level_rewriter_method_opt
-      := fun _ v => match v with
-                    | precomputed_decision_tree => "precomputed_decision_tree"
-                    | unreduced_decision_tree => "unreduced_decision_tree"
-                    | unreduced_naive => "unreduced_naive"
-                    end.
+      := fun v => match v with
+                  | precomputed_decision_tree => "precomputed_decision_tree"
+                  | unreduced_decision_tree => "unreduced_decision_tree"
+                  | unreduced_naive => "unreduced_naive"
+                  end.
     Fixpoint find_too_loose_base_bounds {t}
       : ZRange.type.base.option.interp t -> ZRange.type.base.option.interp t-> bool * list (nat * nat) * list (zrange * zrange)
       := match t return ZRange.type.base.option.interp t -> ZRange.type.option.interp t-> bool * list (nat * nat) * list (zrange * zrange) with
@@ -352,16 +352,16 @@ Module Pipeline.
            ((if none_some then "Found None where Some was expected"::nil else nil)
               ++ (List.map
                     (A:=nat*nat)
-                    (fun '(l1, l2) => "Found a list of length " ++ show false l1 ++ " where a list of length " ++ show false l2 ++ " was expected.")
+                    (fun '(l1, l2) => "Found a list of length " ++ show l1 ++ " where a list of length " ++ show l2 ++ " was expected.")
                     lens)
               ++ (List.map
                     (A:=zrange*zrange)
-                    (fun '(b1, b2) => "The bounds " ++ show false b1 ++ " are looser than the expected bounds " ++ show false b2)
+                    (fun '(b1, b2) => "The bounds " ++ show b1 ++ " are looser than the expected bounds " ++ show b2)
                     bs)).
 
     Definition show_lines_Expr {t} (arg_bounds : type.for_each_lhs_of_arrow ZRange.type.option.interp t) (include_input_bounds : bool)
       : ShowLines (Expr t)
-      := fun with_parens syntax_tree
+      := fun syntax_tree
          => let _ := default_language_naming_conventions in
             let _ := default_documentation_options in
             match ToString.ToFunctionLines
@@ -370,65 +370,63 @@ Module Pipeline.
                     false (* do extra bounds check *) false (* internal static *) false (* static *) "" "f" syntax_tree (fun _ _ => nil) None arg_bounds ZRange.type.base.option.None with
             | inl (E_lines, types_used)
               => ["The syntax tree:"]
-                   ++ show_lines false syntax_tree
+                   ++ show_lines syntax_tree
                    ++ [""; "which can be pretty-printed as:"]
                    ++ E_lines ++ [""]
-                   ++ (if include_input_bounds then ["with input bounds " ++ show true arg_bounds ++ "." ++ String.NewLine]%string else [])
+                   ++ (if include_input_bounds then ["with input bounds " ++ show_lvl arg_bounds 0 ++ "." ++ String.NewLine]%string else [])
             | inr errs
               => (["(Unprintible syntax tree used in bounds analysis)" ++ String.NewLine]%string)
-                   ++ ["Stringification failed on the syntax tree:"] ++ show_lines false syntax_tree ++ [errs]
+                   ++ ["Stringification failed on the syntax tree:"] ++ show_lines syntax_tree ++ [errs]
             end%list.
 
     Global Instance show_lines_ErrorMessage : ShowLines ErrorMessage
-      := fun parens e
+      := fun e
          => let _ := default_language_naming_conventions in
             let _ := default_documentation_options in
-            maybe_wrap_parens_lines
-              parens
-              match e with
-              | Computed_bounds_are_not_tight_enough t computed_bounds expected_bounds syntax_tree arg_bounds
-                => ((["Computed bounds " ++ show true computed_bounds ++ " are not tight enough (expected bounds not looser than " ++ show true expected_bounds ++ ")."]%string)
-                      ++ [explain_too_loose_bounds (t:=type.base _) computed_bounds expected_bounds]
-                      ++ show_lines_Expr arg_bounds true (* re-print the input bounds at the end; they're very relevant *) false syntax_tree)%list
-              | No_modular_inverse descr v m
-                => ["Could not compute a modular inverse (" ++ descr ++ ") for " ++ show false v ++ " mod " ++ show false m]
-              | Value_not_leZ descr lhs rhs
-                => ["Value not ≤ (" ++ descr ++ ") : expected " ++ show false lhs ++ " ≤ " ++ show false rhs]
-              | Value_not_leQ descr lhs rhs
-                => ["Value not ≤ (" ++ descr ++ ") : expected " ++ show false lhs ++ " ≤ " ++ show false rhs]
-              | Value_not_ltZ descr lhs rhs
-                => ["Value not < (" ++ descr ++ ") : expected " ++ show false lhs ++ " < " ++ show false rhs]
-              | Value_not_lt_listZ descr lhs rhs
-                => ["Value not < (" ++ descr ++ ") : expected " ++ show false lhs ++ " < " ++ show false rhs]
-              | Value_not_le_listZ descr lhs rhs
-                => ["Value not ≤ (" ++ descr ++ ") : expected " ++ show false lhs ++ " ≤ " ++ show false rhs]
-              | Values_not_provably_distinctZ descr lhs rhs
-                => ["Values not provably distinct (" ++ descr ++ ") : expected " ++ show true lhs ++ " ≠ " ++ show true rhs]
-              | Values_not_provably_equalZ descr lhs rhs
-              | Values_not_provably_equal_listZ descr lhs rhs
-                => ["Values not provably equal (" ++ descr ++ ") : expected " ++ show true lhs ++ " = " ++ show true rhs]
-              | Unsupported_casts_in_input t e ls
-                => ["Unsupported casts in input syntax tree:"]
-                     ++ show_lines false e
-                     ++ ["Unsupported casts: " ++ @show_list _ (fun p v => show p (projT2 v)) false ls]
-              | Stringification_failed t e err => ["Stringification failed on the syntax tree:"] ++ show_lines false e ++ [err]
-              | Invalid_argument msg
-                => ["Invalid argument: " ++ msg]%string
-              | Assembly_parsing_error msgs
-                => ((["Error while parsing assembly:"]%string)
-                      ++ show_lines parens msgs)
-              | Unused_global_assembly_labels labels
-                => ["The following global functions are present in the hints file but do not correspond to any requested function: " ++ String.concat ", " labels]%string
-              | Equivalence_checking_failure _ e asm arg_bounds err
-                => (["Error while checking for equivalence of syntax tree and assembly:"]
-                      ++ show_lines_Expr arg_bounds false (* don't re-print input bounds; they're not relevant *) false e
-                      ++ [""; "Assembly:"]
-                      ++ show_lines false asm
-                      ++ [""; "Equivalence checking error:"]
-                      ++ show_lines false err)
-              end.
+            match e with
+            | Computed_bounds_are_not_tight_enough t computed_bounds expected_bounds syntax_tree arg_bounds
+              => ((["Computed bounds " ++ show_lvl computed_bounds 0 ++ " are not tight enough (expected bounds not looser than " ++ show_lvl expected_bounds 0 ++ ")."]%string)
+                    ++ [explain_too_loose_bounds (t:=type.base _) computed_bounds expected_bounds]
+                    ++ show_lines_Expr arg_bounds true (* re-print the input bounds at the end; they're very relevant *) syntax_tree)%list
+            | No_modular_inverse descr v m
+              => ["Could not compute a modular inverse (" ++ descr ++ ") for " ++ show v ++ " mod " ++ show m]%string
+            | Value_not_leZ descr lhs rhs
+              => ["Value not ≤ (" ++ descr ++ ") : expected " ++ show lhs ++ " ≤ " ++ show rhs]%string
+            | Value_not_leQ descr lhs rhs
+              => ["Value not ≤ (" ++ descr ++ ") : expected " ++ show lhs ++ " ≤ " ++ show rhs]%string
+            | Value_not_ltZ descr lhs rhs
+              => ["Value not < (" ++ descr ++ ") : expected " ++ show lhs ++ " < " ++ show rhs]%string
+            | Value_not_lt_listZ descr lhs rhs
+              => ["Value not < (" ++ descr ++ ") : expected " ++ show lhs ++ " < " ++ show rhs]%string
+            | Value_not_le_listZ descr lhs rhs
+              => ["Value not ≤ (" ++ descr ++ ") : expected " ++ show lhs ++ " ≤ " ++ show rhs]%string
+            | Values_not_provably_distinctZ descr lhs rhs
+              => ["Values not provably distinct (" ++ descr ++ ") : expected " ++ show lhs ++ " ≠ " ++ show rhs]%string
+            | Values_not_provably_equalZ descr lhs rhs
+            | Values_not_provably_equal_listZ descr lhs rhs
+              => ["Values not provably equal (" ++ descr ++ ") : expected " ++ show lhs ++ " = " ++ show rhs]%string
+            | Unsupported_casts_in_input t e ls
+              => ["Unsupported casts in input syntax tree:"]
+                   ++ show_lines e
+                   ++ ["Unsupported casts: " ++ @show_list _ (fun v => show (projT2 v)) ls]%string
+            | Stringification_failed t e err => ["Stringification failed on the syntax tree:"] ++ show_lines e ++ [err]
+            | Invalid_argument msg
+              => ["Invalid argument: " ++ msg]%string
+            | Assembly_parsing_error msgs
+              => ((["Error while parsing assembly:"]%string)
+                    ++ show_lines msgs)
+            | Unused_global_assembly_labels labels
+              => ["The following global functions are present in the hints file but do not correspond to any requested function: " ++ String.concat ", " labels]%string
+            | Equivalence_checking_failure _ e asm arg_bounds err
+              => (["Error while checking for equivalence of syntax tree and assembly:"]
+                    ++ show_lines_Expr arg_bounds false (* don't re-print input bounds; they're not relevant *) e
+                    ++ [""; "Assembly:"]
+                    ++ show_lines asm
+                    ++ [""; "Equivalence checking error:"]
+                    ++ show_lines err)
+            end%list.
     Local Instance show_ErrorMessage : Show ErrorMessage
-      := fun parens err => String.concat String.NewLine (show_lines parens err).
+      := fun err => String.concat String.NewLine (show_lines err).
   End show.
 
   Definition invert_result {T} (v : ErrorT T)

--- a/src/CLI.v
+++ b/src/CLI.v
@@ -192,7 +192,7 @@ Module ForExtraction.
                       | _, ErrorT.Error err, rest
                         => let in_name := ("In " ++ name ++ ":") in
                            let cur :=
-                               match show_lines false err with
+                               match show_lines err with
                                | [serr] => [in_name ++ " " ++ serr]
                                | serr => in_name::serr
                                end in
@@ -345,12 +345,12 @@ Module ForExtraction.
   Definition inbounds_multiplier_spec : named_argT
     := ([Arg.long_key "inbounds-multiplier"],
         Arg.String,
-        ["The (improper) fraction by which the bounds of each input limb are scaled (default: " ++ show false default_inbounds_multiplier ++ ")"]).
+        ["The (improper) fraction by which the bounds of each input limb are scaled (default: " ++ show default_inbounds_multiplier ++ ")"]).
   Definition default_outbounds_multiplier := 1.
   Definition outbounds_multiplier_spec : named_argT
     := ([Arg.long_key "outbounds-multiplier"],
         Arg.String,
-        ["The (improper) fraction by which the bounds of each output limb are scaled (default: " ++ show false default_outbounds_multiplier ++ ")"]).
+        ["The (improper) fraction by which the bounds of each output limb are scaled (default: " ++ show default_outbounds_multiplier ++ ")"]).
   Definition inbounds_spec : named_argT
     := ([Arg.long_key "inbounds"],
         Arg.String,
@@ -380,11 +380,11 @@ Module ForExtraction.
     := ([Arg.long_key "asm-reg"],
         Arg.Custom (parse_string_and parse_list_REG) "REG",
         ["A comma-separated list of registers to use for calling conventions.  Only relevant when --hints-file is specified."
-         ; "Defaults to the System V AMD64 ABI of " ++ String.concat "," (List.map (show false) default_assembly_calling_registers) ++ ".  Note that registers are first used for outputs and then inputs."]).
+         ; "Defaults to the System V AMD64 ABI of " ++ String.concat "," (List.map show default_assembly_calling_registers) ++ ".  Note that registers are first used for outputs and then inputs."]).
   Definition asm_stack_size_spec : named_argT
     := ([Arg.long_key "asm-stack-size"],
         Arg.Custom (parse_string_and parse_N) "ℕ",
-        ["The number of bytes of stack.  Only relevant when --hints-file is specified.  Default: " ++ show false (default_assembly_stack_size:N) ++ "."]).
+        ["The number of bytes of stack.  Only relevant when --hints-file is specified.  Default: " ++ show (default_assembly_stack_size:N) ++ "."]).
   Definition no_error_on_unused_asm_functions_spec : named_argT
     := ([Arg.long_key "no-error-on-unused-asm-functions"],
         Arg.Unit,
@@ -726,7 +726,7 @@ Module ForExtraction.
                          | _, _, Some cls
                            => "curve description (via class name): " ++ cls
                          end
-                       ; "machine_wordsize = " ++ show false (machine_wordsize:Z) ++ " (from """ ++ str_machine_wordsize ++ """)"]%string)
+                       ; "machine_wordsize = " ++ show (machine_wordsize:Z) ++ " (from """ ++ str_machine_wordsize ++ """)"]%string)
                   ++ show_lines_args args)%list in
            inl (Synthesize (snd args) header prefix).
 
@@ -841,8 +841,8 @@ Module ForExtraction.
              let '(str_tight_bounds_multiplier, tight_bounds_multiplier) := collapse_list_default ("", tight_bounds_multiplier_default) (List.map (@snd _ _) tight_bounds_multiplier) in
              let tight_bounds_multiplier : tight_upperbound_fraction_opt := tight_bounds_multiplier in
              match get_num_limbs s c machine_wordsize n, n with
-             | None, NumLimbs n => inr ["Internal error: get_num_limbs (on (" ++ PowersOfTwo.show_Z false s ++ ", " ++ show_c false c ++ ", " ++ show false (machine_wordsize:Z) ++ ", " ++ show false n ++ ")) returned None even though the argument was NumLimbs"]
-             | None, Auto idx => inr ["Invalid index " ++ show false idx ++ " when guessing the number of limbs for s-c = " ++ PowersOfTwo.show_Z false s ++ " - " ++ show_c false c ++ "; valid indices must index into the list " ++ show false (get_possible_limbs s c machine_wordsize) ++ "."]
+             | None, NumLimbs n => inr ["Internal error: get_num_limbs (on (" ++ PowersOfTwo.show_Z s ++ ", " ++ show_c c ++ ", " ++ show (machine_wordsize:Z) ++ ", " ++ show n ++ ")) returned None even though the argument was NumLimbs"]
+             | None, Auto idx => inr ["Invalid index " ++ show idx ++ " when guessing the number of limbs for s-c = " ++ PowersOfTwo.show_Z s ++ " - " ++ show_c c ++ "; valid indices must index into the list " ++ show (get_possible_limbs s c machine_wordsize) ++ "."]
              | Some n, _
                => inl
                     ((str_n, str_sc, str_tight_bounds_multiplier, show_requests),
@@ -853,9 +853,9 @@ Module ForExtraction.
             fun '((str_n, str_sc, str_tight_bounds_multiplier, show_requests),
                   (n, s, c, tight_bounds_multiplier, requests))
             => ["requested operations: " ++ show_requests;
-               "n = " ++ show false n ++ " (from """ ++ str_n ++ """)";
-               "s-c = " ++ PowersOfTwo.show_Z false s ++ " - " ++ show_c false c ++ " (from """ ++ str_sc ++ """)";
-               "tight_bounds_multiplier = " ++ show false (tight_bounds_multiplier:Q) ++ " (from """ ++ str_tight_bounds_multiplier ++ """)"]%string;
+               "n = " ++ show n ++ " (from """ ++ str_n ++ """)";
+               "s-c = " ++ PowersOfTwo.show_Z s ++ " - " ++ show_c c ++ " (from """ ++ str_sc ++ """)";
+               "tight_bounds_multiplier = " ++ show (tight_bounds_multiplier:Q) ++ " (from """ ++ str_tight_bounds_multiplier ++ """)"]%string;
 
           Synthesize
           := fun _ opts '(n, s, c, tight_bounds_multiplier, requests) comment_header prefix
@@ -890,7 +890,7 @@ Module ForExtraction.
             fun '((str_m, show_requests),
                   (m, requests))
             => ["requested operations: " ++ show_requests;
-               "m = " ++ Hex.show_Z false m ++ " (from """ ++ str_m ++ """)";
+               "m = " ++ Hex.show_Z m ++ " (from """ ++ str_m ++ """)";
                "                                                                  ";
                "NOTE: In addition to the bounds specified above each function, all";
                "  functions synthesized for this Montgomery arithmetic require the";
@@ -932,7 +932,7 @@ Module ForExtraction.
             fun '((str_sc, show_requests),
                   (s, c, requests))
             => ["requested operations: " ++ show_requests;
-               "s-c = " ++ PowersOfTwo.show_Z false s ++ " - " ++ show_c false c ++ " (from """ ++ str_sc ++ """)"];
+               "s-c = " ++ PowersOfTwo.show_Z s ++ " - " ++ show_c c ++ " (from """ ++ str_sc ++ """)"];
 
           Synthesize
           := fun _ opts '(s, c, requests) comment_header prefix
@@ -993,14 +993,14 @@ Module ForExtraction.
             fun '((str_src_n, str_sc, str_src_limbwidth, str_dst_limbwidth, str_inbounds_multiplier, str_outbounds_multiplier, use_bitwidth_in, use_bitwidth_out, str_inbounds, str_outbounds, show_requests),
                   (src_n, s, c, src_limbwidth, dst_limbwidth, inbounds_multiplier, outbounds_multiplier, inbounds, outbounds, requests))
             => ["requested operations: " ++ show_requests;
-               "src_n = " ++ show false src_n ++ " (from """ ++ str_src_n ++ """)";
-               "s-c = " ++ PowersOfTwo.show_Z false s ++ " - " ++ show_c false c ++ " (from """ ++ str_sc ++ """)";
-               "src_limbwidth = " ++ show false src_limbwidth ++ " (from """ ++ str_src_limbwidth ++ """)";
-               "dst_limbwidth = " ++ show false dst_limbwidth ++ " (from """ ++ str_dst_limbwidth ++ """)";
-               "inbounds_multiplier = " ++ show false inbounds_multiplier ++ " (from """ ++ str_inbounds_multiplier ++ """)";
-               "outbounds_multiplier = " ++ show false outbounds_multiplier ++ " (from """ ++ str_outbounds_multiplier ++ """)";
-               "inbounds = " ++ show false inbounds ++ " (from """ ++ str_inbounds ++ """ and use_bithwidth_in = " ++ show false use_bitwidth_in ++ ")";
-               "outbounds = " ++ show false outbounds ++ " (from """ ++ str_outbounds ++ """ and use_bithwidth_out = " ++ show false use_bitwidth_out ++ ")"];
+               "src_n = " ++ show src_n ++ " (from """ ++ str_src_n ++ """)";
+               "s-c = " ++ PowersOfTwo.show_Z s ++ " - " ++ show_c c ++ " (from """ ++ str_sc ++ """)";
+               "src_limbwidth = " ++ show src_limbwidth ++ " (from """ ++ str_src_limbwidth ++ """)";
+               "dst_limbwidth = " ++ show dst_limbwidth ++ " (from """ ++ str_dst_limbwidth ++ """)";
+               "inbounds_multiplier = " ++ show inbounds_multiplier ++ " (from """ ++ str_inbounds_multiplier ++ """)";
+               "outbounds_multiplier = " ++ show outbounds_multiplier ++ " (from """ ++ str_outbounds_multiplier ++ """)";
+               "inbounds = " ++ show inbounds ++ " (from """ ++ str_inbounds ++ """ and use_bithwidth_in = " ++ show use_bitwidth_in ++ ")";
+               "outbounds = " ++ show outbounds ++ " (from """ ++ str_outbounds ++ """ and use_bithwidth_out = " ++ show use_bitwidth_out ++ ")"];
 
           Synthesize
           := fun _ opts '(src_n, s, c, src_limbwidth, dst_limbwidth, inbounds_multiplier, outbounds_multiplier, inbounds, outbounds, requests) comment_header prefix

--- a/src/PushButtonSynthesis/BaseConversion.v
+++ b/src/PushButtonSynthesis/BaseConversion.v
@@ -67,11 +67,11 @@ Local Opaque
 Inductive bounds := exactly (_ : list Z) | use_prime | use_bitwidth.
 
 Global Instance show_bounds : Show bounds
-  := fun with_parens v
+  := fun v
      => match v with
         | use_prime => "use_prime"
         | use_bitwidth => "use_bitwidth"
-        | exactly l => @show_list _ PowersOfTwo.show_Z with_parens l
+        | exactly l => @show_list _ PowersOfTwo.show_Z l
         end%string.
 
 Definition default_bounds : bounds := use_prime.
@@ -290,7 +290,7 @@ Section __.
         FromPipelineToString
           machine_wordsize prefix "convert_bases" convert_bases
           (docstring_with_summary_from_lemma!
-             (fun fname : string => [text_before_function_name ++ fname ++ " converts a field element from base " ++ Decimal.show_Q false src_limbwidth ++ " to base " ++ Decimal.show_Q false dst_limbwidth ++ " in little-endian order."]%string)
+             (fun fname : string => [text_before_function_name ++ fname ++ " converts a field element from base " ++ Decimal.show_Q src_limbwidth ++ " to base " ++ Decimal.show_Q dst_limbwidth ++ " in little-endian order."]%string)
              (convert_bases_correct src_weight dst_weight src_n dst_n in_bounds)).
 
   Local Ltac solve_extra_bounds_side_conditions :=
@@ -357,7 +357,7 @@ Section __.
                (comment_header
                   ++ ["";
                      "Computed values:";
-                     "  dst_n = " ++ show false dst_n]%string)))
+                     "  dst_n = " ++ show dst_n]%string)))
            function_name_prefix requests.
   End for_stringification.
 End __.

--- a/src/PushButtonSynthesis/Primitives.v
+++ b/src/PushButtonSynthesis/Primitives.v
@@ -32,6 +32,7 @@ Require Import Crypto.Arithmetic.UniformWeight.
 Require Import Crypto.BoundsPipeline.
 Require Import Crypto.COperationSpecifications.
 Require Import Crypto.PushButtonSynthesis.ReificationCache.
+Require Import Crypto.Util.Strings.Show.
 Require Crypto.Assembly.Parse.
 Require Import Crypto.Assembly.Equivalence.
 Import ListNotations.
@@ -336,8 +337,16 @@ Module CorrectnessStringification.
          end
     end.
 
+  Ltac to_level lvl :=
+    lazymatch type of lvl with
+    | Z => constr:(Level.level lvl)
+    | _ => lvl
+    end.
+
   Ltac maybe_parenthesize str natural cur_lvl :=
-    let should_paren := (eval cbv in (Z.ltb cur_lvl natural)) in
+    let natural := to_level natural in
+    let cur_lvl := to_level cur_lvl in
+    let should_paren := (eval cbv in (Level.ltb cur_lvl natural)) in
     lazymatch should_paren with
     | true => constr:(("(" ++ str ++ ")")%string)
     | false => str
@@ -455,20 +464,23 @@ Module CorrectnessStringification.
     end.
 
   Ltac stringify_rec0 ctx correctness lvl :=
+    let lvl := to_level lvl in
+    let term_lvl := constr:(term_lvl) in
+    let rel_lvl := constr:(rel_lvl) in
+    let next_rel_lvl := constr:(Level.next rel_lvl) in
+    let app_lvl := constr:(app_lvl) in
+    let next_app_lvl := constr:(Level.next app_lvl) in
     let correctness := eta_match correctness in
     let recurse v lvl := stringify_rec0 ctx v lvl in
     let name_of_var := find_head_in_ctx ctx correctness in
     let stringify_if testv t f :=
-        let stest := recurse testv 200 in
-        let st := recurse t 200 in
-        let sf := recurse f 200 in
-        maybe_parenthesize (("if " ++ stest ++ " then " ++ st ++ " else " ++ sf)%string) 200 lvl in
-    let show_Z _ :=
-        maybe_parenthesize (Show.Decimal.show_Z false correctness) 1 lvl in
-    let show_nat _ :=
-        maybe_parenthesize (Show.Decimal.show_nat false correctness) 1 lvl in
-    let show_list_Z_Z _ :=
-        maybe_parenthesize (@Show.show_list _ (@Show.show_prod _ _ Show.Decimal.show_Z Show.Decimal.show_Z) false correctness) 1 lvl in
+        let stest := recurse testv term_lvl in
+        let st := recurse t term_lvl in
+        let sf := recurse f term_lvl in
+        maybe_parenthesize (("if " ++ stest ++ " then " ++ st ++ " else " ++ sf)%string) term_lvl lvl in
+    let show_Z _ := constr:(Decimal.show_lvl_Z correctness lvl) in
+    let show_nat _ := constr:(Decimal.show_lvl_nat correctness lvl) in
+    let show_list_Z_Z _ := constr:(@show_lvl_list _ (@show_lvl_prod _ _ Decimal.show_lvl_Z Decimal.show_lvl_Z) correctness lvl) in
     let stringify_prefix f natural arg_lvl :=
         lazymatch correctness with
         | ?F ?x
@@ -505,24 +517,24 @@ Module CorrectnessStringification.
         end in
     lazymatch constr:((name_of_var, name_of_fun)) with
     | (Some ?name, _)
-      => maybe_parenthesize name 1 lvl
+      => maybe_parenthesize name (Level.level 1) lvl
     | (None, Some ?name)
       => lazymatch correctness with
          | ?f ?x
-           => let sx := recurse x 9 in
-              maybe_parenthesize ((name ++ " " ++ sx)%string) 10 lvl
+           => let sx := recurse x (Level.next app_lvl) in
+              maybe_parenthesize ((name ++ " " ++ sx)%string) constr:(app_lvl) lvl
          end
     | (None, None)
       => lazymatch correctness with
          | ?x = ?y :> ?T
            => lazymatch (eval cbv in T) with
-              | Z => let sx := recurse x 69 in
-                     let sy := recurse y 69 in
-                     maybe_parenthesize ((sx ++ " = " ++ sy)%string) 70 lvl
+              | Z => let sx := recurse x next_rel_lvl in
+                     let sy := recurse y next_rel_lvl in
+                     maybe_parenthesize ((sx ++ " = " ++ sy)%string) rel_lvl lvl
               | list Z
-                => let sx := recurse x 69 in
-                   let sy := recurse y 69 in
-                   maybe_parenthesize ((sx ++ " = " ++ sy)%string) 70 lvl
+                => let sx := recurse x next_rel_lvl in
+                   let sy := recurse y next_rel_lvl in
+                   maybe_parenthesize ((sx ++ " = " ++ sy)%string) rel_lvl lvl
               | prod ?A ?B
                 => let v := (eval cbn [fst snd] in (fst x = fst y /\ snd x = snd y)) in
                    recurse v lvl
@@ -531,18 +543,18 @@ Module CorrectnessStringification.
               end
          | eval (weight 8 1) _ ?v
            => let sv := recurse v 9 in
-              maybe_parenthesize (("bytes_eval " ++ sv)%string) 10 lvl
+              maybe_parenthesize (("bytes_eval " ++ sv)%string) app_lvl lvl
          | Associational.eval ?c
            => let sc := recurse c 9 in
-              maybe_parenthesize (("Associational.eval " ++ sc)%string) 10 lvl
+              maybe_parenthesize (("Associational.eval " ++ sc)%string) app_lvl lvl
          | uweight ?machine_wordsize ?v
            => recurse (2^(machine_wordsize * Z.of_nat v)) lvl
          | weight 8 1 ?i
            => recurse (2^(8 * Z.of_nat i)) lvl
          | List.map ?x ?y
-           => let sx := recurse x 9 in
-              let sy := recurse y 9 in
-              maybe_parenthesize (("map " ++ sx ++ " " ++ sy)%string) 10 lvl
+           => let sx := recurse x next_app_lvl in
+              let sy := recurse y next_app_lvl in
+              maybe_parenthesize (("map " ++ sx ++ " " ++ sy)%string) app_lvl lvl
          | match ?testv with true => ?t | false => ?f end
            => stringify_if testv t f
          | match ?testv with or_introl _ => ?t | or_intror _ => ?f end
@@ -552,8 +564,8 @@ Module CorrectnessStringification.
          | Crypto.Util.Decidable.dec ?p
            => recurse p lvl
          | Z.odd ?x
-           => let sx := recurse x 9 in
-              maybe_parenthesize ((sx ++ " is odd")%string) 10 lvl
+           => let sx := recurse x next_app_lvl in
+              maybe_parenthesize ((sx ++ " is odd")%string) app_lvl lvl
          | Z0 => show_Z ()
          | Zpos _ => show_Z ()
          | Zneg _ => show_Z ()
@@ -565,10 +577,10 @@ Module CorrectnessStringification.
               | false => recurse (x + 1)%nat lvl
               end
          | Z.of_nat ?x => recurse x lvl
-         | ?x <= ?y <  ?z => stringify_infix2 "≤" "<" 70 69 69 69
-         | ?x <= ?y <= ?z => stringify_infix2 "≤" "≤" 70 69 69 69
-         | ?x <  ?y <= ?z => stringify_infix2 "<" "≤" 70 69 69 69
-         | ?x <  ?y <  ?z => stringify_infix2 "<" "<" 70 69 69 69
+         | ?x <= ?y <  ?z => stringify_infix2 "≤" "<" rel_lvl next_rel_lvl next_rel_lvl next_rel_lvl
+         | ?x <= ?y <= ?z => stringify_infix2 "≤" "≤" rel_lvl next_rel_lvl next_rel_lvl next_rel_lvl
+         | ?x <  ?y <= ?z => stringify_infix2 "<" "≤" rel_lvl next_rel_lvl next_rel_lvl next_rel_lvl
+         | ?x <  ?y <  ?z => stringify_infix2 "<" "<" rel_lvl next_rel_lvl next_rel_lvl next_rel_lvl
          | iff _ _ => stringify_infix "↔" 95 94 94
          | and _ _  => stringify_infix "∧" 80 80 80
          | andb _ _ => stringify_infix "∧" 80 80 80
@@ -578,20 +590,20 @@ Module CorrectnessStringification.
          | Z.add _ _ => stringify_infix "+" 50 50 49
          | Z.sub _ _ => stringify_infix "-" 50 50 49
          | Z.opp _ => stringify_prefix "-" 35 35
-         | Z.le _ _ => stringify_infix "≤" 70 69 69
-         | Z.lt _ _ => stringify_infix "<" 70 69 69
-         | Z.leb _ _ => stringify_infix "≤" 70 69 69
-         | Z.ltb _ _ => stringify_infix "<" 70 69 69
+         | Z.le _ _ => stringify_infix "≤" rel_lvl next_rel_lvl next_rel_lvl
+         | Z.lt _ _ => stringify_infix "<" rel_lvl next_rel_lvl next_rel_lvl
+         | Z.leb _ _ => stringify_infix "≤" rel_lvl next_rel_lvl next_rel_lvl
+         | Z.ltb _ _ => stringify_infix "<" rel_lvl next_rel_lvl next_rel_lvl
          | Nat.mul _ _ => stringify_infix "*" 40 40 39
          | Nat.pow _ _ => stringify_infix "^" 30 29 30
          | Nat.add _ _ => stringify_infix "+" 50 50 49
          | Nat.sub _ _ => stringify_infix "-ℕ" 50 50 49
          | Z.div _ _
-           => let res := stringify_infix' 69 " " "/" 40 40 39 in
-              maybe_parenthesize ("⌊" ++ res ++ "⌋") 9 lvl
+           => let res := stringify_infix' next_rel_lvl " " "/" 40 40 39 in
+              maybe_parenthesize ("⌊" ++ res ++ "⌋") next_app_lvl lvl
          | List.seq ?x ?y
-           => let sx := recurse x 9 in
-              let sy := recurse (pred y) 9 in
+           => let sx := recurse x next_app_lvl in
+              let sy := recurse (pred y) next_app_lvl in
               constr:("[" ++ sx ++ ".." ++ sy ++ "]")
          | pred ?n
            => let iv := test_is_var_or_const n in
@@ -602,8 +614,8 @@ Module CorrectnessStringification.
                 => recurse (n - 1)%nat lvl
               end
          | fun x : ?T => ?f
-           => let slam := stringify_function_binders ctx correctness ltac:(fun ctx body => stringify_rec0 ctx body 200) in
-              maybe_parenthesize ("λ" ++ slam) 200 lvl
+           => let slam := stringify_function_binders ctx correctness ltac:(fun ctx body => stringify_rec0 ctx body term_lvl) in
+              maybe_parenthesize ("λ" ++ slam) term_lvl lvl
          | ?v
            => let iv := test_is_var_or_const v in
               lazymatch iv with
@@ -629,7 +641,7 @@ Module CorrectnessStringification.
     let recurse so_far_rev v := stringify_preconditions ctx so_far_rev v in
     lazymatch correctness with
     | ?A -> ?B
-      => let sA := stringify_rec0 ctx A 200 in
+      => let sA := stringify_rec0 ctx A constr:(term_lvl) in
          recurse (sA :: so_far_rev) B
     | ?T
       => let so_far := (eval cbv [List.rev] in (List.rev so_far_rev)) in
@@ -639,7 +651,7 @@ Module CorrectnessStringification.
   Ltac stringify_postconditions ctx correctness :=
     let correctness := eta_match correctness in
     let recurse v := stringify_postconditions ctx v in
-    let default _ := let v := stringify_rec0 ctx correctness 200 in
+    let default _ := let v := stringify_rec0 ctx correctness constr:(term_lvl) in
                      constr:(v::nil) in
     lazymatch correctness with
     | _ <= _ <  _ => default ()
@@ -1130,7 +1142,7 @@ Section __.
                 | Success (Some (prefix, function_asms))
                   => let '(asm_ls, ls, unused_asm_ls) := split_to_assembly_functions function_asms ls in
                      (* TODO: Currently we just pass the prefix/header through unchanged; maybe we should instead generate a better header? *)
-                     let asm_ls_prefix := [(assembly_output, "header-prefix", Success (Show.show_lines false prefix))] in
+                     let asm_ls_prefix := [(assembly_output, "header-prefix", Success (Show.show_lines prefix))] in
                      let asm_ls_check
                          := if (error_on_unused_assembly_functions && (0 <? List.length unused_asm_ls))%nat
                             then [(assembly_output, "check", Error (Pipeline.Unused_global_assembly_labels
@@ -1148,7 +1160,7 @@ Section __.
                                            (synthesis_res.(Pipeline.arg_bounds))
                                            (synthesis_res.(Pipeline.out_bounds))
                                    with
-                                   | Success lines => Success (Show.show_lines false lines)
+                                   | Success lines => Success (Show.show_lines lines)
                                    | Error err => Error (Pipeline.Equivalence_checking_failure
                                                            (synthesis_res.(Pipeline.expr))
                                                            asm_lines

--- a/src/PushButtonSynthesis/SaturatedSolinas.v
+++ b/src/PushButtonSynthesis/SaturatedSolinas.v
@@ -243,7 +243,7 @@ Section __.
                   ++ ["";
                      "Computed values:";
                      "";
-                     "  # reductions = " ++ show false nreductions]%string)))
+                     "  # reductions = " ++ show nreductions]%string)))
            function_name_prefix requests.
   End for_stringification.
 End __.

--- a/src/PushButtonSynthesis/UnsaturatedSolinas.v
+++ b/src/PushButtonSynthesis/UnsaturatedSolinas.v
@@ -542,8 +542,8 @@ Section __.
                @ GallinaReify.Reify (Qnum limbwidth) @ GallinaReify.Reify (Z.pos (Qden limbwidth)) @ GallinaReify.Reify n)
             (Some loose_bounds, tt)).
 
-  Definition seval (arg_name : string) (with_parens : bool) (* s for string *)
-    := show with_parens (invert_expr.smart_App_curried (reval _) (arg_name, tt)).
+  Definition seval (arg_name : string) (* s for string *)
+    := show (invert_expr.smart_App_curried (reval _) (arg_name, tt)).
 
   Definition rbytes_eval (* r for reified *)
     := Pipeline.RepeatRewriteAddAssocLeftAndFlattenThunkedRects
@@ -556,8 +556,8 @@ Section __.
                @ GallinaReify.Reify s)
             (prime_bytes_bounds, tt)).
 
-  Definition sbytes_eval (arg_name : string) (with_parens : bool) (* s for string *)
-    := show with_parens (invert_expr.smart_App_curried (rbytes_eval _) (arg_name, tt)).
+  Definition sbytes_eval (arg_name : string) (* s for string *)
+    := show (invert_expr.smart_App_curried (rbytes_eval _) (arg_name, tt)).
 
   Definition selectznz : Pipeline.ErrorT _ := Primitives.selectznz n machine_wordsize.
   Definition sselectznz (prefix : string)
@@ -825,10 +825,10 @@ Section __.
                      ; "Computed values:"]
                  ++ (List.map
                        (fun s => "  " ++ s)%string
-                       ((ToString.prefix_and_indent "carry_chain = " [show false idxs])
-                          ++ (ToString.prefix_and_indent "eval z = " [seval "z" false])
-                          ++ (ToString.prefix_and_indent "bytes_eval z = " [sbytes_eval "z" false])
-                          ++ (ToString.prefix_and_indent "balance = " [let show_Z := Hex.show_Z in show false balance])))))
+                       ((ToString.prefix_and_indent "carry_chain = " [show idxs])
+                          ++ (ToString.prefix_and_indent "eval z = " [seval "z"])
+                          ++ (ToString.prefix_and_indent "bytes_eval z = " [sbytes_eval "z"])
+                          ++ (ToString.prefix_and_indent "balance = " [let show_lvl_Z := Hex.show_lvl_Z in show balance])))))
            function_name_prefix requests.
   End for_stringification.
 End __.

--- a/src/PushButtonSynthesis/WordByWordMontgomery.v
+++ b/src/PushButtonSynthesis/WordByWordMontgomery.v
@@ -577,8 +577,8 @@ Section __.
                @ GallinaReify.Reify machine_wordsize @ GallinaReify.Reify n)
             (Some bounds, tt)).
 
-  Definition seval (arg_name : string) (with_parens : bool) (* s for string *)
-    := Show.show with_parens (invert_expr.smart_App_curried (reval _) (arg_name, tt)).
+  Definition seval (arg_name : string) (* s for string *)
+    := Show.show (invert_expr.smart_App_curried (reval _) (arg_name, tt)).
 
   Definition rbytes_eval (* r for reified *)
     := Pipeline.RepeatRewriteAddAssocLeftAndFlattenThunkedRects
@@ -591,8 +591,8 @@ Section __.
                @ GallinaReify.Reify s)
             (prime_bytes_bounds, tt)).
 
-  Definition sbytes_eval (arg_name : string) (with_parens : bool) (* s for string *)
-    := Show.show with_parens (invert_expr.smart_App_curried (rbytes_eval _) (arg_name, tt)).
+  Definition sbytes_eval (arg_name : string) (* s for string *)
+    := Show.show (invert_expr.smart_App_curried (rbytes_eval _) (arg_name, tt)).
 
   Definition reval_twos_complement (* r for reified *)
     := Pipeline.RepeatRewriteAddAssocLeftAndFlattenThunkedRects
@@ -606,8 +606,8 @@ Section __.
                @ GallinaReify.Reify n)
             (Some bounds, tt)).
 
-  Definition seval_twos_complement (arg_name : string) (with_parens : bool) (* s for string *)
-    := Show.show with_parens (invert_expr.smart_App_curried (reval_twos_complement _) (arg_name, tt)).
+  Definition seval_twos_complement (arg_name : string) (* s for string *)
+    := Show.show (invert_expr.smart_App_curried (reval_twos_complement _) (arg_name, tt)).
 
   Definition selectznz : Pipeline.ErrorT _ := Primitives.selectznz n machine_wordsize.
   Definition sselectznz (prefix : string)
@@ -1093,9 +1093,9 @@ Section __.
                      ; "Computed values:"]
                  ++ (List.map
                        (fun s => "  " ++ s)%string
-                       ((ToString.prefix_and_indent "eval z = " [seval "z" false])
-                          ++ (ToString.prefix_and_indent "bytes_eval z = " [sbytes_eval "z" false])
-                          ++ (ToString.prefix_and_indent "twos_complement_eval z = " [seval_twos_complement "z" false])))))
+                       ((ToString.prefix_and_indent "eval z = " [seval "z"])
+                          ++ (ToString.prefix_and_indent "bytes_eval z = " [sbytes_eval "z"])
+                          ++ (ToString.prefix_and_indent "twos_complement_eval z = " [seval_twos_complement "z"])))))
            function_name_prefix requests.
   End for_stringification.
 End __.

--- a/src/Rewriter/PerfTesting/Core.v
+++ b/src/Rewriter/PerfTesting/Core.v
@@ -91,8 +91,9 @@ Module Import UnsaturatedSolinas.
       limbwidth := limbwidth n s c;
       machine_wordsize : Z }.
 
-  Global Instance show_params : Show params
-    := fun _ p => ("{| n := " ++ show false n ++ "; s := " ++ show false s ++ "; c := " ++ show false c ++ "; idxs := " ++ show false idxs ++ "; machine_wordsize := " ++ show false machine_wordsize ++ "|}")%string.
+  Global Instance show_lvl_params : ShowLevel params
+    := fun p => neg_wrap_parens ("{| n := " ++ show_lvl n term_lvl ++ "; s := " ++ show_lvl s term_lvl ++ "; c := " ++ show_lvl c term_lvl ++ "; idxs := " ++ show_lvl idxs term_lvl ++ "; machine_wordsize := " ++ show_lvl machine_wordsize term_lvl ++ "|}")%string.
+  Global Instance show_params : Show params := show_lvl_params.
 
   Definition of_string (p : string) (bitwidth : Z) : list params
     := match parseZ_arith_to_taps p with
@@ -159,7 +160,7 @@ Module Import UnsaturatedSolinas.
                     (seq _ _ id id)
                     (List.map
                        (fun method
-                        => let make_descr := fun kind => ("Testing UnsaturatedSolinas " ++ prime ++ " (bitwidth = " ++ str_bitwidth ++ " ) (index = " ++ str_index ++ " ) (method = " ++ show false method ++ " ) (params = " ++ show false p ++ " ) " ++ kind ++ " with extraction " ++ extr_descr)%string in
+                        => let make_descr := fun kind => ("Testing UnsaturatedSolinas " ++ prime ++ " (bitwidth = " ++ str_bitwidth ++ " ) (index = " ++ str_index ++ " ) (method = " ++ show method ++ " ) (params = " ++ show p ++ " ) " ++ kind ++ " with extraction " ++ extr_descr)%string in
                            (seq _ _)
                              (fun _ => time _ (make_descr "PipelineFullToStringsOf") (fun _ => PipelineFullToStringsOf (p, method)))
                              (fun _
@@ -302,8 +303,9 @@ Module Import WordByWordMontgomery.
             | None => 0
             end }.
 
-  Global Instance show_params : Show params
-    := fun _ p => ("{| m := " ++ show false m ++ "; machine_wordsize := " ++ show false machine_wordsize ++ "|}")%string.
+  Global Instance show_lvl_params : ShowLevel params
+    := fun p => neg_wrap_parens ("{| m := " ++ show_lvl m term_lvl ++ "; machine_wordsize := " ++ show_lvl machine_wordsize term_lvl ++ "|}")%string.
+  Global Instance show_params : Show params := show_lvl_params.
 
   Definition of_string (p : string) (bitwidth : Z) : option params
     := match parseZ_arith_strict p with
@@ -367,7 +369,7 @@ Module Import WordByWordMontgomery.
                     (seq _ _ id id)
                     (List.map
                        (fun method
-                        => let make_descr := fun kind => ("Testing WordByWordMontgomery " ++ prime ++ " (bitwidth = " ++ str_bitwidth ++ " ) (method = " ++ show false method ++ " ) (params = " ++ show false p ++ " ) " ++ kind ++ " with extraction " ++ extr_descr)%string in
+                        => let make_descr := fun kind => ("Testing WordByWordMontgomery " ++ prime ++ " (bitwidth = " ++ str_bitwidth ++ " ) (method = " ++ show method ++ " ) (params = " ++ show p ++ " ) " ++ kind ++ " with extraction " ++ extr_descr)%string in
                            (seq _ _)
                              (fun _ => time _ (make_descr "PipelineFullToStringsOf") (fun _ => PipelineFullToStringsOf (p, method)))
                              (fun _

--- a/src/SlowPrimeSynthesisExamples.v
+++ b/src/SlowPrimeSynthesisExamples.v
@@ -179,7 +179,6 @@ Module debugging_sat_solinas_25519.
 
     Time Redirect "log" Compute
          Show.show (* [show] for pretty-printing of the AST without needing lots of imports *)
-         false
          (Pipeline.BoundsPipelineToString
             "fiat" "mul"
             false (* subst01 *)
@@ -393,7 +392,6 @@ Module debugging_sat_solinas_25519_expanded.
     Time Redirect "log"
          Compute
          Show.show (* [show] for pretty-printing of the AST without needing lots of imports *)
-         false
          (Pipeline.BoundsPipelineToString
             "fiat" "mul"
             false (* subst01 *)

--- a/src/StandaloneOCamlMain.v
+++ b/src/StandaloneOCamlMain.v
@@ -13,6 +13,9 @@ Global Set Warnings Append "-extraction-opaque-accessed".
 Extraction Language OCaml.
 Global Unset Extraction Optimize.
 
+(** Work around COQBUG(https://github.com/coq/coq/issues/4875) / COQBUG(https://github.com/coq/coq/issues/7954) / COQBUG(https://github.com/coq/coq/issues/7954) / https://discuss.ocaml.org/t/why-wont-ocaml-specialize-weak-type-variables-in-dead-code/7776 *)
+Extraction Inline Show.ShowLevel_of_Show.
+
 Inductive int : Set := int_O | int_S (x : int).
 
 (** We pull a hack to get coqchk to not report these as axioms; for

--- a/src/Stringification/C.v
+++ b/src/Stringification/C.v
@@ -239,7 +239,7 @@ Module Compilers.
            | base.type.list _ => fun _ => ["#error ""complex list"";"]
            | base.type.option _ => fun _ => ["#error option;"]
            | base.type.unit => fun _ => ["#error unit;"]
-           | base.type.type_base t => fun _ => ["#error " ++ show false t ++ ";"]%string
+           | base.type.type_base t => fun _ => ["#error " ++ show t ++ ";"]%string
            end.
 
       Definition to_arg_list {language_naming_conventions : language_naming_conventions_opt} (prefix : string) {t} : var_data t -> list string
@@ -267,7 +267,7 @@ Module Compilers.
            | base.type.list _ => fun _ => ["#error ""complex list"";"]
            | base.type.option _ => fun _ => ["#error option;"]
            | base.type.unit => fun _ => ["#error unit;"]
-           | base.type.type_base t => fun _ => ["#error " ++ show false t ++ ";"]%string
+           | base.type.type_base t => fun _ => ["#error " ++ show t ++ ";"]%string
            end.
 
       Definition to_retarg_list {language_naming_conventions : language_naming_conventions_opt} (prefix : string) {t} : var_data t -> list string

--- a/src/Stringification/Go.v
+++ b/src/Stringification/Go.v
@@ -327,7 +327,7 @@ Module Go.
     | base.type.list _ => fun _ => ["var _error = error_complex_list"]
     | base.type.option _ => fun _ => ["var _error = error_option"]
     | base.type.unit => fun _ => ["var _error = error_unit"]
-    | base.type.type_base t => fun _ => ["var _error = error_" ++ show false t]%string
+    | base.type.type_base t => fun _ => ["var _error = error_" ++ show t]%string
     end%string.
 
   Definition to_arg_list {language_naming_conventions : language_naming_conventions_opt} (internal_private : bool) (prefix : string) (mode : Mode) {t} : var_data t -> list string :=

--- a/src/Stringification/IR.v
+++ b/src/Stringification/IR.v
@@ -673,7 +673,7 @@ Module Compilers.
                  | ident.snd A B => fun r xy => ret (cast_down_if_needed r (@snd _ _ xy))
                  | ident.List_nth_default tZ
                    => fun r d ls n
-                      => List.nth_default (inr ["Invalid list index " ++ show false n]%string)
+                      => List.nth_default (inr ["Invalid list index " ++ show n]%string)
                                           (List.map (fun x => ret (cast_down_if_needed r x)) ls) n
                  | ident.Z_shiftr
                    => fun r e '(offset, roffset)
@@ -724,12 +724,12 @@ Module Compilers.
                                    let rin' := Some ty in
                                    let '(e, _) := Zcast rin' (e, r) in
                                    ret (cast_down_if_needed rout (cast_up_if_needed rout (Z_lnot ty @@@ e, rin')))
-                              | None => inr ["Invalid modulus for Z.lnot (not 2^(2^_)): " ++ show false modulus]%string
+                              | None => inr ["Invalid modulus for Z.lnot (not 2^(2^_)): " ++ show modulus]%string
                               end
                          | None => inr ["Invalid non-literal modulus for Z.lnot"]%string
                          end
                  | ident.pair A B
-                   => fun _ _ _ => inr ["Invalid identifier in arithmetic expression " ++ show true idc]%string
+                   => fun _ _ _ => inr ["Invalid identifier in arithmetic expression " ++ show idc]%string
                  | ident.Z_opp (* we pretend this is [0 - _] *)
                    => fun r x =>
                         let zero := (literal 0 @@@ TT, Some (int.of_zrange_relaxed (relax_zrange r[0~>0]))) in
@@ -819,7 +819,7 @@ Module Compilers.
                  | ident.fancy_selm
                  | ident.fancy_sell
                  | ident.fancy_addm
-                   => fun _ => type.interpM_return _ _ _ (inr ["Invalid identifier in arithmetic expression " ++ show true idc]%string)
+                   => fun _ => type.interpM_return _ _ _ (inr ["Invalid identifier in arithmetic expression " ++ show idc]%string)
                  end%core%Cexpr%option%zrange.
 
             Fixpoint collect_args_and_apply_unknown_casts {t}
@@ -895,7 +895,7 @@ Module Compilers.
                                   | None
                                     => mkcons int.option.None int.option.None
                                   end))
-                 | _ => inr ["Invalid identifier where cast or constructor was expected: " ++ show false idc]%string
+                 | _ => inr ["Invalid identifier where cast or constructor was expected: " ++ show idc]%string
                  end.
 
             Definition collect_args_and_apply_casts {t} (idc : ident.ident t)
@@ -932,7 +932,7 @@ Module Compilers.
                  | base.type.option _
                  | base.type.type_base _
                  | base.type.unit
-                   => fun _ _ => inr ["Invalid type " ++ show false t]%string
+                   => fun _ _ => inr ["Invalid type " ++ show t]%string
                  end.
 
             Fixpoint arith_expr_of_PHOAS
@@ -959,13 +959,13 @@ Module Compilers.
                       | inr errs => type.interpM_return _ _ _ (inr errs)
                       end
                  | expr.Var (type.arrow _ _) _
-                   => type.interpM_return _ _ _ (inr ["Invalid non-arithmetic let-bound Var of type " ++ show false t]%string)
+                   => type.interpM_return _ _ _ (inr ["Invalid non-arithmetic let-bound Var of type " ++ show t]%string)
                  | expr.App (type.arrow _ _) _ _ _
-                   => type.interpM_return _ _ _ (inr ["Invalid non-arithmetic let-bound App of type " ++ show false t]%string)
+                   => type.interpM_return _ _ _ (inr ["Invalid non-arithmetic let-bound App of type " ++ show t]%string)
                  | expr.LetIn _ _ _ _
-                   => type.interpM_return _ _ _ (inr ["Invalid non-arithmetic let-bound LetIn of type " ++ show false t]%string)
+                   => type.interpM_return _ _ _ (inr ["Invalid non-arithmetic let-bound LetIn of type " ++ show t]%string)
                  | expr.Abs _ _ _
-                   => type.interpM_return _ _ _ (inr ["Invalid non-arithmetic let-bound Abs of type: " ++ show false t]%string)
+                   => type.interpM_return _ _ _ (inr ["Invalid non-arithmetic let-bound Abs of type: " ++ show t]%string)
                  end.
 
             Definition arith_expr_of_base_PHOAS
@@ -1001,14 +1001,14 @@ Module Compilers.
                                  else [Assign false type.Z r n e]))
                  | base.type.type_base _
                  | base.type.unit
-                   => fun _ _ => inr ["Invalid type " ++ show false t]%string
+                   => fun _ _ => inr ["Invalid type " ++ show t]%string
                  | base.type.prod A B
                    => fun '(rva, rvb) e
                       => match invert_pair e with
                          | Some (ea, eb)
                            => ea',, eb' <- @make_return_assignment_of_base_arith A rva ea, @make_return_assignment_of_base_arith B rvb eb;
                                 ret (ea' ++ eb')
-                         | None => inr ["Invalid non-pair expr of type " ++ show false t]%string
+                         | None => inr ["Invalid non-pair expr of type " ++ show t]%string
                          end
                  | base.type.list tZ
                    => fun '(n, r, len) e
@@ -1020,7 +1020,7 @@ Module Compilers.
                                    (List.combine (List.seq 0 len) ls)))
                  | base.type.list _
                  | base.type.option _
-                   => fun _ _ => inr ["Invalid type of expr: " ++ show false t]%string
+                   => fun _ _ => inr ["Invalid type of expr: " ++ show t]%string
                  end%list.
             Definition make_return_assignment_of_arith {t}
               : var_data t
@@ -1028,11 +1028,11 @@ Module Compilers.
                 -> ErrT expr
               := match t with
                  | type.base t => make_return_assignment_of_base_arith
-                 | type.arrow s d => fun _ _ => inr ["Invalid type of expr: " ++ show false t]%string
+                 | type.arrow s d => fun _ _ => inr ["Invalid type of expr: " ++ show t]%string
                  end.
 
             Definition report_type_mismatch (expected : API.type) (given : API.type) : string
-              := ("Type mismatch; expected " ++ show false expected ++ " but given " ++ show false given ++ ".")%string.
+              := ("Type mismatch; expected " ++ show expected ++ " but given " ++ show given ++ ".")%string.
 
             Fixpoint arith_expr_of_PHOAS_args
                      {t}
@@ -1046,7 +1046,7 @@ Module Compilers.
                            inl ((arg, arg'), args')
                  | type.arrow s d
                    => fun '(arg, args)
-                      => arg' ,, args' <- @inr unit _ ["Invalid argument of non-ℤ type " ++ show false s]%string , @arith_expr_of_PHOAS_args d args;
+                      => arg' ,, args' <- @inr unit _ ["Invalid argument of non-ℤ type " ++ show s]%string , @arith_expr_of_PHOAS_args d args;
                            inr ["Impossible! (type error got lost somewhere)"]
                  end.
 
@@ -1133,7 +1133,7 @@ Module Compilers.
                 (e : @Compilers.expr.expr base.type ident.ident var_data t)
               : ErrT (expr * var_data t)
               := let _ := @PHOAS.expr.partially_show_expr in
-                 let ret_err := inr ["Not a comment " ++ show false e]%string in
+                 let ret_err := inr ["Not a comment " ++ show e]%string in
                  match invert_AppIdent e, var_data_of_string_opt "()" with
                  | Some (existT t (idc, arg)), Some retdata
                    => let should_keep_live := match idc return option bool with
@@ -1144,7 +1144,7 @@ Module Compilers.
                       match should_keep_live with
                       | Some should_keep_live
                         => inl ([Comment
-                                   (PHOAS.expr.show_lines_expr_gen (@string_of_var_data) (@var_data_of_string_opt) false arg) (* comment lines *)
+                                   (PHOAS.expr.show_lines_expr_gen (@string_of_var_data) (@var_data_of_string_opt) arg) (* comment lines *)
                                    (if should_keep_live then extract_var_data_list arg else []) (* live variables *)],
                                 retdata)
                       | None => ret_err
@@ -1159,11 +1159,11 @@ Module Compilers.
                  else
                    let _ := @PHOAS.expr.partially_show_expr in
                    match found with
-                   | None => inr ["Missing range on " ++ descr ++ " " ++ show true idc ++ ": " ++ show true ev]%string
+                   | None => inr ["Missing range on " ++ descr ++ " " ++ show idc ++ ": " ++ show ev]%string
                    | Some ty
                      => if int.is_tighter_than ty (int.of_zrange_relaxed (relax_zrange r[0~>2^s-1]))
                         then ret tt
-                        else inr ["Final bounds check failed on " ++ descr ++ " " ++ show false idc ++ "; expected an unsigned " ++ Decimal.Z.to_string s ++ "-bit number (relaxed to " ++ show false (int.of_zrange_relaxed (relax_zrange r[0~>2^s-1])) ++ "), but found a " ++ show false ty ++ "."]%string
+                        else inr ["Final bounds check failed on " ++ descr ++ " " ++ show idc ++ "; expected an unsigned " ++ Decimal.Z.to_string s ++ "-bit number (relaxed to " ++ show (int.of_zrange_relaxed (relax_zrange r[0~>2^s-1])) ++ "), but found a " ++ show ty ++ "."]%string
                    end.
 
             Let recognize_1ref_ident
@@ -1182,7 +1182,7 @@ Module Compilers.
                  | ident.Z_zselect
                    => Some
                         (fun rout '((econdv, (econd, rcond)), ((e1v, (e1, r1)), ((e2v, (e2, r2)), tt)))
-                         => (*let err := inr ["Invalid argument to Z.zselect not known to be 0 or 1: " ++ show false econdv]%string in*)
+                         => (*let err := inr ["Invalid argument to Z.zselect not known to be 0 or 1: " ++ show econdv]%string in*)
                            _ <- bounds_check do_bounds_check "first argument to" idc 1 econdv rcond;
                              let '((e1, r1), (e2, r2)) :=
                                  funcall_upcast (t:=tZ*tZ) (rout, rout) ((e1, r1), (e2, r2)) in
@@ -1192,7 +1192,7 @@ Module Compilers.
                                    | None => inr ["Missing cast annotation on return of Z.zselect"]
                                    end;
                                ret (fun retptr => [Call (Z_zselect ty @@@ (retptr, (econd, e1, e2)))]%Cexpr))
-                 | _ => None (* fun _ => inr ["Unrecognized identifier (expecting a 1-pointer-returning function): " ++ show false idc]%string *)
+                 | _ => None (* fun _ => inr ["Unrecognized identifier (expecting a 1-pointer-returning function): " ++ show idc]%string *)
                  end.
 
             Let round_up_to_split_type (lgs : Z) (t : option int.type) : option int.type
@@ -1204,7 +1204,7 @@ Module Compilers.
                  | Some r
                    => if ZRange.type.is_bounded_by (t:=tZ) r v
                       then inl tt
-                      else inr ["Literal value " ++ show true v ++ " is not within the casted range " ++ show true r ++ " (when trying to parse the " ++ nth ++ " argument of " ++ show true idc ++ ")"]%string
+                      else inr ["Literal value " ++ show v ++ " is not within the casted range " ++ show r ++ " (when trying to parse the " ++ nth ++ " argument of " ++ show idc ++ ")"]%string
                  end.
 
             Let recognize_3arg_2ref_ident
@@ -1246,8 +1246,8 @@ Module Compilers.
                        let '(e2, _) := result_upcast (t:=tZ) (Some (int.of_zrange_relaxed r[0 ~> 2 ^ s - 1])) (e2, r2) in
                        inl ((round_up_to_split_type s (fst rout), snd rout),
                             fun retptr => [Call (idc' @@@ (retptr, (literal 0 @@@ TT, e1, e2)))%Cexpr]))
-                  | Some _, _ => inr ["Unrecognized identifier when attempting to construct an assignment with 2 arguments: " ++ show true idc]%string
-                  | None, _ => inr ["Expression is not a literal power of two of type ℤ: " ++ show true s ++ " (when trying to parse the first argument of " ++ show true idc ++ ")"]%string
+                  | Some _, _ => inr ["Unrecognized identifier when attempting to construct an assignment with 2 arguments: " ++ show idc]%string
+                  | None, _ => inr ["Expression is not a literal power of two of type ℤ: " ++ show s ++ " (when trying to parse the first argument of " ++ show idc ++ ")"]%string
                   end.
 
             Let recognize_4arg_2ref_ident
@@ -1281,8 +1281,8 @@ Module Compilers.
                          let '(e3, _) := result_upcast (t:=tZ) (Some (int.of_zrange_relaxed (relax_zrange r[0 ~> 2 ^ s - 1]))) (e3, r3) in
                          inl ((round_up_to_split_type s (fst rout), snd rout),
                               fun retptr => [Call (idc' @@@ (retptr, (e1, e2, e3)))%Cexpr]))
-                 | Some _, _ => inr ["Unrecognized identifier when attempting to construct an assignment with 2 arguments: " ++ show true idc]%string
-                 | None, _ => inr ["Expression is not a literal power of two of type ℤ: " ++ show true s ++ " (when trying to parse the first argument of " ++ show true idc ++ ")"]%string
+                 | Some _, _ => inr ["Unrecognized identifier when attempting to construct an assignment with 2 arguments: " ++ show idc]%string
+                 | None, _ => inr ["Expression is not a literal power of two of type ℤ: " ++ show s ++ " (when trying to parse the first argument of " ++ show idc ++ ")"]%string
                  end.
 
             Let recognize_2ref_ident
@@ -1297,7 +1297,7 @@ Module Compilers.
                    => recognize_3arg_2ref_ident
                  | (type.base tZ -> type.base tZ -> type.base tZ -> type.base tZ -> type.base (tZ * tZ))%etype
                    => recognize_4arg_2ref_ident
-                 | _ => fun do_bounds_check idc rout args => inr ["Unrecognized type for function call: " ++ show false t ++ " (when trying to handle the identifer " ++ show false idc ++ ")"]%string
+                 | _ => fun do_bounds_check idc rout args => inr ["Unrecognized type for function call: " ++ show t ++ " (when trying to handle the identifer " ++ show idc ++ ")"]%string
                  end.
 
             Definition declare_name
@@ -1308,7 +1308,7 @@ Module Compilers.
               : ErrT (expr * string * bool (* is pointer *) * arith_expr type.Zptr)
               := (n ,, r <- (match make_name count with
                              | Some n => ret n
-                             | None => inr ["Variable naming-function does not support the index " ++ show false count]%string
+                             | None => inr ["Variable naming-function does not support the index " ++ show count]%string
                              end,
                              match r with
                              | Some r => ret r
@@ -1337,7 +1337,7 @@ Module Compilers.
                              Some
                                (args <- arith_expr_of_PHOAS_args args;
                                   idce <- recognize rout args;
-                                  v <- declare_name (show false idc) count make_name rout;
+                                  v <- declare_name (show idc) count make_name rout;
                                   let '(decls, n, is_ptr, retv) := v in
                                   ret ((decls ++ (idce retv))%list, (n, is_ptr, rout)))%err)%option in
                  match res_ref with
@@ -1349,7 +1349,7 @@ Module Compilers.
                         match make_name count with
                         | Some n1
                           => ret ([Assign true type.Z r1 n1 e1], (n1, false, r1))
-                        | None => inr ["Variable naming-function does not support the index " ++ show false count]%string
+                        | None => inr ["Variable naming-function does not support the index " ++ show count]%string
                         end
                  end.
 
@@ -1370,12 +1370,12 @@ Module Compilers.
                    => args <- arith_expr_of_PHOAS_args args;
                         idce <- recognize_2ref_ident do_bounds_check idc (rout1, rout2) args;
                         let '((rout1, rout2), idce) := idce in
-                        v1,, v2 <- (declare_name (show false idc) count make_name rout1,
-                                    declare_name (show false idc) (Pos.succ count) make_name rout2);
+                        v1,, v2 <- (declare_name (show idc) count make_name rout1,
+                                    declare_name (show idc) (Pos.succ count) make_name rout2);
                           let '(decls1, n1, is_ptr1, retv1) := v1 in
                           let '(decls2, n2, is_ptr2, retv2) := v2 in
                           ret (decls1 ++ decls2 ++ (idce (retv1, retv2)%Cexpr), ((n1, is_ptr1, rout1), (n2, is_ptr2, rout2)))%list
-                 | None => inr ["Invalid assignment of non-identifier-application: " ++ show false e]%string
+                 | None => inr ["Invalid assignment of non-identifier-application: " ++ show e]%string
                  end.
 
             Let make_assign_arg_ref
@@ -1390,7 +1390,7 @@ Module Compilers.
                  | type.base tZ => make_assign_arg_1ref_opt do_bounds_check
                  | type.base (tZ * tZ)%etype => make_assign_arg_2ref do_bounds_check
                  | type.base base.type.unit => fun e _ _ => make_comment e
-                 | _ => fun e _ _ => inr ["Invalid type of assignment expression: " ++ show false t ++ " (with expression " ++ show true e ++ ")"]
+                 | _ => fun e _ _ => inr ["Invalid type of assignment expression: " ++ show t ++ " (with expression " ++ show e ++ ")"]
                  end.
 
             Fixpoint size_of_type (t : base.type) : positive
@@ -1526,8 +1526,8 @@ Module Compilers.
                                 d (f vs) make_in_name inbounds count _
                                 (fun '(count, (vss, rv))
                                  => k (count, ((vs, vss), rv)))
-                         | None, _ => inr ["Unable to bind names for all arguments and bounds at type " ++ show false s]%string%list
-                         | _, None => inr ["Invalid non-λ expression of arrow type (" ++ show false t ++ "): " ++ show true e]%string%list
+                         | None, _ => inr ["Unable to bind names for all arguments and bounds at type " ++ show s]%string%list
+                         | _, None => inr ["Invalid non-λ expression of arrow type (" ++ show t ++ "): " ++ show e]%string%list
                          end
                  end%core%expr e inbounds.
 
@@ -1590,7 +1590,7 @@ Module Compilers.
                       @expr_of_PHOAS'_cps
                         t e make_in_name inbounds count _
                         (fun '(count, (din, e)) => k (count, (din, dout, e)))
-                 | None => inr ["Unable to bind names for all return arguments and bounds at type " ++ show false (type.final_codomain t)]%string
+                 | None => inr ["Unable to bind names for all return arguments and bounds at type " ++ show (type.final_codomain t)]%string
                  end.
 
             Definition expr_of_PHOAS

--- a/src/Stringification/JSON.v
+++ b/src/Stringification/JSON.v
@@ -185,7 +185,7 @@ Module JSON.
   Local Notation quote_string s := ("""" ++ s ++ """")%string (only parsing).
 
   Fixpoint to_base_arg_list {t} : base_var_data t -> Compilers.ZRange.type.base.option.interp t -> list (string * string * (string * string))
-    := let show_Z s := quote_string (Hex.show_Z false s) in
+    := let show_Z s := quote_string (Hex.show_Z s) in
        let opt_to_json T f (b : option T) :=
            match b with
            | None => (None_object, None_object)
@@ -214,7 +214,7 @@ Module JSON.
        | base.type.list _ => fun _ _ => [("#error ""complex list""", "", (None_object, None_object))]
        | base.type.option _ => fun _ _ => [("#error option", "", (None_object, None_object))]
        | base.type.unit => fun _ _ => [("#error unit", "", (None_object, None_object))]
-       | base.type.type_base t => fun _ _ => [("#error " ++ show false t, "", (None_object, None_object))]
+       | base.type.type_base t => fun _ _ => [("#error " ++ show t, "", (None_object, None_object))]
        end%string.
 
   Definition to_arg_list {t} : var_data t -> Compilers.ZRange.type.option.interp t -> list (string * string * (string * string)) :=

--- a/src/Stringification/Java.v
+++ b/src/Stringification/Java.v
@@ -242,7 +242,7 @@ Module Java.
     | base.type.list _ => fun _ => ["error_complex_list"]
     | base.type.option _ => fun _ => ["error_option"]
     | base.type.unit => fun _ => ["error_unit"]
-    | base.type.type_base t => fun _ => ["error_" ++ show false t]%string
+    | base.type.type_base t => fun _ => ["error_" ++ show t]%string
     end%string.
 
   Definition to_arg_list (prefix : string) (mode : Mode) {t} : var_data t -> list string :=

--- a/src/Stringification/Language.v
+++ b/src/Stringification/Language.v
@@ -225,7 +225,7 @@ Module Compilers.
              end.
         Global Existing Instance show_lvl_for_each_lhs_of_arrow.
         Definition show_for_each_lhs_of_arrow {base_type} {f : type.type base_type -> Type} {show_f : forall t, Show (f t)} {t : type.type base_type} : Show (type.for_each_lhs_of_arrow f t)
-          := let __ := fun t => @ShowLevel_of_Show (f t) in
+          := let _ := fun t => @ShowLevel_of_Show (f t) in
              show_lvl_for_each_lhs_of_arrow.
 
         Global Instance show_lvl_type : forall {base_type} {S : ShowLevel base_type}, ShowLevel (type.type base_type)
@@ -237,7 +237,7 @@ Module Compilers.
                   end.
         Global Instance show_lvl {base_type} {S : ShowLevel base_type} : ShowLevel (type.type base_type) := show_lvl_type.
         Global Instance show_type {base_type} {S : Show base_type} : Show (type.type base_type)
-          := let __ := @ShowLevel_of_Show base_type in
+          := let _ := @ShowLevel_of_Show base_type in
              show_lvl_type.
         Global Instance show {base_type} {S : Show base_type} : Show (type.type base_type) := show_type.
       End type.

--- a/src/Stringification/Rust.v
+++ b/src/Stringification/Rust.v
@@ -221,7 +221,7 @@ Module Rust.
     | base.type.list _ => fun _ => ["#error ""complex list"";"]
     | base.type.option _ => fun _ => ["#error option;"]
     | base.type.unit => fun _ => ["#error unit;"]
-    | base.type.type_base t => fun _ => ["#error " ++ show false t ++ ";"]%string
+    | base.type.type_base t => fun _ => ["#error " ++ show t ++ ";"]%string
     end%string.
 
   Definition to_arg_list {language_naming_conventions : language_naming_conventions_opt} (internal_private : bool) (prefix : string) (mode : Mode) {t} : var_data t -> list string :=

--- a/src/Stringification/Zig.v
+++ b/src/Stringification/Zig.v
@@ -170,7 +170,7 @@ Module Zig.
     | base.type.list _ => fun _ => ["@compilerError(""complex list"");"]
     | base.type.option _ => fun _ => ["@compilerError(""option"");"]
     | base.type.unit => fun _ => ["@compilerError(""unit"");"]
-    | base.type.type_base t => fun _ => ["@compilerError(""" ++ show false t ++ """);"]%string
+    | base.type.type_base t => fun _ => ["@compilerError(""" ++ show t ++ """);"]%string
     end%string.
 
   Definition to_arg_list {language_naming_conventions : language_naming_conventions_opt} (internal_private : bool) (prefix : string) (mode : Mode) {t} : var_data t -> list string :=

--- a/src/UnsaturatedSolinasHeuristics/Tests.v
+++ b/src/UnsaturatedSolinasHeuristics/Tests.v
@@ -169,14 +169,14 @@ Time Definition balances
                                        let dif := map2 Z.sub bal tub in
                                        ((bw, n),
                                         ("balance:                                        ",
-                                         (let show_Z := PowersOfTwo.show_Z in show false bal),
-                                         (let show_Z := Hex.show_Z in show false bal)),
+                                         (let show_lvl_Z := PowersOfTwo.show_lvl_Z in show bal),
+                                         (let show_lvl_Z := Hex.show_lvl_Z in show bal)),
                                         ("tight_upperbounds:                              ",
-                                         (let show_Z := PowersOfTwo.show_Z in show false tub),
-                                         (let show_Z := Hex.show_Z in show false tub)),
+                                         (let show_lvl_Z := PowersOfTwo.show_lvl_Z in show tub),
+                                         (let show_lvl_Z := Hex.show_lvl_Z in show tub)),
                                         ("balance - tight_upperbounds:                    ",
-                                         (let show_Z := PowersOfTwo.show_Z in show false dif),
-                                         (let show_Z := Hex.show_Z in show false dif))))
+                                         (let show_lvl_Z := PowersOfTwo.show_lvl_Z in show dif),
+                                         (let show_lvl_Z := Hex.show_lvl_Z in show dif))))
                                    ns)
                              ls))
                       (parseZ_arith_to_taps p))

--- a/src/Util/ErrorT/Show.v
+++ b/src/Util/ErrorT/Show.v
@@ -14,8 +14,8 @@ Global Instance show_lvl_ErrorT {ErrT T} {show_ErrT : ShowLevel ErrT} {show_T : 
         | Error msg => show_lvl_app (fun 'tt => "Error") msg
         end.
 Global Instance show_ErrorT {ErrT T} {show_ErrT : Show ErrT} {show_T : Show T} : Show (@ErrorT ErrT T)
-  := let __ := @ShowLevel_of_Show ErrT in
-     let __ := @ShowLevel_of_Show T in
+  := let _ := @ShowLevel_of_Show ErrT in
+     let _ := @ShowLevel_of_Show T in
      _.
 
 Global Instance show_lines_ErrorT {ErrT T} {show_lines_ErrT : ShowLines ErrT} {show_lines_T : ShowLines T}

--- a/src/Util/ErrorT/Show.v
+++ b/src/Util/ErrorT/Show.v
@@ -6,30 +6,30 @@ Import ListNotations.
 Local Open Scope list_scope.
 Local Open Scope string_scope.
 
-Global Instance show_ErrorT {ErrT T} {show_ErrT : Show ErrT} {show_T : Show T}
-  : Show (@ErrorT ErrT T)
-  := fun with_parens v
-     => maybe_wrap_parens
-          with_parens
-          match v with
-          | Success v => "Success " ++ show true v
-          | Error msg => "Error " ++ show true msg
-          end.
+Global Instance show_lvl_ErrorT {ErrT T} {show_ErrT : ShowLevel ErrT} {show_T : ShowLevel T}
+  : ShowLevel (@ErrorT ErrT T)
+  := fun v
+     => match v with
+        | Success v => show_lvl_app (fun 'tt => "Success") v
+        | Error msg => show_lvl_app (fun 'tt => "Error") msg
+        end.
+Global Instance show_ErrorT {ErrT T} {show_ErrT : Show ErrT} {show_T : Show T} : Show (@ErrorT ErrT T)
+  := let __ := @ShowLevel_of_Show ErrT in
+     let __ := @ShowLevel_of_Show T in
+     _.
 
 Global Instance show_lines_ErrorT {ErrT T} {show_lines_ErrT : ShowLines ErrT} {show_lines_T : ShowLines T}
   : ShowLines (@ErrorT ErrT T)
-  := fun with_parens v
-     => maybe_wrap_parens_lines
-          with_parens
-          (let '(prefix, lines)
-               := match v with
-                  | Success v => ("Success", show_lines true v)
-                  | Error msg => ("Error", show_lines true msg)
-                  end in
-           match lines with
-           | [] => [prefix ++ " ()"]
-           | [line] => [prefix ++ " " ++ line]
-           | lines => (([prefix ++ " ("]%string)
-                         ++ (List.map (fun s => "  " ++ s)%string lines)
-                         ++ [")"])%list
-           end).
+  := fun v
+     => let '(prefix, lines)
+            := match v with
+               | Success v => ("Success", show_lines v)
+               | Error msg => ("Error", show_lines msg)
+               end in
+        match lines with
+        | [] => [prefix ++ " ()"]
+        | [line] => [prefix ++ " " ++ line]
+        | lines => (([prefix ++ " ("]%string)
+                      ++ (List.map (fun s => "  " ++ s)%string lines)
+                      ++ [")"])%list
+        end.

--- a/src/Util/Level.v
+++ b/src/Util/Level.v
@@ -1,0 +1,135 @@
+Require Import Coq.ZArith.ZArith.
+Require Import Coq.micromega.Lia.
+Require Import Coq.Relations.Relations.
+Require Import Coq.Classes.Morphisms.
+Require Import Crypto.Util.Bool.Reflect.
+Require Import Crypto.Util.Decidable.
+
+Module Level.
+  Local Coercion is_true : bool >-> Sortclass.
+  Local Set Boolean Equality Schemes.
+  Local Set Decidable Equality Schemes.
+  Inductive Level :=
+  | neg_inf
+  | level (lvl : Z)
+  | pos_inf
+  .
+  Notation t := Level (only parsing).
+  Module Export Exports1.
+    Delimit Scope level_scope with level.
+    Bind Scope level_scope with Level.
+    Global Coercion level : Z >-> Level.
+  End Exports1.
+  Local Open Scope level_scope.
+
+  Definition of_nat (n : nat) : Level := Z.of_nat n.
+  Definition of_N (n : N) : Level := Z.of_N n.
+  Definition of_pos (n : positive) : Level := Z.pos n.
+
+  Module Export Exports2.
+    Global Coercion of_nat : nat >-> Level.
+    Global Coercion of_N : N >-> Level.
+    Global Coercion of_pos : positive >-> Level.
+  End Exports2.
+
+  (** next tighter level *)
+  Definition next (l : Level) : Level
+    := match l with
+       | neg_inf => neg_inf
+       | level lvl => level (Z.pred lvl)
+       | pos_inf => pos_inf
+       end.
+  (** previous looser level *)
+  Definition prev (l : Level) : Level
+    := match l with
+       | neg_inf => neg_inf
+       | level lvl => level (Z.succ lvl)
+       | pos_inf => pos_inf
+       end.
+
+  Notation eqb := Level_beq.
+  Lemma eqb_eq x y : eqb x y = true <-> x = y.
+  Proof. split; [ apply internal_Level_dec_bl | apply internal_Level_dec_lb ]. Qed.
+  Lemma eqb_neq x y : eqb x y = false <-> x <> y.
+  Proof. rewrite <- eqb_eq; destruct (eqb x y); split; congruence. Qed.
+  Lemma eqb_refl x : eqb x x = true.
+  Proof. rewrite eqb_eq; reflexivity. Qed.
+  Lemma eqb_sym x y : eqb x y = eqb y x.
+  Proof. destruct (eqb x y) eqn:?, (eqb y x) eqn:?; rewrite ?eqb_eq, ?eqb_neq in *; subst; congruence. Qed.
+  Lemma eqb_spec : reflect_rel eq eqb.
+  Proof. intros x y; destruct (eqb x y) eqn:?; constructor; rewrite ?eqb_eq, ?eqb_neq in *; assumption. Qed.
+  Definition dec_eq_Level : DecidableRel (@eq Level) := dec_rel_of_bool_dec_rel eqb internal_Level_dec_bl internal_Level_dec_lb.
+  Lemma eqb_compat : Proper (eq ==> eq ==> eq) eqb.
+  Proof. repeat intro; subst; reflexivity. Qed.
+
+  Definition compare (l1 l2 : Level) : comparison
+    := match l1, l2 with
+       | neg_inf, neg_inf => Eq
+       | neg_inf, _ => Lt
+       | _, neg_inf => Gt
+       | pos_inf, pos_inf => Eq
+       | pos_inf, _ => Gt
+       | _, pos_inf => Lt
+       | level l1, level l2 => Z.compare l1 l2
+       end.
+  Definition ltb (l1 l2 : Level) : bool
+    := match compare l1 l2 with
+       | Lt => true
+       | _ => false
+       end.
+  Definition leb (l1 l2 : Level) : bool
+    := orb (eqb l1 l2) (ltb l1 l2).
+  Definition le : relation Level := leb.
+  Definition lt : relation Level := ltb.
+  Module Export Exports3.
+    Global Arguments le _ _ / .
+    Global Arguments lt _ _ / .
+    Global Arguments ltb !_ !_ / .
+    Global Arguments leb !_ !_ / .
+    Global Arguments compare !_ !_ / .
+  End Exports3.
+
+  Module Import Notations1.
+    Notation "-∞" := neg_inf.
+    Notation "∞" := pos_inf.
+    Infix "?=" := compare : level_scope.
+    Infix "=?" := eqb : level_scope.
+    Infix "<=?" := leb : level_scope.
+    Infix "<?" := ltb : level_scope.
+    Infix "<=" := le : level_scope.
+    Infix "<" := lt : level_scope.
+    Notation "l1 >=? l2" := (leb l2 l1) (only parsing) : level_scope.
+    Notation "l1 >? l2" := (ltb l2 l1) (only parsing) : level_scope.
+    Notation "l1 >= l2" := (le l2 l1) (only parsing) : level_scope.
+    Notation "l1 > l2" := (lt l2 l1) (only parsing) : level_scope.
+  End Notations1.
+  Lemma compare_spec x y : CompareSpec (x = y) (x < y) (y < x) (x ?= y).
+  Proof.
+    destruct x as [|x|], y as [|y|]; cbv [lt ltb compare]; try destruct (Z.compare_spec x y), (Z.compare_spec y x); constructor;
+      subst; try reflexivity; try lia.
+  Qed.
+  Lemma compare_refl x : (x ?= x) = Eq.
+  Proof. destruct x; cbn; try reflexivity; now rewrite Z.compare_refl. Qed.
+  Lemma compare_antisym x y : (y ?= x) = CompOpp (x ?= y).
+  Proof. destruct x, y; cbn; try reflexivity; now rewrite Z.compare_antisym. Qed.
+  Lemma compare_eq x y : (x ?= y) = Eq -> x = y.
+  Proof. destruct x, y; cbn; try congruence; intro; now apply f_equal, Z.compare_eq. Qed.
+  Lemma compare_eq_iff x y : (x ?= y) = Eq <-> x = y.
+  Proof. destruct x, y; cbn; rewrite ?Z.compare_eq_iff; split; congruence. Qed.
+
+  Module Export Notations.
+    Export Notations1.
+  End Notations.
+
+  Module Export Exports.
+    Export Exports1.
+    Export Exports2.
+    Export Exports3.
+    Global Existing Instances eqb_spec dec_eq_Level eqb_compat | 10.
+  End Exports.
+End Level.
+Export Level.Notations.
+Export Level.Exports.
+Notation Level := Level.Level.
+
+Inductive Associativity := LeftAssoc | RightAssoc | NoAssoc | FullyAssoc | ExplicitAssoc (l r : Level).

--- a/src/Util/MSetPositive/Show.v
+++ b/src/Util/MSetPositive/Show.v
@@ -5,4 +5,5 @@ Require Import Crypto.Util.Strings.Show.
 Module Import ShowMSetPositive := ShowWSets PositiveSet.
 
 Global Instance show_PositiveSet : Show PositiveSet.t := _.
-Global Instance show_lines_PositiveSet : ShowLines PositiveSet.t := _.
+Global Instance show_lvl_PositiveSet : ShowLevel PositiveSet.t := _.
+Global Instance show_lines_PositiveSet : ShowLines PositiveSet.t := let __ := @ShowLines_of_Show PositiveSet.elt in _.

--- a/src/Util/MSetPositive/Show.v
+++ b/src/Util/MSetPositive/Show.v
@@ -6,4 +6,4 @@ Module Import ShowMSetPositive := ShowWSets PositiveSet.
 
 Global Instance show_PositiveSet : Show PositiveSet.t := _.
 Global Instance show_lvl_PositiveSet : ShowLevel PositiveSet.t := _.
-Global Instance show_lines_PositiveSet : ShowLines PositiveSet.t := let __ := @ShowLines_of_Show PositiveSet.elt in _.
+Global Instance show_lines_PositiveSet : ShowLines PositiveSet.t := let _ := @ShowLines_of_Show PositiveSet.elt in _.

--- a/src/Util/MSets/Show.v
+++ b/src/Util/MSets/Show.v
@@ -3,10 +3,12 @@ Require Import Coq.MSets.MSetInterface.
 Require Import Crypto.Util.Strings.Show.
 
 Module ShowWSetsOn (E : Equalities.DecidableType) (W : WSetsOn E).
+  Global Instance show_lvl_t {show_elt : ShowLevel E.t} : ShowLevel W.t
+    := fun v => show_lvl (W.elements v).
   Global Instance show_t {show_elt : Show E.t} : Show W.t
-    := fun with_parens v => show with_parens (W.elements v).
+    := fun v => show (W.elements v).
   Global Instance show_lines_t {show_elt : ShowLines E.t} : ShowLines W.t
-    := fun with_parens v => show_lines with_parens (W.elements v).
+    := fun v => show_lines (W.elements v).
 End ShowWSetsOn.
 
 Module ShowWSets (W : WSets) := ShowWSetsOn W.E W.

--- a/src/Util/Strings/NamingConventions.v
+++ b/src/Util/Strings/NamingConventions.v
@@ -24,32 +24,37 @@ Global Existing Instances name_case_kind_Listable name_case_kind_FinitelyListabl
 
 (* M-x query-replace-regex RET \([^ ]+\) => _ RET \1 => "\1" *)
 Global Instance show_name_case_kind : Show name_case_kind
-  := fun with_parens v
+  := fun v
      => match v with
         | lower => "lower"
         | upper => "upper"
         end.
+Global Instance show_lvl_name_case_kind : ShowLevel name_case_kind := show_name_case_kind.
 
 Definition parse_name_case_kind_list : list (string * name_case_kind)
   := Eval vm_compute in
       List.map
-        (fun v => (show false v, v))
+        (fun v => (show v, v))
         (list_all name_case_kind).
 
 Global Instance show_word_case_data : Show word_case_data
-  := fun parens v
-     => ("{| first_letter_case := " ++ show false v.(first_letter_case))
-          ++ " ; rest_letters_case := " ++ show false v.(rest_letters_case) ++ " |}".
+  := fun v
+     => ("{| first_letter_case := " ++ show v.(first_letter_case))
+          ++ " ; rest_letters_case := " ++ show v.(rest_letters_case) ++ " |}".
+Global Instance show_lvl_word_case_data : ShowLevel word_case_data := show_word_case_data.
+
 Global Instance show_capitalization_data : Show capitalization_data
-  := fun parens v
-     => ("{| separator := " ++ show false v.(separator))
-          ++ (" ; first_word_case := " ++ show false v.(first_word_case))
-          ++ " ; rest_words_case := " ++ show false v.(rest_words_case) ++ " |}".
+  := fun v
+     => ("{| separator := " ++ show v.(separator))
+          ++ (" ; first_word_case := " ++ show v.(first_word_case))
+          ++ " ; rest_words_case := " ++ show v.(rest_words_case) ++ " |}".
+Global Instance show_lvl_capitalization_data : ShowLevel capitalization_data := show_capitalization_data.
 
 Global Instance show_capitalization_convention : Show capitalization_convention
-  := fun parens v
-     => ("{| capitalization_convention_data := " ++ show false v.(capitalization_convention_data))
-          ++ " ; only_lower_first_letters := " ++ show false v.(only_lower_first_letters) ++ " |}".
+  := fun v
+     => ("{| capitalization_convention_data := " ++ show v.(capitalization_convention_data))
+          ++ " ; only_lower_first_letters := " ++ show v.(only_lower_first_letters) ++ " |}".
+Global Instance show_lvl_capitalization_convention : ShowLevel capitalization_convention := show_capitalization_convention.
 
 Definition case_adjust_ascii (data : name_case_kind) : Ascii.ascii -> Ascii.ascii
   := match data with

--- a/src/Util/Strings/Show.v
+++ b/src/Util/Strings/Show.v
@@ -5,13 +5,101 @@ Require Crypto.Util.Strings.String.
 Require Import Crypto.Util.ZUtil.Definitions.
 Require Import Coq.Strings.HexString.
 Require Import Crypto.Util.Strings.Decimal.
-Import ListNotations. Local Open Scope list_scope. Local Open Scope string_scope.
+Require Export Crypto.Util.Level.
+Import ListNotations. Local Open Scope Z_scope. Local Open Scope list_scope. Local Open Scope string_scope.
+Local Open Scope level_scope.
 
-Class Show T := show : bool (* parens *) -> T -> string.
-Class ShowLines T := show_lines : bool -> T -> list string.
+Class ShowLevel T := show_lvl : T -> Level -> string.
+Class ShowLevel2 A B := show_lvl2 : A -> B -> Level -> string.
+Class ShowLevel3 A B C := show_lvl3 : A -> B -> C -> Level -> string.
+Class Show T := show : T -> string.
+Class ShowLines T := show_lines : T -> list string.
+Definition show_lvl2_explicit (F : ShowLevel unit -> ShowLevel unit -> ShowLevel2 unit unit)
+  : (Level -> string) -> (Level -> string) -> (Level -> string)
+  := fun show_f show_x => F (fun 'tt => show_f) (fun 'tt => show_x) tt tt.
+Notation app_lvl := (Level.level 10) (only parsing).
+Notation term_lvl := (Level.level 200) (only parsing).
+Notation pair_lvl := (Level.prev term_lvl) (only parsing).
+Notation pair_assoc := LeftAssoc (only parsing).
+Notation opp_lvl := (Level.level 35) (only parsing).
+Notation impl_lvl := (Level.level 99) (only parsing).
+Notation impl_assoc := RightAssoc (only parsing).
+Notation iff_lvl := (Level.level 95) (only parsing).
+Notation iff_assoc := RightAssoc (only parsing).
+Notation lneg_lvl := (Level.level 75) (only parsing).
+Notation rel_lvl := (Level.level 70) (only parsing).
+Notation rel_assoc := RightAssoc (only parsing).
+Notation add_lvl := (Level.level 50) (only parsing).
+Notation add_assoc := FullyAssoc (only parsing).
+Notation sub_lvl := (Level.level 50) (only parsing).
+Notation sub_assoc := LeftAssoc (only parsing).
+Notation mul_lvl := (Level.level 40) (only parsing).
+Notation mul_assoc := FullyAssoc (only parsing).
+Notation div_lvl := (Level.level 40) (only parsing).
+Notation div_assoc := NoAssoc (only parsing).
+Notation mod_lvl := (Level.level 40) (only parsing).
+Notation mod_assoc := NoAssoc (only parsing).
+Notation andb_lvl := (Level.level 40) (only parsing).
+Notation andb_assoc := FullyAssoc (only parsing).
+Notation orb_lvl := (Level.level 40) (only parsing).
+Notation orb_assoc := FullyAssoc (only parsing).
+Notation pow_lvl := (Level.level 30) (only parsing).
+Notation pow_assoc := RightAssoc (only parsing).
+
+Global Instance Show_of_ShowLevel {T} `{ShowLevel T} : Show T | 1000 := fun t => show_lvl t term_lvl.
+Definition ShowLevel_of_Show {T} `{Show T} : ShowLevel T := fun t _ => show t.
+Definition ShowLines_of_Show {T} `{Show T} : ShowLines T := fun t => [show t].
+Global Instance Show_of_ShowLines {T} `{ShowLines T} : Show T | 1000 := fun t => String.concat String.NewLine (show_lines t).
+Global Coercion Show_of_ShowLevel : ShowLevel >-> Show.
+Global Coercion ShowLevel_of_Show : Show >-> ShowLevel.
+
+Global Instance show_lvl_const : ShowLevel (unit -> string) := fun f _ => f tt.
+Global Instance show_lvl_id : ShowLevel (Level -> string) := fun f lvl => f lvl.
 
 Definition maybe_wrap_parens (parens : bool) (s : string)
   := if parens then "(" ++ s ++ ")" else s.
+(** wrap with parentheses if the level is negative *)
+Definition neg_wrap_parens_with_lvl (f : Level -> string) : Level -> string
+  := fun lvl => maybe_wrap_parens (lvl <? 0) (f lvl).
+Definition neg_wrap_parens (f : string) : Level -> string
+  := neg_wrap_parens_with_lvl (fun _ => f).
+Definition ShowLevel2_binop_assoc (assoc : Associativity) (binop_lvl : Level) (binop : string) {A B}
+           `{ShowLevel A, ShowLevel B}
+  : ShowLevel2 A B
+  := fun a b lvl
+     => maybe_wrap_parens
+          (lvl <? binop_lvl)
+          (let lvl := binop_lvl in
+           match assoc with
+           | LeftAssoc => show_lvl a lvl ++ binop ++ show_lvl b (Level.next lvl)
+           | RightAssoc => show_lvl a (Level.next lvl) ++ binop ++ show_lvl b lvl
+           | NoAssoc => show_lvl a (Level.next lvl) ++ binop ++ show_lvl b (Level.next lvl)
+           | FullyAssoc => show_lvl a lvl ++ binop ++ show_lvl b lvl
+           | ExplicitAssoc lvl_l lvl_r => show_lvl a lvl_l ++ binop ++ show_lvl b lvl_r
+           end).
+Definition show_lvl_binop (assoc : Associativity) (binop_lvl : Level) {A B} `{SA : ShowLevel A, SB : ShowLevel B}
+  : A -> string -> B -> Level -> string
+  := fun a binop b => ShowLevel2_binop_assoc assoc binop_lvl binop a b.
+Definition show_lvl_app {A B} `{ShowLevel A, ShowLevel B} : ShowLevel2 A B
+  := ShowLevel2_binop_assoc LeftAssoc app_lvl " ".
+Definition show_lvl_app2 {A B C} `{ShowLevel A, ShowLevel B, ShowLevel C} : ShowLevel3 A B C
+  := fun a b c => show_lvl_app (show_lvl_app a b) c.
+Definition show_lvl_preop_assoc (assoc : Associativity) (op_lvl : Level) {A}
+           `{ShowLevel A}
+  : string -> A -> Level -> string
+  := fun preop a => show_lvl_binop assoc op_lvl (fun 'tt => "") preop a.
+Definition show_lvl_postop_assoc (assoc : Associativity) (op_lvl : Level) {A}
+           `{ShowLevel A}
+  : A -> string -> Level -> string
+  := fun a postop => show_lvl_binop assoc op_lvl a postop (fun 'tt => "").
+Definition show_lvl_unop (unop_lvl : Level) (unop : string) {A}
+           `{ShowLevel A}
+  : ShowLevel A
+  := fun a => show_lvl_preop_assoc RightAssoc unop_lvl unop a.
+Definition show_lvl_postop (postop_lvl : Level) {A}
+           `{ShowLevel A}
+  : A -> string -> Level -> string
+  := fun a postop => show_lvl_postop_assoc LeftAssoc postop_lvl a postop.
 
 Definition maybe_wrap_parens_lines (parens : bool) (s : list string)
   := match s, parens with
@@ -21,45 +109,45 @@ Definition maybe_wrap_parens_lines (parens : bool) (s : list string)
      | s, true => "(" :: List.map (String " ") s ++ [")"]
      end%list.
 
-Global Instance show_lines_of_show {T} `{Show T} : ShowLines T | 1000
-  := fun parens v => [show parens v].
-
-Global Instance show_unit : Show unit := fun _ _ => "tt".
-Global Instance show_True : Show True := fun _ _ => "I".
-Global Instance show_False : Show False := fun _ pf => match pf with end.
-Global Instance show_Empty_set : Show Empty_set := fun _ pf => match pf with end.
-Global Instance show_bool : Show bool := fun _ b => if b then "true" else "false".
-Global Instance show_option {T} `{Show T} : Show (option T)
-  := fun p v
-     => match v with
-       | Some v
-         => maybe_wrap_parens
-             p
-             ("Some " ++ show true v)
-       | None => "None"
-       end.
-Global Instance show_list {T} `{Show T} : Show (list T)
-  := fun _ ls => "[" ++ String.concat ", " (List.map (show false) ls) ++ "]".
-Global Instance show_prod {A B} `{Show A, Show B} : Show (A * B)
-  := fun _ '(a, b) => "(" ++ show false a ++ ", " ++ show true b ++ ")".
-Global Instance show_string : Show string := fun _ s => """" ++ s ++ """".
-Global Instance show_ascii : Show ascii := fun _ ch => String "'" (String ch "'").
-
-Global Instance show_lines_option {T} `{ShowLines T} : ShowLines (option T)
-  := fun p v
+Global Instance show_lvl_unit : ShowLevel unit := fun 'tt => neg_wrap_parens "tt".
+Global Instance show_lvl_True : ShowLevel True := fun 'I => neg_wrap_parens "I".
+Global Instance show_lvl_False : ShowLevel False := fun pf => match pf with end.
+Global Instance show_lvl_Empty_set : ShowLevel Empty_set := fun pf => match pf with end.
+Global Instance show_lvl_bool : ShowLevel bool := fun b => neg_wrap_parens (if b then "true" else "false").
+Global Instance show_lvl_option {T} `{ShowLevel T} : ShowLevel (option T)
+  := fun v
      => match v with
         | Some v
-          => maybe_wrap_parens_lines
-               p
-               match show_lines true v with
-               | [s] => ["Show " ++ s]
-               | s => "Show"::List.map (String " ") s
+          => show_lvl_app (fun 'tt => "Some") (show_lvl v)
+        | None => neg_wrap_parens "None"
+        end.
+Global Instance show_option {T} `{Show T} : Show (option T) | 2000 := let __ := @ShowLevel_of_Show T in _.
+Global Instance show_lvl_list {T} `{ShowLevel T} : ShowLevel (list T)
+  := fun ls => neg_wrap_parens
+                 ("[" ++ String.concat ", " (List.map (fun v => show_lvl v term_lvl) ls) ++ "]").
+Global Instance show_list {T} `{Show T} : Show (list T) | 2000 := let __ := @ShowLevel_of_Show T in _.
+Global Instance show_lvl_prod {A B} `{ShowLevel A, ShowLevel B} : ShowLevel (A * B)
+  := fun '(a, b) => show_lvl_binop pair_assoc pair_lvl a ", " b.
+Global Instance show_prod {A B} `{Show A, Show B} : Show (A * B) | 2000 :=
+  let __ := @ShowLevel_of_Show A in
+  let __ := @ShowLevel_of_Show B in
+  _.
+Global Instance show_lvl_string : ShowLevel string := fun s => neg_wrap_parens ("""" ++ (String.replace """" """""" s) ++ """").
+Global Instance show_lvl_ascii : ShowLevel ascii := fun ch => neg_wrap_parens (String "'" (String ch "'")).
+
+Global Instance show_lines_option {T} `{ShowLines T} : ShowLines (option T)
+  := fun v
+     => match v with
+        | Some v
+          => match show_lines v with
+             | [s] => ["Show " ++ s]
+             | s => "Show"::List.map (String " ") s
                end
         | None => ["None"]
         end.
 Global Instance show_lines_list {T} `{ShowLines T} : ShowLines (list T)
-  := fun _ ls
-     => let ls := List.map (show_lines false) ls in
+  := fun ls
+     => let ls := List.map show_lines ls in
         (if List.forallb
               (fun lines => Nat.eqb (List.length lines) 1)
               ls
@@ -74,113 +162,144 @@ Global Instance show_lines_list {T} `{ShowLines T} : ShowLines (list T)
                               ++ ["]"]
                        end)%list.
 Global Instance show_lines_prod {A B} `{ShowLines A, ShowLines B} : ShowLines (A * B)
-  := fun _ '(a, b)
-     => match show_lines false a, show_lines true b with
+  := fun '(a, b)
+     => match show_lines a, show_lines b with
         | [a], [b] => ["(" ++ a ++ ", " ++ b ++ ")"]%string
         | a, b => ["("] ++ a ++ [", "] ++ b ++ [")"]
         end%list.
 
 Module Export Decimal.
-  Global Instance show_positive : Show positive
-    := fun _ p
-       => Decimal.Pos.to_string p.
-  Global Instance show_N : Show N
-    := fun _ n
-       => match n with
-          | N0 => "0"
-          | Npos p => show false p
-          end.
-  Global Instance show_nat : Show nat
-    := fun _ n => show false (N.of_nat n).
-  Global Instance show_Z : Show Z
-    := fun _ z
+  Global Instance show_lvl_positive : ShowLevel positive
+    := fun p => neg_wrap_parens (Decimal.Pos.to_string p).
+  Global Instance show_positive : Show positive := show_lvl_positive.
+  Global Instance show_lvl_N : ShowLevel N
+    := fun n => neg_wrap_parens
+                  match n with
+                  | N0 => "0"
+                  | Npos p => show p
+                  end.
+  Global Instance show_N : Show N := show_lvl_N.
+  Global Instance show_lvl_nat : ShowLevel nat
+    := fun n => show_lvl (N.of_nat n).
+  Global Instance show_nat : Show nat := show_lvl_nat.
+  Global Instance show_lvl_Z : ShowLevel Z
+    := fun z
        => match z with
-          | Zneg p => "-" ++ show false p
-          | Z0 => "0"
-          | Zpos p => show false p
+          | Zneg p => show_lvl_unop opp_lvl "-" p
+          | Z0 => neg_wrap_parens "0"
+          | Zpos p => show_lvl p
           end.
-  Definition show_Q_frac : Show Q
-    := fun parens q
+  Global Instance show_Z : Show Z := show_lvl_Z.
+  Definition show_lvl_Q_frac : ShowLevel Q
+    := fun q
        => if (Qden q =? 1)%positive
-          then show parens (Qnum q)
-          else maybe_wrap_parens
-                 parens
-                 (show true (Qnum q) ++ " / " ++ show true (Qden q)).
-  Global Instance show_Q : Show Q
-    := fun parens q
+          then show_lvl (Qnum q)
+          else show_lvl_binop
+                 div_assoc div_lvl
+                 (Qnum q) " / " (Qden q).
+  Definition show_Q_frac : Show Q := show_lvl_Q_frac.
+  Global Instance show_lvl_Q : ShowLevel Q
+    := fun q
        => if (Qden q =? 1)%positive
-          then show parens (Qnum q)
+          then show_lvl (Qnum q)
           else let lg10 := Z.log10 (Z.pos (Qden q)) in
                if (10^lg10 =? Z.pos (Qden q))%Z
                then let lg10 := Z.to_nat lg10 in
-                    let int_part := show_Z false (Qnum q / Z.pos (Qden q))%Z in
-                    let dec_part := show_Z false (Z.abs (Qnum q) mod (Z.pos (Qden q)))%Z in
-                    int_part
-                      ++ "."
-                      ++ String.string_of_list_ascii (List.repeat "0"%char (lg10 - length dec_part)) ++ dec_part
+                    let int_part := show_Z (Z.abs (Qnum q) / Z.pos (Qden q))%Z in
+                    let dec_part := show_Z (Z.abs (Qnum q) mod (Z.pos (Qden q)))%Z in
+                    let abs_part
+                        := int_part
+                             ++ "."
+                             ++ String.string_of_list_ascii (List.repeat "0"%char (lg10 - length dec_part)) ++ dec_part in
+                    if (Qnum q <? 0)%Z
+                    then show_lvl_unop opp_lvl "-" (fun 'tt => abs_part)
+                    else neg_wrap_parens abs_part
                else
-                 show_Q_frac parens q.
+                 show_lvl_Q_frac q.
+  Global Instance show_Q : Show Q := show_lvl_Q.
 End Decimal.
 
 Module Hex.
-  Definition show_positive : Show positive
-    := fun _ p => HexString.of_pos p.
-  Definition show_Z : Show Z
-    := fun _ z => HexString.of_Z z.
-  Definition show_N : Show N
-    := fun _ n
+  Definition show_lvl_positive : ShowLevel positive
+    := fun p => neg_wrap_parens (HexString.of_pos p).
+  Definition show_positive : Show positive := show_lvl_positive.
+  Definition show_lvl_Z : ShowLevel Z
+    := fun z => let s := HexString.of_Z (Z.abs z) in
+                if z <? 0
+                then show_lvl_unop opp_lvl "-" (fun 'tt => s)
+                else neg_wrap_parens s.
+  Definition show_Z : Show Z := show_lvl_Z.
+  Definition show_lvl_N : ShowLevel N
+    := fun n
        => match n with
-         | N0 => "0"
-         | Npos p => show_positive false p
-         end.
-  Definition show_nat : Show nat
-    := fun _ n => show_N false (N.of_nat n).
-  Definition show_Q : Show Q
-    := fun parens q
+         | N0 => neg_wrap_parens "0"
+         | Npos p => show_lvl_positive p
+          end.
+  Definition show_N : Show N := show_lvl_N.
+  Definition show_lvl_nat : ShowLevel nat
+    := fun n => show_lvl_N (N.of_nat n).
+  Definition show_nat : Show nat := show_lvl_nat.
+  Definition show_lvl_Q : ShowLevel Q
+    := fun q
        => if (Qden q =? 1)%positive
-         then show_Z parens (Qnum q)
-         else maybe_wrap_parens
-                parens
-                (show_Z true (Qnum q) ++ " / " ++ show_positive true (Qden q)).
+          then show_lvl_Z (Qnum q)
+          else show_lvl_binop
+                 div_assoc div_lvl
+                 (show_lvl_Z (Qnum q)) " / " (show_lvl_positive (Qden q)).
+  Definition show_Q : Show Q := show_lvl_Q.
 End Hex.
 
 Module PowersOfTwo.
-  Fixpoint show_Z_up_to' (max : nat) (max_dec : Z) (neg : bool) : Show Z
+  Fixpoint show_lvl_Z_up_to' (max : nat) (max_dec : Z) (neg : bool) : ShowLevel Z
     := match max with
-       | O => Hex.show_Z
+       | O => Hex.show_lvl_Z
        | S n'
-         => fun with_parens z
+         => fun z
             => if z <? max_dec
-               then Decimal.show_Z with_parens z
+               then Decimal.show_lvl_Z z
                else if Z.abs (2^Z.log2_up z - z) <=? Z.abs (z - 2^Z.log2 z)
                     then let log2z := Z.log2_up z in
                          let z := 2^log2z - z in
                          if z =? 0
-                         then "2^" ++ Decimal.show_Z false log2z
-                         else maybe_wrap_parens
-                                with_parens
-                                ("2^" ++ Decimal.show_Z false log2z
-                                      ++ (if neg then "+" else "-")
-                                      ++ show_Z_up_to' n' max_dec (negb neg) false z)
+                         then show_lvl_binop
+                                pow_assoc pow_lvl
+                                2 "^" (Decimal.show_lvl_Z log2z)
+                         else show_lvl_binop
+                                FullyAssoc add_lvl
+                                (show_lvl_binop
+                                   pow_assoc pow_lvl
+                                   2 "^" (Decimal.show_lvl_Z log2z))
+                                (if neg then "+" else "-")
+                                (show_lvl_Z_up_to' n' max_dec (negb neg) z)
                     else let log2z := Z.log2 z in
                          let z := z - 2^log2z in
                          if z =? 0
-                         then "2^" ++ Decimal.show_Z false log2z
-                         else maybe_wrap_parens
-                                with_parens
-                                ("2^" ++ Decimal.show_Z false log2z
-                                      ++ (if neg then "-" else "+")
-                                      ++ show_Z_up_to' n' max_dec neg false z)
+                         then show_lvl_binop
+                                pow_assoc pow_lvl
+                                2 "^" (Decimal.show_lvl_Z log2z)
+                         else show_lvl_binop
+                                FullyAssoc add_lvl
+                                (show_lvl_binop
+                                   pow_assoc pow_lvl
+                                   2 "^" (Decimal.show_lvl_Z log2z))
+                                (if neg then "-" else "+")
+                                (show_lvl_Z_up_to' n' max_dec neg z)
        end%Z%string.
 
-  Definition show_Z_up_to (max : nat) (max_dec : Z) : Show Z
-    := fun with_parens z
+  Definition show_lvl_Z_up_to (max : nat) (max_dec : Z) : ShowLevel Z
+    := fun z
        => (if z <? 0
-           then "-" ++ (show_Z_up_to' max max_dec false true (-z))
+           then fun lvl
+                => maybe_wrap_parens
+                     (lvl <? add_lvl)%level
+                     ("-" ++ show_lvl_Z_up_to' max max_dec false (-z) add_lvl)
            else if z =? 0
-                then "0"
-                else show_Z_up_to' max max_dec false with_parens z)%Z.
-
+                then neg_wrap_parens "0"
+                else show_lvl_Z_up_to' max max_dec false z)%Z.
+  Definition show_Z_up_to (max : nat) (max_dec : Z) : Show Z
+    := show_lvl_Z_up_to max max_dec.
+  Definition show_lvl_Z : ShowLevel Z
+    := fun z => show_lvl_Z_up_to (S (Z.to_nat (Z.log2_up (Z.abs z)))) 32 z.
   Definition show_Z : Show Z
-    := fun with_parens z => show_Z_up_to (S (Z.to_nat (Z.log2_up (Z.abs z)))) 32 with_parens z.
+    := show_lvl_Z.
 End PowersOfTwo.

--- a/src/Util/Strings/Show.v
+++ b/src/Util/Strings/Show.v
@@ -121,16 +121,16 @@ Global Instance show_lvl_option {T} `{ShowLevel T} : ShowLevel (option T)
           => show_lvl_app (fun 'tt => "Some") (show_lvl v)
         | None => neg_wrap_parens "None"
         end.
-Global Instance show_option {T} `{Show T} : Show (option T) | 2000 := let __ := @ShowLevel_of_Show T in _.
+Global Instance show_option {T} `{Show T} : Show (option T) | 2000 := let _ := @ShowLevel_of_Show T in _.
 Global Instance show_lvl_list {T} `{ShowLevel T} : ShowLevel (list T)
   := fun ls => neg_wrap_parens
                  ("[" ++ String.concat ", " (List.map (fun v => show_lvl v term_lvl) ls) ++ "]").
-Global Instance show_list {T} `{Show T} : Show (list T) | 2000 := let __ := @ShowLevel_of_Show T in _.
+Global Instance show_list {T} `{Show T} : Show (list T) | 2000 := let _ := @ShowLevel_of_Show T in _.
 Global Instance show_lvl_prod {A B} `{ShowLevel A, ShowLevel B} : ShowLevel (A * B)
   := fun '(a, b) => show_lvl_binop pair_assoc pair_lvl a ", " b.
 Global Instance show_prod {A B} `{Show A, Show B} : Show (A * B) | 2000 :=
-  let __ := @ShowLevel_of_Show A in
-  let __ := @ShowLevel_of_Show B in
+  let _ := @ShowLevel_of_Show A in
+  let _ := @ShowLevel_of_Show B in
   _.
 Global Instance show_lvl_string : ShowLevel string := fun s => neg_wrap_parens ("""" ++ (String.replace """" """""" s) ++ """").
 Global Instance show_lvl_ascii : ShowLevel ascii := fun ch => neg_wrap_parens (String "'" (String ch "'")).

--- a/src/Util/ZRange/Show.v
+++ b/src/Util/ZRange/Show.v
@@ -4,5 +4,6 @@ Require Import Crypto.Util.ZRange.
 Local Open Scope string_scope.
 
 Global Instance show_zrange : Show zrange
-  := fun _ r
-     => "[" ++ Hex.show_Z false (lower r) ++ " ~> " ++ Hex.show_Z false (upper r) ++ "]".
+  := fun r
+     => "[" ++ Hex.show_Z (lower r) ++ " ~> " ++ Hex.show_Z (upper r) ++ "]".
+Global Instance show_lvl_zrange : ShowLevel zrange := show_zrange.


### PR DESCRIPTION
Now `show` and `show_lines` no longer take a `with_parens` argument, and
instead that functionality is generalized into `ShowLevel` / `show_lvl`.
This is the first step towards having more flexibility in parenthesizing
printed expressions, in a more principled way.  It's sort-of a
test-drive of a more uniform way of level-based printing.