### PR TITLE
[legacy] Adapt to coq/coq#13837 ("apply with" does not rename arguments)

### DIFF
--- a/src/Arithmetic/Saturated/UniformWeight.v
+++ b/src/Arithmetic/Saturated/UniformWeight.v
@@ -44,10 +44,10 @@ Section UniformWeight.
            | _ => rewrite B.Positional.eval_unit; [ ]
            | _ => rewrite B.Positional.eval_step; [ ]
            | _ => rewrite IHn; [ ]
-           | _ => rewrite eval_from_eq with (offset0:=S offset)
+           | _ => rewrite @eval_from_eq with (offset:=S offset)
                by (intros; f_equal; lia)
-           | _ => rewrite eval_from_eq with
-                  (wt:=fun i => uweight (S i)) (offset0:=1%nat)
+           | _ => rewrite @eval_from_eq with
+                  (wt:=fun i => uweight (S i)) (offset:=1%nat)
                by (intros; f_equal; lia)
            | _ => ring
            end.

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -9806,12 +9806,12 @@ Module PreFancy.
         induction 1; intros; cbn [of_straightline interp].
         { apply replace_interp_cast_scalar; auto. }
         { erewrite !of_straightline_ident_correct by (eauto; cbv [range_ok]; apply in_word_range_word_range).
-          rewrite replace_interp_cast_scalar with (interp_cast'0:=interp_cast') by auto.
+          rewrite @replace_interp_cast_scalar with (interp_cast':=interp_cast') by auto.
           eauto using ident_interp_has_range. }
         { erewrite !of_straightline_ident_correct by
               (eauto; try solve [cbv [range_ok]; split; auto using in_word_range_word_range];
                cbv [is_tighter_than_bool_range_type]; apply andb_true_iff; split; auto).
-          rewrite replace_interp_cast_scalar with (interp_cast'0:=interp_cast') by auto.
+          rewrite @replace_interp_cast_scalar with (interp_cast':=interp_cast') by auto.
           eauto using ident_interp_has_range. }
       Qed.
     End no_interp_cast.
@@ -11181,7 +11181,7 @@ Module BarrettReduction.
              SuchThat (barrett_reduce = x mod M)
              As barrett_reduce_correct.
       Proof.
-        erewrite <-reduce_correct with (rep:=represents) (muSelect:=muSelect) (k0:=k) (mut:=[muLow;1]) (xt0:=xt)
+        erewrite <- @reduce_correct with (rep:=represents) (muSelect:=muSelect) (k:=k) (mut:=[muLow;1]) (xt:=xt)
           by (auto using x_bounds, muSelect_correct, x_rep, mu_rep; lia).
         subst barrett_reduce. reflexivity.
       Qed.


### PR DESCRIPTION
Should be backwards compatible.