### PR TITLE
Zig backend: favor "inline fn" over "fn ... callconv(.Inline)"

### DIFF
--- a/fiat-zig/src/curve25519_32.zig
+++ b/fiat-zig/src/curve25519_32.zig
@@ -37,7 +37,7 @@ pub const TightFieldElement = [10]u32;
 /// Output Bounds:
 ///   out1: [0x0 ~> 0x3ffffff]
 ///   out2: [0x0 ~> 0x1]
-fn addcarryxU26(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn addcarryxU26(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(u32, arg1) + arg2) + arg3);
@@ -60,7 +60,7 @@ fn addcarryxU26(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(
 /// Output Bounds:
 ///   out1: [0x0 ~> 0x3ffffff]
 ///   out2: [0x0 ~> 0x1]
-fn subborrowxU26(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn subborrowxU26(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = cast(i32, (cast(i64, cast(i32, (cast(i64, arg2) - cast(i64, arg1)))) - cast(i64, arg3)));
@@ -83,7 +83,7 @@ fn subborrowxU26(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv
 /// Output Bounds:
 ///   out1: [0x0 ~> 0x1ffffff]
 ///   out2: [0x0 ~> 0x1]
-fn addcarryxU25(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn addcarryxU25(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(u32, arg1) + arg2) + arg3);
@@ -106,7 +106,7 @@ fn addcarryxU25(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(
 /// Output Bounds:
 ///   out1: [0x0 ~> 0x1ffffff]
 ///   out2: [0x0 ~> 0x1]
-fn subborrowxU25(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn subborrowxU25(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = cast(i32, (cast(i64, cast(i32, (cast(i64, arg2) - cast(i64, arg1)))) - cast(i64, arg3)));
@@ -127,7 +127,7 @@ fn subborrowxU25(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv
 ///   arg3: [0x0 ~> 0xffffffff]
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
-fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (~(~arg1));

--- a/fiat-zig/src/curve25519_64.zig
+++ b/fiat-zig/src/curve25519_64.zig
@@ -37,7 +37,7 @@ pub const TightFieldElement = [5]u64;
 /// Output Bounds:
 ///   out1: [0x0 ~> 0x7ffffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn addcarryxU51(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn addcarryxU51(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(u64, arg1) + arg2) + arg3);
@@ -60,7 +60,7 @@ fn addcarryxU51(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(
 /// Output Bounds:
 ///   out1: [0x0 ~> 0x7ffffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn subborrowxU51(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn subborrowxU51(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = cast(i64, (cast(i128, cast(i64, (cast(i128, arg2) - cast(i128, arg1)))) - cast(i128, arg3)));
@@ -81,7 +81,7 @@ fn subborrowxU51(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv
 ///   arg3: [0x0 ~> 0xffffffffffffffff]
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
-fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (~(~arg1));

--- a/fiat-zig/src/p224_32.zig
+++ b/fiat-zig/src/p224_32.zig
@@ -42,7 +42,7 @@ pub const NonMontgomeryDomainFieldElement = [7]u32;
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn addcarryxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn addcarryxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(u64, arg1) + cast(u64, arg2)) + cast(u64, arg3));
@@ -65,7 +65,7 @@ fn addcarryxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn subborrowxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn subborrowxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(i64, arg2) - cast(i64, arg1)) - cast(i64, arg3));
@@ -87,7 +87,7 @@ fn subborrowxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0xffffffff]
-fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) callconv(.Inline) void {
+inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (cast(u64, arg1) * cast(u64, arg2));
@@ -108,7 +108,7 @@ fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) callconv(.Inline) void 
 ///   arg3: [0x0 ~> 0xffffffff]
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
-fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (~(~arg1));

--- a/fiat-zig/src/p224_64.zig
+++ b/fiat-zig/src/p224_64.zig
@@ -42,7 +42,7 @@ pub const NonMontgomeryDomainFieldElement = [4]u64;
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn addcarryxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn addcarryxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(u128, arg1) + cast(u128, arg2)) + cast(u128, arg3));
@@ -65,7 +65,7 @@ fn addcarryxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn subborrowxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn subborrowxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(i128, arg2) - cast(i128, arg1)) - cast(i128, arg3));
@@ -87,7 +87,7 @@ fn subborrowxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0xffffffffffffffff]
-fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) callconv(.Inline) void {
+inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (cast(u128, arg1) * cast(u128, arg2));
@@ -108,7 +108,7 @@ fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) callconv(.Inline) void 
 ///   arg3: [0x0 ~> 0xffffffffffffffff]
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
-fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (~(~arg1));

--- a/fiat-zig/src/p256_32.zig
+++ b/fiat-zig/src/p256_32.zig
@@ -42,7 +42,7 @@ pub const NonMontgomeryDomainFieldElement = [8]u32;
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn addcarryxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn addcarryxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(u64, arg1) + cast(u64, arg2)) + cast(u64, arg3));
@@ -65,7 +65,7 @@ fn addcarryxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn subborrowxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn subborrowxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(i64, arg2) - cast(i64, arg1)) - cast(i64, arg3));
@@ -87,7 +87,7 @@ fn subborrowxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0xffffffff]
-fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) callconv(.Inline) void {
+inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (cast(u64, arg1) * cast(u64, arg2));
@@ -108,7 +108,7 @@ fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) callconv(.Inline) void 
 ///   arg3: [0x0 ~> 0xffffffff]
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
-fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (~(~arg1));

