### PR TITLE
 Add `--asm-ignore-unique-name-mismatch`

### DIFF
--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -227,6 +227,9 @@ Typeclasses Opaque assembly_hints_lines_opt.
 (** Error if there are un-requested assembly functions *)
 Class error_on_unused_assembly_functions_opt := error_on_unused_assembly_functions : bool.
 Typeclasses Opaque error_on_unused_assembly_functions_opt.
+(** Ignore function-name mismatch errors when there's only one assembly function and only one actual function requested *)
+Class ignore_unique_asm_names_opt := ignore_unique_asm_names : bool.
+Typeclasses Opaque ignore_unique_asm_names_opt.
 Inductive synthesis_output_kind := normal_output | assembly_output.
 Notation no_select_size_of_no_select machine_wordsize
   := (if no_select return no_select_size_opt

--- a/src/CLI.v
+++ b/src/CLI.v
@@ -415,10 +415,10 @@ Module ForExtraction.
     := ([Arg.long_key "asm-reg-rtl"],
         Arg.Unit,
         ["By default, registers are assumed to be assigned to function arguments from left to right in the hints file.  This flag reverses that convention to be right-to-left.  Note that this flag interacts with --asm-input-first, which determines whether the output pointers are to the left or to the right of the input arguments."]).
-  Definition asm_ignore_unique_names_spec : named_argT
-    := ([Arg.long_key "asm-ignore-unique-name-mismatch"],
+  Definition asm_error_on_unique_names_mismatch_spec : named_argT
+    := ([Arg.long_key "asm-error-on-unique-name-mismatch"],
         Arg.Unit,
-        ["Ignore function-name mismatch errors when there's only one assembly function and only one actual function requested."]).
+        ["By default, when there's only one assembly function in a --hints-file and only one function requested to be synthesized, the name of the assembly function is ignored.  Passing this flag disables this behavior, raising an error if the names mismatch regardless of whether there are multiple functions or just one."]).
   Definition doc_text_before_function_name_spec : named_argT
     := ([Arg.long_key "doc-text-before-function-name"],
         Arg.String,
@@ -595,7 +595,7 @@ Module ForExtraction.
         ; no_error_on_unused_asm_functions_spec
         ; asm_input_first_spec
         ; asm_reg_rtl_spec
-        ; asm_ignore_unique_names_spec
+        ; asm_error_on_unique_names_mismatch_spec
         ; doc_text_before_function_name_spec
         ; doc_text_before_type_name_spec
         ; doc_newline_before_package_declaration_spec
@@ -643,7 +643,7 @@ Module ForExtraction.
              , no_error_on_unused_asm_functionsv
              , asm_input_firstv
              , asm_reg_rtlv
-             , asm_ignore_unique_namesv
+             , asm_error_on_unique_names_mismatchv
              , doc_text_before_function_namev
              , doc_text_before_type_namev
              , doc_newline_before_package_declarationv
@@ -707,7 +707,7 @@ Module ForExtraction.
                       |}
                   ; assembly_calling_registers := to_reg_list asm_regv
                   ; assembly_stack_size := to_N_opt asm_stack_sizev
-                  ; ignore_unique_asm_names := to_bool asm_ignore_unique_namesv
+                  ; ignore_unique_asm_names := negb (to_bool asm_error_on_unique_names_mismatchv)
                   ; error_on_unused_assembly_functions := negb (to_bool no_error_on_unused_asm_functionsv)
                   ; assembly_output_first := negb (to_bool asm_input_firstv)
                   ; assembly_argument_registers_left_to_right := negb (to_bool asm_reg_rtlv)

--- a/src/CLI.v
+++ b/src/CLI.v
@@ -415,6 +415,10 @@ Module ForExtraction.
     := ([Arg.long_key "asm-reg-rtl"],
         Arg.Unit,
         ["By default, registers are assumed to be assigned to function arguments from left to right in the hints file.  This flag reverses that convention to be right-to-left.  Note that this flag interacts with --asm-input-first, which determines whether the output pointers are to the left or to the right of the input arguments."]).
+  Definition asm_ignore_unique_names_spec : named_argT
+    := ([Arg.long_key "asm-ignore-unique-name-mismatch"],
+        Arg.Unit,
+        ["Ignore function-name mismatch errors when there's only one assembly function and only one actual function requested."]).
   Definition doc_text_before_function_name_spec : named_argT
     := ([Arg.long_key "doc-text-before-function-name"],
         Arg.String,
@@ -488,6 +492,8 @@ Module ForExtraction.
       ; widen_carry :> widen_carry_opt
       (** Should we widen the byte type to the full bitwidth? *)
       ; widen_bytes :> widen_bytes_opt
+      (** Should we ignore function-name mismatch errors when there's only one assembly function and only one actual function requested? *)
+      ; ignore_unique_asm_names :> ignore_unique_asm_names_opt
       (** What method should we use for rewriting? *)
       ; low_level_rewriter_method :> low_level_rewriter_method_opt
         := default_low_level_rewriter_method
@@ -589,6 +595,7 @@ Module ForExtraction.
         ; no_error_on_unused_asm_functions_spec
         ; asm_input_first_spec
         ; asm_reg_rtl_spec
+        ; asm_ignore_unique_names_spec
         ; doc_text_before_function_name_spec
         ; doc_text_before_type_name_spec
         ; doc_newline_before_package_declaration_spec
@@ -636,6 +643,7 @@ Module ForExtraction.
              , no_error_on_unused_asm_functionsv
              , asm_input_firstv
              , asm_reg_rtlv
+             , asm_ignore_unique_namesv
              , doc_text_before_function_namev
              , doc_text_before_type_namev
              , doc_newline_before_package_declarationv
@@ -699,6 +707,7 @@ Module ForExtraction.
                       |}
                   ; assembly_calling_registers := to_reg_list asm_regv
                   ; assembly_stack_size := to_N_opt asm_stack_sizev
+                  ; ignore_unique_asm_names := to_bool asm_ignore_unique_namesv
                   ; error_on_unused_assembly_functions := negb (to_bool no_error_on_unused_asm_functionsv)
                   ; assembly_output_first := negb (to_bool asm_input_firstv)
                   ; assembly_argument_registers_left_to_right := negb (to_bool asm_reg_rtlv)

--- a/src/PushButtonSynthesis/BarrettReduction.v
+++ b/src/PushButtonSynthesis/BarrettReduction.v
@@ -73,6 +73,7 @@ Section rbarrett_red.
   Local Instance split_multiret_to : split_multiret_to_opt := None.
   Local Instance unfold_value_barrier : unfold_value_barrier_opt := true.
   Local Instance assembly_hints_lines : assembly_hints_lines_opt := None.
+  Local Instance ignore_unique_asm_names : ignore_unique_asm_names_opt := false.
   Local Instance low_level_rewriter_method : low_level_rewriter_method_opt := default_low_level_rewriter_method.
 
   Let fancy_args

--- a/src/PushButtonSynthesis/BaseConversion.v
+++ b/src/PushButtonSynthesis/BaseConversion.v
@@ -97,6 +97,7 @@ Section __.
           {should_split_multiret : should_split_multiret_opt}
           {unfold_value_barrier : unfold_value_barrier_opt}
           {assembly_hints_lines : assembly_hints_lines_opt}
+          {ignore_unique_asm_names : ignore_unique_asm_names_opt}
           {widen_carry : widen_carry_opt}
           {widen_bytes : widen_bytes_opt}
           {assembly_calling_registers : assembly_calling_registers_opt}

--- a/src/PushButtonSynthesis/FancyMontgomeryReduction.v
+++ b/src/PushButtonSynthesis/FancyMontgomeryReduction.v
@@ -76,6 +76,7 @@ Section rmontred.
   Local Instance split_multiret_to : split_multiret_to_opt := None.
   Local Instance unfold_value_barrier : unfold_value_barrier_opt := true.
   Local Instance assembly_hints_lines : assembly_hints_lines_opt := None.
+  Local Instance ignore_unique_asm_names : ignore_unique_asm_names_opt := false.
   Local Instance low_level_rewriter_method : low_level_rewriter_method_opt := default_low_level_rewriter_method.
 
   Let fancy_args

--- a/src/PushButtonSynthesis/Primitives.v
+++ b/src/PushButtonSynthesis/Primitives.v
@@ -806,6 +806,7 @@ Section __.
           {error_on_unused_assembly_functions : error_on_unused_assembly_functions_opt}
           {assembly_output_first : assembly_output_first_opt}
           {assembly_argument_registers_left_to_right : assembly_argument_registers_left_to_right_opt}
+          {ignore_unique_asm_names : ignore_unique_asm_names_opt}
           (n : nat)
           (machine_wordsize : machine_wordsize_opt).
   Definition saturated_bounds : list (ZRange.type.option.interp base.type.Z)
@@ -1135,8 +1136,8 @@ Section __.
 
     Definition split_to_assembly_functions {A B} (assembly_data : list (string * A)) (normal_data : list (string * B))
       : list (string * (A * B)) * list (string * B) * list (string * A)
-      := if andb (Nat.eqb (length assembly_data) 1%nat) (Nat.eqb (length normal_data) 1%nat) 
-         then match assembly_data, normal_data with cons (_, a) _, cons (n, b) _ => (cons (n, (a,b)) nil, nil, nil) | _, _ => (nil, normal_data, assembly_data) end
+      := if (ignore_unique_asm_names && (length assembly_data =? 1) && (length normal_data =? 1))%nat%bool
+         then match assembly_data, normal_data with [(_, a)], [(n, b)] => ([(n, (a,b))], nil, nil) | _, _ => (nil, normal_data, assembly_data) end
          else
          let ls := List.map (fun '(n1, normal_data)
                              => ((n1, normal_data), List.find (fun '(n2, _) => n1 =? n2)%string assembly_data))

--- a/src/PushButtonSynthesis/Primitives.v
+++ b/src/PushButtonSynthesis/Primitives.v
@@ -1135,7 +1135,10 @@ Section __.
 
     Definition split_to_assembly_functions {A B} (assembly_data : list (string * A)) (normal_data : list (string * B))
       : list (string * (A * B)) * list (string * B) * list (string * A)
-      := let ls := List.map (fun '(n1, normal_data)
+      := if andb (Nat.eqb (length assembly_data) 1%nat) (Nat.eqb (length normal_data) 1%nat) 
+         then match assembly_data, normal_data with cons (_, a) _, cons (n, b) _ => (cons (n, (a,b)) nil, nil, nil) | _, _ => (nil, normal_data, assembly_data) end
+         else
+         let ls := List.map (fun '(n1, normal_data)
                              => ((n1, normal_data), List.find (fun '(n2, _) => n1 =? n2)%string assembly_data))
                             normal_data in
          let '(lsAB, lsB) := List.partition (fun '(_, o) => match o with Some _ => true | None => false end) ls in

--- a/src/PushButtonSynthesis/SaturatedSolinas.v
+++ b/src/PushButtonSynthesis/SaturatedSolinas.v
@@ -79,6 +79,7 @@ Section __.
           {should_split_multiret : should_split_multiret_opt}
           {unfold_value_barrier : unfold_value_barrier_opt}
           {assembly_hints_lines : assembly_hints_lines_opt}
+          {ignore_unique_asm_names : ignore_unique_asm_names_opt}
           {widen_carry : widen_carry_opt}
           (widen_bytes : widen_bytes_opt := true) (* true, because we don't allow byte-sized things anyway, so we should not expect carries to be widened to byte-size when emitting C code *)
           {assembly_calling_registers : assembly_calling_registers_opt}

--- a/src/PushButtonSynthesis/SmallExamples.v
+++ b/src/PushButtonSynthesis/SmallExamples.v
@@ -24,6 +24,7 @@ Local Instance : split_mul_to_opt := None.
 Local Instance : split_multiret_to_opt := None.
 Local Instance : unfold_value_barrier_opt := true.
 Local Instance : assembly_hints_lines_opt := None.
+Local Instance : ignore_unique_asm_names_opt := false.
 Local Instance : only_signed_opt := false.
 Local Instance : no_select_size_opt := None.
 Local Existing Instance default_low_level_rewriter_method.

--- a/src/PushButtonSynthesis/UnsaturatedSolinas.v
+++ b/src/PushButtonSynthesis/UnsaturatedSolinas.v
@@ -100,6 +100,7 @@ Section __.
           {should_split_multiret : should_split_multiret_opt}
           {unfold_value_barrier : unfold_value_barrier_opt}
           {assembly_hints_lines : assembly_hints_lines_opt}
+          {ignore_unique_asm_names : ignore_unique_asm_names_opt}
           {widen_carry : widen_carry_opt}
           {widen_bytes : widen_bytes_opt}
           {tight_upperbound_fraction : tight_upperbound_fraction_opt}

--- a/src/PushButtonSynthesis/WordByWordMontgomery.v
+++ b/src/PushButtonSynthesis/WordByWordMontgomery.v
@@ -114,6 +114,7 @@ Section __.
           {should_split_multiret : should_split_multiret_opt}
           {unfold_value_barrier : unfold_value_barrier_opt}
           {assembly_hints_lines : assembly_hints_lines_opt}
+          {ignore_unique_asm_names : ignore_unique_asm_names_opt}
           {widen_carry : widen_carry_opt}
           {widen_bytes : widen_bytes_opt}
           {assembly_calling_registers : assembly_calling_registers_opt}

--- a/src/Rewriter/PerfTesting/Core.v
+++ b/src/Rewriter/PerfTesting/Core.v
@@ -62,6 +62,7 @@ Local Instance : should_split_mul_opt := false.
 Local Instance : should_split_multiret_opt := false.
 Local Instance : unfold_value_barrier_opt := true.
 Local Instance : assembly_hints_lines_opt := None.
+Local Instance : ignore_unique_asm_names_opt := false.
 Local Instance : widen_bytes_opt := false.
 Local Instance : widen_carry_opt := false.
 Local Instance : tight_upperbound_fraction_opt := default_tight_upperbound_fraction.

--- a/src/SlowPrimeSynthesisExamples.v
+++ b/src/SlowPrimeSynthesisExamples.v
@@ -40,6 +40,7 @@ Local Existing Instance default_low_level_rewriter_method.
 Local Existing Instance AbstractInterpretation.default_Options.
 Local Instance : unfold_value_barrier_opt := true.
 Local Instance : assembly_hints_lines_opt := None.
+Local Instance : ignore_unique_asm_names_opt := false.
 Local Instance : tight_upperbound_fraction_opt := default_tight_upperbound_fraction.
 Local Existing Instance default_language_naming_conventions.
 Local Existing Instance default_documentation_options.


### PR DESCRIPTION
Don't unconditionally ignore mismatch between the name of the assembly function and the name of the synthesized function.

@andres-erbsen Does making this a command-line flag seem reasonable to you (under the presumption that sometimes we might want to be warned if we're using the wrong assembly file, and also that we should be in strict mode by default to catch such mistakes earlier)?  Does the name seem fine?