### PR TITLE
Switch to a heterogenous `base_interp_beq`

### DIFF
--- a/src/AbstractInterpretation/ZRange.v
+++ b/src/AbstractInterpretation/ZRange.v
@@ -43,7 +43,7 @@ Module Compilers.
              | base.type.type_base base.type.Z => is_tighter_than_bool
              | base.type.type_base _ as t
              | base.type.unit as t
-               => base.interp_beq (@base.base_interp_beq)
+               => base.interp_beq (fun t => @base.base_interp_beq t t)
              | base.type.prod A B
                => fun '(a, b) '(a', b')
                   => @is_tighter_than A a a' && @is_tighter_than B b b'
@@ -57,7 +57,7 @@ Module Compilers.
              | base.type.type_base base.type.Z => fun r z => ZRange.is_bounded_by_bool z r
              | base.type.type_base _ as t
              | base.type.unit as t
-               => base.interp_beq (@base.base_interp_beq)
+               => base.interp_beq (fun t => @base.base_interp_beq t t)
              | base.type.prod A B
                => fun '(a, b) '(a', b')
                   => @is_bounded_by A a a' && @is_bounded_by B b b'
@@ -66,29 +66,36 @@ Module Compilers.
              | base.type.option A
                => option_beq_hetero (@is_bounded_by A)
              end.
-        Fixpoint interp_beq {t} : interp t -> interp t -> bool
-          := match t return interp t -> interp t -> bool with
-             | base.type.type_base base.type.Z => zrange_beq
-             | base.type.type_base _ as t
-             | base.type.unit as t
-               => base.interp_beq (@base.base_interp_beq)
-             | base.type.prod A B
+        Fixpoint interp_beq {t1 t2} : interp t1 -> interp t2 -> bool
+          := match t1, t2 return interp t1 -> interp t2 -> bool with
+             | base.type.type_base base.type.Z, base.type.type_base base.type.Z => zrange_beq
+             | base.type.type_base base.type.Z, _ | _, base.type.type_base base.type.Z => fun _ _ => false
+             | base.type.type_base _ as t1, base.type.type_base _ as t2
+             | base.type.unit as t1, base.type.unit as t2
+               => base.interp_beq_hetero (@base.base_interp_beq)
+             | base.type.prod A1 B1, base.type.prod A2 B2
                => fun '(a, b) '(a', b')
-                  => @interp_beq A a a' && @interp_beq B b b'
-             | base.type.list A
-               => list_beq _ (@interp_beq A)
-             | base.type.option A
-               => option_beq (@interp_beq A)
+                  => @interp_beq A1 A2 a a' && @interp_beq B1 B2 b b'
+             | base.type.list A1, base.type.list A2
+               => list_beq_hetero (@interp_beq A1 A2)
+             | base.type.option A1, base.type.option A2
+               => option_beq_hetero (@interp_beq A1 A2)
+             | base.type.type_base _, _
+             | base.type.unit, _
+             | base.type.prod _ _, _
+             | base.type.list _, _
+             | base.type.option _, _
+               => fun _ _ => false
              end%bool.
 
-        Global Instance reflect_interp_eq {t} : reflect_rel (@eq _) (@interp_beq t).
+        Global Instance reflect_interp_eq {t} : reflect_rel (@eq _) (@interp_beq t t).
         Proof.
           induction t; cbn [interp_beq]; intros; break_innermost_match; try exact _.
         Defined.
 
-        Lemma interp_beq_bl {t x y} : @interp_beq t x y = true -> x = y.
+        Lemma interp_beq_bl {t x y} : @interp_beq t t x y = true -> x = y.
         Proof. apply reflect_to_beq; exact _. Qed.
-        Lemma interp_beq_lb {t x y} : x = y -> @interp_beq t x y = true.
+        Lemma interp_beq_lb {t x y} : x = y -> @interp_beq t t x y = true.
         Proof. apply reflect_to_beq; exact _. Qed.
 
         Module option.
@@ -142,6 +149,17 @@ Module Compilers.
                | base.type.prod A B
                  => fun '(a, b) => a <- @lift_Some A a; b <- @lift_Some B b; Datatypes.Some (a, b)
                end%option.
