### PR TITLE
Bump minimum Coq dependency to 8.11, use coqutil

### DIFF
--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -17,14 +17,10 @@ jobs:
         - { COQ_VERSION: "8.13.1", COQ_PACKAGE: "coq-8.13.1 libcoq-8.13.1-ocaml-dev", SKIP_BEDROCK2: "" , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
         - { COQ_VERSION: "8.12.2", COQ_PACKAGE: "coq-8.12.2 libcoq-8.12.2-ocaml-dev", SKIP_BEDROCK2: "1", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
         - { COQ_VERSION: "8.11.1", COQ_PACKAGE: "coq-8.11.1 libcoq-8.11.1-ocaml-dev", SKIP_BEDROCK2: "1", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
-        - { COQ_VERSION: "8.10.2", COQ_PACKAGE: "coq-8.10.2 libcoq-8.10.2-ocaml-dev", SKIP_BEDROCK2: "1", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
-        - { COQ_VERSION: "8.9.1" , COQ_PACKAGE: "coq-8.9.1 libcoq-8.9.1-ocaml-dev"  , SKIP_BEDROCK2: "1", SKIP_VALIDATE: "1", PPA: "ppa:jgross-h/many-coq-versions" }
         - { COQ_VERSION: "master", COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_BEDROCK2: "" , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-master-daily", EXTRA_GH_REPORTIFY: "--warnings" }
         - { COQ_VERSION: "v8.13" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_BEDROCK2: "" , SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.13-daily" }
         - { COQ_VERSION: "v8.12" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_BEDROCK2: "1", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.12-daily" }
         - { COQ_VERSION: "v8.11" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_BEDROCK2: "1", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.11-daily" }
-        - { COQ_VERSION: "v8.10" , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_BEDROCK2: "1", SKIP_VALIDATE: "" , PPA: "ppa:jgross-h/coq-8.10-daily" }
-        - { COQ_VERSION: "v8.9"  , COQ_PACKAGE: "coq libcoq-ocaml-dev"              , SKIP_BEDROCK2: "1", SKIP_VALIDATE: "1", PPA: "ppa:jgross-h/coq-8.9-daily" }
         ghc: [ 'latest' ]
         cabal: [ 'latest' ]
         os: ['ubuntu-latest']

--- a/.gitignore
+++ b/.gitignore
@@ -107,8 +107,6 @@ _build/
 setup.data
 setup.log
 
-/_CoqProject
-
 # Merlin configuring file for Vim and Emacs
 .merlin
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Building
 [pkg.go-shield]: https://pkg.go.dev/badge/github.com/mit-plv/fiat-crypto/fiat-go.svg
 [pkg.go-link]: https://pkg.go.dev/github.com/mit-plv/fiat-crypto/fiat-go
 
-This repository requires [Coq](https://coq.inria.fr/) [8.9](https://github.com/coq/coq/releases/tag/V8.9.0) or later.
+This repository requires [Coq](https://coq.inria.fr/) [8.11](https://github.com/coq/coq/releases/tag/V8.11.0) or later.
 Note that if you install Coq from Ubuntu aptitude packages, you need `libcoq-ocaml-dev` in addition to `coq`.
 Note that in some cases (such as installing Coq via homebrew on Mac), you may also need to install `ocaml-findlib` (for `ocamlfind`).
 If you want to build the bedrock2 code, you need [Coq 8.13](https://github.com/coq/coq/releases/tag/V8.13.0) or later (otherwise you can pass `SKIP_BEDROCK2=1` to `make`).

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,6 +1,6 @@
 -R src Crypto
 -arg -w -arg +implicit-core-hint-db,+implicits-in-term,+non-reversible-notation,+deprecated-intros-until-0,+deprecated-focus,+unused-intro-pattern,+variable-collision,+omega-is-deprecated,+deprecated-instantiate-syntax,+non-recursive
-@NATIVE_COMPILER_ARG@
+-arg -native-compiler -arg ondemand
 src/BoundsPipeline.v
 src/CLI.v
 src/COperationSpecifications.v


### PR DESCRIPTION
Now that Debian bullseye has reached stable, with it's Coq 8.12.0
package, we can bump our minimum version of Coq to 8.11, since the
latest Ubuntu LTS, 20.04 (focal), has 8.11.0.  This allows us to use
coqutil, which is now maintaining compatibility with Coq back to 8.11.

This is blocked on ~https://github.com/mit-plv/rupicola/pull/14~ https://github.com/mit-plv/rupicola/pull/15 (we should update the submodule to point to a commit on master once that's merged).
Before this is merged, we should also tag a final release compatible with Coq 8.9 and 8.10.