--- a/fiat-zig/src/p256_64.zig
+++ b/fiat-zig/src/p256_64.zig
@@ -42,7 +42,7 @@ pub const NonMontgomeryDomainFieldElement = [4]u64;
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn addcarryxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn addcarryxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(u128, arg1) + cast(u128, arg2)) + cast(u128, arg3));
@@ -65,7 +65,7 @@ fn addcarryxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn subborrowxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn subborrowxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(i128, arg2) - cast(i128, arg1)) - cast(i128, arg3));
@@ -87,7 +87,7 @@ fn subborrowxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0xffffffffffffffff]
-fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) callconv(.Inline) void {
+inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (cast(u128, arg1) * cast(u128, arg2));
@@ -108,7 +108,7 @@ fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) callconv(.Inline) void 
 ///   arg3: [0x0 ~> 0xffffffffffffffff]
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
-fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (~(~arg1));

--- a/fiat-zig/src/p384_32.zig
+++ b/fiat-zig/src/p384_32.zig
@@ -42,7 +42,7 @@ pub const NonMontgomeryDomainFieldElement = [12]u32;
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn addcarryxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn addcarryxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(u64, arg1) + cast(u64, arg2)) + cast(u64, arg3));
@@ -65,7 +65,7 @@ fn addcarryxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn subborrowxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn subborrowxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(i64, arg2) - cast(i64, arg1)) - cast(i64, arg3));
@@ -87,7 +87,7 @@ fn subborrowxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0xffffffff]
-fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) callconv(.Inline) void {
+inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (cast(u64, arg1) * cast(u64, arg2));
@@ -108,7 +108,7 @@ fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) callconv(.Inline) void 
 ///   arg3: [0x0 ~> 0xffffffff]
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
-fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (~(~arg1));

--- a/fiat-zig/src/p384_64.zig
+++ b/fiat-zig/src/p384_64.zig
@@ -42,7 +42,7 @@ pub const NonMontgomeryDomainFieldElement = [6]u64;
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn addcarryxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn addcarryxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(u128, arg1) + cast(u128, arg2)) + cast(u128, arg3));
@@ -65,7 +65,7 @@ fn addcarryxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn subborrowxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn subborrowxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(i128, arg2) - cast(i128, arg1)) - cast(i128, arg3));
@@ -87,7 +87,7 @@ fn subborrowxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0xffffffffffffffff]
-fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) callconv(.Inline) void {
+inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (cast(u128, arg1) * cast(u128, arg2));
@@ -108,7 +108,7 @@ fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) callconv(.Inline) void 
 ///   arg3: [0x0 ~> 0xffffffffffffffff]
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
-fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (~(~arg1));

--- a/fiat-zig/src/p434_64.zig
+++ b/fiat-zig/src/p434_64.zig
@@ -42,7 +42,7 @@ pub const NonMontgomeryDomainFieldElement = [7]u64;
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn addcarryxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn addcarryxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(u128, arg1) + cast(u128, arg2)) + cast(u128, arg3));
@@ -65,7 +65,7 @@ fn addcarryxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn subborrowxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn subborrowxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(i128, arg2) - cast(i128, arg1)) - cast(i128, arg3));
@@ -87,7 +87,7 @@ fn subborrowxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0xffffffffffffffff]
-fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) callconv(.Inline) void {
+inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (cast(u128, arg1) * cast(u128, arg2));
@@ -108,7 +108,7 @@ fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) callconv(.Inline) void 
 ///   arg3: [0x0 ~> 0xffffffffffffffff]
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
-fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (~(~arg1));

