### PR TITLE
Zig: emulate unsafe casts

### DIFF
--- a/fiat-zig/src/curve25519_32.zig
+++ b/fiat-zig/src/curve25519_32.zig
@@ -13,8 +13,20 @@
 //   balance = [0x7ffffda, 0x3fffffe, 0x7fffffe, 0x3fffffe, 0x7fffffe, 0x3fffffe, 0x7fffffe, 0x3fffffe, 0x7fffffe, 0x3fffffe]
 
 const std = @import("std");
-const cast = std.meta.cast;
 const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+
+inline fn cast(comptime DestType: type, target: anytype) DestType {
+    if (@typeInfo(@TypeOf(target)) == .Int) {
+        const dest = @typeInfo(DestType).Int;
+        const source = @typeInfo(@TypeOf(target)).Int;
+        if (dest.bits < source.bits) {
+            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
+        } else {
+            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+        }
+    }
+    return @as(DestType, target);
+}
 
 // The type LooseFieldElement is a field element with loose bounds.
 // Bounds: [[0x0 ~> 0xc000000], [0x0 ~> 0x6000000], [0x0 ~> 0xc000000], [0x0 ~> 0x6000000], [0x0 ~> 0xc000000], [0x0 ~> 0x6000000], [0x0 ~> 0xc000000], [0x0 ~> 0x6000000], [0x0 ~> 0xc000000], [0x0 ~> 0x6000000]]

--- a/fiat-zig/src/curve25519_64.zig
+++ b/fiat-zig/src/curve25519_64.zig
@@ -13,8 +13,20 @@
 //   balance = [0xfffffffffffda, 0xffffffffffffe, 0xffffffffffffe, 0xffffffffffffe, 0xffffffffffffe]
 
 const std = @import("std");
-const cast = std.meta.cast;
 const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+
+inline fn cast(comptime DestType: type, target: anytype) DestType {
+    if (@typeInfo(@TypeOf(target)) == .Int) {
+        const dest = @typeInfo(DestType).Int;
+        const source = @typeInfo(@TypeOf(target)).Int;
+        if (dest.bits < source.bits) {
+            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
+        } else {
+            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+        }
+    }
+    return @as(DestType, target);
+}
 
 // The type LooseFieldElement is a field element with loose bounds.
 // Bounds: [[0x0 ~> 0x18000000000000], [0x0 ~> 0x18000000000000], [0x0 ~> 0x18000000000000], [0x0 ~> 0x18000000000000], [0x0 ~> 0x18000000000000]]

--- a/fiat-zig/src/p224_32.zig
+++ b/fiat-zig/src/p224_32.zig
@@ -18,8 +18,20 @@
 //                            if x1 & (2^224-1) < 2^223 then x1 & (2^224-1) else (x1 & (2^224-1)) - 2^224
 
 const std = @import("std");
-const cast = std.meta.cast;
 const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+
+inline fn cast(comptime DestType: type, target: anytype) DestType {
+    if (@typeInfo(@TypeOf(target)) == .Int) {
+        const dest = @typeInfo(DestType).Int;
+        const source = @typeInfo(@TypeOf(target)).Int;
+        if (dest.bits < source.bits) {
+            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
+        } else {
+            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+        }
+    }
+    return @as(DestType, target);
+}
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.
 // Bounds: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]

--- a/fiat-zig/src/p224_64.zig
+++ b/fiat-zig/src/p224_64.zig
@@ -18,8 +18,20 @@
 //                            if x1 & (2^256-1) < 2^255 then x1 & (2^256-1) else (x1 & (2^256-1)) - 2^256
 
 const std = @import("std");
-const cast = std.meta.cast;
 const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+
+inline fn cast(comptime DestType: type, target: anytype) DestType {
+    if (@typeInfo(@TypeOf(target)) == .Int) {
+        const dest = @typeInfo(DestType).Int;
+        const source = @typeInfo(@TypeOf(target)).Int;
+        if (dest.bits < source.bits) {
+            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
+        } else {
+            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+        }
+    }
+    return @as(DestType, target);
+}
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.
 // Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]

