### PR TITLE
Update Zig tests after std.testing.* changes

### DIFF
--- a/fiat-zig/src/main.zig
+++ b/fiat-zig/src/main.zig
@@ -36,7 +36,7 @@ fn testVector(comptime fiat: type, expected_s: []const u8) !void {
     var expected: [as.len]u8 = undefined;
     _ = try fmt.hexToBytes(&expected, expected_s);
     std.debug.print("> {s}\n", .{fmt.fmtSliceHexLower(&as)});
-    std.testing.expectEqualSlices(u8, &expected, &as);
+    try std.testing.expectEqualSlices(u8, &expected, &as);
 }
 
 test "curve25519" {

--- a/inversion/zig/inversion.zig
+++ b/inversion/zig/inversion.zig
@@ -92,5 +92,5 @@ test "Field inversion" {
     const x = Fe.fromBytes(s);
 
     const xinv = x.invert();
-    std.testing.expect(x.mul(xinv).eql(Fe.one));
+    try std.testing.expect(x.mul(xinv).eql(Fe.one));
 }


### PR DESCRIPTION
A breaking change was just introduced in the Zig testing framework.

This updates the Zig tests for it.