+          Fixpoint is_informative {t} : interp t -> bool (* true iff there's some bounds info *)
+            := match t with
+               | base.type.type_base _
+               | base.type.list _
+               | base.type.option _
+                 => Option.is_Some
+               | base.type.unit
+                 => fun _ => false
+               | base.type.prod A B
+                 => fun '(a, b) => orb (@is_informative A a) (@is_informative B b)
+               end.
           (** Keep data about list length and nat value, but not zrange *)
           Fixpoint strip_ranges {t} : interp t -> interp t
             := match t with
@@ -196,27 +214,33 @@ Module Compilers.
                        end
                | base.type.unit => fun 'tt 'tt => true
                end.
-          Fixpoint interp_beq {t} : interp t -> interp t -> bool
-            := match t return interp t -> interp t -> bool with
-               | base.type.type_base _ as t => option_beq base.interp_beq
-               | base.type.prod A B
+          Fixpoint interp_beq {t1 t2} : interp t1 -> interp t2 -> bool
+            := match t1, t2 return interp t1 -> interp t2 -> bool with
+               | base.type.type_base _ as t1, base.type.type_base _ as t2 => option_beq_hetero base.interp_beq
+               | base.type.prod A1 B1, base.type.prod A2 B2
                  => fun '(a, b) '(a', b')
-                    => @interp_beq A a a' && @interp_beq B b b'
-               | base.type.list A
-                 => option_beq (list_beq _ (@interp_beq A))
-               | base.type.option A
-                 => option_beq (option_beq (@interp_beq A))
-               | base.type.unit => fun 'tt 'tt => true
+                    => @interp_beq A1 A2 a a' && @interp_beq B1 B2 b b'
+               | base.type.list A1, base.type.list A2
+                 => option_beq_hetero (list_beq_hetero (@interp_beq A1 A2))
+               | base.type.option A1, base.type.option A2
+                 => option_beq_hetero (option_beq_hetero (@interp_beq A1 A2))
+               | base.type.unit, base.type.unit => fun 'tt 'tt => true
+               | base.type.type_base _, _
+               | base.type.unit, _
+               | base.type.prod _ _, _
+               | base.type.list _, _
+               | base.type.option _, _
+                 => fun _ _ => false
                end.
 
-          Global Instance reflect_interp_eq {t} : reflect_rel (@eq _) (@interp_beq t).
+          Global Instance reflect_interp_eq {t} : reflect_rel (@eq _) (@interp_beq t t).
           Proof.
             induction t; cbn [interp_beq]; intros; break_innermost_match; try exact _.
           Defined.
 
-          Lemma interp_beq_bl {t x y} : @interp_beq t x y = true -> x = y.
+          Lemma interp_beq_bl {t x y} : @interp_beq t t x y = true -> x = y.
           Proof. apply reflect_to_beq; exact _. Qed.
-          Lemma interp_beq_lb {t x y} : x = y -> @interp_beq t x y = true.
+          Lemma interp_beq_lb {t x y} : x = y -> @interp_beq t t x y = true.
           Proof. apply reflect_to_beq; exact _. Qed.
 
           Fixpoint is_bounded_by {t} : interp t -> binterp t -> bool

--- a/src/Language/APINotations.v
+++ b/src/Language/APINotations.v
@@ -102,7 +102,7 @@ Module Compilers.
   Global Arguments ident_zrange_rect {_} : assert.
   Global Arguments eta_base_cps {_} _ _ : assert.
   Global Arguments ident_interp {_} _ : assert.
-  Global Arguments base_interp_beq {_} _ _ : assert.
+  Global Arguments base_interp_beq {_ _} _ _ : assert.
   Global Arguments reflect_base_interp_beq {_}.
   Global Arguments ident_is_var_like {_} _ : assert.
   Global Arguments eqv_Reflexive_Proper {_} _.

--- a/src/Util/Bool/Reflect.v
+++ b/src/Util/Bool/Reflect.v
@@ -15,6 +15,7 @@ Require Import Crypto.Util.ListUtil.
 Require Import Crypto.Util.Sum.
 Require Import Crypto.Util.Comparison.
 Require Import Crypto.Util.Tactics.DestructHead.
+Require Import Crypto.Util.Tactics.SplitInContext.
 Require Crypto.Util.PrimitiveProd.
 
 Lemma reflect_to_dec_iff {P b1 b2} : reflect P b1 -> (b1 = b2) <-> (if b2 then P else ~P).
@@ -28,17 +29,17 @@ Proof. intro; apply reflect_to_dec_iff; assumption. Qed.
 Lemma reflect_of_dec {P} {b1 b2 : bool} : reflect P b1 -> (if b2 then P else ~P) -> (b1 = b2).
 Proof. intro; apply reflect_to_dec_iff; assumption. Qed.
 
-Lemma reflect_of_brel {A R Rb} (bl : forall a a' : A, Rb a a' = true -> (R a a' : Prop))
-      (lb : forall a a' : A, R a a' -> Rb a a' = true)
+Lemma reflect_of_brel {A A' R Rb} (bl : forall (a : A) (a' : A'), Rb a a' = true -> (R a a' : Prop))
+      (lb : forall a a', R a a' -> Rb a a' = true)
   : forall x y, reflect (R x y) (Rb x y).
 Proof.
   intros x y; specialize (bl x y); specialize (lb x y).
   destruct (Rb x y); constructor; auto; repeat intro; abstract (exfalso; intuition congruence).
 Qed.
 
-Lemma reflect_to_brel {A R Rb} (H : forall x y : A, reflect (R x y) (Rb x y))
-  : (forall a a' : A, Rb a a' = true -> R a a')
-    /\ (forall a a' : A, R a a' -> Rb a a' = true).
+Lemma reflect_to_brel {A A' R Rb} (H : forall (x : A) (y : A'), reflect (R x y) (Rb x y))
+  : (forall a a', Rb a a' = true -> R a a')
+    /\ (forall a a', R a a' -> Rb a a' = true).
 Proof.
   split; intros x y; specialize (H x y); destruct H; trivial; repeat intro; abstract (exfalso; intuition congruence).
 Qed.
@@ -210,10 +211,15 @@ Ltac solve_reflect_step :=
   first [ match goal with
           | [ H : reflect _ ?b |- _ ] => tryif is_var b then destruct H else (inversion H; clear H)
           | [ |- reflect _ _ ] => constructor
-          | [ |- reflect (?R ?x ?y) (?Rb ?x ?y) ] => apply (@reflect_of_brel _ R Rb)
-          | [ H : forall x y, reflect (?R x y) (?Rb x y) |- _ ] => apply (@reflect_to_brel _ R Rb) in H
+          | [ |- reflect (?R ?x ?y) (?Rb ?x ?y) ] => apply (@reflect_of_brel _ _ R Rb)
+          | [ H : forall x y, reflect (?R x y) (?Rb x y) |- _ ] => apply (@reflect_to_brel _ _ R Rb) in H
+          | [ H : forall a x y, reflect (@?R a x y) (@?Rb a x y) |- _ ]
+            => let H' := fresh in
+               pose proof (fun a => @reflect_to_brel _ _ (R a) (Rb a) (H a)) as H'; clear H;
+               rename H' into H; cbv beta in H
           end
         | progress destruct_head'_and
+        | progress split_and
         | progress intros
         | progress subst
         | solve [ eauto ]
@@ -261,6 +267,9 @@ Local Hint Resolve internal_prod_dec_bl internal_prod_dec_lb
       sig_dec_bl sig_dec_lb
       sig_dec_bl_hprop sig_dec_lb_hprop
       internal_comparison_dec_bl internal_comparison_dec_lb
+      prod_bl_hetero prod_lb_hetero prod_bl_hetero_eq prod_lb_hetero_eq
+      option_bl_hetero option_lb_hetero option_bl_hetero_eq option_lb_hetero_eq
+      list_bl_hetero list_lb_hetero list_bl_hetero_eq list_lb_hetero_eq
   : core.
 
 Local Hint Extern 0 => solve [ solve_reflect ] : typeclass_instances.
@@ -285,27 +294,44 @@ Global Instance reflect_eq_bool : reflect_rel (@eq bool) Bool.eqb | 10. exact _.
 Global Instance reflect_eq_Empty_set : reflect_rel (@eq Empty_set) (fun _ _ => true) | 10. exact _. Qed.
 Global Existing Instances Ascii.eqb_spec String.eqb_spec | 10.
 Global Instance reflect_eq_prod {A B eqA eqB} `{reflect_rel (@eq A) eqA, reflect_rel (@eq B) eqB} : reflect_rel (@eq (A * B)) (prod_beq A B eqA eqB) | 10. exact _. Qed.
+Global Instance reflect_eq_prod_hetero {A1 B1 A2 B2 bA bB RA RB} `{reflect_rel RA bA, reflect_rel RB bB}
+  : reflect_rel (fun (x : A1 * B1) (y : A2 * B2) => RA (fst x) (fst y) /\ RB (snd x) (snd y))
+                (prod_beq_hetero bA bB) | 20.
+Proof. exact _. Qed.
+Global Instance reflect_eq_prod_hetero_uniform {A B eqA eqB} `{reflect_rel (@eq A) eqA, reflect_rel (@eq B) eqB} : reflect_rel (@eq (A * B)) (prod_beq_hetero eqA eqB) | 15. exact _. Qed.
 Global Instance reflect_eq_option {A eqA} `{reflect_rel (@eq A) eqA} : reflect_rel (@eq (option A)) (option_beq eqA) | 10. exact _. Qed.
+Global Instance reflect_eq_option_hetero {A1 A2 bA RA} `{reflect_rel RA bA} : reflect_rel (option_eq RA) (@option_beq_hetero A1 A2 bA) | 20. exact _. Qed.
+Global Instance reflect_eq_option_hetero_uniform {A eqA} `{reflect_rel (@eq A) eqA} : reflect_rel (@eq (option A)) (option_beq_hetero eqA) | 15. exact _. Qed.
 Global Instance reflect_eq_list {A eqA} `{reflect_rel (@eq A) eqA} : reflect_rel (@eq (list A)) (list_beq A eqA) | 10. exact _. Qed.
+Global Instance reflect_eq_list_hetero {A1 A2 RA bA} `{reflect_rel RA bA} : reflect_rel (list_eq RA) (@list_beq_hetero A1 A2 bA) | 20. exact _. Qed.
+Global Instance reflect_eq_list_hetero_uniform {A eqA} `{reflect_rel (@eq A) eqA} : reflect_rel (@eq (list A)) (list_beq_hetero eqA) | 15. exact _. Qed.
 Global Instance reflect_eq_list_nil_r {A eqA} {ls} : reflect (ls = @nil A) (list_beq A eqA ls (@nil A)) | 10.
 Proof. destruct ls; [ left; reflexivity | right; abstract congruence ]. Qed.
 Global Instance reflect_eq_list_nil_l {A eqA} {ls} : reflect (@nil A = ls) (list_beq A eqA (@nil A) ls) | 10.
+Proof. destruct ls; [ left; reflexivity | right; abstract congruence ]. Qed.
+Global Instance reflect_eq_list_nil_r_hetero {A1 A2 eqA} {ls} : reflect (ls = nil) (@list_beq_hetero A1 A2 eqA ls nil) | 10.
+Proof. destruct ls; [ left; reflexivity | right; abstract congruence ]. Qed.
+Global Instance reflect_eq_list_nil_l_hetero {A1 A2 eqA} {ls} : reflect (nil = ls) (@list_beq_hetero A1 A2 eqA nil ls) | 10.
 Proof. destruct ls; [ left; reflexivity | right; abstract congruence ]. Qed.
 Global Instance reflect_eq_sum {A B eqA eqB} `{reflect_rel (@eq A) eqA, reflect_rel (@eq B) eqB} : reflect_rel (@eq (A + B)) (sum_beq A B eqA eqB) | 10. exact _. Qed.
 Global Instance reflect_sumwise {A B RA RB eqA eqB} `{reflect_rel RA eqA, reflect_rel RB eqB} : reflect_rel (@sumwise A B RA RB) (@sum_beq A B eqA eqB) | 100.
 Proof. intros [?|?] [?|?]; cbn; exact _. Qed.
 Global Instance reflect_sum_le {A B RA RB leA leB} `{reflect_rel RA leA, reflect_rel RB leB} : reflect_rel (@sum_le A B RA RB) (@sum_leb A B leA leB) | 10.
 Proof. intros [?|?] [?|?]; cbn; exact _. Qed.
+Global Instance reflect_eq_sigT {A P eqA} {eqP : forall a a', P a -> P a' -> bool}
+       `{reflect_rel (@eq A) eqA, forall a : A, reflect_rel (@eq (P a)) (eqP a a)}
+  : reflect_rel (@eq (@sigT A P)) (sigT_beq eqA eqP) | 15.
+Proof. exact _. Qed.
 Global Instance reflect_eq_sigT_hprop {A P eqA} `{reflect_rel (@eq A) eqA, forall a : A, IsHProp (P a)} : reflect_rel (@eq (@sigT A P)) (sigT_beq eqA (fun _ _ _ _ => true)) | 10. exact _. Qed.
 Global Instance reflect_eq_sig_hprop {A eqA} {P : A -> Prop} `{reflect_rel (@eq A) eqA, forall a : A, IsHProp (P a)} : reflect_rel (@eq (@sig A P)) (sig_beq eqA (fun _ _ _ _ => true)) | 10. exact _. Qed.
 Global Instance reflect_eq_comparison : reflect_rel (@eq comparison) comparison_beq | 10. exact _. Qed.
-Global Instance reflect_eq_None_r {A x} : reflect (x = @None A) (is_None x) | 10.
+Global Instance reflect_eq_None_r {A x} : reflect (x = @None A) (is_None x) | 100.
 Proof. destruct x; cbv; constructor; congruence. Qed.
-Global Instance reflect_eq_None_l {A x} : reflect (@None A = x) (is_None x) | 10.
+Global Instance reflect_eq_None_l {A x} : reflect (@None A = x) (is_None x) | 100.
 Proof. destruct x; cbv; constructor; congruence. Qed.
-Global Instance reflect_eq_nil_r {A x} : reflect (x = @nil A) (is_nil x) | 10.
+Global Instance reflect_eq_nil_r {A x} : reflect (x = @nil A) (is_nil x) | 100.
 Proof. destruct x; cbv; constructor; congruence. Qed.
-Global Instance reflect_eq_nil_l {A x} : reflect (@nil A = x) (is_nil x) | 10.
+Global Instance reflect_eq_nil_l {A x} : reflect (@nil A = x) (is_nil x) | 100.
 Proof. destruct x; cbv; constructor; congruence. Qed.
 
 Module Export Primitive.

--- a/src/Util/ListUtil.v
+++ b/src/Util/ListUtil.v
@@ -1,4 +1,5 @@
 Require Import Coq.Lists.List.
+Require Import Coq.Lists.SetoidList.
 Require Import Coq.micromega.Lia.
 Require Import Coq.Arith.Peano_dec.
 Require Import Coq.ZArith.ZArith.
@@ -442,6 +443,24 @@ Lemma list_lb_hetero {A B} {AB_beq : A -> B -> bool} {AB_R : A -> B -> Prop}
 Proof using Type.
   induction x, y; cbn in *; rewrite ?Bool.andb_true_iff; intuition (congruence || eauto).
 Qed.
+
+Lemma list_beq_hetero_uniform {A : Type} A_beq {x y}
+  : list_beq_hetero A_beq x y = @list_beq A A_beq x y.
+Proof. destruct x, y; cbn; reflexivity. Qed.
+
+Lemma list_bl_hetero_eq {A}
+      {A_beq : A -> A -> bool}
+      (A_bl : forall x y, A_beq x y = true -> x = y)
+      {x y}
+  : list_beq_hetero A_beq x y = true -> x = y.
+Proof using Type. rewrite list_beq_hetero_uniform; now apply internal_list_dec_bl. Qed.
+
+Lemma list_lb_hetero_eq {A}
+      {A_beq : A -> A -> bool}
+      (A_lb : forall x y, x = y -> A_beq x y = true)
+      {x y}
+  : x = y -> list_beq_hetero A_beq x y = true.
+Proof using Type. rewrite list_beq_hetero_uniform; now apply internal_list_dec_lb. Qed.
 
 Lemma nth_default_cons : forall {T} (x u0 : T) us, nth_default x (u0 :: us) 0 = u0.
 Proof. auto. Qed.

--- a/src/Util/Option.v
+++ b/src/Util/Option.v
@@ -124,6 +124,24 @@ Proof using Type.
   destruct x, y; cbn in *; eauto; intuition congruence.
 Qed.
 
+Lemma option_beq_hetero_uniform {A : Type} A_beq {x y}
+  : option_beq_hetero A_beq x y = @option_beq A A_beq x y.
+Proof. destruct x, y; reflexivity. Qed.
+
+Lemma option_bl_hetero_eq {A}
+      {A_beq : A -> A -> bool}
+      (A_bl : forall x y, A_beq x y = true -> x = y)
+      {x y}
+  : option_beq_hetero A_beq x y = true -> x = y.
+Proof using Type. rewrite option_beq_hetero_uniform; now apply internal_option_dec_bl. Qed.
+
+Lemma option_lb_hetero_eq {A}
+      {A_beq : A -> A -> bool}
+      (A_lb : forall x y, x = y -> A_beq x y = true)
+      {x y}
+  : x = y -> option_beq_hetero A_beq x y = true.
+Proof using Type. rewrite option_beq_hetero_uniform; now apply internal_option_dec_lb. Qed.
+
 Global Instance bind_Proper {A B}
   : Proper (eq ==> (pointwise_relation _ eq) ==> eq) (@bind A B).
 Proof.


### PR DESCRIPTION
This is in preparation for having typedefs based on bounds info.

If this passes CI, then we can merge mit-plv/rewriter#28.