### PR TITLE
Add `--no-shiftr-avoid-uint1`

### DIFF
--- a/src/AbstractInterpretation/Proofs.v
+++ b/src/AbstractInterpretation/Proofs.v
@@ -969,7 +969,7 @@ Module Compilers.
 
         Lemma interp_ident_Proper annotate_with_state t idc
           : related_bounded_value (abstract_interp_ident t idc) (UnderLets.interp (@ident_interp) (interp_ident annotate_with_state idc)) (ident_interp idc).
-        Proof.
+        Proof using abstract_domain'_R_symmetric abstract_domain'_R_transitive abstract_interp_ident_Proper abstract_interp_ident_Proper' abstraction_relation'_Proper bottom'_Proper bottom'_related extract_list_state_length_good extract_list_state_related extract_option_state_related interp_annotate_expr strip_annotation_related.
           pose idc as idc'.
           destruct idc; first [ refine (@interp_ident_Proper_not_nth_default _ _ idc')
                               | refine (@interp_ident_Proper_nth_default _ _) ].
@@ -998,7 +998,7 @@ Module Compilers.
                      _
                      (extract e_st st)
                      (type.app_curried (expr.interp (@ident_interp) (eval_with_bound skip_annotations_under annotate_with_state e1 st)) arg1)).
-        Proof. cbv [extract eval_with_bound]; apply @interp_eval_with_bound' with (abstract_domain'_R:=abstract_domain'_R); auto using interp_annotate, interp_ident_Proper, ident.interp_Proper. Qed.
+        Proof using abstract_domain'_R_symmetric abstract_domain'_R_transitive abstract_interp_ident_Proper abstract_interp_ident_Proper' abstraction_relation'_Proper bottom'_Proper bottom'_related extract_list_state_length_good extract_list_state_related extract_option_state_related interp_annotate_expr strip_annotation_related. cbv [extract eval_with_bound]; apply @interp_eval_with_bound' with (abstract_domain'_R:=abstract_domain'_R); auto using interp_annotate, interp_ident_Proper, ident.interp_Proper. Qed.
 
         Lemma interp_eta_expand_with_bound
               {t} (e1 e2 : expr t)
@@ -1010,7 +1010,7 @@ Module Compilers.
                    (Harg12 : type.and_for_each_lhs_of_arrow (@type.eqv) arg1 arg2)
                    (Harg1 : type.and_for_each_lhs_of_arrow (@abstraction_relation) b_in arg1),
             type.app_curried (expr.interp (@ident_interp) (eta_expand_with_bound e1 b_in)) arg1 = type.app_curried (expr.interp (@ident_interp) e2) arg2.
-        Proof. cbv [partial.ident.eta_expand_with_bound]; eapply interp_eta_expand_with_bound'; eauto using interp_annotate, ident.interp_Proper. Qed.
+        Proof using abstract_domain'_R_symmetric abstract_domain'_R_transitive abstract_interp_ident_Proper' abstraction_relation'_Proper bottom'_Proper bottom'_related extract_list_state_length_good extract_list_state_related extract_option_state_related interp_annotate_expr. cbv [partial.ident.eta_expand_with_bound]; eapply interp_eta_expand_with_bound'; eauto using interp_annotate, ident.interp_Proper. Qed.
       End with_type.
     End ident.
 
@@ -1039,8 +1039,8 @@ Module Compilers.
         rewrite Bool.andb_true_iff; split; auto.
       Qed.
 
-      Lemma abstract_interp_ident_related {assume_cast_truncates : bool} {t} (idc : ident t)
-        : type.related_hetero (@abstraction_relation') (@abstract_interp_ident assume_cast_truncates t idc) (ident.interp idc).
+      Lemma abstract_interp_ident_related {opts : AbstractInterpretation.Options} {assume_cast_truncates : bool} {t} (idc : ident t)
+        : type.related_hetero (@abstraction_relation') (abstract_interp_ident assume_cast_truncates t idc) (ident.interp idc).
       Proof using Type. apply ZRange.ident.option.interp_related. Qed.
 
       Local Ltac zrange_interp_idempotent_t :=
@@ -1070,25 +1070,25 @@ Module Compilers.
                        end
                      | progress cbv [is_bounded_by_bool] ].
 
-      Lemma zrange_interp_tighter_bounded_Z_cast {assume_cast_truncates r1 r2 v}
+      Lemma zrange_interp_tighter_bounded_Z_cast {opts : AbstractInterpretation.Options} {assume_cast_truncates r1 r2 v}
             (H1 : ZRange.type.base.option.is_bounded_by (t:=base.type.Z) r1 v = true)
             (H2 : ZRange.type.base.option.is_bounded_by (t:=base.type.Z) r2 v = true)
         : ZRange.type.base.option.is_bounded_by (t:=base.type.Z) (ZRange.ident.option.interp assume_cast_truncates ident.Z_cast r1 r2) v = true.
       Proof using Type. destruct r1, r2, assume_cast_truncates; zrange_interp_idempotent_t. Qed.
 
-      Lemma zrange_interp_tighter_bounded_Z_cast2 {assume_cast_truncates r1 r2 v}
+      Lemma zrange_interp_tighter_bounded_Z_cast2 {opts : AbstractInterpretation.Options} {assume_cast_truncates r1 r2 v}
             (H1 : ZRange.type.base.option.is_bounded_by (t:=base.type.Z*base.type.Z) r1 v = true)
             (H2 : ZRange.type.base.option.is_bounded_by (t:=base.type.Z*base.type.Z) r2 v = true)
         : ZRange.type.base.option.is_bounded_by (t:=base.type.Z*base.type.Z) (ZRange.ident.option.interp assume_cast_truncates ident.Z_cast2 r1 r2) v = true.
       Proof using Type. destruct r1, r2, assume_cast_truncates; zrange_interp_idempotent_t. Qed.
 
       Local Notation related_bounded_value := (@related_bounded_value base.type ident abstract_domain' base.interp (@ident.interp) (@abstraction_relation') bottom' (fun t => abstract_domain'_R t)).
-      Lemma always_strip_annotation_related {assume_cast_truncates : bool} {t} (idc : ident t)
-            v (Hv : @always_strip_annotation assume_cast_truncates _ t idc = Some v)
-        : related_bounded_value (@abstract_interp_ident assume_cast_truncates t idc) v (ident.interp idc).
+      Lemma always_strip_annotation_related {opts : AbstractInterpretation.Options} {assume_cast_truncates : bool} {t} (idc : ident t)
+            v (Hv : always_strip_annotation assume_cast_truncates t idc = Some v)
+        : related_bounded_value (abstract_interp_ident assume_cast_truncates t idc) v (ident.interp idc).
       Proof using Type.