--- a/fiat-zig/src/p448_solinas_32.zig
+++ b/fiat-zig/src/p448_solinas_32.zig
@@ -37,7 +37,7 @@ pub const TightFieldElement = [16]u32;
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xfffffff]
 ///   out2: [0x0 ~> 0x1]
-fn addcarryxU28(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn addcarryxU28(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(u32, arg1) + arg2) + arg3);
@@ -60,7 +60,7 @@ fn addcarryxU28(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xfffffff]
 ///   out2: [0x0 ~> 0x1]
-fn subborrowxU28(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn subborrowxU28(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = cast(i32, (cast(i64, cast(i32, (cast(i64, arg2) - cast(i64, arg1)))) - cast(i64, arg3)));
@@ -81,7 +81,7 @@ fn subborrowxU28(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv
 ///   arg3: [0x0 ~> 0xffffffff]
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
-fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (~(~arg1));

--- a/fiat-zig/src/p448_solinas_64.zig
+++ b/fiat-zig/src/p448_solinas_64.zig
@@ -37,7 +37,7 @@ pub const TightFieldElement = [8]u64;
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn addcarryxU56(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn addcarryxU56(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(u64, arg1) + arg2) + arg3);
@@ -60,7 +60,7 @@ fn addcarryxU56(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn subborrowxU56(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn subborrowxU56(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = cast(i64, (cast(i128, cast(i64, (cast(i128, arg2) - cast(i128, arg1)))) - cast(i128, arg3)));
@@ -81,7 +81,7 @@ fn subborrowxU56(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv
 ///   arg3: [0x0 ~> 0xffffffffffffffff]
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
-fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (~(~arg1));

--- a/fiat-zig/src/p521_64.zig
+++ b/fiat-zig/src/p521_64.zig
@@ -37,7 +37,7 @@ pub const TightFieldElement = [9]u64;
 /// Output Bounds:
 ///   out1: [0x0 ~> 0x3ffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn addcarryxU58(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn addcarryxU58(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(u64, arg1) + arg2) + arg3);
@@ -60,7 +60,7 @@ fn addcarryxU58(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(
 /// Output Bounds:
 ///   out1: [0x0 ~> 0x3ffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn subborrowxU58(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn subborrowxU58(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = cast(i64, (cast(i128, cast(i64, (cast(i128, arg2) - cast(i128, arg1)))) - cast(i128, arg3)));
@@ -83,7 +83,7 @@ fn subborrowxU58(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv
 /// Output Bounds:
 ///   out1: [0x0 ~> 0x1ffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn addcarryxU57(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn addcarryxU57(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(u64, arg1) + arg2) + arg3);
@@ -106,7 +106,7 @@ fn addcarryxU57(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(
 /// Output Bounds:
 ///   out1: [0x0 ~> 0x1ffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn subborrowxU57(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn subborrowxU57(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = cast(i64, (cast(i128, cast(i64, (cast(i128, arg2) - cast(i128, arg1)))) - cast(i128, arg3)));
@@ -127,7 +127,7 @@ fn subborrowxU57(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv
 ///   arg3: [0x0 ~> 0xffffffffffffffff]
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
-fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (~(~arg1));

--- a/fiat-zig/src/poly1305_32.zig
+++ b/fiat-zig/src/poly1305_32.zig
@@ -37,7 +37,7 @@ pub const TightFieldElement = [5]u32;
 /// Output Bounds:
 ///   out1: [0x0 ~> 0x3ffffff]
 ///   out2: [0x0 ~> 0x1]
-fn addcarryxU26(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn addcarryxU26(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(u32, arg1) + arg2) + arg3);
@@ -60,7 +60,7 @@ fn addcarryxU26(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(
 /// Output Bounds:
 ///   out1: [0x0 ~> 0x3ffffff]
 ///   out2: [0x0 ~> 0x1]
-fn subborrowxU26(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn subborrowxU26(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = cast(i32, (cast(i64, cast(i32, (cast(i64, arg2) - cast(i64, arg1)))) - cast(i64, arg3)));
@@ -81,7 +81,7 @@ fn subborrowxU26(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv
 ///   arg3: [0x0 ~> 0xffffffff]
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
-fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (~(~arg1));

--- a/fiat-zig/src/poly1305_64.zig
+++ b/fiat-zig/src/poly1305_64.zig
@@ -37,7 +37,7 @@ pub const TightFieldElement = [3]u64;
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xfffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn addcarryxU44(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn addcarryxU44(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(u64, arg1) + arg2) + arg3);
@@ -60,7 +60,7 @@ fn addcarryxU44(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xfffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn subborrowxU44(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn subborrowxU44(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = cast(i64, (cast(i128, cast(i64, (cast(i128, arg2) - cast(i128, arg1)))) - cast(i128, arg3)));
@@ -83,7 +83,7 @@ fn subborrowxU44(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv
 /// Output Bounds:
 ///   out1: [0x0 ~> 0x7ffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn addcarryxU43(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn addcarryxU43(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(u64, arg1) + arg2) + arg3);
@@ -106,7 +106,7 @@ fn addcarryxU43(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(
 /// Output Bounds:
 ///   out1: [0x0 ~> 0x7ffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn subborrowxU43(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn subborrowxU43(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = cast(i64, (cast(i128, cast(i64, (cast(i128, arg2) - cast(i128, arg1)))) - cast(i128, arg3)));
@@ -127,7 +127,7 @@ fn subborrowxU43(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv
 ///   arg3: [0x0 ~> 0xffffffffffffffff]
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
-fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (~(~arg1));

--- a/fiat-zig/src/secp256k1_32.zig
+++ b/fiat-zig/src/secp256k1_32.zig
@@ -42,7 +42,7 @@ pub const NonMontgomeryDomainFieldElement = [8]u32;
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn addcarryxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn addcarryxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(u64, arg1) + cast(u64, arg2)) + cast(u64, arg3));
@@ -65,7 +65,7 @@ fn addcarryxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn subborrowxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn subborrowxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(i64, arg2) - cast(i64, arg1)) - cast(i64, arg3));
@@ -87,7 +87,7 @@ fn subborrowxU32(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) callconv
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0xffffffff]
-fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) callconv(.Inline) void {
+inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (cast(u64, arg1) * cast(u64, arg2));
@@ -108,7 +108,7 @@ fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) callconv(.Inline) void 
 ///   arg3: [0x0 ~> 0xffffffff]
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
-fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) callconv(.Inline) void {
+inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (~(~arg1));

--- a/fiat-zig/src/secp256k1_64.zig
+++ b/fiat-zig/src/secp256k1_64.zig
@@ -42,7 +42,7 @@ pub const NonMontgomeryDomainFieldElement = [4]u64;
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn addcarryxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn addcarryxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(u128, arg1) + cast(u128, arg2)) + cast(u128, arg3));
@@ -65,7 +65,7 @@ fn addcarryxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
-fn subborrowxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn subborrowxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = ((cast(i128, arg2) - cast(i128, arg1)) - cast(i128, arg3));
@@ -87,7 +87,7 @@ fn subborrowxU64(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) callconv
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0xffffffffffffffff]
-fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) callconv(.Inline) void {
+inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (cast(u128, arg1) * cast(u128, arg2));
@@ -108,7 +108,7 @@ fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) callconv(.Inline) void 
 ///   arg3: [0x0 ~> 0xffffffffffffffff]
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
-fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) callconv(.Inline) void {
+inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
     const x1 = (~(~arg1));

--- a/src/Stringification/Zig.v
+++ b/src/Stringification/Zig.v
@@ -310,9 +310,9 @@ Module Zig.
              (f : type.for_each_lhs_of_arrow var_data t * var_data (type.base (type.final_codomain t)) * IR.expr)
     : list string :=
     let '(args, rets, body) := f in
-    ((if private then "fn " else "pub fn ") ++ name ++
+    ((if private then "inline fn " else "pub fn ") ++ name ++
       "(" ++ String.concat ", " (to_arg_list internal_private all_private prefix Out rets ++ to_arg_list_for_each_lhs_of_arrow internal_private all_private prefix args) ++
-      ")" ++ (if private then " callconv(.Inline) " else " ") ++ "void {")%string :: (["    @setRuntimeSafety(mode == .Debug);"; ""]%string)%list ++ (List.map (fun s => "    " ++ s)%string (to_strings internal_private prefix body)) ++ ["}"%string]%list.
+      ") void {")%string :: (["    @setRuntimeSafety(mode == .Debug);"; ""]%string)%list ++ (List.map (fun s => "    " ++ s)%string (to_strings internal_private prefix body)) ++ ["}"%string]%list.
 
   (** In Zig, there is no munging of return arguments (they remain
       passed by pointers), so all variables are live *)


### PR DESCRIPTION
Both are equivalent, but the former is now preferred.

No functional changes.