--- a/fiat-zig/src/p256_32.zig
+++ b/fiat-zig/src/p256_32.zig
@@ -18,8 +18,20 @@
 //                            if x1 & (2^256-1) < 2^255 then x1 & (2^256-1) else (x1 & (2^256-1)) - 2^256
 
 const std = @import("std");
-const cast = std.meta.cast;
 const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+
+inline fn cast(comptime DestType: type, target: anytype) DestType {
+    if (@typeInfo(@TypeOf(target)) == .Int) {
+        const dest = @typeInfo(DestType).Int;
+        const source = @typeInfo(@TypeOf(target)).Int;
+        if (dest.bits < source.bits) {
+            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
+        } else {
+            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+        }
+    }
+    return @as(DestType, target);
+}
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.
 // Bounds: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]

--- a/fiat-zig/src/p256_64.zig
+++ b/fiat-zig/src/p256_64.zig
@@ -18,8 +18,20 @@
 //                            if x1 & (2^256-1) < 2^255 then x1 & (2^256-1) else (x1 & (2^256-1)) - 2^256
 
 const std = @import("std");
-const cast = std.meta.cast;
 const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+
+inline fn cast(comptime DestType: type, target: anytype) DestType {
+    if (@typeInfo(@TypeOf(target)) == .Int) {
+        const dest = @typeInfo(DestType).Int;
+        const source = @typeInfo(@TypeOf(target)).Int;
+        if (dest.bits < source.bits) {
+            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
+        } else {
+            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+        }
+    }
+    return @as(DestType, target);
+}
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.
 // Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]

--- a/fiat-zig/src/p384_32.zig
+++ b/fiat-zig/src/p384_32.zig
@@ -18,8 +18,20 @@
 //                            if x1 & (2^384-1) < 2^383 then x1 & (2^384-1) else (x1 & (2^384-1)) - 2^384
 
 const std = @import("std");
-const cast = std.meta.cast;
 const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+
+inline fn cast(comptime DestType: type, target: anytype) DestType {
+    if (@typeInfo(@TypeOf(target)) == .Int) {
+        const dest = @typeInfo(DestType).Int;
+        const source = @typeInfo(@TypeOf(target)).Int;
+        if (dest.bits < source.bits) {
+            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
+        } else {
+            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+        }
+    }
+    return @as(DestType, target);
+}
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.
 // Bounds: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]

--- a/fiat-zig/src/p384_64.zig
+++ b/fiat-zig/src/p384_64.zig
@@ -18,8 +18,20 @@
 //                            if x1 & (2^384-1) < 2^383 then x1 & (2^384-1) else (x1 & (2^384-1)) - 2^384
 
 const std = @import("std");
-const cast = std.meta.cast;
 const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+
+inline fn cast(comptime DestType: type, target: anytype) DestType {
+    if (@typeInfo(@TypeOf(target)) == .Int) {
+        const dest = @typeInfo(DestType).Int;
+        const source = @typeInfo(@TypeOf(target)).Int;
+        if (dest.bits < source.bits) {
+            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
+        } else {
+            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+        }
+    }
+    return @as(DestType, target);
+}
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.
 // Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]

--- a/fiat-zig/src/p434_64.zig
+++ b/fiat-zig/src/p434_64.zig
@@ -18,8 +18,20 @@
 //                            if x1 & (2^448-1) < 2^447 then x1 & (2^448-1) else (x1 & (2^448-1)) - 2^448
 
 const std = @import("std");
-const cast = std.meta.cast;
 const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+
+inline fn cast(comptime DestType: type, target: anytype) DestType {
+    if (@typeInfo(@TypeOf(target)) == .Int) {
+        const dest = @typeInfo(DestType).Int;
+        const source = @typeInfo(@TypeOf(target)).Int;
+        if (dest.bits < source.bits) {
+            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
+        } else {
+            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+        }
+    }
+    return @as(DestType, target);
+}
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.
 // Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]