-        pose proof (@abstract_interp_ident_related assume_cast_truncates _ ident.Z_cast).
-        pose proof (fun x1 x2 y1 y2 H x01 x02 y01 y02 H' => @abstract_interp_ident_related assume_cast_truncates _ ident.Z_cast2 (x1, x2) (y1, y2) H (x01, x02) (y01, y02) H').
+        pose proof (@abstract_interp_ident_related _ assume_cast_truncates _ ident.Z_cast).
+        pose proof (fun x1 x2 y1 y2 H x01 x02 y01 y02 H' => @abstract_interp_ident_related _ assume_cast_truncates _ ident.Z_cast2 (x1, x2) (y1, y2) H (x01, x02) (y01, y02) H').
         cbv [always_strip_annotation] in *; break_innermost_match_hyps; inversion_option; subst.
         all: repeat first [ reflexivity
                           | progress cbn [related_bounded_value UnderLets.interp fst snd type.related_hetero] in *
@@ -1130,7 +1130,7 @@ Module Compilers.
                           | match goal with
                             | [ H : ZRange.ident.option.interp ?act ident.Z_cast ?r1 ?r2 = Some ?r3 |- ZRange.type.base.is_bounded_by ?r3 ?v = true ]
                               => let H' := fresh in
-                                 pose proof (@zrange_interp_tighter_bounded_Z_cast act r1 r2 v) as H';
+                                 pose proof (@zrange_interp_tighter_bounded_Z_cast _ act r1 r2 v) as H';
                                  rewrite H in H'; now apply H'
                             | [ H : context G[ZRange.ident.option.interp ?act ident.Z_cast2 ?r1 ?r2] |- _ ]
                               => let G' := context G[(ZRange.ident.option.interp act ident.Z_cast (fst r1) (fst r2),
@@ -1139,9 +1139,9 @@ Module Compilers.
                             end ].
       Qed.
 
-      Lemma strip_annotation_related {assume_cast_truncates strip_annotations : bool} {t} (idc : ident t)
-            v (Hv : @strip_annotation assume_cast_truncates strip_annotations _ t idc = Some v)
-        : related_bounded_value (@abstract_interp_ident assume_cast_truncates t idc) v (ident.interp idc).
+      Lemma strip_annotation_related {opts : AbstractInterpretation.Options} {assume_cast_truncates strip_annotations : bool} {t} (idc : ident t)
+            v (Hv : strip_annotation assume_cast_truncates strip_annotations t idc = Some v)
+        : related_bounded_value (abstract_interp_ident assume_cast_truncates t idc) v (ident.interp idc).
       Proof using Type.
         destruct strip_annotations; cbv [strip_annotation] in *; try congruence;
           now apply always_strip_annotation_related.