--- a/fiat-zig/src/p448_solinas_32.zig
+++ b/fiat-zig/src/p448_solinas_32.zig
@@ -13,8 +13,20 @@
 //   balance = [0x1ffffffe, 0x1ffffffe, 0x1ffffffe, 0x1ffffffe, 0x1ffffffe, 0x1ffffffe, 0x1ffffffe, 0x1ffffffe, 0x1ffffffc, 0x1ffffffe, 0x1ffffffe, 0x1ffffffe, 0x1ffffffe, 0x1ffffffe, 0x1ffffffe, 0x1ffffffe]
 
 const std = @import("std");
-const cast = std.meta.cast;
 const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+
+inline fn cast(comptime DestType: type, target: anytype) DestType {
+    if (@typeInfo(@TypeOf(target)) == .Int) {
+        const dest = @typeInfo(DestType).Int;
+        const source = @typeInfo(@TypeOf(target)).Int;
+        if (dest.bits < source.bits) {
+            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
+        } else {
+            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+        }
+    }
+    return @as(DestType, target);
+}
 
 // The type LooseFieldElement is a field element with loose bounds.
 // Bounds: [[0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000]]

--- a/fiat-zig/src/p448_solinas_64.zig
+++ b/fiat-zig/src/p448_solinas_64.zig
@@ -13,8 +13,20 @@
 //   balance = [0x1fffffffffffffe, 0x1fffffffffffffe, 0x1fffffffffffffe, 0x1fffffffffffffe, 0x1fffffffffffffc, 0x1fffffffffffffe, 0x1fffffffffffffe, 0x1fffffffffffffe]
 
 const std = @import("std");
-const cast = std.meta.cast;
 const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+
+inline fn cast(comptime DestType: type, target: anytype) DestType {
+    if (@typeInfo(@TypeOf(target)) == .Int) {
+        const dest = @typeInfo(DestType).Int;
+        const source = @typeInfo(@TypeOf(target)).Int;
+        if (dest.bits < source.bits) {
+            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
+        } else {
+            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+        }
+    }
+    return @as(DestType, target);
+}
 
 // The type LooseFieldElement is a field element with loose bounds.
 // Bounds: [[0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000]]

--- a/fiat-zig/src/p521_64.zig
+++ b/fiat-zig/src/p521_64.zig
@@ -13,8 +13,20 @@
 //   balance = [0x7fffffffffffffe, 0x7fffffffffffffe, 0x7fffffffffffffe, 0x7fffffffffffffe, 0x7fffffffffffffe, 0x7fffffffffffffe, 0x7fffffffffffffe, 0x7fffffffffffffe, 0x3fffffffffffffe]
 
 const std = @import("std");
-const cast = std.meta.cast;
 const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+
+inline fn cast(comptime DestType: type, target: anytype) DestType {
+    if (@typeInfo(@TypeOf(target)) == .Int) {
+        const dest = @typeInfo(DestType).Int;
+        const source = @typeInfo(@TypeOf(target)).Int;
+        if (dest.bits < source.bits) {
+            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
+        } else {
+            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+        }
+    }
+    return @as(DestType, target);
+}
 
 // The type LooseFieldElement is a field element with loose bounds.
 // Bounds: [[0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0x600000000000000]]

--- a/fiat-zig/src/poly1305_32.zig
+++ b/fiat-zig/src/poly1305_32.zig
@@ -13,8 +13,20 @@
 //   balance = [0x7fffff6, 0x7fffffe, 0x7fffffe, 0x7fffffe, 0x7fffffe]
 
 const std = @import("std");
-const cast = std.meta.cast;
 const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+
+inline fn cast(comptime DestType: type, target: anytype) DestType {
+    if (@typeInfo(@TypeOf(target)) == .Int) {
+        const dest = @typeInfo(DestType).Int;
+        const source = @typeInfo(@TypeOf(target)).Int;
+        if (dest.bits < source.bits) {
+            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
+        } else {
+            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+        }
+    }
+    return @as(DestType, target);
+}
 
 // The type LooseFieldElement is a field element with loose bounds.
 // Bounds: [[0x0 ~> 0xc000000], [0x0 ~> 0xc000000], [0x0 ~> 0xc000000], [0x0 ~> 0xc000000], [0x0 ~> 0xc000000]]

--- a/fiat-zig/src/poly1305_64.zig
+++ b/fiat-zig/src/poly1305_64.zig
@@ -13,8 +13,20 @@
 //   balance = [0x1ffffffffff6, 0xffffffffffe, 0xffffffffffe]
 
 const std = @import("std");
-const cast = std.meta.cast;
 const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+
+inline fn cast(comptime DestType: type, target: anytype) DestType {
+    if (@typeInfo(@TypeOf(target)) == .Int) {
+        const dest = @typeInfo(DestType).Int;
+        const source = @typeInfo(@TypeOf(target)).Int;
+        if (dest.bits < source.bits) {
+            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
+        } else {
+            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+        }
+    }
+    return @as(DestType, target);
+}
 
 // The type LooseFieldElement is a field element with loose bounds.
 // Bounds: [[0x0 ~> 0x300000000000], [0x0 ~> 0x180000000000], [0x0 ~> 0x180000000000]]

--- a/fiat-zig/src/secp256k1_32.zig
+++ b/fiat-zig/src/secp256k1_32.zig
@@ -18,8 +18,20 @@
 //                            if x1 & (2^256-1) < 2^255 then x1 & (2^256-1) else (x1 & (2^256-1)) - 2^256
 
 const std = @import("std");
-const cast = std.meta.cast;
 const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+
+inline fn cast(comptime DestType: type, target: anytype) DestType {
+    if (@typeInfo(@TypeOf(target)) == .Int) {
+        const dest = @typeInfo(DestType).Int;
+        const source = @typeInfo(@TypeOf(target)).Int;
+        if (dest.bits < source.bits) {
+            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
+        } else {
+            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+        }
+    }
+    return @as(DestType, target);
+}
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.
 // Bounds: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]

--- a/fiat-zig/src/secp256k1_64.zig
+++ b/fiat-zig/src/secp256k1_64.zig
@@ -18,8 +18,20 @@
 //                            if x1 & (2^256-1) < 2^255 then x1 & (2^256-1) else (x1 & (2^256-1)) - 2^256
 
 const std = @import("std");
-const cast = std.meta.cast;
 const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+
+inline fn cast(comptime DestType: type, target: anytype) DestType {
+    if (@typeInfo(@TypeOf(target)) == .Int) {
+        const dest = @typeInfo(DestType).Int;
+        const source = @typeInfo(@TypeOf(target)).Int;
+        if (dest.bits < source.bits) {
+            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
+        } else {
+            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+        }
+    }
+    return @as(DestType, target);
+}
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.
 // Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]

--- a/src/Stringification/Zig.v
+++ b/src/Stringification/Zig.v
@@ -95,9 +95,21 @@ Module Zig.
              (typedef_map : list typedef_info)
     : list string
     := (["";
-        "const std = @import(""std"");";
-        "const cast = std.meta.cast;";
-        "const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels"]
+         "const std = @import(""std"");";
+         "const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels";
+         "";
+         "inline fn cast(comptime DestType: type, target: anytype) DestType {";
+         "    if (@typeInfo(@TypeOf(target)) == .Int) {";
+         "        const dest = @typeInfo(DestType).Int;";
+         "        const source = @typeInfo(@TypeOf(target)).Int;";
+         "        if (dest.bits < source.bits) {";
+         "            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));";
+         "        } else {";
+         "            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));";
+         "        }";
+         "    }";
+         "    return @as(DestType, target);";
+         "}"]
           ++ (if skip_typedefs
               then []
               else List.flat_map


### PR DESCRIPTION
Unsafe C-like casts have been removed from the language (or, rather, moved to a dark corner).

So, include code to emulate them by upcasting or downcasting at compile time according to the source and target bit sizes.