@@ -1171,7 +1171,7 @@ Module Compilers.
         cbv [abstraction_relation' extract_option_state option_eq]; intros; subst; cbn in *; cbv [option_beq_hetero] in *; break_match; break_match_hyps; auto; congruence.
       Qed.
 
-      Lemma Extract_FromFlat_ToFlat' {assume_cast_truncates : bool} {t} (e : Expr t) (Hwf : Wf e) b_in1 b_in2
+      Lemma Extract_FromFlat_ToFlat' {opts : AbstractInterpretation.Options} {assume_cast_truncates : bool} {t} (e : Expr t) (Hwf : Wf e) b_in1 b_in2
             (Hb : type.and_for_each_lhs_of_arrow (fun t => type.eqv) b_in1 b_in2)
         : partial.Extract assume_cast_truncates (GeneralizeVar.FromFlat (GeneralizeVar.ToFlat e)) b_in1
           = partial.Extract assume_cast_truncates e b_in2.
@@ -1183,13 +1183,13 @@ Module Compilers.
         apply GeneralizeVar.wf_from_flat_to_flat, Hwf.
       Qed.
 
-      Lemma Extract_FromFlat_ToFlat {assume_cast_truncates : bool} {t} (e : Expr t) (Hwf : Wf e) b_in
+      Lemma Extract_FromFlat_ToFlat {opts : AbstractInterpretation.Options} {assume_cast_truncates : bool} {t} (e : Expr t) (Hwf : Wf e) b_in
             (Hb : Proper (type.and_for_each_lhs_of_arrow (fun t => type.eqv)) b_in)
         : partial.Extract assume_cast_truncates (GeneralizeVar.FromFlat (GeneralizeVar.ToFlat e)) b_in
           = partial.Extract assume_cast_truncates e b_in.
       Proof using Type. apply Extract_FromFlat_ToFlat'; assumption. Qed.
 
-      Lemma Extract_GeneralizeVar {assume_cast_truncates : bool} {t} (e : Expr t) (Hwf : Wf e) b_in
+      Lemma Extract_GeneralizeVar {opts : AbstractInterpretation.Options} {assume_cast_truncates : bool} {t} (e : Expr t) (Hwf : Wf e) b_in
             (Hb : Proper (type.and_for_each_lhs_of_arrow (fun t => type.eqv)) b_in)
         : partial.Extract assume_cast_truncates (GeneralizeVar.GeneralizeVar (e _)) b_in
           = partial.Extract assume_cast_truncates e b_in.
@@ -1240,6 +1240,7 @@ Module Compilers.
         Local Hint Resolve interp_annotate_expr abstract_interp_ident_related : core.
 
         Lemma interp_eval_with_bound
+              {opts : AbstractInterpretation.Options}
               {assume_cast_truncates : bool}
               {skip_annotations_under : forall t, ident t -> bool}
               {strip_preexisting_annotations : bool}
@@ -1286,6 +1287,7 @@ Module Compilers.
         Qed.
 
         Lemma Interp_EvalWithBound
+              {opts : AbstractInterpretation.Options}
               {assume_cast_truncates : bool}
               {skip_annotations_under : forall t, ident t -> bool}
               {strip_preexisting_annotations : bool}
@@ -1363,6 +1365,7 @@ Module Compilers.
       Qed.
 
       Lemma interp_strip_annotations
+            {opts : AbstractInterpretation.Options}
             {assume_cast_truncates : bool}
             {t} (e_st e1 e2 : expr t)
             (Hwf : expr.wf3 nil e_st e1 e2)
@@ -1390,6 +1393,7 @@ Module Compilers.
       Qed.
 
       Lemma Interp_StripAnnotations
+            {opts : AbstractInterpretation.Options}
             {assume_cast_truncates : bool}
             {t} (E : Expr t)
             (Hwf : Wf E)
@@ -1401,10 +1405,11 @@ Module Compilers.
           type.app_curried (expr.Interp (@ident.interp) (StripAnnotations assume_cast_truncates E b_in)) arg1
           = type.app_curried (expr.Interp (@ident.interp) E) arg2.
       Proof using Type.
-        apply (@interp_strip_annotations assume_cast_truncates t (E _) (E _) (E _)); try apply expr.Wf3_of_Wf; auto.
+        apply (@interp_strip_annotations _ assume_cast_truncates t (E _) (E _) (E _)); try apply expr.Wf3_of_Wf; auto.
       Qed.
 
       Lemma Interp_StripAnnotations_bounded
+            {opts : AbstractInterpretation.Options}
             {assume_cast_truncates : bool}
             {t} (E : Expr t)
             (Hwf : expr.Wf E)
@@ -1418,7 +1423,7 @@ Module Compilers.
             (type.app_curried (expr.Interp (@ident.interp) (StripAnnotations assume_cast_truncates E b_in)) arg1)
           = true.
       Proof using Type.
-        apply (@interp_strip_annotations assume_cast_truncates t (E _) (E _) (E _)); try apply expr.Wf3_of_Wf; auto.
+        apply (@interp_strip_annotations _ assume_cast_truncates t (E _) (E _) (E _)); try apply expr.Wf3_of_Wf; auto.
       Qed.
 
       Lemma Interp_EtaExpandWithListInfoFromBound
@@ -1441,6 +1446,7 @@ Module Compilers.
   Import API.
 
   Lemma Interp_PartialEvaluateWithBounds
+        {opts : AbstractInterpretation.Options}
         relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations
         (Hrelax : forall r r' z, is_tighter_than_bool z r = true
                                  -> relax_zrange r = Some r'
@@ -1466,6 +1472,7 @@ Module Compilers.
   Qed.
 
   Lemma Interp_PartialEvaluateWithBounds_bounded
+        {opts : AbstractInterpretation.Options}
         relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations
         (Hrelax : forall r r' z, is_tighter_than_bool z r = true
                                  -> relax_zrange r = Some r'
@@ -1489,6 +1496,7 @@ Module Compilers.
   Qed.
 
   Lemma Interp_PartialEvaluateWithListInfoFromBounds
+        {opts : AbstractInterpretation.Options}
         {t} (E : Expr t)
         (Hwf : Wf E)
         (Ht : type.is_not_higher_order t = true)
@@ -1508,6 +1516,7 @@ Module Compilers.
   Qed.
 
   Theorem CheckedPartialEvaluateWithBounds_Correct
+          {opts : AbstractInterpretation.Options}
           (relax_zrange : zrange -> option zrange)
           (assume_cast_truncates : bool)
           (skip_annotations_under : forall t, ident t -> bool)

--- a/src/AbstractInterpretation/Wf.v
+++ b/src/AbstractInterpretation/Wf.v
@@ -841,18 +841,18 @@ Module Compilers.
           -> option_eq (expr.wf nil)
                        (@annotate_expr relax_zrange var1 t s1)
                        (@annotate_expr relax_zrange var2 t s2).
-      Proof.
+      Proof using Type.
         intros ?; subst s2.
         cbv [annotate_expr Crypto.Util.Option.bind option_eq]; break_innermost_match;
           repeat constructor.
       Qed.
 
       Global Instance bottom'_Proper {t} : Proper (abstract_domain'_R t) (bottom' t).
-      Proof. reflexivity. Qed.
+      Proof using Type. reflexivity. Qed.
 
-      Global Instance abstract_interp_ident_Proper {assume_cast_truncates : bool} {t}
+      Global Instance abstract_interp_ident_Proper {opts : AbstractInterpretation.Options} {assume_cast_truncates : bool} {t}
         : Proper (eq ==> @abstract_domain_R t) (abstract_interp_ident assume_cast_truncates t).
-      Proof.
+      Proof using Type.
         cbv [abstract_interp_ident abstract_domain_R type.related respectful type.interp]; intros idc idc' ?; subst idc'; destruct idc;
           repeat first [ reflexivity
                        | progress subst
@@ -889,7 +889,7 @@ Module Compilers.
       Global Instance extract_list_state_Proper {t}
         : Proper (abstract_domain'_R _ ==> option_eq (SetoidList.eqlistA (@abstract_domain'_R t)))
                  (extract_list_state t).
-      Proof.
+      Proof using Type.
         intros st st' ?; subst st'; cbv [option_eq extract_list_state]; break_innermost_match; reflexivity.
       Qed.
 
@@ -905,10 +905,10 @@ Module Compilers.
               (expr.Ident ident.Z_cast2)
               (#(@ident.Literal base.type.zrange r1%zrange), #(@ident.Literal base.type.zrange r2%zrange))%expr_pat).
 
-      Lemma wf_always_strip_annotation (assume_cast_truncates : bool) {var1 var2} G {t} idc
+      Lemma wf_always_strip_annotation {opts : AbstractInterpretation.Options} (assume_cast_truncates : bool) {var1 var2} G {t} idc
         : option_eq (wf_value G)
-                    (@always_strip_annotation assume_cast_truncates var1 t idc)
-                    (@always_strip_annotation assume_cast_truncates var2 t idc).
+                    (always_strip_annotation assume_cast_truncates (var:=var1) t idc)
+                    (always_strip_annotation assume_cast_truncates (var:=var2) t idc).
       Proof using Type.
         cbv [always_strip_annotation]; break_innermost_match; try reflexivity;
           cbn [option_eq wf_value].
@@ -927,10 +927,10 @@ Module Compilers.
                           | progress cbn [abstract_domain_R type.related] in * ].
       Qed.
 
-      Lemma wf_strip_annotation (assume_cast_truncates : bool) (strip_annotations : bool) {var1 var2} G {t} idc
+      Lemma wf_strip_annotation {opts : AbstractInterpretation.Options} (assume_cast_truncates : bool) (strip_annotations : bool) {var1 var2} G {t} idc
         : option_eq (wf_value G)
-                    (@strip_annotation assume_cast_truncates strip_annotations var1 t idc)
-                    (@strip_annotation assume_cast_truncates strip_annotations var2 t idc).
+                    (strip_annotation assume_cast_truncates strip_annotations (var:=var1) t idc)
+                    (strip_annotation assume_cast_truncates strip_annotations (var:=var2) t idc).
       Proof using Type.
         cbv [strip_annotation]; break_innermost_match; now try apply wf_always_strip_annotation.
       Qed.
@@ -946,7 +946,7 @@ Module Compilers.
                       ((fun '(r1, r2) => (annotation_of_state relax_zrange r1, annotation_of_state relax_zrange r2))
                          (rew pf in st) = (Some r1, Some r2))
                       /\ existT (@expr var) t e = existT (@expr var) _ (cstZZ r1 r2))).
-      Proof.
+      Proof using Type.
         split.
         { cbv [is_annotated_for]; break_innermost_match; try discriminate.
           all: rewrite ?Bool.andb_true_iff.
@@ -985,7 +985,7 @@ Module Compilers.
           -> ((abstract_domain'_R _ ==> eq)%signature)
                (@is_annotated_for relax_zrange var1 t t' e1)
                (@is_annotated_for relax_zrange var2 t t' e2).
-      Proof.
+      Proof using Type.
         repeat intro; subst;
           match goal with |- ?x = ?y => destruct x eqn:?, y eqn:? end.
         all: repeat first [ match goal with
@@ -1052,19 +1052,19 @@ Module Compilers.
 
       Lemma extract_list_state_length
         : forall t v1 v2, abstract_domain'_R _ v1 v2 -> option_map (@length _) (extract_list_state t v1) = option_map (@length _) (extract_list_state t v2).
-      Proof.
+      Proof using Type.
         intros; subst; cbv [option_map extract_list_state]; break_innermost_match; reflexivity.
       Qed.
       Lemma extract_list_state_rel
         : forall t v1 v2, abstract_domain'_R _ v1 v2 -> forall l1 l2, extract_list_state t v1 = Some l1 -> extract_list_state t v2 = Some l2 -> List.Forall2 (@abstract_domain'_R t) l1 l2.
-      Proof.
+      Proof using Type.
         intros; cbv [extract_list_state] in *; subst; inversion_option; subst.
         now rewrite Forall2_Forall, Forall_forall; cbv [Proper].
       Qed.
 
       Lemma extract_option_state_rel
         : forall t v1 v2, abstract_domain'_R _ v1 v2 -> option_eq (option_eq (abstract_domain'_R _)) (extract_option_state t v1) (extract_option_state t v2).
-      Proof.
+      Proof using Type.
         cbv [extract_option_state option_eq]; intros; subst; break_match; reflexivity.
       Qed.
 
@@ -1072,10 +1072,10 @@ Module Compilers.
         Context {var1 var2 : type -> Type}.
         Local Notation wf_value_with_lets := (@wf_value_with_lets base.type ident abstract_domain' (fun t => abstract_domain'_R t) var1 var2).
 
-        Lemma wf_eval {t} G G' e1 e2 (Hwf : expr.wf G e1 e2)
+        Lemma wf_eval {opts : AbstractInterpretation.Options} {t} G G' e1 e2 (Hwf : expr.wf G e1 e2)
               (HGG' : forall t v1 v2, List.In (existT _ t (v1, v2)) G -> wf_value_with_lets G' v1 v2)
-          : expr.wf G' (@eval var1 t e1) (@eval var2 t e2).
-        Proof.
+          : expr.wf G' (t:=t) (eval (var:=var1) e1) (eval (var:=var2) e2).
+        Proof using Type.
           eapply ident.wf_eval;
             solve [ eassumption
                   | exact _
@@ -1091,10 +1091,12 @@ Module Compilers.
           : expr.wf G (@strip_all_annotations strip_annotations_under var1 t e1) (@strip_all_annotations strip_annotations_under var2 t e2).
         Proof using Type. revert Hwf; apply ident.wf_strip_all_annotations, @wf_annotation_to_cast. Qed.
 
-        Lemma wf_eval_with_bound {relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations t} G G' e1 e2 (Hwf : expr.wf G e1 e2) st1 st2 (Hst : type.and_for_each_lhs_of_arrow (@abstract_domain_R) st1 st2)
+        Lemma wf_eval_with_bound {opts : AbstractInterpretation.Options} {relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations t} G G' e1 e2 (Hwf : expr.wf G e1 e2) st1 st2 (Hst : type.and_for_each_lhs_of_arrow (@abstract_domain_R) st1 st2)
               (HGG' : forall t v1 v2, List.In (existT _ t (v1, v2)) G -> wf_value_with_lets G' v1 v2)
-          : expr.wf G' (@eval_with_bound relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations var1 t e1 st1) (@eval_with_bound relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations var2 t e2 st2).
-        Proof.
+          : expr.wf G' (var1:=var1) (var2:=var2) (t:=t)
+                    (eval_with_bound relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations e1 st1)
+                    (eval_with_bound relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations e2 st2).
+        Proof using Type.
           eapply ident.wf_eval_with_bound;
             solve [ eassumption
                   | exact _
@@ -1106,10 +1108,10 @@ Module Compilers.
                   | apply is_annotated_for_Proper ].
         Qed.
 
-        Lemma wf_strip_annotations {assume_cast_truncates} {t} G G' e1 e2 (Hwf : expr.wf G e1 e2) st1 st2 (Hst : type.and_for_each_lhs_of_arrow (@abstract_domain_R) st1 st2)
+        Lemma wf_strip_annotations {opts : AbstractInterpretation.Options} {assume_cast_truncates} {t} G G' e1 e2 (Hwf : expr.wf G e1 e2) st1 st2 (Hst : type.and_for_each_lhs_of_arrow (@abstract_domain_R) st1 st2)
               (HGG' : forall t v1 v2, List.In (existT _ t (v1, v2)) G -> wf_value_with_lets G' v1 v2)
-          : expr.wf G' (@strip_annotations assume_cast_truncates var1 t e1 st1) (@strip_annotations assume_cast_truncates var2 t e2 st2).
-        Proof.
+          : expr.wf G' (t:=t) (strip_annotations assume_cast_truncates (var:=var1) e1 st1) (strip_annotations assume_cast_truncates (var:=var2) e2 st2).
+        Proof using Type.
           eapply ident.wf_eval_with_bound;
             solve [ eassumption
                   | exact _
@@ -1122,8 +1124,8 @@ Module Compilers.
         Qed.
 
         Lemma wf_eta_expand_with_bound {relax_zrange t} G e1 e2 (Hwf : expr.wf G e1 e2) st1 st2 (Hst : type.and_for_each_lhs_of_arrow (@abstract_domain_R) st1 st2)
-          : expr.wf G (@eta_expand_with_bound relax_zrange var1 t e1 st1) (@eta_expand_with_bound relax_zrange var2 t e2 st2).
-        Proof.
+          : expr.wf G (t:=t) (eta_expand_with_bound relax_zrange (var:=var1) e1 st1) (eta_expand_with_bound relax_zrange (var:=var2) e2 st2).
+        Proof using Type.
           eapply ident.wf_eta_expand_with_bound;
             solve [ eassumption
                   | exact _
@@ -1140,32 +1142,32 @@ Module Compilers.
         intros ??; now apply wf_strip_all_annotations.
       Qed.
 
-      Lemma Wf_Eval {t} (e : Expr t) (Hwf : Wf e) : Wf (Eval e).
-      Proof.
+      Lemma Wf_Eval {opts : AbstractInterpretation.Options} {t} (e : Expr t) (Hwf : Wf e) : Wf (Eval e).
+      Proof using Type.
         intros ??; eapply wf_eval with (G:=nil); cbn [List.In]; try apply Hwf; tauto.
       Qed.
 
-      Lemma Wf_EvalWithBound {relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations t} (e : Expr t) bound (Hwf : Wf e) (bound_valid : Proper (type.and_for_each_lhs_of_arrow (@abstract_domain_R)) bound)
+      Lemma Wf_EvalWithBound {opts : AbstractInterpretation.Options} {relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations t} (e : Expr t) bound (Hwf : Wf e) (bound_valid : Proper (type.and_for_each_lhs_of_arrow (@abstract_domain_R)) bound)
         : Wf (EvalWithBound relax_zrange assume_cast_truncates skip_annotations_under strip_preexisting_annotations e bound).
-      Proof.
+      Proof using Type.
         intros ??; eapply wf_eval_with_bound with (G:=nil); cbn [List.In]; try apply Hwf; tauto.
       Qed.
 
-      Lemma Wf_StripAnnotations {assume_cast_truncates} {t} (e : Expr t) bound (Hwf : Wf e) (bound_valid : Proper (type.and_for_each_lhs_of_arrow (@abstract_domain_R)) bound)
+      Lemma Wf_StripAnnotations {opts : AbstractInterpretation.Options} {assume_cast_truncates} {t} (e : Expr t) bound (Hwf : Wf e) (bound_valid : Proper (type.and_for_each_lhs_of_arrow (@abstract_domain_R)) bound)
         : Wf (StripAnnotations assume_cast_truncates e bound).
-      Proof.
+      Proof using Type.
         intros ??; eapply wf_strip_annotations with (G:=nil); cbn [List.In]; try tauto; apply Hwf.
       Qed.
 
       Lemma Wf_EtaExpandWithBound {relax_zrange t} (e : Expr t) bound (Hwf : Wf e) (bound_valid : Proper (type.and_for_each_lhs_of_arrow (@abstract_domain_R)) bound)
         : Wf (EtaExpandWithBound relax_zrange e bound).
-      Proof.
+      Proof using Type.
         intros ??; eapply wf_eta_expand_with_bound with (G:=nil); cbn [List.In]; try apply Hwf; tauto.
       Qed.
 
       Local Instance Proper_strip_ranges {t}
         : Proper (@abstract_domain_R t ==> @abstract_domain_R t) (@ZRange.type.option.strip_ranges t).
-      Proof.
+      Proof using Type.
         cbv [Proper abstract_domain_R respectful].
         induction t as [t|s IHs d IHd]; cbn in *; destruct_head'_prod; destruct_head'_and; cbn in *; intros; subst; cbv [respectful] in *;
           eauto.
@@ -1173,7 +1175,7 @@ Module Compilers.
 
       Lemma Wf_EtaExpandWithListInfoFromBound {t} (e : Expr t) bound (Hwf : Wf e) (bound_valid : Proper (type.and_for_each_lhs_of_arrow (@abstract_domain_R)) bound)
         : Wf (EtaExpandWithListInfoFromBound e bound).
-      Proof.
+      Proof using Type.
         eapply Wf_EtaExpandWithBound; [ assumption | ].
         clear dependent e.
         cbv [Proper] in *; induction t as [t|s IHs d IHd]; cbn in *; destruct_head'_prod; destruct_head'_and; cbn in *; eauto.
@@ -1186,6 +1188,7 @@ Module Compilers.
   Import API.
 
   Lemma Wf_PartialEvaluateWithListInfoFromBounds
+        {opts : AbstractInterpretation.Options}
         {t} (E : Expr t)
         (b_in : type.for_each_lhs_of_arrow ZRange.type.option.interp t)
         (Hwf : Wf E)
@@ -1196,6 +1199,7 @@ Module Compilers.
   Hint Opaque PartialEvaluateWithListInfoFromBounds : wf interp rewrite.
 
   Lemma Wf_PartialEvaluateWithBounds
+        {opts : AbstractInterpretation.Options}
         {relax_zrange} {assume_cast_truncates : bool} {skip_annotations_under : forall t, ident t -> bool} {strip_preexisting_annotations : bool} {t} (E : Expr t)
         (b_in : type.for_each_lhs_of_arrow ZRange.type.option.interp t)
         (Hwf : Wf E)

--- a/src/AbstractInterpretation/ZRange.v
+++ b/src/AbstractInterpretation/ZRange.v
@@ -16,6 +16,24 @@ Module Compilers.
   Export Language.API.Compilers.
 
   Module ZRange.
+    Module Export Settings.
+      Class shiftr_avoid_uint1_opt := shiftr_avoid_uint1 : bool.
+      Typeclasses Opaque shiftr_avoid_uint1_opt.
+      Module AbstractInterpretation.
+        Local Set Primitive Projections.
+        Class Options
+          := { shiftr_avoid_uint1 : shiftr_avoid_uint1_opt
+             }.
+        Definition default_Options : Options
+          := {| shiftr_avoid_uint1 := true |}.
+        Module Export Exports.
+          Global Existing Instance Build_Options.
+          Global Hint Immediate shiftr_avoid_uint1 : typeclass_instances.
+          Global Coercion shiftr_avoid_uint1 : Options >-> shiftr_avoid_uint1_opt.
+        End Exports.
+      End AbstractInterpretation.
+      Export AbstractInterpretation.Exports.
+    End Settings.
     Module type.
       Local Notation binterp := base.interp.
       Local Notation tinterp_gen := type.interp.
@@ -480,7 +498,7 @@ Module Compilers.
              | None, None => None
              end.
         Local Notation tZ := (base.type.type_base base.type.Z).
-        Definition interp (assume_cast_truncates : bool) {t} (idc : ident t) : type.option.interp t
+        Definition interp {shiftr_avoid_uint1 : shiftr_avoid_uint1_opt} (assume_cast_truncates : bool) {t} (idc : ident t) : type.option.interp t
           := let interp_Z_cast := if assume_cast_truncates then interp_Z_cast_truncate else interp_Z_cast in
              match idc in ident.ident t return type.option.interp t with
              | ident.Literal t v => @of_literal (base.type.type_base t) v
@@ -713,9 +731,12 @@ Module Compilers.
              | ident.Z_sub as idc
                => fun x y => x <- x; y <- y; Some (ZRange.four_corners (ident.interp idc) x y)
              | ident.Z_div as idc
-             | ident.Z_shiftr as idc
              | ident.Z_shiftl as idc
                => fun x y => x <- x; y <- y; Some (ZRange.four_corners_and_zero (ident.interp idc) x y)
+             | ident.Z_shiftr as idc
+               => fun x y => x <- x; y <- y; Some (let r := ZRange.four_corners_and_zero (ident.interp idc) x y in
+                                                   (* kludge to avoid uint1 after >> *)
+                                                   if shiftr_avoid_uint1 && (r =? r[0~>1]) then r[0~>2] else r)
              | ident.Z_add_with_carry as idc
                => fun x y z => x <- x; y <- y; z <- z; Some (ZRange.eight_corners (ident.interp idc) x y z)
              | ident.Z_cc_m as idc
@@ -888,4 +909,5 @@ Module Compilers.
       End option.
     End ident.
   End ZRange.
+  Export ZRange.Settings.
 End Compilers.

--- a/src/AbstractInterpretation/ZRange.v
+++ b/src/AbstractInterpretation/ZRange.v
@@ -25,7 +25,7 @@ Module Compilers.
           := { shiftr_avoid_uint1 : shiftr_avoid_uint1_opt
              }.
         Definition default_Options : Options
-          := {| shiftr_avoid_uint1 := true |}.
+          := {| shiftr_avoid_uint1 := false |}.
         Module Export Exports.
           Global Existing Instance Build_Options.
           Global Hint Immediate shiftr_avoid_uint1 : typeclass_instances.

--- a/src/Bedrock/Field/Stringification/Stringification.v
+++ b/src/Bedrock/Field/Stringification/Stringification.v
@@ -150,6 +150,7 @@ Notation wrapper_relax_zrange relax_zrange
 
 (* TODO: for now, name_list is just ignored -- could probably make it not ignored *)
 Definition Bedrock2_ToFunctionLines
+           {opts : AbstractInterpretation.Options}
            {relax_zrange : relax_zrange_opt}
            {language_naming_conventions : language_naming_conventions_opt}
            {documentation_options : documentation_options_opt}

--- a/src/Bedrock/Field/Translation/Parameters/Defaults.v
+++ b/src/Bedrock/Field/Translation/Parameters/Defaults.v
@@ -20,6 +20,10 @@ Global Existing Instances Types.rep.Z Types.rep.listZ_mem.
 Global Existing Instance default_low_level_rewriter_method.
 (* Output options involving typedefs, carry bounds, etc, which are generally not relevant to bedrock2 *)
 Global Existing Instance default_output_options.
+(* Abstract interpretation options; currently only involving (>>) uint1 bounds, which is not relevant to bedrock2 *)
+Global Instance : AbstractInterpretation.Options
+  := let _ := AbstractInterpretation.default_Options in
+     {| AbstractInterpretation.shiftr_avoid_uint1 := false (* we need to not avoid uint1 to pass bounds analysis tightness, for some reason? *) |}.
 (* Split multiplications into two outputs, not just one huge word *)
 Global Instance should_split_mul : should_split_mul_opt := true.
 (* For functions that return multiple values, split into two LetIns (this is

--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -161,6 +161,7 @@ Module typedef.
   Global Arguments description {_ _ _} _.
 End typedef.
 Notation typedef := typedef.typedef (only parsing).
+Export ZRange.Settings.
 (** Which of the rewriter methods do we use? *)
 (** Note that we don't currently generate a precomputed naive method, because it eats too much RAM to do so. *)
 Inductive low_level_rewriter_method_opt :=
@@ -391,6 +392,7 @@ Module Pipeline.
          => let _ := default_language_naming_conventions in
             let _ := default_documentation_options in
             let _ := default_output_options in
+            let _ := AbstractInterpretation.default_Options in
             match ToString.ToFunctionLines
                     (relax_zrange := fun r => r)
                     machine_wordsize
@@ -505,6 +507,7 @@ Module Pipeline.
              end; |}.
 
   Definition PreBoundsPipeline
+             {opts : AbstractInterpretation.Options}
              {low_level_rewriter_method : low_level_rewriter_method_opt}
              {only_signed : only_signed_opt}
              {unfold_value_barrier : unfold_value_barrier_opt}
@@ -543,6 +546,7 @@ Module Pipeline.
        List.fold_right (fun f v => f v) E (List.repeat (RewriteRules.RewriteAddAssocLeft opts) n).
 
   Definition BoundsPipeline
+             {opts : AbstractInterpretation.Options}
              {low_level_rewriter_method : low_level_rewriter_method_opt}
              {only_signed : only_signed_opt}
              {no_select_size : no_select_size_opt}
@@ -637,6 +641,7 @@ Module Pipeline.
       end.
 
   Definition BoundsPipelineToExtendedResult
+             {opts : AbstractInterpretation.Options}
              {output_language_api : ToString.OutputLanguageAPI}
              {language_naming_conventions : language_naming_conventions_opt}
              {documentation_options : documentation_options_opt}
@@ -686,6 +691,7 @@ Module Pipeline.
        end.
 
   Definition BoundsPipelineToStrings
+             {opts : AbstractInterpretation.Options}
              {output_language_api : ToString.OutputLanguageAPI}
              {language_naming_conventions : language_naming_conventions_opt}
              {documentation_options : documentation_options_opt}
@@ -733,6 +739,7 @@ Module Pipeline.
        end.
 
   Definition BoundsPipelineToString
+             {opts : AbstractInterpretation.Options}
              {output_language_api : ToString.OutputLanguageAPI}
              {language_naming_conventions : language_naming_conventions_opt}
              {documentation_options : documentation_options_opt}
@@ -806,16 +813,16 @@ Module Pipeline.
     end.
 
   Notation type_of_pipeline result
-    := ((fun a b c d e f g h i possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c d e f g h i possible_values t E arg_bounds out_bounds = result') => t) _ _ _ _ _ _ _ _ _ _ _ _ _ _ result eq_refl)
+    := ((fun a b c d e f g h i j possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c d e f g h i j possible_values t E arg_bounds out_bounds = result') => t) _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ result eq_refl)
          (only parsing).
   Notation arg_bounds_of_pipeline result
-    := ((fun a b c d e f g h i possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c d e f g h i possible_values t E arg_bounds out_bounds = result') => arg_bounds) _ _ _ _ _ _ _ _ _ _ _ _ _ _ result eq_refl)
+    := ((fun a b c d e f g h i j possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c d e f g h i j possible_values t E arg_bounds out_bounds = result') => arg_bounds) _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ result eq_refl)
          (only parsing).
   Notation out_bounds_of_pipeline result
-    := ((fun a b c d e f g h i possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c d e f g h i possible_values t E arg_bounds out_bounds = result') => out_bounds) _ _ _ _ _ _ _ _ _ _ _ _ _ _ result eq_refl)
+    := ((fun a b c d e f g h i j possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c d e f g h i j possible_values t E arg_bounds out_bounds = result') => out_bounds) _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ result eq_refl)
          (only parsing).
   Notation possible_values_of_pipeline result
-    := ((fun a b c d e f g h i possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c d e f g h i possible_values t E arg_bounds out_bounds = result') => possible_values) _ _ _ _ _ _ _ _ _ _ _ _ _ _ result eq_refl)
+    := ((fun a b c d e f g h i j possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c d e f g h i j possible_values t E arg_bounds out_bounds = result') => possible_values) _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ result eq_refl)
          (only parsing).
   Notation arg_typedefs_via_tc_of_pipeline result
     := (match type_of_pipeline result, arg_bounds_of_pipeline result return _ with
@@ -1083,6 +1090,7 @@ Module Pipeline.
           | progress destruct_head'_and ].
 
   Lemma BoundsPipeline_correct
+             {opts : AbstractInterpretation.Options}
              {low_level_rewriter_method : low_level_rewriter_method_opt}
              {only_signed : only_signed_opt}
              {no_select_size : no_select_size_opt}
@@ -1140,6 +1148,7 @@ Module Pipeline.
        /\ Wf rv.
 
   Lemma BoundsPipeline_correct_trans
+        {opts : AbstractInterpretation.Options}
         {low_level_rewriter_method : low_level_rewriter_method_opt}
         {only_signed : only_signed_opt}
         {no_select_size : no_select_size_opt}

--- a/src/CLI.v
+++ b/src/CLI.v
@@ -316,6 +316,8 @@ Module ForExtraction.
         ["For any (comma-separated) bitwidths passed to this argument, use bitwidth-sized bounds rather than tighter bounds for the carry return value of primitives such as addcarryx and subborrowx."]).
   Definition cmovznz_by_mul_spec : named_argT
     := ([Arg.long_key "cmovznz-by-mul"], Arg.Unit, ["Use an alternative implementation of cmovznz using multiplication rather than bitwise-and with -1."]).
+  Definition no_shiftr_avoid_uint1_spec : named_argT
+    := ([Arg.long_key "no-shiftr-avoid-uint1"], Arg.Unit, ["Don't avoid uint1 types at the output of (>>) operations."]).
   Definition tight_bounds_multiplier_default := default_tight_upperbound_fraction.
   Definition tight_bounds_multiplier_spec : named_argT
     := ([Arg.long_key "tight-bounds-mul-by"],
@@ -473,6 +475,9 @@ Module ForExtraction.
       ; output_options :> output_options_opt
       (** Should we use the alternate implementation of cmovznz *)
       ; use_mul_for_cmovznz :> use_mul_for_cmovznz_opt
+      (** Various abstract interpretation options *)
+      (** Should we avoid uint1 at the output of shiftr *)
+      ; abstract_interpretation_options :> AbstractInterpretation.Options
       (** Should we split apart oversized operations? *)
       ; should_split_mul :> should_split_mul_opt
       (** Should we split apart multi-return operations? *)
@@ -574,6 +579,7 @@ Module ForExtraction.
         ; no_field_element_typedefs_spec
         ; relax_primitive_carry_to_bitwidth_spec
         ; cmovznz_by_mul_spec
+        ; no_shiftr_avoid_uint1_spec
         ; only_signed_spec
         ; hint_file_spec
         ; output_file_spec
@@ -620,6 +626,7 @@ Module ForExtraction.
              , no_field_element_typedefsv
              , relax_primitive_carry_to_bitwidthv
              , cmovznz_by_mulv
+             , no_shiftr_avoid_uint1v
              , only_signedv
              , hint_file_namesv
              , output_file_namev
@@ -682,6 +689,9 @@ Module ForExtraction.
                   ; should_split_multiret := to_bool split_multiretv
                   ; unfold_value_barrier := negb (to_bool value_barrierv)
                   ; use_mul_for_cmovznz := to_bool cmovznz_by_mulv
+                  ; abstract_interpretation_options :=
+                      {| AbstractInterpretation.shiftr_avoid_uint1 := negb (to_bool no_shiftr_avoid_uint1v)
+                      |}
                   ; emit_primitives := negb (to_bool no_primitivesv)
                   ; output_options :=
                       {| skip_typedefs_ := to_bool no_field_element_typedefsv

--- a/src/CLI.v
+++ b/src/CLI.v
@@ -316,8 +316,8 @@ Module ForExtraction.
         ["For any (comma-separated) bitwidths passed to this argument, use bitwidth-sized bounds rather than tighter bounds for the carry return value of primitives such as addcarryx and subborrowx."]).
   Definition cmovznz_by_mul_spec : named_argT
     := ([Arg.long_key "cmovznz-by-mul"], Arg.Unit, ["Use an alternative implementation of cmovznz using multiplication rather than bitwise-and with -1."]).
-  Definition no_shiftr_avoid_uint1_spec : named_argT
-    := ([Arg.long_key "no-shiftr-avoid-uint1"], Arg.Unit, ["Don't avoid uint1 types at the output of (>>) operations."]).
+  Definition shiftr_avoid_uint1_spec : named_argT
+    := ([Arg.long_key "shiftr-avoid-uint1"], Arg.Unit, ["Avoid uint1 types at the output of (>>) operations."]).
   Definition tight_bounds_multiplier_default := default_tight_upperbound_fraction.
   Definition tight_bounds_multiplier_spec : named_argT
     := ([Arg.long_key "tight-bounds-mul-by"],
@@ -579,7 +579,7 @@ Module ForExtraction.
         ; no_field_element_typedefs_spec
         ; relax_primitive_carry_to_bitwidth_spec
         ; cmovznz_by_mul_spec
-        ; no_shiftr_avoid_uint1_spec
+        ; shiftr_avoid_uint1_spec
         ; only_signed_spec
         ; hint_file_spec
         ; output_file_spec
@@ -626,7 +626,7 @@ Module ForExtraction.
              , no_field_element_typedefsv
              , relax_primitive_carry_to_bitwidthv
              , cmovznz_by_mulv
-             , no_shiftr_avoid_uint1v
+             , shiftr_avoid_uint1v
              , only_signedv
              , hint_file_namesv
              , output_file_namev
@@ -690,7 +690,7 @@ Module ForExtraction.
                   ; unfold_value_barrier := negb (to_bool value_barrierv)
                   ; use_mul_for_cmovznz := to_bool cmovznz_by_mulv
                   ; abstract_interpretation_options :=
-                      {| AbstractInterpretation.shiftr_avoid_uint1 := negb (to_bool no_shiftr_avoid_uint1v)
+                      {| AbstractInterpretation.shiftr_avoid_uint1 := to_bool shiftr_avoid_uint1v
                       |}
                   ; emit_primitives := negb (to_bool no_primitivesv)
                   ; output_options :=

--- a/src/CompilersTestCases.v
+++ b/src/CompilersTestCases.v
@@ -22,6 +22,8 @@ Import Language.API.Compilers.
 Local Coercion Z.of_nat : nat >-> Z.
 Import Compilers.API.
 
+Local Existing Instance AbstractInterpretation.default_Options.
+
 Local Notation "x + y"
   := ((#ident.Z_add @ x @ y)%expr)
      : expr_scope.

--- a/src/PushButtonSynthesis/BarrettReduction.v
+++ b/src/PushButtonSynthesis/BarrettReduction.v
@@ -64,6 +64,7 @@ Section rbarrett_red.
   Local Existing Instance default_language_naming_conventions.
   Local Existing Instance default_documentation_options.
   Local Existing Instance default_output_options.
+  Local Existing Instance AbstractInterpretation.default_Options.
   Local Instance widen_carry : widen_carry_opt := false.
   Local Instance widen_bytes : widen_bytes_opt := true.
   Local Instance only_signed : only_signed_opt := false.

--- a/src/PushButtonSynthesis/BaseConversion.v
+++ b/src/PushButtonSynthesis/BaseConversion.v
@@ -81,6 +81,7 @@ Section __.
           {language_naming_conventions : language_naming_conventions_opt}
           {documentation_options : documentation_options_opt}
           {output_options : output_options_opt}
+          {opts : AbstractInterpretation.Options}
           {package_namev : package_name_opt}
           {class_namev : class_name_opt}
           {static : static_opt}

--- a/src/PushButtonSynthesis/FancyMontgomeryReduction.v
+++ b/src/PushButtonSynthesis/FancyMontgomeryReduction.v
@@ -67,6 +67,7 @@ Section rmontred.
   Local Existing Instance default_language_naming_conventions.
   Local Existing Instance default_documentation_options.
   Local Existing Instance default_output_options.
+  Local Existing Instance AbstractInterpretation.default_Options.
   Local Instance widen_carry : widen_carry_opt := false.
   Local Instance widen_bytes : widen_bytes_opt := true.
   Local Instance only_signed : only_signed_opt := false.

--- a/src/PushButtonSynthesis/Primitives.v
+++ b/src/PushButtonSynthesis/Primitives.v
@@ -783,6 +783,7 @@ Section __.
           {language_naming_conventions : language_naming_conventions_opt}
           {documentation_options : documentation_options_opt}
           {output_options : output_options_opt}
+          {absint_opts : AbstractInterpretation.Options}
           {package_namev : package_name_opt}
           {class_namev : class_name_opt}
           {static : static_opt}
@@ -820,6 +821,11 @@ Section __.
   Local Instance no_select_size : no_select_size_opt := no_select_size_of_no_select machine_wordsize.
   Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
   Local Instance split_multiret_to : split_multiret_to_opt := split_multiret_to_of_should_split_multiret machine_wordsize possible_values.
+  (** We override this instance with a version that does not avoid
+      uint1, so that the primitive operations, which in fact do use
+      (>>) to get carries, don't have issues *)
+  Local Instance absint_opts_with_no_shiftr_avoid_uint1 : AbstractInterpretation.Options
+    := {| AbstractInterpretation.shiftr_avoid_uint1 := false |}.
   Local Notation adc_sbb_return_carry_range s
     := ((if List.existsb (Z.eqb s) relax_adc_sbb_return_carry_to_bitwidth then r[0~>2^s%Z-1] else r[0~>1])%zrange).
   Lemma length_saturated_bounds : List.length saturated_bounds = n.

--- a/src/PushButtonSynthesis/SaturatedSolinas.v
+++ b/src/PushButtonSynthesis/SaturatedSolinas.v
@@ -63,6 +63,7 @@ Section __.
           {language_naming_conventions : language_naming_conventions_opt}
           {documentation_options : documentation_options_opt}
           {output_options : output_options_opt}
+          {opts : AbstractInterpretation.Options}
           {package_namev : package_name_opt}
           {class_namev : class_name_opt}
           {static : static_opt}

--- a/src/PushButtonSynthesis/SmallExamples.v
+++ b/src/PushButtonSynthesis/SmallExamples.v
@@ -72,6 +72,7 @@ Local Existing Instance ToString.C.OutputCAPI.
 Local Existing Instance default_language_naming_conventions.
 Local Existing Instance default_documentation_options.
 Local Existing Instance default_output_options.
+Local Existing Instance AbstractInterpretation.default_Options.
 Local Instance : package_name_opt := None.
 Local Instance : class_name_opt := None.
 Local Instance : static_opt := true.

--- a/src/PushButtonSynthesis/UnsaturatedSolinas.v
+++ b/src/PushButtonSynthesis/UnsaturatedSolinas.v
@@ -84,6 +84,7 @@ Section __.
           {language_naming_conventions : language_naming_conventions_opt}
           {documentation_options : documentation_options_opt}
           {output_options : output_options_opt}
+          {opts : AbstractInterpretation.Options}
           {package_namev : package_name_opt}
           {class_namev : class_name_opt}
           {static : static_opt}

--- a/src/PushButtonSynthesis/WordByWordMontgomery.v
+++ b/src/PushButtonSynthesis/WordByWordMontgomery.v
@@ -98,6 +98,7 @@ Section __.
           {language_naming_conventions : language_naming_conventions_opt}
           {documentation_options : documentation_options_opt}
           {output_options : output_options_opt}
+          {opts : AbstractInterpretation.Options}
           {package_namev : package_name_opt}
           {class_namev : class_name_opt}
           {static : static_opt}
@@ -250,7 +251,7 @@ Section __.
       /\ s = 2^Z.log2 s
       /\ s <= uweight machine_wordsize n
       /\ s <= uweight 8 n_bytes.
-  Proof.
+  Proof using curve_good.
     prepare_use_curve_good (); cbv [s c] in *.
     { destruct m eqn:?; cbn; lia. }
     { use_curve_good_t. }
@@ -1000,7 +1001,7 @@ Section __.
   Proof using curve_good. Primitives.prove_correctness use_curve_good. Qed.
 
   Lemma Wf_selectznz res (Hres : selectznz = Success res) : Wf res.
-  Proof using Type. prove_pipeline_wf (). Qed.
+  Proof using Type. revert Hres; cbv [selectznz]; apply Wf_selectznz. Qed.
 
   Section ring.
     Context from_montgomery_res (Hfrom_montgomery : from_montgomery = Success from_montgomery_res)

--- a/src/Rewriter/PerfTesting/Core.v
+++ b/src/Rewriter/PerfTesting/Core.v
@@ -47,6 +47,7 @@ Local Existing Instance Stringification.C.Compilers.ToString.C.OutputCAPI.
 Local Existing Instance default_language_naming_conventions.
 Local Existing Instance default_documentation_options.
 Local Existing Instance default_output_options.
+Local Existing Instance AbstractInterpretation.default_Options.
 Local Instance : package_name_opt := None.
 Local Instance : class_name_opt := None.
 Local Instance : static_opt := true.

--- a/src/SlowPrimeSynthesisExamples.v
+++ b/src/SlowPrimeSynthesisExamples.v
@@ -37,6 +37,7 @@ Local Coercion QArith_base.inject_Z : Z >-> Q.
 Local Coercion Z.pos : positive >-> Z.
 
 Local Existing Instance default_low_level_rewriter_method.
+Local Existing Instance AbstractInterpretation.default_Options.
 Local Instance : unfold_value_barrier_opt := true.
 Local Instance : assembly_hints_lines_opt := None.
 Local Instance : tight_upperbound_fraction_opt := default_tight_upperbound_fraction.

--- a/src/Stringification/C.v
+++ b/src/Stringification/C.v
@@ -587,6 +587,7 @@ Module Compilers.
       Local Instance : lift_declarations_opt := true.
 
       Definition ToFunctionLines
+                 {absint_opts : AbstractInterpretation.Options}
                  {relax_zrange : relax_zrange_opt}
                  {language_naming_conventions : language_naming_conventions_opt}
                  {documentation_options : documentation_options_opt}
@@ -626,6 +627,7 @@ Module Compilers.
            end.
 
       Definition ToFunctionString
+                 {absint_opts : AbstractInterpretation.Options}
                  {relax_zrange : relax_zrange_opt}
                  {language_naming_conventions : language_naming_conventions_opt}
                  {documentation_options : documentation_options_opt}

--- a/src/Stringification/Go.v
+++ b/src/Stringification/Go.v
@@ -545,6 +545,7 @@ Module Go.
                bits_std_bitwidths)).
 
   Definition ToFunctionLines
+             {absint_opts : AbstractInterpretation.Options}
              {relax_zrange : relax_zrange_opt}
              {language_naming_conventions : language_naming_conventions_opt}
              {documentation_options : documentation_options_opt}

--- a/src/Stringification/IR.v
+++ b/src/Stringification/IR.v
@@ -1711,6 +1711,7 @@ Module Compilers.
                    (make_name name_list) (reset_if_names_given name_list).
 
             Definition ExprOfPHOAS_with_opt_outbounds_cps
+                       {absint_opts : AbstractInterpretation.Options}
                        {t}
                        (e : @API.Expr t)
                        (name_list : option (list string))
@@ -1726,6 +1727,7 @@ Module Compilers.
                    (e _) (make_in_name name_list) (make_out_name name_list) inbounds outbounds intypedefs outtypedefs 1 (reset_if_names_given name_list) k.
 
             Definition ExprOfPHOAS_cps
+                       {absint_opts : AbstractInterpretation.Options}
                        {t}
                        (e : @API.Expr t)
                        (name_list : option (list string))
@@ -1738,6 +1740,7 @@ Module Compilers.
               := ExprOfPHOAS_with_opt_outbounds_cps e name_list inbounds None intypedefs outtypedefs k.
 
             Definition var_data_of_PHOAS
+                       {absint_opts : AbstractInterpretation.Options}
                        {t}
                        (e : @API.Expr t)
                        (name_list : option (list string))
@@ -1750,6 +1753,7 @@ Module Compilers.
                    (fun '(count, (din, dout, e)) => ret (din, dout)).
 
             Definition var_data_of_PHOAS_bounds
+                       {absint_opts : AbstractInterpretation.Options}
                        {t}
                        (e : @API.Expr t)
                        (name_list : option (list string))
@@ -1763,6 +1767,7 @@ Module Compilers.
                    (fun '(count, (din, dout, e)) => ret (din, dout)).
 
             Definition ExprOfPHOAS
+                       {absint_opts : AbstractInterpretation.Options}
                        {relax_adc_sbb_return_carry_to_bitwidth : relax_adc_sbb_return_carry_to_bitwidth_opt}
                        (do_bounds_check : bool)
                        {t}

--- a/src/Stringification/JSON.v
+++ b/src/Stringification/JSON.v
@@ -366,6 +366,7 @@ Module JSON.
   Local Instance : lift_declarations_opt := false.
 
   Definition ToFunctionLines
+             {absint_opts : AbstractInterpretation.Options}
              {relax_zrange : relax_zrange_opt}
              {language_naming_conventions : language_naming_conventions_opt}
              {documentation_options : documentation_options_opt}

--- a/src/Stringification/Java.v
+++ b/src/Stringification/Java.v
@@ -385,6 +385,7 @@ Module Java.
          ++ [" */"%string].
 
   Definition ToFunctionLines
+             {absint_opts : AbstractInterpretation.Options}
              {relax_zrange : relax_zrange_opt}
              {language_naming_conventions : language_naming_conventions_opt}
              {documentation_options : documentation_options_opt}

--- a/src/Stringification/Language.v
+++ b/src/Stringification/Language.v
@@ -1638,7 +1638,8 @@ Module Compilers.
         (** Converts a PHOAS AST to lines of code * info on which
             primitive functions are called, or else an error string *)
         ToFunctionLines
-        : forall {relax_zrange : relax_zrange_opt}
+        : forall {absint_opts : AbstractInterpretation.Options}
+                 {relax_zrange : relax_zrange_opt}
                  {language_naming_conventions : language_naming_conventions_opt}
                  {documentation_options : documentation_options_opt}
                  {output_options : output_options_opt}

--- a/src/Stringification/Rust.v
+++ b/src/Stringification/Rust.v
@@ -386,6 +386,7 @@ Module Rust.
   Local Instance : lift_declarations_opt := false.
 
   Definition ToFunctionLines
+             {absint_opts : AbstractInterpretation.Options}
              {relax_zrange : relax_zrange_opt}
              {language_naming_conventions : language_naming_conventions_opt}
              {documentation_options : documentation_options_opt}

--- a/src/Stringification/Zig.v
+++ b/src/Stringification/Zig.v
@@ -334,6 +334,7 @@ Module Zig.
   Local Instance : lift_declarations_opt := false.
 
   Definition ToFunctionLines
+             {absint_opts : AbstractInterpretation.Options}
              {relax_zrange : relax_zrange_opt}
              {language_naming_conventions : language_naming_conventions_opt}
              {documentation_options : documentation_options_opt}


### PR DESCRIPTION
We now default to avoiding uint1 in the result of `>>` operations, as
per
https://github.com/mit-plv/fiat-crypto/pull/1015#discussion_r708691741.

This is required for making symbolic equivalence checking with assembly
go through.  It might be possible to improve the symbolic equivalence
checker to know enough about bounds analysis (or to also do bounds
analysis) so that this is not necessary?