### PR TITLE
Convert ladderstep to stack allocation and begin the same for Montgomery ladder

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -88,6 +88,7 @@ src/Bedrock/Field/Common/Arrays/MaxBounds.v
 src/Bedrock/Field/Common/Names/MakeNames.v
 src/Bedrock/Field/Common/Names/VarnameGenerator.v
 src/Bedrock/Field/Interface/Compilation.v
+src/Bedrock/Field/Interface/Compilation2.v
 src/Bedrock/Field/Interface/Representation.v
 src/Bedrock/Field/Stringification/FlattenVarData.v
 src/Bedrock/Field/Stringification/LoadStoreListVarData.v

--- a/output-tests/Crypto.Bedrock.Group.ScalarMult.LadderStep.ladderstep_body.expected
+++ b/output-tests/Crypto.Bedrock.Group.ScalarMult.LadderStep.ladderstep_body.expected
@@ -1,28 +1,56 @@
 ladderstep_body = 
-fun field_parameters : FieldParameters =>
+fun (width : Z) (BW : Bitwidth width) (word : word width)
+  (mem : map.map word byte) (word_ok : word.ok word) 
+  (mem_ok : map.ok mem) (field_parameters : FieldParameters)
+  (field_representaton : FieldRepresentation)
+  (field_representation_ok : FieldRepresentation_ok) =>
 noskips
-  (cmd.seq (cmd.call [] add ["A"; "X2"; "Z2"])
-     (cmd.seq (cmd.call [] square ["AA"; "A"])
-        (cmd.seq (cmd.call [] sub ["B"; "X2"; "Z2"])
-           (cmd.seq (cmd.call [] square ["BB"; "B"])
-              (cmd.seq (cmd.call [] sub ["E"; "AA"; "BB"])
-                 (cmd.seq (cmd.call [] add ["C"; "X3"; "Z3"])
-                    (cmd.seq (cmd.call [] sub ["D"; "X3"; "Z3"])
-                       (cmd.seq (cmd.call [] mul ["DA"; "D"; "A"])
-                          (cmd.seq (cmd.call [] mul ["CB"; "C"; "B"])
-                             (cmd.seq (cmd.call [] add ["X3"; "DA"; "CB"])
-                                (cmd.seq (cmd.call [] square ["X3"; "X3"])
+  (cmd.stackalloc "A" size_in_bytes
+     (cmd.seq (cmd.call [] add ["A"; "X2"; "Z2"])
+        (cmd.stackalloc "AA" size_in_bytes
+           (cmd.seq (cmd.call [] square ["AA"; "A"])
+              (cmd.stackalloc "B" size_in_bytes
+                 (cmd.seq (cmd.call [] sub ["B"; "X2"; "Z2"])
+                    (cmd.stackalloc "BB" size_in_bytes
+                       (cmd.seq (cmd.call [] square ["BB"; "B"])
+                          (cmd.stackalloc "E" size_in_bytes
+                             (cmd.seq (cmd.call [] sub ["E"; "AA"; "BB"])
+                                (cmd.stackalloc "C" size_in_bytes
                                    (cmd.seq
-                                      (cmd.call [] sub ["Z3"; "DA"; "CB"])
-                                      (cmd.seq
-                                         (cmd.call [] square ["Z3"; "Z3"])
+                                      (cmd.call [] add ["C"; "X3"; "Z3"])
+                                      (cmd.stackalloc "D" size_in_bytes
                                          (cmd.seq
-                                            (cmd.call [] mul
-                                               ["Z3"; "X1"; "Z3"])
-                                            (cmd.seq
-                                               (cmd.call [] mul
-                                                 ["X2"; "AA"; "BB"])
+                                            (cmd.call [] sub
+                                               ["D"; "X3"; "Z3"])
+                                            (cmd.stackalloc "DA"
+                                               size_in_bytes
                                                (cmd.seq
+                                                 (cmd.call [] mul
+                                                 ["DA"; "D"; "A"])
+                                                 (cmd.stackalloc "CB"
+                                                 size_in_bytes
+                                                 (cmd.seq
+                                                 (cmd.call [] mul
+                                                 ["CB"; "C"; "B"])
+                                                 (cmd.seq
+                                                 (cmd.call [] add
+                                                 ["X3"; "DA"; "CB"])
+                                                 (cmd.seq
+                                                 (cmd.call [] square
+                                                 ["X3"; "X3"])
+                                                 (cmd.seq
+                                                 (cmd.call [] sub
+                                                 ["Z3"; "DA"; "CB"])
+                                                 (cmd.seq
+                                                 (cmd.call [] square
+                                                 ["Z3"; "Z3"])
+                                                 (cmd.seq
+                                                 (cmd.call [] mul
+                                                 ["Z3"; "X1"; "Z3"])
+                                                 (cmd.seq
+                                                 (cmd.call [] mul
+                                                 ["X2"; "AA"; "BB"])
+                                                 (cmd.seq
                                                  (cmd.call [] scmula24
                                                  ["Z2"; "E"])
                                                  (cmd.seq
@@ -35,7 +63,14 @@ noskips
                                                  (fun (v : string) (c : cmd)
                                                  => 
                                                  cmd.seq (cmd.unset v) c)
-                                                 cmd.skip [])))))))))))))))))))
-     : FieldParameters -> cmd
+                                                 cmd.skip []))))))))))))))))))))))))))))
+     : forall (width : Z) (BW : Bitwidth width) (word : word width)
+         (mem : map.map word byte),
+       word.ok word ->
+       map.ok mem ->
+       forall (field_parameters : FieldParameters)
+         (field_representaton : FieldRepresentation),
+       FieldRepresentation_ok -> cmd
 
-Arguments ladderstep_body {field_parameters}
+Arguments ladderstep_body {width}%Z_scope {BW word mem word_ok mem_ok
+  field_parameters field_representaton field_representation_ok}

--- a/src/Bedrock/Field/Interface/Compilation2.v
+++ b/src/Bedrock/Field/Interface/Compilation2.v
@@ -60,7 +60,7 @@ Section Compile.
   Qed.
 
   #[refine]
-  Instance felem_alloc : Allocable FElem :=
+  Instance felem_alloc : Allocable (FElem None) :=
     {
     size_in_bytes := felem_size_in_bytes;
     size_in_bytes_mod := felem_size_in_bytes_mod;
@@ -74,7 +74,6 @@ Section Compile.
     }      
     {
       intros; intros m H.
-      exists None.
       apply FElem'_from_bytes.
       eauto.
     }

--- a/src/Bedrock/Group/Point.v
+++ b/src/Bedrock/Group/Point.v
@@ -19,6 +19,8 @@ Section Compile.
   Context {field_parameters : FieldParameters}
           {field_representation : FieldRepresentation}.
 
+  (* TODO: uses removed notation.
+     Find out whether anything still uses this file
   Lemma compile_point_assign :
     forall (l: locals) (mem: mem)
            (locals_ok : locals -> Prop)
@@ -44,4 +46,5 @@ Section Compile.
   Proof.
     repeat straightline'. eauto.
   Qed.
+   *)
 End Compile.

--- a/src/Bedrock/Group/ScalarMult/LadderStep.v
+++ b/src/Bedrock/Group/ScalarMult/LadderStep.v
@@ -20,322 +20,6 @@ Section __.
           {field_representation_ok : FieldRepresentation_ok}.
   Hint Resolve relax_bounds : compiler.
 
-  (*
-  (*Modified from stack_alloc*)
-  Definition felem_alloc : Comp (felem) := fun _ => True.
-   *)
-
-  Definition felem_alloc (v : F M_pos) := v.
-  Arguments felem_alloc : simpl never.
-  
-  Lemma compile_felem_alloc
-        (tr : Semantics.trace)
-        (mem locals : map.rep)
-        (functions : list (string * (list string * list string * cmd)))
-        (e : felem) :
-    let v := (feval e)%F in
-    forall (P : F M_pos -> Type)
-           (pred : P v -> predicate)
-           (k : nlet_eq_k P v) (v_impl k_impl : cmd)
-           (Rin Rout : map.rep -> Prop)
-           (out : felem)
-           (out_var : string),
-      (*
-      (FElem out_ptr out ⋆ Rout) mem ->
-      (FElem e_ptr e ⋆ Rin) mem ->
-       *)
-      Rout mem ->
-      Rin mem ->
-      bounded_by loose_bounds e ->
-      (let v0 := v in
-       forall (out0 : felem) (out_ptr : word.rep) (m : map.rep),
-         feval out0 = v0 ->
-         bounded_by loose_bounds out0 ->
-         (Placeholder out_ptr ⋆ Rout) m ->
-         <{ Trace := tr;
-            Memory := m;
-            Locals := map.put locals out_var out_ptr;
-            Functions := functions }>
-         v_impl
-         <{ fun tr' mem l => tr' = tr /\ (FElem out_ptr out0 ⋆ Rout) mem /\ l = map.put locals out_var out_ptr }>) ->
-      (let v0 := v in
-       forall (out0 : felem) (out_ptr : word.rep) (m : map.rep),
-         feval out0 = v0 ->
-         bounded_by loose_bounds out0 ->
-         (FElem out_ptr out0 ⋆ Rout) m ->
-         <{ Trace := tr;
-            Memory := m;
-            Locals := map.put locals out_var out_ptr;
-            Functions := functions }>
-         k_impl
-         <{fun tr' mem' locals' =>
-             exists m' mStack' : map.rep, Placeholder out_ptr mStack' /\
-                                          map.split mem' m' mStack' /\
-                                          pred (k v0 eq_refl) tr' m' locals' }>) ->
-      <{ Trace := tr;
-         Memory := mem;
-         Locals := locals;
-         Functions := functions }>
-      cmd.stackalloc out_var (@felem_size_in_bytes field_parameters _ field_representaton)
-                     (cmd.seq v_impl k_impl)
-      <{ pred (let/n x as out_var eq:Heq := felem_alloc v in
-               k x Heq) }>.
-  Proof.
-    red.
-    red.
-    cbn.
-    intros.
-    split; eauto using felem_size_in_bytes_mod.
-    change (Memory.anybytes ?p felem_size_in_bytes ?m) with (Placeholder p m).
-    intros ptr mStack mCombined Hany Hsplit.
-    eapply WeakestPrecondition_weaken; cycle 1.
-    - eapply H2; eauto.
-      exists mStack.
-      exists mem.
-      intuition.
-      apply map.split_comm; eauto.
-    - intros tr' mem' locals' [Htr [Hmem Hloc]]; subst.
-      unfold felem_alloc.
-      unfold nlet_eq.
-      eapply H3; eauto.
-  Qed.
-
-  (*
-   Local Ltac prove_field_compilation :=
-    repeat straightline';
-    handle_call;
-    lazymatch goal with
-    | |- sep _ _ _ => ecancel_assumption
-    | _ => idtac
-    end; eauto;
-    sepsimpl; repeat straightline'; subst; eauto.
-   *)
-
-  Definition pred_sep {A} R (pred : A -> predicate) (v : A) tr' mem' locals':=
-    (R * Basics.flip (pred v tr') locals')%sep mem'.
-  
-  Lemma compile_binop_alloc {name} {op: BinOp name}
-        {tr mem locals functions} x y:
-    let v := felem_alloc (bin_model (feval x) (feval y)) in
-    forall {P} {pred: P v -> predicate} {k: nlet_eq_k P v} {k_impl}
-      Rin x_ptr x_var y_ptr y_var out_var,
-
-      (_: spec_of name) functions ->
-      bounded_by bin_xbounds x ->
-      bounded_by bin_ybounds y ->
-
-      (*
-      map.get locals out_var = Some out_ptr ->
-       
-      (FElem out_ptr out * Rout)%sep mem ->
-       *)
-      (*Rout mem -> TODO: is this okay?*)
-      let Rout := (FElem x_ptr x * FElem y_ptr y * Rin)%sep in
-      (FElem x_ptr x * FElem y_ptr y * Rin)%sep mem ->
-      map.get locals x_var = Some x_ptr ->
-      map.get locals y_var = Some y_ptr ->
-
-      out_var <> x_var ->
-      out_var <> y_var ->
-
-      (let v := v in
-       forall out out_ptr m (Heq: feval out = v),
-         bounded_by bin_outbounds out ->
-         sep (FElem out_ptr out) Rout m ->
-         (<{ Trace := tr;
-             Memory := m;
-             Locals := map.put locals out_var out_ptr;
-             Functions := functions }>
-          k_impl
-          <{ pred_sep (Placeholder out_ptr) pred (k v eq_refl) }>)) ->
-      <{ Trace := tr;
-         Memory := mem;
-         Locals := locals;
-         Functions := functions }>
-      
-      cmd.stackalloc out_var (@felem_size_in_bytes field_parameters _ field_representaton)
-                     (cmd.seq
-                        (cmd.call [] name [expr.var out_var; expr.var x_var; expr.var y_var ])
-                        k_impl)
-      <{ pred (nlet_eq [out_var] v k) }>.
-  Proof.
-    repeat straightline'.
-    split; eauto using felem_size_in_bytes_mod.
-    intros out_ptr mStack mCombined Hplace%FElem_from_bytes.
-    destruct Hplace as [out Hout].
-    repeat straightline'.
-    straightline_call.
-    intuition eauto.
-    {
-      exists (FElem out_ptr out * Rin)%sep.
-      assert (((FElem x_ptr x ⋆ FElem y_ptr y ⋆ Rin) * FElem out_ptr out)%sep mCombined).
-      exists mem.
-      exists mStack.
-      intuition.
-      ecancel_assumption.
-    }
-    {
-      exists mStack.
-      exists mem.
-      intuition eauto.
-      apply map.split_comm; eauto.
-    }
-    repeat straightline'.
-    eapply WeakestPrecondition_weaken with (p1 := pred_sep (Memory.anybytes out_ptr felem_size_in_bytes)
-                                                           pred (let/n x as out_var eq:Heq := v in
-                                                                 k x Heq)).
-    {
-      unfold pred_sep.
-      repeat straightline'.
-      destruct H9 as [mStack' [m' [Hmem [HmStack Hm]]]].
-      unfold Basics.flip in Hm.
-      exists m'.
-      exists mStack'.
-      intuition.
-      apply map.split_comm; auto.
-    }
-    eapply H7; repeat straightline'.
-    {
-      unfold v.
-      unfold felem_alloc.
-      eauto.
-    }
-    eauto.
-    {
-      unfold Rout.
-      ecancel_assumption.
-    }
-  Qed.
-
-   Ltac cleanup_op_lemma lem := (* This makes [simple apply] work *)
-    let lm := fresh in
-    let op := match lem with _ _ ?op => op end in
-    let op_hd := term_head op in
-    let simp proj :=
-        (let hd := term_head proj in
-         let reduced := (eval cbv [op_hd hd] in proj) in
-         change proj with reduced in (type of lm)) in
-    pose lem as lm;
-    first [ simp (bin_model (BinOp := op));
-            simp (bin_xbounds (BinOp := op));
-            simp (bin_ybounds (BinOp := op));
-            simp (bin_outbounds (BinOp := op))
-          | simp (un_model (UnOp := op));
-            simp (un_xbounds (UnOp := op));
-            simp (un_outbounds (UnOp := op)) ];
-    let t := type of lm in
-    let t := (eval cbv beta in t) in
-    exact (lm: t).
-  
-  Notation make_bin_alloc_lemma op :=
-    ltac:(cleanup_op_lemma (@compile_binop_alloc _ op)) (only parsing).
-
-  Definition compile_mul := make_bin_alloc_lemma bin_mul.
-  Definition compile_add := make_bin_alloc_lemma bin_add.
-  Definition compile_sub := make_bin_alloc_lemma bin_sub.
-
-  
-   Lemma compile_unop_alloc {name} (op: UnOp name) {tr mem locals functions} x:
-    let v := felem_alloc (un_model (feval x)) in
-    forall {P} {pred: P v -> predicate} {k: nlet_eq_k P v} {k_impl}
-      Rin x_ptr x_var out_var,
-
-      (_: spec_of name) functions ->
-      bounded_by un_xbounds x ->
-
-      
-      let Rout := (FElem x_ptr x * Rin)%sep in
-      (*
-        map.get locals out_var = Some out_ptr ->
-        (FElem out_ptr out * Rout)%sep mem ->
-       *)
-
-      (FElem x_ptr x * Rin)%sep mem ->
-      map.get locals x_var = Some x_ptr ->
-      out_var <> x_var ->
-
-      (let v := v in
-       forall out out_ptr m (Heq : feval out = v),
-         bounded_by un_outbounds out ->
-         sep (FElem out_ptr out) Rout m ->
-         (<{ Trace := tr;
-             Memory := m;
-             Locals := map.put locals out_var out_ptr;
-             Functions := functions }>
-          k_impl
-          <{ pred_sep (Placeholder out_ptr) pred (k v eq_refl)
-
-            (*fun tr' mem' locals' =>
-             exists m' mStack' : map.rep, Placeholder out_ptr mStack' /\
-                                          map.split mem' m' mStack' /\
-                                          pred (k v eq_refl) tr' m' locals' 
-
-             *)}>)) ->
-      <{ Trace := tr;
-         Memory := mem;
-         Locals := locals;
-         Functions := functions }>
-      cmd.stackalloc out_var (@felem_size_in_bytes field_parameters _ field_representaton)
-                     (cmd.seq
-                        (cmd.call [] name [expr.var out_var; expr.var x_var])
-                        k_impl)
-      <{ pred (nlet_eq [out_var] v k) }>.
-   Proof.
-    repeat straightline'.
-    split; eauto using felem_size_in_bytes_mod.
-    intros out_ptr mStack mCombined Hplace%FElem_from_bytes.
-    destruct Hplace as [out Hout].
-    repeat straightline'.
-    straightline_call.
-    intuition eauto.
-    {
-      exists (FElem out_ptr out * Rin)%sep.
-      assert (((FElem x_ptr x ⋆ Rin) * FElem out_ptr out)%sep mCombined).
-      exists mem.
-      exists mStack.
-      intuition.
-      ecancel_assumption.
-    }
-    {
-      exists mStack.
-      exists mem.
-      intuition eauto.
-      apply map.split_comm; eauto.
-    }
-    repeat straightline'.
-    eapply WeakestPrecondition_weaken with (p1 := pred_sep (Memory.anybytes out_ptr felem_size_in_bytes)
-                                                           pred (let/n x as out_var eq:Heq := v in
-                                                                 k x Heq)).
-    {
-      unfold pred_sep.
-      repeat straightline'.
-      destruct H6 as [mStack' [m' [Hmem [HmStack Hm]]]].
-      unfold Basics.flip in Hm.
-      exists m'.
-      exists mStack'.
-      intuition.
-      apply map.split_comm; auto.
-    }
-    eapply H4; repeat straightline'.
-    {
-      unfold v.
-      unfold felem_alloc.
-      eauto.
-    }
-    eauto.
-    {
-      unfold Rout.
-      ecancel_assumption.
-    }
-  Qed.
-
-   Notation make_un_lemma op :=
-     ltac:(cleanup_op_lemma (@compile_unop_alloc _ op)) (only parsing).
-
-   Definition compile_square := make_un_lemma un_square.
-   Definition compile_scmula24 := make_un_lemma un_scmula24.
-   Definition compile_inv := make_un_lemma un_inv.
-
   Section Gallina.
     Local Open Scope F_scope.
 
@@ -343,7 +27,6 @@ Section __.
                (X1: F M_pos) (P1 P2: point) : (point * point) :=
       let '(X2, Z2) := P1 in
       let '(X3, Z3) := P2 in
-      (*TODO: set things up so eq isn't needed *)
       let/n A := felem_alloc (X2+Z2) in
       let/n AA := felem_alloc (A^2) in
       let/n B := felem_alloc (X2-Z2) in
@@ -366,15 +49,13 @@ Section __.
       let/n Z2 := a24*E in
       let/n Z2:= (AA+Z2) in
       let/n Z2 := E*Z2 in
-      (* ((X4, Z4), (X5, Z5)) *)
       ((X2, Z2), (X3, Z3)).
   End Gallina.
 
   Instance spec_of_ladderstep : spec_of "ladderstep" :=
     fnspec! "ladderstep"
-          (pX1 pX2 pZ2 pX3 pZ3
-               (*pA pAA pB pBB pE pC pD pDA pCB*) : Semantics.word)
-          / (X1 X2 Z2 X3 Z3 (*A AA B BB E C D DA CB*) : felem) R,
+          (pX1 pX2 pZ2 pX3 pZ3 : Semantics.word)
+          / (X1 X2 Z2 X3 Z3 : felem) R,
     { requires tr mem :=
         bounded_by tight_bounds X1
         /\ bounded_by tight_bounds X2
@@ -383,16 +64,10 @@ Section __.
         /\ bounded_by tight_bounds Z3
         /\ (FElem pX1 X1
             * FElem pX2 X2 * FElem pZ2 Z2
-            * FElem pX3 X3 * FElem pZ3 Z3
-            (** FElem pA A * FElem pAA AA
-             * FElem pB B * FElem pBB BB
-             * FElem pE E * FElem pC C
-             * FElem pD D * FElem pDA DA
-             * FElem pCB CB*) * R)%sep mem;
+            * FElem pX3 X3 * FElem pZ3 Z3 * R)%sep mem;
       ensures tr' mem' :=
         tr = tr'
         /\ exists X4 Z4 X5 Z5 (* output values *)
-                  (*A' AA' B' BB' E' C' D' DA' CB' (* new intermediates *)*)
                   : felem,
           (ladderstep_gallina
              (feval X1) (feval X2, feval Z2)
@@ -403,11 +78,7 @@ Section __.
           /\ bounded_by tight_bounds X5
           /\ bounded_by tight_bounds Z5
           /\ (FElem pX1 X1 * FElem pX2 X4 * FElem pZ2 Z4
-              * FElem pX3 X5 * FElem pZ3 Z5
-              (** FElem pA A' * FElem pAA AA'
-               * FElem pB B' * FElem pBB BB'
-               * FElem pE E' * FElem pC C' * FElem pD D'
-               * FElem pDA DA' * FElem pCB CB'*) * R)%sep mem'}.
+              * FElem pX3 X5 * FElem pZ3 Z5 * R)%sep mem'}.
 
   Lemma compile_ladderstep : forall {tr mem locals functions}
         (x1 x2 z2 x3 z3 : F M_pos),
@@ -415,12 +86,7 @@ Section __.
     forall {P} {pred: P v -> predicate} {k: nlet_eq_k P v} {k_impl}
            Rout
            X1 X1_ptr X1_var X2 X2_ptr X2_var Z2 Z2_ptr Z2_var
-           X3 X3_ptr X3_var Z3 Z3_ptr Z3_var
-    (* A A_ptr A_var AA AA_ptr AA_var
-           B B_ptr B_var BB BB_ptr BB_var
-           E E_ptr E_var C C_ptr C_var
-           D D_ptr D_var DA DA_ptr DA_var
-           CB CB_ptr CB_var*),
+           X3 X3_ptr X3_var Z3 Z3_ptr Z3_var,
 
       spec_of_ladderstep functions ->
 
@@ -436,31 +102,16 @@ Section __.
       bounded_by tight_bounds Z3 ->
       (FElem X1_ptr X1
        * FElem X2_ptr X2 * FElem Z2_ptr Z2
-       * FElem X3_ptr X3 * FElem Z3_ptr Z3
-      (* * FElem A_ptr A * FElem AA_ptr AA
-       * FElem B_ptr B * FElem BB_ptr BB
-       * FElem E_ptr E * FElem C_ptr C
-       * FElem D_ptr D * FElem DA_ptr DA
-       * FElem CB_ptr CB *) * Rout)%sep mem ->
+       * FElem X3_ptr X3 * FElem Z3_ptr Z3 * Rout)%sep mem ->
 
         map.get locals X1_var = Some X1_ptr ->
         map.get locals X2_var = Some X2_ptr ->
         map.get locals Z2_var = Some Z2_ptr ->
         map.get locals X3_var = Some X3_ptr ->
         map.get locals Z3_var = Some Z3_ptr ->
-        (*map.get locals A_var = Some A_ptr ->
-        map.get locals AA_var = Some AA_ptr ->
-        map.get locals B_var = Some B_ptr ->
-        map.get locals BB_var = Some BB_ptr ->
-        map.get locals E_var = Some E_ptr ->
-        map.get locals C_var = Some C_ptr ->
-        map.get locals D_var = Some D_ptr ->
-        map.get locals DA_var = Some DA_ptr ->
-        map.get locals CB_var = Some CB_ptr ->*)
 
         (let v := v in
          forall (X4 Z4 X5 Z5 (* output values *)
-                    (*A' AA' B' BB' E' C' D' DA' CB' (* new intermediates *)*)
                  : felem) m
                 (Heq : ladderstep_gallina
                          (feval X1) (feval X2, feval Z2)
@@ -471,11 +122,7 @@ Section __.
           bounded_by tight_bounds X5 ->
           bounded_by tight_bounds Z5 ->
           (FElem X1_ptr X1 * FElem X2_ptr X4 * FElem Z2_ptr Z4
-           * FElem X3_ptr X5 * FElem Z3_ptr Z5
-           (* * FElem A_ptr A' * FElem AA_ptr AA'
-           * FElem B_ptr B' * FElem BB_ptr BB'
-           * FElem E_ptr E' * FElem C_ptr C' * FElem D_ptr D'
-           * FElem DA_ptr DA' * FElem CB_ptr CB' *) * Rout)%sep m ->
+           * FElem X3_ptr X5 * FElem Z3_ptr Z5 * Rout)%sep m ->
            (<{ Trace := tr;
                Memory := m;
                Locals := locals;
@@ -491,11 +138,7 @@ Section __.
           (cmd.call [] "ladderstep"
                     [ expr.var X1_var; expr.var X2_var;
                         expr.var Z2_var; expr.var X3_var;
-                          expr.var Z3_var (*; expr.var A_var;
-                            expr.var AA_var; expr.var B_var;
-                              expr.var BB_var; expr.var E_var;
-                                expr.var C_var; expr.var D_var;
-                                  expr.var DA_var; expr.var CB_var *)])
+                          expr.var Z3_var])
           k_impl
         <{ pred (nlet_eq
                    [X1_var; X2_var; Z2_var; X3_var; Z3_var]
@@ -509,24 +152,6 @@ Section __.
         end.
     Qed.
 
-  (*TODO: move, along with allocating lemma *)
-  Ltac field_compile_step :=
-  (first
-   [ simple eapply compile_scmula24
-   | simple eapply compile_mul
-   | simple eapply compile_add
-   | simple eapply compile_sub
-   | simple eapply compile_square
-   | simple eapply compile_inv
-   | simple eapply Compilation.compile_scmula24
-   | simple eapply Compilation.compile_mul
-   | simple eapply Compilation.compile_add
-   | simple eapply Compilation.compile_sub
-   | simple eapply Compilation.compile_square
-   | simple eapply Compilation.compile_inv ]); lazymatch goal with
-                                   | |- feval _ = _ => try eassumption; try reflexivity
-                                   | |- _ => idtac
-                                   end.
   
   Ltac ladderstep_compile_custom :=
     simple apply compile_nlet_as_nlet_eq;
@@ -539,39 +164,9 @@ Section __.
            end.
 
   Ltac compile_custom ::= ladderstep_compile_custom.
-  
-Definition
-  ladderstep_body' :=
-  noskips
-  (cmd.seq (cmd.call [] add [expr.var "X2"; expr.var "Z2"; expr.var "A"])
-     (cmd.seq (cmd.call [] square [expr.var "A"; expr.var "AA"])
-        (cmd.seq (cmd.call [] sub [expr.var "X2"; expr.var "Z2"; expr.var "B"])
-           (cmd.seq (cmd.call [] square [expr.var "B"; expr.var "BB"])
-              (cmd.seq (cmd.call [] sub [expr.var "AA"; expr.var "BB"; expr.var "E"])
-                 (cmd.seq (cmd.call [] add [expr.var "X3"; expr.var "Z3"; expr.var "C"])
-                    (cmd.seq (cmd.call [] sub [expr.var "X3"; expr.var "Z3"; expr.var "D"])
-                       (cmd.seq (cmd.call [] mul [expr.var "D"; expr.var "A"; expr.var "DA"])
-                          (cmd.seq (cmd.call [] mul [expr.var "C"; expr.var "B"; expr.var "CB"])
-                             (cmd.seq (cmd.call [] add [expr.var "DA"; expr.var "CB"; expr.var "X3"])
-                                (cmd.seq (cmd.call [] square [expr.var "X3"; expr.var "X3"])
-                                   (cmd.seq (cmd.call [] sub [expr.var "DA"; expr.var "CB"; expr.var "Z3"])
-                                      (cmd.seq (cmd.call [] square [expr.var "Z3"; expr.var "Z3"])
-                                         (cmd.seq (cmd.call [] mul [expr.var "X1"; expr.var "Z3"; expr.var "Z3"])
-                                            (cmd.seq
-                                               (cmd.call [] mul [expr.var "AA"; expr.var "BB"; expr.var "X2"])
-                                               (cmd.seq (cmd.call [] scmula24 [expr.var "E"; expr.var "Z2"])
-                                                  (cmd.seq
-                                                     (cmd.call [] add
-                                                        [expr.var "AA"; expr.var "Z2"; expr.var "Z2"])
-                                                     (cmd.seq
-                                                        (cmd.call [] mul
-                                                           [expr.var "E"; expr.var "Z2"; expr.var "Z2"])
-                                                        (fold_right
-                                                           (fun (v : string) (c : cmd) => cmd.seq (cmd.unset v) c)
-                                                           cmd.skip []))))))))))))))))))).
 
-Axiom TODO : False.
-Derive ladderstep_body SuchThat
+  
+  Derive ladderstep_body SuchThat
          (let args := ["X1"; "X2"; "Z2"; "X3"; "Z3"] in
           ltac:(
             let proc := constr:(("ladderstep",
@@ -582,95 +177,9 @@ Derive ladderstep_body SuchThat
             exact (__rupicola_program_marker ladderstep_gallina -> goal)))
          As ladderstep_correct.
 Proof.
-  (*
-  unfold ladderstep_body.
-  instantiate (1:=
-                  noskips
-                       (cmd.stackalloc "A" felem_size_in_bytes
-                          (cmd.seq (cmd.call [] add [expr.var "A"; expr.var "X2"; expr.var "Z2"])
-                             (cmd.stackalloc "AA" felem_size_in_bytes
-                                (cmd.seq (cmd.call [] square [expr.var "AA"; expr.var "A"])
-                                   (cmd.stackalloc "B" felem_size_in_bytes
-                                      (cmd.seq (cmd.call [] sub [expr.var "B"; expr.var "X2"; expr.var "Z2"])
-                                         (cmd.stackalloc "BB" felem_size_in_bytes
-                                            (cmd.seq (cmd.call [] square [expr.var "BB"; expr.var "B"])
-                                               (cmd.stackalloc "E" felem_size_in_bytes
-                                                  (cmd.seq
-                                                     (cmd.call [] sub [expr.var "E"; expr.var "AA"; expr.var "BB"])
-                                                     (cmd.stackalloc "C" felem_size_in_bytes
-                                                        (cmd.seq
-                                                           (cmd.call [] add
-                                                              [expr.var "C"; expr.var "X3"; expr.var "Z3"])
-                                                           (cmd.stackalloc "D" felem_size_in_bytes
-                                                              (cmd.seq
-                                                                 (cmd.call [] sub
-                                                                    [expr.var "D"; expr.var "X3"; expr.var "Z3"])
-                                                                 (cmd.stackalloc "DA" felem_size_in_bytes
-                                                                    (cmd.seq
-                                                                       (cmd.call [] mul
-                                                                          [expr.var "DA"; 
-                                                                          expr.var "D"; 
-                                                                          expr.var "A"])
-                                                                       (cmd.stackalloc "CB" felem_size_in_bytes
-                                                                          (cmd.seq
-                                                                             (cmd.call [] mul
-                                                                                [expr.var "CB"; 
-                                                                                expr.var "C"; 
-                                                                                expr.var "B"])
-                                                                             (cmd.seq
-                                                                                (cmd.call [] add
-                                                                                   [expr.var "X3"; 
-                                                                                   expr.var "DA"; 
-                                                                                   expr.var "CB"])
-                                                                                (cmd.seq
-                                                                                   (cmd.call [] square
-                                                                                     [
-                                                                                     expr.var "X3"; 
-                                                                                     expr.var "X3"])
-                                                                                   (cmd.seq
-                                                                                     (cmd.call [] sub
-                                                                                     [
-                                                                                     expr.var "Z3"; 
-                                                                                     expr.var "DA"; 
-                                                                                     expr.var "CB"]) cmd.skip)))))))))))))))))))))).
-  destruct TODO.
-Qed.*)
 
   compile_setup.
-  do 16 compile_step.
-  (* 3 s*)
-  (*
-  simple apply compile_nlet_as_nlet_eq.
-  field_compile_step.
-  Set Printing Depth 100.
-  9:instantiate(1:= cmd.skip).
-  7:instantiate(2:= "DA").
-  8:instantiate(2:= "CB").
-  all: destruct TODO.
-  
-  destruct TODO.
-Time Qed.
-    Time
-    1-8:repeat compile_step.
-    eauto with compiler;
-    (* rewrite results in terms of feval to match lemmas *)
-    repeat lazymatch goal with
-           | H : feval _ = ?x |- context [?x] =>
-             is_var x; rewrite <-H
-           end.
-  compile_custom.
-*)
-  compile_step.
-  (* 10 s*)
-  compile_step.
-  (*26s *)
-  compile_step.
-  (*96s *)
   repeat compile_step.
- 
-  (*instantiate(1:= cmd.skip).
-  destruct TODO.
-Time Qed. *)
   {
     unfold pred_sep; simpl.
     unfold Basics.flip; simpl.

--- a/src/Bedrock/Group/ScalarMult/LadderStep.v
+++ b/src/Bedrock/Group/ScalarMult/LadderStep.v
@@ -185,58 +185,23 @@ Proof.
     unfold map.getmany_of_list.
     simpl.
     {
-      (*TODO: do in a better way*)
-      change (fun y => exists ws, @?P ws y) with (Lift1Prop.ex1 P).
-      repeat seprewrite FElem_from_bytes.
-      repeat (sepsimpl;
-              match goal with
-                [H : context [FElem ?p ?v] |- Lift1Prop.ex1 (fun h => FElem ?p h * _)%sep _] =>
-                exists v
-              end).
-      sepsimpl.
+      eapply Proper_sep_impl1;
+        [ eapply FElem_to_bytes | | ecancel_assumption].
+      clear H29 m16.
+      repeat (intros m16 H29;
+      eapply Proper_sep_impl1;
+        [ eapply FElem_to_bytes | | ecancel_assumption];
+        clear H29 m16).
+      intros m16 H29.
       exists [].
-      cbv beta.
-      eapply Proper_sep_iff1.
-      2: reflexivity.
-      {
-        instantiate (1:=
-                       (Lift1Prop.ex1 (fun X4 =>
-                        Lift1Prop.ex1 (fun Z4 =>
-                        Lift1Prop.ex1 (fun X5 =>
-                        Lift1Prop.ex1 (fun Z5 =>
-                        (emp ((feval out13, feval out16, feval out9, feval out12)
-                         = (feval X4, feval Z4, feval X5, feval Z5) /\
-                        bounded_by tight_bounds X4 /\
-                        bounded_by tight_bounds Z4 /\
-                        bounded_by tight_bounds X5 /\ bounded_by tight_bounds Z5))
-                        * (FElem pX1 X1 ⋆ FElem pX2 X4 ⋆ FElem pZ2 Z4 ⋆ FElem pX3 X5 ⋆ FElem pZ3 Z5 ⋆ R))))))%sep).
-        cbv [Lift1Prop.iff1 Lift1Prop.ex1].
-        intuition idtac.
-        {
-          destruct H33 as (?&?&?&?&?).
-          exists x0, x1, x2, x3.
-          intuition idtac.
-          eapply sep_emp_l.
-          intuition idtac.
-        }
-        {
-          destruct H28 as (?&?&?&?&?).
-          exists x0, x1, x2, x3.
-          eapply sep_emp_l in H28.
-          intuition idtac.
-        }
-      }
-      sepsimpl; eexists.
-      sepsimpl; eexists.
-      sepsimpl; eexists.
-      sepsimpl; eexists.
-      sepsimpl.
-      auto.
-      all: try assumption.
+      repeat compile_step.
+      do 4 eexists.
+      intuition.
       ecancel_assumption.
     }
   }
 Qed.
+  
   
 End __.
 

--- a/src/Bedrock/Group/ScalarMult/LadderStep.v
+++ b/src/Bedrock/Group/ScalarMult/LadderStep.v
@@ -582,6 +582,7 @@ Derive ladderstep_body SuchThat
             exact (__rupicola_program_marker ladderstep_gallina -> goal)))
          As ladderstep_correct.
 Proof.
+  (*
   unfold ladderstep_body.
   instantiate (1:=
                   noskips
@@ -633,11 +634,12 @@ Proof.
                                                                                      expr.var "DA"; 
                                                                                      expr.var "CB"]) cmd.skip)))))))))))))))))))))).
   destruct TODO.
-Qed.
+Qed.*)
 
-(*compile_setup.
+  compile_setup.
   do 16 compile_step.
   (* 3 s*)
+  (*
   simple apply compile_nlet_as_nlet_eq.
   field_compile_step.
   Set Printing Depth 100.
@@ -657,56 +659,77 @@ Time Qed.
              is_var x; rewrite <-H
            end.
   compile_custom.
+*)
   compile_step.
   (* 10 s*)
   compile_step.
   (*26s *)
   compile_step.
   (*96s *)
-  instantiate(1:= cmd.skip).
+  repeat compile_step.
+ 
+  (*instantiate(1:= cmd.skip).
   destruct TODO.
-Time Qed.
-  unfold pred_sep; simpl.
-  unfold Basics.flip; simpl.
-  repeat change (fun x => ?h x) with h.
-  unfold map.getmany_of_list.
-  simpl.
+Time Qed. *)
   {
-    (*TODO: do in a better way*)
-    repeat lazymatch goal with
-      [H : (_ * _)%sep _ |-_] =>
-      let m1 := fresh "m" in
-      let m2 := fresh "m" in
-      let Hm1 := fresh "Hm" in
-      let Hm2 := fresh  "Hm" in
-      destruct H as [m1 [m2 [? [Hm1 Hm2]]]]
-           end.
-    match goal with
-      [H := noskips ?c |- _] =>
-      idtac c
-    end.
-    idtac ladderstep_body.
-    destruct TODO.
-    (*
-      repeat lazymatch goal with
-      [H : FElem ?ptr _ ?m' |- (Placeholder ?ptr * _)%sep ?m] =>
-      exists m'; eexists; split; [shelve|]; split;
-        [ apply FElem_from_bytes; eexists; eassumption |]
-           end.
-    exists [].
-    intuition.
-    do 4 eexists.
-    split; [reflexivity|].
-    intuition.
-    repeat lazymatch goal with
-      [H : ?R ?m' |- (_ * ?R)%sep ?m] =>
-      eexists; exists m';
-        split; [shelve|]; split; [| eassumption]
-           end.
-    eassumption.
-     *)
+    unfold pred_sep; simpl.
+    unfold Basics.flip; simpl.
+    repeat change (fun x => ?h x) with h.
+    unfold map.getmany_of_list.
+    simpl.
+    {
+      (*TODO: do in a better way*)
+      change (fun y => exists ws, @?P ws y) with (Lift1Prop.ex1 P).
+      repeat seprewrite FElem_from_bytes.
+      repeat (sepsimpl;
+              match goal with
+                [H : context [FElem ?p ?v] |- Lift1Prop.ex1 (fun h => FElem ?p h * _)%sep _] =>
+                exists v
+              end).
+      sepsimpl.
+      exists [].
+      cbv beta.
+      eapply Proper_sep_iff1.
+      2: reflexivity.
+      {
+        instantiate (1:=
+                       (Lift1Prop.ex1 (fun X4 =>
+                        Lift1Prop.ex1 (fun Z4 =>
+                        Lift1Prop.ex1 (fun X5 =>
+                        Lift1Prop.ex1 (fun Z5 =>
+                        (emp ((feval out13, feval out16, (feval out9, feval out12))
+                         = (feval X4, feval Z4, (feval X5, feval Z5)) /\
+                        bounded_by tight_bounds X4 /\
+                        bounded_by tight_bounds Z4 /\
+                        bounded_by tight_bounds X5 /\ bounded_by tight_bounds Z5))
+                        * (FElem pX1 X1 ⋆ FElem pX2 X4 ⋆ FElem pZ2 Z4 ⋆ FElem pX3 X5 ⋆ FElem pZ3 Z5 ⋆ R))))))%sep).
+        cbv [Lift1Prop.iff1 Lift1Prop.ex1].
+        intuition idtac.
+        {
+          destruct H33 as (?&?&?&?&?).
+          exists x0, x1, x2, x3.
+          intuition idtac.
+          eapply sep_emp_l.
+          intuition idtac.
+        }
+        {
+          destruct H28 as (?&?&?&?&?).
+          exists x0, x1, x2, x3.
+          eapply sep_emp_l in H28.
+          intuition idtac.
+        }
+      }
+      sepsimpl; eexists.
+      sepsimpl; eexists.
+      sepsimpl; eexists.
+      sepsimpl; eexists.
+      sepsimpl.
+      auto.
+      all: try assumption.
+      ecancel_assumption.
+    }
   }
-Qed.*)
+Qed.
   
 End __.
 

--- a/src/Bedrock/Group/ScalarMult/LadderStep.v
+++ b/src/Bedrock/Group/ScalarMult/LadderStep.v
@@ -54,7 +54,7 @@ Section __.
 
   Instance spec_of_ladderstep : spec_of "ladderstep" :=
     fnspec! "ladderstep"
-          (pX1 pX2 pZ2 pX3 pZ3 : Semantics.word)
+          (pX1 pX2 pZ2 pX3 pZ3 : word)
           / (X1 X2 Z2 X3 Z3 : F M_pos) R,
     { requires tr mem :=
         (FElem (Some tight_bounds) pX1 X1
@@ -74,7 +74,7 @@ Section __.
               * FElem (Some tight_bounds) pX3 X5
               * FElem (Some tight_bounds) pZ3 Z5 * R)%sep mem'}.
 
-  Lemma compile_ladderstep {tr mem locals functions}
+  Lemma compile_ladderstep {tr m l functions}
         (x1 x2 z2 x3 z3 : F M_pos) :
     let v := ladderstep_gallina x1 x2 z2 x3 z3 in
     forall {P} {pred: P v -> predicate} {k: nlet_eq_k P v} {k_impl}
@@ -86,33 +86,33 @@ Section __.
 
       (FElem (Some tight_bounds) X1_ptr x1
        * FElem (Some tight_bounds) X2_ptr x2 * FElem (Some tight_bounds) Z2_ptr z2
-       * FElem (Some tight_bounds) X3_ptr x3 * FElem (Some tight_bounds) Z3_ptr z3 * Rout)%sep mem ->
+       * FElem (Some tight_bounds) X3_ptr x3 * FElem (Some tight_bounds) Z3_ptr z3 * Rout)%sep m ->
 
-        map.get locals X1_var = Some X1_ptr ->
-        map.get locals X2_var = Some X2_ptr ->
-        map.get locals Z2_var = Some Z2_ptr ->
-        map.get locals X3_var = Some X3_ptr ->
-        map.get locals Z3_var = Some Z3_ptr ->
+        map.get l X1_var = Some X1_ptr ->
+        map.get l X2_var = Some X2_ptr ->
+        map.get l Z2_var = Some Z2_ptr ->
+        map.get l X3_var = Some X3_ptr ->
+        map.get l Z3_var = Some Z3_ptr ->
 
         (let v := v in
-         forall X4 Z4 X5 Z5 (* output values *) m
+         forall X4 Z4 X5 Z5 (* output values *) m'
                 (Heq : ladderstep_gallina x1 x2 z2 x3 z3
                        = (X4, Z4, X5, Z5)),
           (FElem (Some tight_bounds) X1_ptr x1
            * FElem (Some tight_bounds) X2_ptr X4
            * FElem (Some tight_bounds) Z2_ptr Z4
            * FElem (Some tight_bounds) X3_ptr X5
-           * FElem (Some tight_bounds) Z3_ptr Z5 * Rout)%sep m ->
+           * FElem (Some tight_bounds) Z3_ptr Z5 * Rout)%sep m' ->
            (<{ Trace := tr;
-               Memory := m;
-               Locals := locals;
+               Memory := m';
+               Locals := l;
                Functions := functions }>
             k_impl
             <{ pred (k v eq_refl) }>)) ->
 
         <{ Trace := tr;
-           Memory := mem;
-           Locals := locals;
+           Memory := m;
+           Locals := l;
            Functions := functions }>
         cmd.seq
           (cmd.call [] "ladderstep"
@@ -167,6 +167,7 @@ Section __.
 
     
     Hint Immediate relax_bounds_FElem : ecancel_impl.
+    Hint Immediate drop_bounds_FElem : ecancel_impl.
 
 
     Ltac ecancel_assumption ::=  ecancel_assumption_impl.

--- a/src/Bedrock/Group/ScalarMult/LadderStep.v
+++ b/src/Bedrock/Group/ScalarMult/LadderStep.v
@@ -201,75 +201,170 @@ Section __.
     intros; ecancel_assumption.
     Qed.
 
-    
-    Derive ladderstep_body SuchThat
-           (let args := ["X1"; "X2"; "Z2"; "X3"; "Z3"] in
-            ltac:(
-              let proc := constr:(("ladderstep",
-                                   (args, [], ladderstep_body))
-                                  : Syntax.func) in
-              let goal := Rupicola.Lib.Tactics.program_logic_goal_for_function
-                            proc [mul;add;sub;square;scmula24] in
-              exact (__rupicola_program_marker ladderstep_gallina -> goal)))
-           As ladderstep_correct.
-    Proof.
 
-  compile_setup.
-  repeat compile_step.
-  {
-    eapply Proper_sep_impl1.
-    {
-      intros x H'.
-      eapply Proper_sep_impl1.
-      eapply relax_bounds_FElem.
-      eapply relax_bounds_FElem.
-      ecancel_assumption.
-    }
-    2:{
-      ecancel_assumption.
-    }
-    exact (fun a b=> b).
-  }
-  repeat compile_step.
-  repeat compile_step.
-  {
-    eapply Proper_sep_impl1.
-    {
-      intros x H'.
-      eapply Proper_sep_impl1.
-      eapply relax_bounds_FElem.
-      eapply relax_bounds_FElem.
-      ecancel_assumption.
-    }
-    2:{
-      ecancel_assumption.
-    }
-    exact (fun a b=> b).
-  }
-  repeat compile_step.
-  repeat compile_step.
-  {
-    unfold pred_sep; simpl.
-    repeat change (fun x => ?h x) with h.
-    unfold map.getmany_of_list.
-    simpl.
-    {      
-      repeat match goal with
-      | [ H : _ ?m |- _ ?m] =>
-      eapply Proper_sep_impl1;
-        [ eapply P_to_bytes | clear H m; intros H m | ecancel_assumption]
+(*TODO: move to separate file; copy source and re-edit?*)
+  Require Import coqutil.Tactics.syntactic_unify coqutil.Tactics.rdelta.
+ 
+
+Require Import Coq.Classes.Morphisms.
+Require Import coqutil.sanity coqutil.Decidable coqutil.Tactics.destr.
+Section SepProperties.
+  Context {key value} {map : map.map key value} {ok : map.ok map}.
+  Context {key_eqb: key -> key -> bool} {key_eq_dec: EqDecider key_eqb}.
+  Local Open Scope sep_scope.
+  
+  Definition hd {T} := Eval cbv delta in @List.hd T.
+  Definition tl {T} := Eval cbv delta in @List.tl T.
+  Definition firstn {T} := Eval cbv delta in @List.firstn T.
+  Definition skipn {T} := Eval cbv delta in @List.skipn T.
+  Definition app {T} := Eval cbv delta in @List.app T.
+
+  Local Infix "++" := app. Local Infix "++" := app : list_scope.
+  Let nth n xs := hd (emp(map:=map) True) (skipn n xs).
+  Let remove_nth n (xs : list (map -> Prop)) :=
+    (firstn n xs ++ tl (skipn n xs)).
+
+  
+  Lemma seps_nth_to_head n xs : Lift1Prop.iff1 (sep (nth n xs) (seps (remove_nth n xs))) (seps xs).
+  Proof.
+    cbv [nth remove_nth].
+    pose proof (List.firstn_skipn n xs : (firstn n xs ++ skipn n xs) = xs).
+    set (xsr := skipn n xs) in *; clearbody xsr.
+    set (xsl := firstn n xs) in *; clearbody xsl.
+    subst xs.
+    setoid_rewrite <-seps'_iff1_seps.
+    destruct xsr.
+    { cbn [seps']; rewrite sep_emp_True_l, 2List.app_nil_r; exact (reflexivity _). }
+    cbn [hd tl].
+    induction xsl; cbn; [exact (reflexivity _)|].
+    rewrite <-IHxsl; clear IHxsl.
+    rewrite (sep_comm _ (seps' _)), <-(sep_assoc _ (seps' _)), <-(sep_comm _ (_ * seps' _)).
+    exact (reflexivity _).
+  Qed.
+  
+    (* iff1 instead of eq as a hyp would be a more general lemma, but eq is more convenient to use *)
+  Lemma cancel_seps_at_indices i j xs ys
+        (Hij : Lift1Prop.impl1 (nth i xs) (nth j ys))
+        (Hrest : Lift1Prop.impl1 (seps (remove_nth i xs)) (seps (remove_nth j ys)))
+    : Lift1Prop.impl1 (seps xs) (seps ys).
+  Proof.
+    rewrite <-(seps_nth_to_head i xs), <-(seps_nth_to_head j ys).
+    rewrite Hij, Hrest.
+    exact (reflexivity _).
+  Qed.
+
+  
+End SepProperties.
+  
+  (* leaves two open goals:
+   1) equality between left sep clause #i and right sep clause #j
+   2) updated main goal *)
+Ltac cancel_seps_at_indices i j :=
+  lazymatch goal with
+  | |- Lift1Prop.impl1 (seps ?LHS) (seps ?RHS) =>
+    simple refine (cancel_seps_at_indices i j LHS RHS _ _);
+    cbn [firstn skipn app hd tl]
+  end.
+
+Create HintDb ecancel_impl discriminated.
+Hint Extern 1 => exact (fun m x => x) : ecancel_impl.
+
+Ltac prop_at_index_is_evar j ys :=
+  let p := eval cbn [firstn skipn app hd tl nth] in (nth j ys) in
+      match p with
+      | (fun _ => ?pb) => is_evar pb
+      | _ => fail "malformed input"
       end.
-      eexists.
-      repeat compile_step.
-      do 4 eexists.
-      intuition.
-      ecancel_assumption.
-    }
-  }
-Qed.
+
+(*TODO: performance*)
+Ltac find_implication xs y :=
+  multimatch xs with
+  | cons ?x _ =>
+    let H := fresh in
+    constr:(O)
+  | cons _ ?xs => let i := find_implication xs y in constr:(S i)
+  end.
 
 
+(*TODO: performance. I've replaced the deltavar stuff with heavier operations  *)
+Ltac ecancel_step :=
+      let RHS := lazymatch goal with |- Lift1Prop.impl1 _ (seps ?RHS) => RHS end in
+      let jy := index_and_element_of RHS in (* <-- multi-success! *)
+      let j := lazymatch jy with (?i, _) => i end in
+      let y := lazymatch jy with (_, ?y) => y end in
+      (* For implication, we don't want to touch RHS evars 
+         until everything else is solved.
+         Makes sure j doesn't point to an evar
+       *)
+      assert_fails (idtac; prop_at_index_is_evar 0%nat RHS);      
+      let LHS := lazymatch goal with |- Lift1Prop.impl1 (seps ?LHS) _ => LHS end in
+      let i := find_implication LHS y in (* <-- multi-success! *)
+      cancel_seps_at_indices i j; [solve [auto 1 with ecancel_impl]|].
+(*TODO: should I use deltavar here too?*)
+Ltac ecancel :=
+  cancel; repeat ecancel_step; (solve [ exact (fun m x => x) ]).
 
+
+ Ltac ecancel_assumption_impl :=
+    multimatch goal with
+    | |- ?PG ?m1 =>
+      multimatch goal with
+      | H: ?PH ?m2
+        |- _ =>
+        syntactic_unify_deltavar m1 m2;
+        refine (Morphisms.subrelation_refl Lift1Prop.impl1 PH PG _ m1 H); clear H;
+        cbn[seps];(*TODO: why is this needed?*)
+        solve[ecancel]
+      end
+    end.
+
+ 
+    (*TODO: speed up by combining pred_seps first and using 1 proper/ecancel_assumption?*)
+    Ltac clear_pred_seps :=   
+    unfold pred_sep;
+    repeat change (fun x => ?h x) with h;
+    repeat match goal with
+           | [ H : _ ?m |- _ ?m] =>
+             eapply Proper_sep_impl1;
+               [ eapply P_to_bytes | clear H m; intros H m | ecancel_assumption]
+           end.
+    Ltac compile_solve_side_conditions ::=
+  match goal with
+  | |- (_ ⋆ _) _ => cbn[fst snd] in *; ecancel_assumption
+  | |- map.get _ _ = _ => solve [ subst_lets_in_goal; solve_map_get_goal ]
+  | |- map.getmany_of_list _ _ = _ => apply map.getmany_of_list_cons
+  | |- map.remove_many _ _ = _ => solve_map_remove_many
+  | |- _ = _ => solve_map_eq
+  | |- _ <> _ => congruence
+  | |- _ /\ _ => split
+  | |- exists _,_ => eexists (*TODO: is this worth adding?*)
+  | |- pred_sep _ _ _ _ _ _ => clear_pred_seps
+  | _ => first
+  [ compile_cleanup
+  | compile_autocleanup
+  | reflexivity
+  | compile_use_default_value
+  | solve
+  [ typeclasses eauto | eauto with compiler_cleanup ] ]
+  end.
+
+    
+    Ltac ecancel_assumption ::=  ecancel_assumption_impl.
+
+ 
+Hint Immediate relax_bounds_FElem : ecancel_impl.
+
+Derive ladderstep_body SuchThat
+       (let args := ["X1"; "X2"; "Z2"; "X3"; "Z3"] in
+        ltac:(
+          let proc := constr:(("ladderstep",
+                               (args, [], ladderstep_body))
+                              : Syntax.func) in
+          let goal := Rupicola.Lib.Tactics.program_logic_goal_for_function
+                        proc [mul;add;sub;square;scmula24] in
+          exact (__rupicola_program_marker ladderstep_gallina -> goal)))
+       As ladderstep_correct.
+Proof. compile. Qed.
   
   
 End __.

--- a/src/Bedrock/Group/ScalarMult/LadderStep.v
+++ b/src/Bedrock/Group/ScalarMult/LadderStep.v
@@ -163,6 +163,16 @@ Section __.
 
   Ltac compile_custom ::= ladderstep_compile_custom.
 
+  (*TODO: move to pred_sep if deemed useful*)
+    Lemma merge_pred_sep A (a : A) R1 R2 pred tr m locals
+    : pred_sep (R1*R2)%sep pred a tr m locals ->
+      pred_sep R1 (pred_sep R2 pred) a tr m locals.
+    Proof.
+    unfold pred_sep; simpl.
+    unfold Basics.flip; simpl.
+    repeat change (fun x => ?h x) with h.
+    intros; ecancel_assumption.
+    Qed.
   
   Derive ladderstep_body SuchThat
          (let args := ["X1"; "X2"; "Z2"; "X3"; "Z3"] in
@@ -179,21 +189,19 @@ Proof.
   compile_setup.
   repeat compile_step.
   {
+
     unfold pred_sep; simpl.
     unfold Basics.flip; simpl.
     repeat change (fun x => ?h x) with h.
     unfold map.getmany_of_list.
     simpl.
     {
+      repeat match goal with
+      | [ H : _ ?m |- _ ?m] =>
       eapply Proper_sep_impl1;
-        [ eapply FElem_to_bytes | | ecancel_assumption].
-      clear H29 m16.
-      repeat (intros m16 H29;
-      eapply Proper_sep_impl1;
-        [ eapply FElem_to_bytes | | ecancel_assumption];
-        clear H29 m16).
-      intros m16 H29.
-      exists [].
+        [ eapply FElem_to_bytes | clear H m; intros H m | ecancel_assumption]
+      end.
+      eexists.
       repeat compile_step.
       do 4 eexists.
       intuition.

--- a/src/Bedrock/Group/ScalarMult/LadderStep.v
+++ b/src/Bedrock/Group/ScalarMult/LadderStep.v
@@ -5,6 +5,13 @@ Require Import Crypto.Bedrock.Group.Point.
 Require Import Crypto.Bedrock.Specs.Field.
 Local Open Scope Z_scope.
 
+(*TODO: currently relies on Examples files.
+  This file should either be moved somewhere else or the dependency removed.
+*)
+Require Import Rupicola.Examples.Nondeterminism.NonDeterminism.
+Require Import Rupicola.Examples.Nondeterminism.StackAlloc.
+Import NDMonad.
+
 Section __.
   Context {width: Z} {BW: Bitwidth width} {word: word.word width} {mem: map.map word Byte.byte}.
   Context {locals: map.map String.string word}.
@@ -19,11 +26,51 @@ Section __.
           {field_representation_ok : FieldRepresentation_ok}.
   Hint Resolve relax_bounds : compiler.
 
+  (*Modified from stack_alloc*)
+  Definition felem_alloc : Comp (felem) := fun _ => True.
+
+  Lemma compile_stack_alloc {tr mem locals functions}:
+    let c := felem_alloc in
+    forall {B} {pred: B -> predicate}
+      {k: felem -> Comp B} {k_impl}
+      (R: _ -> Prop) var,
+      R mem ->
+      (forall ptr (bs: felem) mem,
+          (FElem ptr bs * R)%sep mem ->
+          let pred g tr' mem' locals' :=
+              exists R' bs',
+                (FElem ptr bs' * R')%sep mem' /\
+                forall mem'', R' mem'' -> pred g tr' mem'' locals' in
+          <{ Trace := tr;
+             Memory := mem;
+             Locals := map.put locals var ptr;
+             Functions := functions }>
+          k_impl
+          <{ pbind pred (k bs) }>) ->
+      <{ Trace := tr;
+         Memory := mem;
+         Locals := locals;
+         Functions := functions }>
+      cmd.stackalloc var felem_size_in_bytes k_impl
+      <{ pbind pred (bindn [var] c k) }>.
+  Proof.
+  Admitted.
+
+
   Section Gallina.
     Local Open Scope F_scope.
 
     Definition ladderstep_gallina
-               (X1: F M_pos) (P1 P2: point)  : (point * point) :=
+               (X1: F M_pos) (P1 P2: point) : Comp (point * point) :=
+      let/+ A := felem_alloc in
+      let/+ AA := felem_alloc in
+      let/+ B := felem_alloc in
+      let/+ BB := felem_alloc in
+      let/+ E := felem_alloc in
+      let/+ C := felem_alloc in
+      let/+ D := felem_alloc in
+      let/+ DA := felem_alloc in
+      let/+ CB := felem_alloc in
       let '(X2, Z2) := P1 in
       let '(X3, Z3) := P2 in
       let/n A := X2+Z2 in
@@ -49,14 +96,14 @@ Section __.
       let/n Z2:= (AA+Z2) in
       let/n Z2 := E*Z2 in
       (* ((X4, Z4), (X5, Z5)) *)
-      ((X2, Z2), (X3, Z3)).
+      ret ((X2, Z2), (X3, Z3)).
   End Gallina.
 
   Instance spec_of_ladderstep : spec_of "ladderstep" :=
     fnspec! "ladderstep"
           (pX1 pX2 pZ2 pX3 pZ3
-               pA pAA pB pBB pE pC pD pDA pCB : word)
-          / (X1 X2 Z2 X3 Z3 A AA B BB E C D DA CB : felem) R,
+               (*pA pAA pB pBB pE pC pD pDA pCB*) : Semantics.word)
+          / (X1 X2 Z2 X3 Z3 (*A AA B BB E C D DA CB*) : felem) R,
     { requires tr mem :=
         bounded_by tight_bounds X1
         /\ bounded_by tight_bounds X2
@@ -66,43 +113,46 @@ Section __.
         /\ (FElem pX1 X1
             * FElem pX2 X2 * FElem pZ2 Z2
             * FElem pX3 X3 * FElem pZ3 Z3
-            * FElem pA A * FElem pAA AA
+            (** FElem pA A * FElem pAA AA
             * FElem pB B * FElem pBB BB
             * FElem pE E * FElem pC C
             * FElem pD D * FElem pDA DA
-            * FElem pCB CB * R)%sep mem;
-      ensures tr' mem' :=
-        tr = tr'
-        /\ exists X4 Z4 X5 Z5 (* output values *)
-               A' AA' B' BB' E' C' D' DA' CB' (* new intermediates *)
-               : felem,
-          (ladderstep_gallina
-             (feval X1) (feval X2, feval Z2)
-             (feval X3, feval Z3)
-           = ((feval X4, feval Z4), (feval X5, feval Z5)))
-          /\ bounded_by tight_bounds X4
-          /\ bounded_by tight_bounds Z4
-          /\ bounded_by tight_bounds X5
-          /\ bounded_by tight_bounds Z5
-          /\ (FElem pX1 X1 * FElem pX2 X4 * FElem pZ2 Z4
-              * FElem pX3 X5 * FElem pZ3 Z5
-              * FElem pA A' * FElem pAA AA'
-              * FElem pB B' * FElem pBB BB'
-              * FElem pE E' * FElem pC C' * FElem pD D'
-              * FElem pDA DA' * FElem pCB CB' * R)%sep mem'}.
+            * FElem pCB CB*) * R)%sep mem;
+      ensures tr' mem' rets :=
+        (propbind
+           (ladderstep_gallina
+              (feval X1) (feval X2, feval Z2)
+              (feval X3, feval Z3))
+           (fun res =>
+              rets = [] /\
+             tr = tr'
+             /\ exists X4 Z4 X5 Z5 (* output values *)
+                       (*A' AA' B' BB' E' C' D' DA' CB' (* new intermediates *)*)
+                       : felem,
+               (res = ((feval X4, feval Z4), (feval X5, feval Z5)))
+        /\ bounded_by tight_bounds X4
+        /\ bounded_by tight_bounds Z4
+        /\ bounded_by tight_bounds X5
+        /\ bounded_by tight_bounds Z5
+        /\ (FElem pX1 X1 * FElem pX2 X4 * FElem pZ2 Z4
+            * FElem pX3 X5 * FElem pZ3 Z5
+            (** FElem pA A' * FElem pAA AA'
+             * FElem pB B' * FElem pBB BB'
+             * FElem pE E' * FElem pC C' * FElem pD D'
+             * FElem pDA DA' * FElem pCB CB'*) * R)%sep mem'))}.
 
   Lemma compile_ladderstep : forall {tr mem locals functions}
         (x1 x2 z2 x3 z3 : F M_pos),
     let v := ladderstep_gallina x1 (x2, z2) (x3, z3) in
-    forall {P} {pred: P v -> predicate} {k: nlet_eq_k P v} {k_impl}
+    forall {P} {pred: P -> predicate} {k: (point *point) -> Comp P} {k_impl}
            Rout
            X1 X1_ptr X1_var X2 X2_ptr X2_var Z2 Z2_ptr Z2_var
            X3 X3_ptr X3_var Z3 Z3_ptr Z3_var
-           A A_ptr A_var AA AA_ptr AA_var
+          (* A A_ptr A_var AA AA_ptr AA_var
            B B_ptr B_var BB BB_ptr BB_var
            E E_ptr E_var C C_ptr C_var
            D D_ptr D_var DA DA_ptr DA_var
-           CB CB_ptr CB_var,
+           CB CB_ptr CB_var*),
 
       spec_of_ladderstep functions ->
 
@@ -119,18 +169,18 @@ Section __.
       (FElem X1_ptr X1
        * FElem X2_ptr X2 * FElem Z2_ptr Z2
        * FElem X3_ptr X3 * FElem Z3_ptr Z3
-       * FElem A_ptr A * FElem AA_ptr AA
+      (* * FElem A_ptr A * FElem AA_ptr AA
        * FElem B_ptr B * FElem BB_ptr BB
        * FElem E_ptr E * FElem C_ptr C
        * FElem D_ptr D * FElem DA_ptr DA
-       * FElem CB_ptr CB * Rout)%sep mem ->
+       * FElem CB_ptr CB *) * Rout)%sep mem ->
 
         map.get locals X1_var = Some X1_ptr ->
         map.get locals X2_var = Some X2_ptr ->
         map.get locals Z2_var = Some Z2_ptr ->
         map.get locals X3_var = Some X3_ptr ->
         map.get locals Z3_var = Some Z3_ptr ->
-        map.get locals A_var = Some A_ptr ->
+        (*map.get locals A_var = Some A_ptr ->
         map.get locals AA_var = Some AA_ptr ->
         map.get locals B_var = Some B_ptr ->
         map.get locals BB_var = Some BB_ptr ->
@@ -138,32 +188,35 @@ Section __.
         map.get locals C_var = Some C_ptr ->
         map.get locals D_var = Some D_ptr ->
         map.get locals DA_var = Some DA_ptr ->
-        map.get locals CB_var = Some CB_ptr ->
+        map.get locals CB_var = Some CB_ptr ->*)
 
         (let v := v in
          forall (X4 Z4 X5 Z5 (* output values *)
-                    A' AA' B' BB' E' C' D' DA' CB' (* new intermediates *)
+                    (*A' AA' B' BB' E' C' D' DA' CB' (* new intermediates *)*)
                  : felem) m
-                (Heq : ladderstep_gallina
-                         (feval X1) (feval X2, feval Z2)
-                         (feval X3, feval Z3)
-                       = ((feval X4, feval Z4), (feval X5, feval Z5))),
+                (Heq : propbind
+                         (ladderstep_gallina
+                            (feval X1) (feval X2, feval Z2)
+                            (feval X3, feval Z3))
+                         (eq ((feval X4, feval Z4), (feval X5, feval Z5)))),
           bounded_by tight_bounds X4 ->
           bounded_by tight_bounds Z4 ->
           bounded_by tight_bounds X5 ->
           bounded_by tight_bounds Z5 ->
           (FElem X1_ptr X1 * FElem X2_ptr X4 * FElem Z2_ptr Z4
            * FElem X3_ptr X5 * FElem Z3_ptr Z5
-           * FElem A_ptr A' * FElem AA_ptr AA'
+           (* * FElem A_ptr A' * FElem AA_ptr AA'
            * FElem B_ptr B' * FElem BB_ptr BB'
            * FElem E_ptr E' * FElem C_ptr C' * FElem D_ptr D'
-           * FElem DA_ptr DA' * FElem CB_ptr CB' * Rout)%sep m ->
+           * FElem DA_ptr DA' * FElem CB_ptr CB' *) * Rout)%sep m ->
            (<{ Trace := tr;
                Memory := m;
                Locals := locals;
                Functions := functions }>
             k_impl
-            <{ pred (k v eq_refl) }>)) ->
+            <{ pbind pred (bindn
+                   [X1_var; X2_var; Z2_var; X3_var; Z3_var]
+                   v k) }>)) ->
 
         <{ Trace := tr;
            Memory := mem;
@@ -173,22 +226,46 @@ Section __.
           (cmd.call [] "ladderstep"
                     [ expr.var X1_var; expr.var X2_var;
                         expr.var Z2_var; expr.var X3_var;
-                          expr.var Z3_var; expr.var A_var;
+                          expr.var Z3_var (*; expr.var A_var;
                             expr.var AA_var; expr.var B_var;
                               expr.var BB_var; expr.var E_var;
                                 expr.var C_var; expr.var D_var;
-                                  expr.var DA_var; expr.var CB_var ])
+                                  expr.var DA_var; expr.var CB_var *)])
           k_impl
-        <{ pred (nlet_eq
+        <{ pbind pred (bindn
                    [X1_var; X2_var; Z2_var; X3_var; Z3_var]
                    v k) }>.
     Proof.
       repeat straightline'.
-      handle_call;
+      handle_call. 
         lazymatch goal with
         | |- sep _ _ _ => ecancel_assumption
         | _ => solve [eauto]
         end.
+        lazymatch goal with
+        | |- sep _ _ _ => ecancel_assumption
+        | _ => solve [eauto]
+        end.
+        lazymatch goal with
+        | |- sep _ _ _ => ecancel_assumption
+        | _ => solve [eauto]
+        end.
+        lazymatch goal with
+        | |- sep _ _ _ => ecancel_assumption
+        | _ => solve [eauto]
+        end.
+        lazymatch goal with
+        | |- sep _ _ _ => ecancel_assumption
+        | _ => solve [eauto]
+        end.
+        destruct H17.
+        unfold intersection in H17.
+        repeat straightline.
+        eapply H16.
+        6:eauto.
+        all: eauto.
+        exists x.
+        split; eauto.
     Qed.
 
   Ltac ladderstep_compile_custom :=
@@ -202,13 +279,46 @@ Section __.
            end.
 
   Ltac compile_custom ::= ladderstep_compile_custom.
+  
+  Hint Extern 1 => simple eapply compile_stack_alloc; shelve : compiler.
+  
+  Hint Unfold pbind: compiler_cleanup.
+  Hint Extern 1 (ret _ _) => reflexivity : compiler_cleanup.
+  Hint Resolve compile_setup_nondet_pbind : compiler_setup.
+  Hint Extern 2 (IsRupicolaBinding (bindn _ _ _)) => exact true : typeclass_instances.
+  
+Definition
+  ladderstep_body' :=
+  noskips
+  (cmd.seq (cmd.call [] add [expr.var "X2"; expr.var "Z2"; expr.var "A"])
+     (cmd.seq (cmd.call [] square [expr.var "A"; expr.var "AA"])
+        (cmd.seq (cmd.call [] sub [expr.var "X2"; expr.var "Z2"; expr.var "B"])
+           (cmd.seq (cmd.call [] square [expr.var "B"; expr.var "BB"])
+              (cmd.seq (cmd.call [] sub [expr.var "AA"; expr.var "BB"; expr.var "E"])
+                 (cmd.seq (cmd.call [] add [expr.var "X3"; expr.var "Z3"; expr.var "C"])
+                    (cmd.seq (cmd.call [] sub [expr.var "X3"; expr.var "Z3"; expr.var "D"])
+                       (cmd.seq (cmd.call [] mul [expr.var "D"; expr.var "A"; expr.var "DA"])
+                          (cmd.seq (cmd.call [] mul [expr.var "C"; expr.var "B"; expr.var "CB"])
+                             (cmd.seq (cmd.call [] add [expr.var "DA"; expr.var "CB"; expr.var "X3"])
+                                (cmd.seq (cmd.call [] square [expr.var "X3"; expr.var "X3"])
+                                   (cmd.seq (cmd.call [] sub [expr.var "DA"; expr.var "CB"; expr.var "Z3"])
+                                      (cmd.seq (cmd.call [] square [expr.var "Z3"; expr.var "Z3"])
+                                         (cmd.seq (cmd.call [] mul [expr.var "X1"; expr.var "Z3"; expr.var "Z3"])
+                                            (cmd.seq
+                                               (cmd.call [] mul [expr.var "AA"; expr.var "BB"; expr.var "X2"])
+                                               (cmd.seq (cmd.call [] scmula24 [expr.var "E"; expr.var "Z2"])
+                                                  (cmd.seq
+                                                     (cmd.call [] add
+                                                        [expr.var "AA"; expr.var "Z2"; expr.var "Z2"])
+                                                     (cmd.seq
+                                                        (cmd.call [] mul
+                                                           [expr.var "E"; expr.var "Z2"; expr.var "Z2"])
+                                                        (fold_right
+                                                           (fun (v : string) (c : cmd) => cmd.seq (cmd.unset v) c)
+                                                           cmd.skip []))))))))))))))))))).
 
-  Hint Extern 1 (spec_of _) => (simple refine (@spec_of_BinOp _ _ _ _ _ _ _ _ _ _)) : typeclass_instances.
-  Hint Extern 1 (spec_of _) => (simple refine (@spec_of_UnOp _ _ _ _ _ _ _ _ _ _)) : typeclass_instances.
-  Derive ladderstep_body SuchThat
-         (let args := ["X1"; "X2"; "Z2"; "X3"; "Z3";
-                         "A"; "AA"; "B"; "BB"; "E"; "C";
-                         "D"; "DA"; "CB"] in
+Derive ladderstep_body SuchThat
+         (let args := ["X1"; "X2"; "Z2"; "X3"; "Z3"] in
           ltac:(
             let proc := constr:(("ladderstep",
                                  (args, [], ladderstep_body))
@@ -218,10 +328,10 @@ Section __.
             exact (__rupicola_program_marker ladderstep_gallina -> goal)))
          As ladderstep_correct.
   Proof.
-    compile_setup.
-
-    repeat compile_step.
+    compile.
   Qed.
+
+  
 End __.
 
 Existing Instance spec_of_ladderstep.

--- a/src/Bedrock/Group/ScalarMult/LadderStep.v
+++ b/src/Bedrock/Group/ScalarMult/LadderStep.v
@@ -24,9 +24,7 @@ Section __.
     Local Open Scope F_scope.
 
     Definition ladderstep_gallina
-               (X1: F M_pos) (P1 P2: point) : (point * point) :=
-      let '(X2, Z2) := P1 in
-      let '(X3, Z3) := P2 in
+               (X1 X2 Z2 X3 Z3: F M_pos) : F M_pos * F M_pos * F M_pos * F M_pos :=
       let/n A := felem_alloc (X2+Z2) in
       let/n AA := felem_alloc (A^2) in
       let/n B := felem_alloc (X2-Z2) in
@@ -49,7 +47,7 @@ Section __.
       let/n Z2 := a24*E in
       let/n Z2:= (AA+Z2) in
       let/n Z2 := E*Z2 in
-      ((X2, Z2), (X3, Z3)).
+      (X2, Z2, X3, Z3).
   End Gallina.
 
   Instance spec_of_ladderstep : spec_of "ladderstep" :=
@@ -70,9 +68,9 @@ Section __.
         /\ exists X4 Z4 X5 Z5 (* output values *)
                   : felem,
           (ladderstep_gallina
-             (feval X1) (feval X2, feval Z2)
-             (feval X3, feval Z3)
-           = ((feval X4, feval Z4), (feval X5, feval Z5)))
+             (feval X1) (feval X2) (feval Z2)
+             (feval X3) (feval Z3)
+           = (feval X4, feval Z4, feval X5, feval Z5))
           /\ bounded_by tight_bounds X4
           /\ bounded_by tight_bounds Z4
           /\ bounded_by tight_bounds X5
@@ -80,9 +78,9 @@ Section __.
           /\ (FElem pX1 X1 * FElem pX2 X4 * FElem pZ2 Z4
               * FElem pX3 X5 * FElem pZ3 Z5 * R)%sep mem'}.
 
-  Lemma compile_ladderstep : forall {tr mem locals functions}
-        (x1 x2 z2 x3 z3 : F M_pos),
-    let v := ladderstep_gallina x1 (x2, z2) (x3, z3) in
+  Lemma compile_ladderstep {tr mem locals functions}
+        (x1 x2 z2 x3 z3 : F M_pos) :
+    let v := ladderstep_gallina x1 x2 z2 x3 z3 in
     forall {P} {pred: P v -> predicate} {k: nlet_eq_k P v} {k_impl}
            Rout
            X1 X1_ptr X1_var X2 X2_ptr X2_var Z2 Z2_ptr Z2_var
@@ -114,9 +112,9 @@ Section __.
          forall (X4 Z4 X5 Z5 (* output values *)
                  : felem) m
                 (Heq : ladderstep_gallina
-                         (feval X1) (feval X2, feval Z2)
-                         (feval X3, feval Z3)
-                       = ((feval X4, feval Z4), (feval X5, feval Z5))),
+                         (feval X1) (feval X2) (feval Z2)
+                         (feval X3) (feval Z3)
+                       = (feval X4, feval Z4, feval X5, feval Z5)),
           bounded_by tight_bounds X4 ->
           bounded_by tight_bounds Z4 ->
           bounded_by tight_bounds X5 ->
@@ -206,8 +204,8 @@ Proof.
                         Lift1Prop.ex1 (fun Z4 =>
                         Lift1Prop.ex1 (fun X5 =>
                         Lift1Prop.ex1 (fun Z5 =>
-                        (emp ((feval out13, feval out16, (feval out9, feval out12))
-                         = (feval X4, feval Z4, (feval X5, feval Z5)) /\
+                        (emp ((feval out13, feval out16, feval out9, feval out12)
+                         = (feval X4, feval Z4, feval X5, feval Z5) /\
                         bounded_by tight_bounds X4 /\
                         bounded_by tight_bounds Z4 /\
                         bounded_by tight_bounds X5 /\ bounded_by tight_bounds Z5))
@@ -238,7 +236,9 @@ Proof.
       ecancel_assumption.
     }
   }
-Qed.
+  
+  (* TODO: currently takes a few hours *)
+Time Qed.
   
 End __.
 

--- a/src/Bedrock/Group/ScalarMult/LadderStep.v
+++ b/src/Bedrock/Group/ScalarMult/LadderStep.v
@@ -139,7 +139,7 @@ Section __.
                           expr.var Z3_var])
           k_impl
         <{ pred (nlet_eq
-                   [X1_var; X2_var; Z2_var; X3_var; Z3_var]
+                   [X2_var; Z2_var; X3_var; Z3_var]
                    v k) }>.
   Proof.
       repeat straightline'.
@@ -236,9 +236,7 @@ Proof.
       ecancel_assumption.
     }
   }
-  
-  (* TODO: currently takes a few hours *)
-Time Qed.
+Qed.
   
 End __.
 

--- a/src/Bedrock/Group/ScalarMult/LadderStep.v
+++ b/src/Bedrock/Group/ScalarMult/LadderStep.v
@@ -205,4 +205,8 @@ Existing Instance spec_of_ladderstep.
 
 Import Syntax.
 Local Unset Printing Coercions.
+Set Printing Depth 70.
+Print ladderstep_body.
 Redirect "Crypto.Bedrock.Group.ScalarMult.LadderStep.ladderstep_body" Print ladderstep_body.
+(*TODO: should I set it back?*)
+Set Printing Depth 50.

--- a/src/Bedrock/Group/ScalarMult/LadderStep.v
+++ b/src/Bedrock/Group/ScalarMult/LadderStep.v
@@ -1,7 +1,7 @@
 Require Import Rupicola.Lib.Api.
-Require Import Rupicola.Lib.Alloc.
+Require Import Rupicola.Lib.Alloc. 
+Require Import Rupicola.Lib.SeparationLogicImpl.
 Require Import Crypto.Arithmetic.PrimeFieldTheorems.
-Require Import Crypto.Bedrock.Group.Point.
 Require Import Crypto.Bedrock.Specs.Field.
 Require Import Crypto.Bedrock.Field.Interface.Compilation2.
 Local Open Scope Z_scope.
@@ -74,30 +74,19 @@ Section __.
               * FElem (Some tight_bounds) pX3 X5
               * FElem (Some tight_bounds) pZ3 Z5 * R)%sep mem'}.
 
-  (*TODO
   Lemma compile_ladderstep {tr mem locals functions}
         (x1 x2 z2 x3 z3 : F M_pos) :
     let v := ladderstep_gallina x1 x2 z2 x3 z3 in
     forall {P} {pred: P v -> predicate} {k: nlet_eq_k P v} {k_impl}
            Rout
-           X1 X1_ptr X1_var X2 X2_ptr X2_var Z2 Z2_ptr Z2_var
-           X3 X3_ptr X3_var Z3 Z3_ptr Z3_var,
+           X1_ptr X1_var X2_ptr X2_var Z2_ptr Z2_var
+           X3_ptr X3_var Z3_ptr Z3_var,
 
       spec_of_ladderstep functions ->
 
-      feval X1 = x1 ->
-      feval X2 = x2 ->
-      feval Z2 = z2 ->
-      feval X3 = x3 ->
-      feval Z3 = z3 ->
-      bounded_by tight_bounds X1 ->
-      bounded_by tight_bounds X2 ->
-      bounded_by tight_bounds Z2 ->
-      bounded_by tight_bounds X3 ->
-      bounded_by tight_bounds Z3 ->
-      (FElem X1_ptr X1
-       * FElem X2_ptr X2 * FElem Z2_ptr Z2
-       * FElem X3_ptr X3 * FElem Z3_ptr Z3 * Rout)%sep mem ->
+      (FElem (Some tight_bounds) X1_ptr x1
+       * FElem (Some tight_bounds) X2_ptr x2 * FElem (Some tight_bounds) Z2_ptr z2
+       * FElem (Some tight_bounds) X3_ptr x3 * FElem (Some tight_bounds) Z3_ptr z3 * Rout)%sep mem ->
 
         map.get locals X1_var = Some X1_ptr ->
         map.get locals X2_var = Some X2_ptr ->
@@ -106,18 +95,14 @@ Section __.
         map.get locals Z3_var = Some Z3_ptr ->
 
         (let v := v in
-         forall (X4 Z4 X5 Z5 (* output values *)
-                 : felem) m
-                (Heq : ladderstep_gallina
-                         (feval X1) (feval X2) (feval Z2)
-                         (feval X3) (feval Z3)
-                       = (feval X4, feval Z4, feval X5, feval Z5)),
-          bounded_by tight_bounds X4 ->
-          bounded_by tight_bounds Z4 ->
-          bounded_by tight_bounds X5 ->
-          bounded_by tight_bounds Z5 ->
-          (FElem X1_ptr X1 * FElem X2_ptr X4 * FElem Z2_ptr Z4
-           * FElem X3_ptr X5 * FElem Z3_ptr Z5 * Rout)%sep m ->
+         forall X4 Z4 X5 Z5 (* output values *) m
+                (Heq : ladderstep_gallina x1 x2 z2 x3 z3
+                       = (X4, Z4, X5, Z5)),
+          (FElem (Some tight_bounds) X1_ptr x1
+           * FElem (Some tight_bounds) X2_ptr X4
+           * FElem (Some tight_bounds) Z2_ptr Z4
+           * FElem (Some tight_bounds) X3_ptr X5
+           * FElem (Some tight_bounds) Z3_ptr Z5 * Rout)%sep m ->
            (<{ Trace := tr;
                Memory := m;
                Locals := locals;
@@ -145,28 +130,7 @@ Section __.
         | |- sep _ _ _ => ecancel_assumption
         | _ => solve [eauto]
         end.
-    Qed.
-*)
-  
-  Ltac ladderstep_compile_custom :=
-    (*TODO: move some of this into core rupicola?*)
-    lazymatch goal with
-    | [v := alloc _ |-_] =>
-      unfold alloc in v;
-      subst v
-      | _ =>
-        simple apply compile_nlet_as_nlet_eq
-    end;
-    field_compile_step; [ repeat compile_step .. | intros ];
-    eauto with compiler;
-    (* rewrite results in terms of feval to match lemmas *)
-    repeat lazymatch goal with
-           | H : feval _ = ?x |- context [?x] =>
-             is_var x; rewrite <-H
-           end.
-
-  Ltac compile_custom ::= ladderstep_compile_custom.
-
+  Qed.
   
   Lemma relax_bounds_FElem x_ptr x
     : Lift1Prop.impl1 (FElem (Some tight_bounds) x_ptr x)
@@ -201,158 +165,23 @@ Section __.
     intros; ecancel_assumption.
     Qed.
 
-
-(*TODO: move to separate file; copy source and re-edit?*)
-  Require Import coqutil.Tactics.syntactic_unify coqutil.Tactics.rdelta.
- 
-
-Require Import Coq.Classes.Morphisms.
-Require Import coqutil.sanity coqutil.Decidable coqutil.Tactics.destr.
-Section SepProperties.
-  Context {key value} {map : map.map key value} {ok : map.ok map}.
-  Context {key_eqb: key -> key -> bool} {key_eq_dec: EqDecider key_eqb}.
-  Local Open Scope sep_scope.
-  
-  Definition hd {T} := Eval cbv delta in @List.hd T.
-  Definition tl {T} := Eval cbv delta in @List.tl T.
-  Definition firstn {T} := Eval cbv delta in @List.firstn T.
-  Definition skipn {T} := Eval cbv delta in @List.skipn T.
-  Definition app {T} := Eval cbv delta in @List.app T.
-
-  Local Infix "++" := app. Local Infix "++" := app : list_scope.
-  Let nth n xs := hd (emp(map:=map) True) (skipn n xs).
-  Let remove_nth n (xs : list (map -> Prop)) :=
-    (firstn n xs ++ tl (skipn n xs)).
-
-  
-  Lemma seps_nth_to_head n xs : Lift1Prop.iff1 (sep (nth n xs) (seps (remove_nth n xs))) (seps xs).
-  Proof.
-    cbv [nth remove_nth].
-    pose proof (List.firstn_skipn n xs : (firstn n xs ++ skipn n xs) = xs).
-    set (xsr := skipn n xs) in *; clearbody xsr.
-    set (xsl := firstn n xs) in *; clearbody xsl.
-    subst xs.
-    setoid_rewrite <-seps'_iff1_seps.
-    destruct xsr.
-    { cbn [seps']; rewrite sep_emp_True_l, 2List.app_nil_r; exact (reflexivity _). }
-    cbn [hd tl].
-    induction xsl; cbn; [exact (reflexivity _)|].
-    rewrite <-IHxsl; clear IHxsl.
-    rewrite (sep_comm _ (seps' _)), <-(sep_assoc _ (seps' _)), <-(sep_comm _ (_ * seps' _)).
-    exact (reflexivity _).
-  Qed.
-  
-    (* iff1 instead of eq as a hyp would be a more general lemma, but eq is more convenient to use *)
-  Lemma cancel_seps_at_indices i j xs ys
-        (Hij : Lift1Prop.impl1 (nth i xs) (nth j ys))
-        (Hrest : Lift1Prop.impl1 (seps (remove_nth i xs)) (seps (remove_nth j ys)))
-    : Lift1Prop.impl1 (seps xs) (seps ys).
-  Proof.
-    rewrite <-(seps_nth_to_head i xs), <-(seps_nth_to_head j ys).
-    rewrite Hij, Hrest.
-    exact (reflexivity _).
-  Qed.
-
-  
-End SepProperties.
-  
-  (* leaves two open goals:
-   1) equality between left sep clause #i and right sep clause #j
-   2) updated main goal *)
-Ltac cancel_seps_at_indices i j :=
-  lazymatch goal with
-  | |- Lift1Prop.impl1 (seps ?LHS) (seps ?RHS) =>
-    simple refine (cancel_seps_at_indices i j LHS RHS _ _);
-    cbn [firstn skipn app hd tl]
-  end.
-
-Create HintDb ecancel_impl discriminated.
-Hint Extern 1 => exact (fun m x => x) : ecancel_impl.
-
-Ltac prop_at_index_is_evar j ys :=
-  let p := eval cbn [firstn skipn app hd tl nth] in (nth j ys) in
-      match p with
-      | (fun _ => ?pb) => is_evar pb
-      | _ => fail "malformed input"
-      end.
-
-(*TODO: performance*)
-Ltac find_implication xs y :=
-  multimatch xs with
-  | cons ?x _ =>
-    let H := fresh in
-    constr:(O)
-  | cons _ ?xs => let i := find_implication xs y in constr:(S i)
-  end.
-
-
-(*TODO: performance. I've replaced the deltavar stuff with heavier operations  *)
-Ltac ecancel_step :=
-      let RHS := lazymatch goal with |- Lift1Prop.impl1 _ (seps ?RHS) => RHS end in
-      let jy := index_and_element_of RHS in (* <-- multi-success! *)
-      let j := lazymatch jy with (?i, _) => i end in
-      let y := lazymatch jy with (_, ?y) => y end in
-      (* For implication, we don't want to touch RHS evars 
-         until everything else is solved.
-         Makes sure j doesn't point to an evar
-       *)
-      assert_fails (idtac; prop_at_index_is_evar 0%nat RHS);      
-      let LHS := lazymatch goal with |- Lift1Prop.impl1 (seps ?LHS) _ => LHS end in
-      let i := find_implication LHS y in (* <-- multi-success! *)
-      cancel_seps_at_indices i j; [solve [auto 1 with ecancel_impl]|].
-(*TODO: should I use deltavar here too?*)
-Ltac ecancel :=
-  cancel; repeat ecancel_step; (solve [ exact (fun m x => x) ]).
-
-
- Ltac ecancel_assumption_impl :=
-    multimatch goal with
-    | |- ?PG ?m1 =>
-      multimatch goal with
-      | H: ?PH ?m2
-        |- _ =>
-        syntactic_unify_deltavar m1 m2;
-        refine (Morphisms.subrelation_refl Lift1Prop.impl1 PH PG _ m1 H); clear H;
-        cbn[seps];(*TODO: why is this needed?*)
-        solve[ecancel]
-      end
-    end.
-
- 
-    (*TODO: speed up by combining pred_seps first and using 1 proper/ecancel_assumption?*)
-    Ltac clear_pred_seps :=   
-    unfold pred_sep;
-    repeat change (fun x => ?h x) with h;
-    repeat match goal with
-           | [ H : _ ?m |- _ ?m] =>
-             eapply Proper_sep_impl1;
-               [ eapply P_to_bytes | clear H m; intros H m | ecancel_assumption]
-           end.
-    Ltac compile_solve_side_conditions ::=
-  match goal with
-  | |- (_ ⋆ _) _ => cbn[fst snd] in *; ecancel_assumption
-  | |- map.get _ _ = _ => solve [ subst_lets_in_goal; solve_map_get_goal ]
-  | |- map.getmany_of_list _ _ = _ => apply map.getmany_of_list_cons
-  | |- map.remove_many _ _ = _ => solve_map_remove_many
-  | |- _ = _ => solve_map_eq
-  | |- _ <> _ => congruence
-  | |- _ /\ _ => split
-  | |- exists _,_ => eexists (*TODO: is this worth adding?*)
-  | |- pred_sep _ _ _ _ _ _ => clear_pred_seps
-  | _ => first
-  [ compile_cleanup
-  | compile_autocleanup
-  | reflexivity
-  | compile_use_default_value
-  | solve
-  [ typeclasses eauto | eauto with compiler_cleanup ] ]
-  end.
-
     
+    Hint Immediate relax_bounds_FElem : ecancel_impl.
+
+
     Ltac ecancel_assumption ::=  ecancel_assumption_impl.
 
- 
-Hint Immediate relax_bounds_FElem : ecancel_impl.
+  Ltac ladderstep_compile_custom :=
+    try simple apply compile_nlet_as_nlet_eq;
+    field_compile_step; [ repeat compile_step .. | intros ];
+    eauto with compiler;
+    (* rewrite results in terms of feval to match lemmas *)
+    repeat lazymatch goal with
+           | H : feval _ = ?x |- context [?x] =>
+             is_var x; rewrite <-H
+           end.
+
+  Ltac compile_custom ::= ladderstep_compile_custom.
 
 Derive ladderstep_body SuchThat
        (let args := ["X1"; "X2"; "Z2"; "X3"; "Z3"] in
@@ -364,7 +193,15 @@ Derive ladderstep_body SuchThat
                         proc [mul;add;sub;square;scmula24] in
           exact (__rupicola_program_marker ladderstep_gallina -> goal)))
        As ladderstep_correct.
-Proof. compile. Qed.
+Proof.
+  compile_setup.
+  repeat compile_step.
+  (*TODO: why isn't this integrated w/ compile_step?
+    I need something in compile_step that peels off existentials
+   *)
+  repeat compile_cleanup_post.
+  compile_step.
+Qed.
   
   
 End __.

--- a/src/Bedrock/Group/ScalarMult/MontgomeryEquivalence.v
+++ b/src/Bedrock/Group/ScalarMult/MontgomeryEquivalence.v
@@ -15,8 +15,12 @@ Require Import Crypto.Util.Loops.
 Section Equivalence.
   Context {field_parameters : FieldParameters}.
 
+  (*TODO: which of ladderstep_gallina and M.xzladderstep should we change? either?*)
+  Definition reorder_pairs {A B C D} (p : A * B * C * D) : (A*B)*(C*D) :=
+    ((fst (fst (fst p)), snd (fst (fst p))),(snd (fst p), snd p)).
+  
   Lemma ladderstep_gallina_equiv X1 P1 P2 :
-    ladderstep_gallina X1 P1 P2 =
+    reorder_pairs (ladderstep_gallina X1 (fst P1) (snd P1) (fst P2) (snd P2)) =
     @M.xzladderstep
       _ F.add F.sub F.mul a24 X1 P1 P2.
   Proof.
@@ -26,6 +30,7 @@ Section Equivalence.
     rewrite !F.pow_2_r; trivial.
   Qed.
 
+  (*TODO: account for reorder_pairs*)
   Lemma montladder_gallina_equiv
         n scalarbits testb point :
     (forall i, testb i = Z.testbit n (Z.of_nat i)) ->
@@ -38,6 +43,9 @@ Section Equivalence.
     intros. cbv [montladder_gallina M.montladder].
     cbv [Rewriter.Util.LetIn.Let_In Notations.nlet]. cbn [fst snd].
     rewrite downto_while.
+    unfold Alloc.alloc.
+  Abort.
+  (*
     match goal with
     | |- ?lhs = ?rhs =>
       match lhs with
@@ -86,4 +94,5 @@ Section Equivalence.
     }
     { rewrite Z2Nat.id by lia. reflexivity. }
   Qed.
+   *)
 End Equivalence.

--- a/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
+++ b/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
@@ -94,7 +94,7 @@ Section __.
 
     Instance spec_of_montladder : spec_of "montladder" :=
       fnspec! "montladder"
-            (pOUT pK pU (*pX1 pZ1 pX2 pZ2*) : Semantics.word)
+            (pOUT pK pU (*pX1 pZ1 pX2 pZ2*) : word)
             / (K : scalar) (U : F M_pos) (* inputs *)
             out_bound OUT (*X1 Z1 X2 Z2 *) (* intermediates *)
             R,
@@ -169,7 +169,7 @@ Section __.
                             (*TODO: where did outvar come from?*)
                             (map.put (map.put map.empty OUT_var pOUT) K_var K_ptr)
                             U_var U_ptr) X1_var X1_ptr) Z1_var Z1_ptr) X2_var
-                   X2_ptr) Z2_var Z2_ptr) swap_var (b2w swap))
+                   X2_ptr) Z2_var Z2_ptr) swap_var (word.b2w swap))
             /\ ((Scalar K_ptr K * FElem (Some tight_bounds) X1_ptr x1
             * FElem (Some tight_bounds) Z1_ptr z1
             * FElem (Some tight_bounds) X2_ptr x2
@@ -444,7 +444,7 @@ Section __.
       (*TODO: use regular compile_step for downto, figure out invariant inference *)
       (*compile_step.*)
       (*TODO: copy locals into inv*)
-      
+      (* TODO: use loop inference
       simple apply compile_nlet_as_nlet_eq.
       let tmp_var := constr:("tmp") in
       let x1_var := constr:("X1") in
@@ -684,7 +684,7 @@ Section __.
       Unshelve.
       constructor.
 
-(* NOTE: the plan is to completely redo montladder after ladderstep is updated to use stackalloc *)
+(* NOTE: the plan is to completely redo montladder after ladderstep is updated to use stackalloc *)*)
     Abort.
 (*
       pose proof scalarbits_pos.

--- a/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
+++ b/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
@@ -882,56 +882,20 @@ Ltac field_compile_step ::=
     repeat change (fun x => ?h x) with h.
     unfold map.getmany_of_list.
     simpl.
-    {
-      (*TODO: do in a better way*)
-      change (fun y => exists ws, @?P ws y) with (Lift1Prop.ex1 P).
-      repeat seprewrite FElem_from_bytes.
-      repeat (sepsimpl;
-              match goal with
-                [H : context [FElem ?p ?v] |- Lift1Prop.ex1 (fun h => FElem ?p h * _)%sep _] =>
-                exists v
-              end).
-      sepsimpl.
+    {      
+      repeat match goal with
+      | [ H : _ ?m |- _ ?m] =>
+      eapply Proper_sep_impl1;
+        [ eapply FElem_to_bytes | clear H m; intros H m | ecancel_assumption]
+      end.
       exists [].
-      cbv beta.
-      eapply Proper_sep_iff1.
-      2: reflexivity.
-      {
-        instantiate (1:=
-                       Lift1Prop.ex1 (fun OUT0=>
-                      
-                                           (*TODO: tr/tr0 should be same?*)
-     ((emp(tr0 = tr /\
-      feval OUT0 = feval out0 /\
-        bounded_by tight_bounds OUT0))*
-        (FElem pOUT OUT0 ⋆ Scalar pK K ⋆ FElem pU U ⋆ R)))%sep ).
-        cbv [Lift1Prop.iff1 Lift1Prop.ex1].
-        intuition idtac.
-        {
-          subst.
-          destruct H44.
-          exists x4.
-          rewrite sep_emp_l.
-          intuition idtac.
-        }
-        {
-          destruct H21; rewrite sep_emp_l in H21.
-           intuition idtac.
-        }
-        {
-          destruct H21 as [OUT1 H21].
-          rewrite sep_emp_l in H21.
-           exists OUT1; intuition idtac.
-        }
-      }
-      sepsimpl.
-      exists out0.
-      sepsimpl; auto.
-      admit (*TODO: losing info here*).
+      repeat compile_step.
       admit (*TODO: not lined up right*).
+
+      eexists; intuition.
+      (*TODO: out and out0 not limed up; want FElem'?*)
+      admit (*ecancel_assumption.*).
     }
-        }
-      }
       Unshelve.
       constructor.
 

--- a/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
+++ b/src/Bedrock/Group/ScalarMult/MontgomeryLadder.v
@@ -14,6 +14,27 @@ Require Import Crypto.Bedrock.Specs.ScalarField.
 Require Import Crypto.Util.NumTheoryUtil.
 Local Open Scope Z_scope.
 
+
+Notation "'let/n' ( w , x , y , z ) := val 'in' body" :=
+  (nlet [IdentParsing.TC.ident_to_string w;
+        IdentParsing.TC.ident_to_string x;
+        IdentParsing.TC.ident_to_string y;
+        IdentParsing.TC.ident_to_string z]
+        val  (fun '(w, x, y, z) => body))
+   (at level 200, w ident, x  ident, y ident, z ident, body at level 200,
+    only parsing).
+
+Notation "'let/n' ( v , w , x , y , z ) := val 'in' body" :=
+  (nlet [IdentParsing.TC.ident_to_string v;
+        IdentParsing.TC.ident_to_string w;
+        IdentParsing.TC.ident_to_string x;
+        IdentParsing.TC.ident_to_string y;
+        IdentParsing.TC.ident_to_string z]
+        val  (fun '(v, w, x, y, z) => body))
+   (at level 200, v ident,  w ident, x  ident, y ident, z ident, body at level 200,
+     only parsing).
+
+
 Section __.
   Context {width: Z} {BW: Bitwidth width} {word: word.word width} {mem: map.map word Byte.byte}.
   Context {locals: map.map String.string word}.
@@ -37,27 +58,34 @@ Section __.
     Definition montladder_gallina
                (scalarbits : Z) (testbit:nat ->bool) (u:F M_pos)
       : F M_pos :=
-      let/n P1 := (1, 0) in
-      let/n P2 := (u, 1) in
+      let/n X1 := felem_alloc 1 in
+      let/n Z1 := felem_alloc 0 in
+      let/n X2 := felem_alloc u in
+      let/n Z2 := felem_alloc 1 in
+     (* let/d P1 := (1, 0) in
+        let/d P2 := (X2, Z2) in
+      *)
       let/n swap := false in
       let/n count := scalarbits in
-      let '(P1, P2, swap) :=
+      let/n (X1, Z1, X2, Z2, swap) :=
          downto
-           (P1, P2, swap) (* initial state *)
+           (X1, Z1, X2, Z2, swap) (* initial state *)
            (Z.to_nat count)
            (fun state i =>
-              let '(P1, P2, swap) := state in
+              (*TODO: should this be a /n?*)
+              let '(X1, Z1, X2, Z2, swap) := state in
               let/n s_i := testbit i in
               let/n swap := xorb swap s_i in
-              let/n (P1, P2) := cswap swap P1 P2 in
-              let/n (P1, P2) := ladderstep_gallina u P1 P2 in
+              let/n (X1, X2) := cswap swap X1 X2 in
+              let/n (Z1, Z2) := cswap swap Z1 Z2 in
+              let/n (X1, Z1, X2, Z2) := ladderstep_gallina u X1 Z1 X2 Z2 in
               let/n swap := s_i in
-              (P1, P2, swap)
+              (X1, Z1, X2, Z2, swap)
            ) in
-      let/n (P1, P2) := cswap swap P1 P2 in
-      let '(x, z) := P1 in
-      let/n r := F.inv z in
-      let/n r := (x * r) in
+      let/n (X1, X2) := cswap swap X1 X2 in
+      let/n (Z1, Z2) := cswap swap Z1 Z2 in
+      let/n r := F.inv Z1 in
+      let/n r := (X1 * r) in
       r.
   End Gallina.
 
@@ -66,25 +94,19 @@ Section __.
 
     Instance spec_of_montladder : spec_of "montladder" :=
       fnspec! "montladder"
-            (pOUT pK pU pX1 pZ1 pX2 pZ2
-                  pA pAA pB pBB pE pC pD pDA pCB : word)
+            (pOUT pK pU (*pX1 pZ1 pX2 pZ2*) : Semantics.word)
             / (K : scalar) (U : felem) (* inputs *)
-            OUT X1 Z1 X2 Z2 A AA B BB E C D DA CB (* intermediates *)
+            OUT (*X1 Z1 X2 Z2 *) (* intermediates *)
             R,
       { requires tr mem :=
            bounded_by tight_bounds U
            /\ (FElem pOUT OUT * Scalar pK K * FElem pU U
-               * FElem pX1 X1 * FElem pZ1 Z1
-               * FElem pX2 X2 * FElem pZ2 Z2
-               * FElem pA A * FElem pAA AA
-               * FElem pB B * FElem pBB BB
-               * FElem pE E * FElem pC C
-               * FElem pD D * FElem pDA DA
-               * FElem pCB CB * R)%sep mem;
+              (** FElem pX1 X1 * FElem pZ1 Z1
+               * FElem pX2 X2 * FElem pZ2 Z2*)
+               *  R)%sep mem;
         ensures tr' mem' :=
           tr' = tr
-          /\ (exists OUT X1 Z1 X2 Z2
-                     A AA B BB E C D DA CB : felem,
+          /\ (exists OUT (*X1 Z1 X2 Z2*)  : felem,
                  feval OUT = montladder_gallina
                                scalarbits
                                (fun i =>
@@ -93,13 +115,10 @@ Section __.
                                (feval U)
             /\ bounded_by tight_bounds OUT
             /\ (FElem pOUT OUT * Scalar pK K * FElem pU U
-                * FElem pX1 X1 * FElem pZ1 Z1
-                * FElem pX2 X2 * FElem pZ2 Z2
-                * FElem pA A * FElem pAA AA
-                * FElem pB B * FElem pBB BB
-                * FElem pE E * FElem pC C
-                * FElem pD D * FElem pDA DA
-                * FElem pCB CB * R)%sep mem) }.
+                (** FElem pX1 X1 * FElem pZ1 Z1
+                * FElem pX2 X2 * FElem pZ2 Z2 *)
+                * R)%sep mem') }.
+
 
     Ltac apply_compile_cswap_nocopy :=
       simple eapply compile_cswap_nocopy with
@@ -132,26 +151,20 @@ Section __.
             | apply_compile_cswap_nocopy ].
 
     (* TODO: make a new loop invariant, drop the sep-local stuff *)
-    (*
+    (*nat -> bool -> F M_pos * F M_pos * F M_pos * F M_pos * bool -> predicate*)
     Definition downto_inv
-               swap_var X1_var Z1_var X2_var Z2_var K_var
-               K K_ptr X1_ptr Z1_ptr X2_ptr Z2_ptr Rl
-               A_ptr AA_ptr B_ptr BB_ptr E_ptr C_ptr D_ptr DA_ptr CB_ptr
-               (locals : Semantics.locals)
+               (swap_var  X1_var Z1_var X2_var Z2_var K_var : string)
+               K (K_ptr X1_ptr Z1_ptr X2_ptr Z2_ptr : word) R
                (_ : nat)
                (gst : bool)
-               (st : point * point * bool)
-               (_ : list word)
-      : Semantics.mem -> Prop :=
-      let P1 := fst (fst st) in
-      let P2 := snd (fst st) in
-      let swap := snd st in
-      let x1 := fst P1 in
-      let z1 := snd P1 in
-      let x2 := fst P2 in
-      let z2 := snd P2 in
+               (st : F M_pos * F M_pos * F M_pos * F M_pos * bool)
+      : predicate :=
+      fun (_ : Semantics.trace)
+          (mem : Semantics.mem)
+          (locals : Semantics.locals) =>
+      let '(x1, z1, x2, z2, swap) := st in
       let swapped := gst in
-      liftexists X1_ptr' Z1_ptr' X2_ptr' Z2_ptr'
+      (liftexists X1_ptr' Z1_ptr' X2_ptr' Z2_ptr'
                  X1 Z1 X2 Z2,
         (emp (bounded_by tight_bounds X1
               /\ bounded_by tight_bounds Z1
@@ -161,7 +174,7 @@ Section __.
               /\ feval Z1 = z1
               /\ feval X2 = x2
               /\ feval Z2 = z2
-              /\ (if swapped
+            (* /\ (if swapped
                   then (X1_ptr' = X2_ptr
                         /\ Z1_ptr' = Z2_ptr
                         /\ X2_ptr' = X1_ptr
@@ -173,19 +186,14 @@ Section __.
               /\ (Var swap_var (word.of_Z (Z.b2z swap)) * Var K_var K_ptr
                   * Var X1_var X1_ptr' * Var Z1_var Z1_ptr'
                   * Var X2_var X2_ptr' * Var Z2_var Z2_ptr'
-                  * Rl)%sep locals)
+                  * Rl)%sep locals *) )
          * (Scalar K_ptr K * FElem X1_ptr' X1 * FElem Z1_ptr' Z1
-            * FElem X2_ptr' X2 * FElem Z2_ptr' Z2
-            * Placeholder A_ptr * Placeholder AA_ptr
-            * Placeholder B_ptr * Placeholder BB_ptr
-            * Placeholder E_ptr * Placeholder C_ptr
-            * Placeholder D_ptr * Placeholder DA_ptr
-            * Placeholder CB_ptr))%sep.
-*)
+            * FElem X2_ptr' X2 * FElem Z2_ptr' Z2) * R)%sep) mem.
+
     Definition downto_ghost_step
-               (K : scalar) (st : point * point * bool)
+               (K : scalar) (st : F M_pos * F M_pos * F M_pos * F M_pos * bool)
                (gst : bool) (i : nat) :=
-      let swap := snd st in
+      let '(x1, z1, x2, z2, swap) := st in
       let swap := xorb swap (Z.testbit (F.to_Z (sceval K)) (Z.of_nat i)) in
       xorb gst swap.
 
@@ -285,10 +293,296 @@ Section __.
 
     Existing Instance spec_of_sctestbit.
 
-    Local Hint Extern 1 (spec_of _) => (simple refine (@spec_of_felem_small_literal _ _ _ _ _ _ _ _)) : typeclass_instances.
+
+      Lemma compile_felem_small_literal_alloc {tr mem locals functions} x:
+    let v := felem_alloc (F.of_Z _ x) in
+    forall {P} {pred: P v -> predicate} {k: nlet_eq_k P v} {k_impl}
+      (R : _ -> Prop) (wx : word) out_var,
+
+      spec_of_felem_small_literal functions ->
+      R mem ->
+
+      word.unsigned wx = x ->
+
+      (let v := v in
+       forall X m out_ptr,
+         (FElem out_ptr X * R)%sep m ->
+         feval X = v ->
+         bounded_by tight_bounds X ->
+         (<{ Trace := tr;
+             Memory := m;
+             Locals := map.put locals out_var out_ptr;
+             Functions := functions }>
+          k_impl
+          <{ pred_sep (Placeholder out_ptr) pred (k v eq_refl) }>)) ->
+      <{ Trace := tr;
+         Memory := mem;
+         Locals := locals;
+         Functions := functions }>
+      cmd.stackalloc out_var (@felem_size_in_bytes field_parameters _ field_representaton)
+                     (cmd.seq
+                        (cmd.call [] felem_small_literal
+                                  [expr.var out_var; expr.literal x])
+                        k_impl)
+      <{ pred (nlet_eq [out_var] v k) }>.
+  Proof.
+     repeat straightline'.
+     split; eauto using felem_size_in_bytes_mod.
+     intros out_ptr mStack mCombined Hplace%FElem_from_bytes.
+     destruct Hplace as [out Hout].
+     repeat straightline'.
+     straightline_call.
+     intuition eauto.
+     {
+       exists mStack.
+       exists mem.
+       intuition eauto.
+       apply map.split_comm; eauto.
+     }
+     repeat straightline'.
+     eapply WeakestPrecondition_weaken
+       with (p1 := pred_sep (Memory.anybytes out_ptr felem_size_in_bytes)
+                            pred (let/n x as out_var eq:Heq := v in
+                                  k x Heq)).
+     {
+       unfold pred_sep.
+       repeat straightline'.
+       destruct H4 as [mStack' [m' [Hmem [HmStack Hm]]]].
+       unfold Basics.flip in Hm.
+       exists m'.
+       exists mStack'.
+       intuition.
+       apply map.split_comm; auto.
+     }
+     eapply H2; repeat straightline'.
+     {
+       unfold v.
+       unfold felem_alloc.
+       eauto.
+     }
+     eauto.
+     {
+       rewrite H6.
+       rewrite <- H1.
+       rewrite word.of_Z_unsigned.
+       rewrite H1.
+       reflexivity.
+     }
+     eauto.
+  Qed.
+
+  
+  Lemma compile_felem_copy_alloc {tr mem locals functions} x :
+    let v := feval x in
+    forall {P} {pred: P v -> predicate} {k: nlet_eq_k P v} {k_impl}
+      R x_ptr x_var out_var,
+
+      spec_of_felem_copy functions ->
+
+      (FElem x_ptr x  * R)%sep mem ->
+      map.get locals x_var = Some x_ptr ->
+
+      out_var<> x_var ->
+      
+      (let v := v in
+       forall X m out_ptr,
+         (FElem out_ptr X * (FElem x_ptr x  * R))%sep m ->
+         feval X = v ->
+         (<{ Trace := tr;
+             Memory := m;
+             Locals := map.put locals out_var out_ptr;
+             Functions := functions }>
+          k_impl
+          <{ pred_sep (Placeholder out_ptr) pred (k v eq_refl) }>)) ->
+      <{ Trace := tr;
+         Memory := mem;
+         Locals := locals;
+         Functions := functions }>
+      cmd.stackalloc out_var (@felem_size_in_bytes field_parameters _ field_representaton)
+      (cmd.seq
+        (cmd.call [] felem_copy [expr.var out_var; expr.var x_var])
+        k_impl)
+      <{ pred (nlet_eq [out_var] v k) }>.
+  Proof.
+     repeat straightline'.
+     split; eauto using felem_size_in_bytes_mod.
+     intros out_ptr mStack mCombined Hplace%FElem_from_bytes.
+     destruct Hplace as [out Hout].
+     repeat straightline'.
+     straightline_call.
+     intuition eauto.
+     {
+       apply sep_assoc.
+       apply sep_comm.
+       apply sep_assoc.
+       exists mStack.
+       exists mem.
+       intuition eauto.
+       eauto.
+       apply map.split_comm; eauto.
+       apply sep_comm; eauto.
+     }
+     repeat straightline'.
+     eapply WeakestPrecondition_weaken
+       with (p1 := pred_sep (Memory.anybytes out_ptr felem_size_in_bytes)
+                            pred (let/n x as out_var eq:Heq := v in
+                                  k x Heq)).
+     {
+       unfold pred_sep.
+       repeat straightline'.
+       destruct H5 as [mStack' [m' [Hmem [HmStack Hm]]]].
+       unfold Basics.flip in Hm.
+       exists m'.
+       exists mStack'.
+       intuition.
+       apply map.split_comm; auto.
+     }
+     eapply H3; repeat straightline'.
+     {
+       unfold v.
+       unfold felem_alloc.
+       ecancel_assumption.
+     }
+     eauto.
+  Qed.
+
+  (*TODO: why doesn't simple eapply work? *)
+Ltac field_compile_step ::=
+  first [ simple eapply compile_scmula24 (* must precede compile_mul *)
+        | simple eapply compile_mul
+        | simple eapply compile_add
+        | simple eapply compile_sub
+        | simple eapply compile_square
+        | simple eapply compile_inv
+        (*must come second due to eapply *)
+        | eapply compile_scmula24_alloc (* must precede compile_mul_alloc *)
+        | eapply compile_mul_alloc
+        | eapply compile_add_alloc
+        | eapply compile_sub_alloc
+        | eapply compile_square_alloc
+        | eapply compile_inv_alloc 
+        | eapply compile_felem_small_literal_alloc
+        | eapply compile_felem_copy_alloc ];
+  lazymatch goal with
+  | |- feval _ = _ => try eassumption; try reflexivity
+  | |- _ => idtac
+  end.
+
+
+  
+  Ltac ladderstep_compile_custom :=
+    simple apply compile_nlet_as_nlet_eq;
+    field_compile_step; [ repeat compile_step .. | intros ];
+    eauto with compiler;
+    (* rewrite results in terms of feval to match lemmas *)
+    repeat lazymatch goal with
+           | H : feval _ = ?x |- context [?x] =>
+             is_var x; rewrite <-H
+           end.
+  
+  Ltac compile_custom ::= ladderstep_compile_custom.
+
+
+  
+  (*TODO: move to right place*)
+  (* There are two ways cswap could be compiled; you can either swap the local
+     variables (the pointers), or you can leave the pointers and copy over the
+     data. This version does the copying. *)
+  Lemma compile_cswap_nocopy {tr mem locals functions} (swap: bool) {A} (x y: A) :
+    let v := cswap swap x y in
+    forall {P} {pred: P v -> predicate}
+      {k: nlet_eq_k P v} {k_impl}
+      R (Data : word -> A -> Semantics.mem -> Prop)
+      swap_var x_var x_ptr y_var y_ptr tmp,
+
+      map.get locals swap_var = Some (word.of_Z (Z.b2z swap)) ->
+      map.get locals x_var = Some x_ptr ->
+      map.get locals y_var = Some y_ptr ->
+
+      (* tmp is a strictly temporary variable, confined to one part of the
+         if-clause; it gets unset after use *)
+      map.get locals tmp = None ->
+      (Data x_ptr x * Data y_ptr y * R)%sep mem ->
+
+      (let v := v in
+       <{ Trace := tr;
+          Memory := mem;
+          Locals := map.put (map.put locals x_var (fst (cswap swap x_ptr y_ptr))) y_var
+                      (snd (cswap swap x_ptr y_ptr));
+          Functions := functions }>
+       k_impl
+       <{ pred (k v eq_refl) }>) ->
+      <{ Trace := tr;
+         Memory := mem;
+         Locals := locals;
+         Functions := functions }>
+      cmd.seq
+        (cmd.cond
+           (expr.var swap_var)
+           (cmd.seq
+              (cmd.seq
+                 (cmd.seq
+                    (cmd.set tmp (expr.var x_var))
+                    (cmd.set x_var (expr.var y_var)))
+                 (cmd.set y_var (expr.var tmp)))
+              (cmd.unset tmp))
+           (cmd.skip))
+        k_impl
+      <{ pred (nlet_eq [x_var; y_var] v k) }>.
+  Proof.
+    intros; subst v; unfold cswap.
+    simple eapply compile_if with
+        (val_pred := fun _ tr' mem' locals' =>
+                      tr' = tr /\
+                      mem' = mem /\
+                      locals' =
+                      let locals := map.put locals x_var (if swap then y_ptr else x_ptr) in
+                      let locals := map.put locals y_var (if swap then x_ptr else y_ptr) in
+                      locals);
+      repeat compile_step;
+      repeat straightline'; subst_lets_in_goal; cbn; ssplit; eauto.
+    - rewrite !map.remove_put_diff, !map.remove_put_same, map.remove_not_in by congruence.
+      reflexivity.
+    - rewrite (map.put_noop x_var x_ptr), map.put_noop by assumption.
+      reflexivity.
+    - cbv beta in *; repeat compile_step; cbn.
+      destruct swap; eassumption.
+  Qed.
+
+  
+  Lemma compile_cswap_pair {tr mem locals functions} (swap: bool) {A} (x y: A * A) x1 x2 :
+    let v := cswap swap x y in
+    forall {P} {pred: P v -> predicate}
+      {k: nlet_eq_k P v} {k_impl},
+      (let __ := 0 in (* placeholder FIXME why? *)
+       <{ Trace := tr;
+          Memory := mem;
+          Locals := locals;
+          Functions := functions }>
+       k_impl
+       <{ pred (nlet_eq [x1] (cswap swap (fst x) (fst y))
+                     (fun xy1 eq1 =>
+                        nlet_eq [x2] (cswap swap (snd x) (snd y))
+                             (fun xy2 eq2 =>
+                                let x := (fst xy1, fst xy2) in
+                                let y := (snd xy1, snd xy2) in
+                                k (x, y) ltac:(eauto)))) }>) ->
+      <{ Trace := tr;
+         Memory := mem;
+         Locals := locals;
+         Functions := functions }>
+      k_impl
+      <{ pred (nlet_eq [x1; x2] v k) }>.
+  Proof.
+    repeat straightline'.
+    subst_lets_in_goal. destruct_products.
+    destruct swap; cbv [cswap dlet] in *; cbn [fst snd] in *.
+    all:eauto.
+  Qed.
+
+
     Derive montladder_body SuchThat
-           (let args := ["OUT"; "K"; "U"; "X1"; "Z1"; "X2"; "Z2";
-                           "A"; "AA"; "B"; "BB"; "E"; "C"; "D"; "DA"; "CB"] in
+           (let args := ["OUT"; "K"; "U" (*;"X1"; "Z1"; "X2"; "Z2" *)] in
             let montladder : Syntax.func :=
                 ("montladder", (args, [], montladder_body)) in
           ltac:(
@@ -298,6 +592,223 @@ Section __.
             exact (__rupicola_program_marker montladder_gallina -> goal)))
          As montladder_correct.
     Proof.
+      pose proof scalarbits_pos.
+      pose proof unsigned_of_Z_1.
+      pose proof unsigned_of_Z_0.
+      compile_setup.
+      unfold F.one.
+      unfold F.zero.
+      compile_step.
+      compile_step.
+      compile_step.
+      compile_step.
+      compile_step.
+      compile_step.
+      compile_step.
+      compile_step.
+      compile_step.
+      compile_step.
+      simple apply compile_nlet_as_nlet_eq.
+      let tmp_var := constr:("tmp") in
+      let x1_var := constr:("X1") in
+      let z1_var := constr:("Z1") in
+      let x2_var := constr:("X2") in
+      let z2_var := constr:("Z2") in
+      let counter_var := constr:("count") in
+      eapply compile_downto with (i_var := counter_var)
+      (wcount := word.of_Z scalarbits)
+      (ginit := false)
+      (ghost_step := downto_ghost_step K)
+      (Inv :=
+         downto_inv
+           _ x1_var z1_var x2_var z2_var _
+           _ pK out_ptr out_ptr0 out_ptr1 out_ptr2
+           _).
+      {
+        unfold downto_inv.
+        repeat compile_step.
+        exists out_ptr.
+        exists out_ptr0.
+        exists out_ptr1.
+        exists out_ptr2.
+        exists X.
+        exists X0.
+        exists X1.
+        exists X2.
+        progress sepsimpl; eauto.
+        admit(*TODO: why no bounds for X1?*).
+        (*instantiate (3:="count").*)
+        (*instantiate (2:="K").*)
+(*        admit.*)
+        ecancel_assumption.
+      }
+      compile_step.
+      admit (*z/word math*).
+      lia.
+      {
+        compile_step.
+        unfold downto_inv in H11.
+        repeat destruct st as [st ?].
+        do 8 destruct H11 as [? H11].
+        sepsimpl.
+        eapply compile_nlet_as_nlet_eq.
+        eapply compile_sctestbit; eauto.
+        ecancel_assumption.
+        instantiate (1:="K"); admit (*TODO: need pK in locals; add to downto_inv?*).
+        compile_step.
+        repeat compile_step.
+        admit(*TODO: what is b? also from inv?*).
+        repeat compile_step.
+        
+
+
+
+Locate "let/n".
+
+
+
+
+
+        
+        (*TODO: update cswap lemma*)
+        eapply  compile_cswap_pair; eauto.
+        admit (*map_get*).
+        exact H11.
+        intros. clear_old_seps.
+        match goal with gst' := downto_ghost_step _ _ _ _ |- _ =>
+                                subst gst' end.
+        destruct_products.
+        cbv [downto_inv] in * |-. sepsimpl_hyps.
+        eexists; intros.
+
+        (* convert locals back to literal map using the separation-logic
+           condition; an alternative would be to have all lemmas play nice with
+           locals in separation logic *)
+        match goal with H : sep _ _ (map.remove _ ?i_var)
+                        |- context [map.get _ ?i_var = Some ?wi] =>
+                        eapply Var_put_remove with (v:=wi) in H;
+                          eapply sep_assoc in H
+        end.
+        literal_locals_from_sep.
+        unfold downto_inv in *.
+        repeat destruct st as [st ?].
+        simpl in *.
+        do 8 destruct H11 as [? H11].
+        sepsimpl.
+        eapply compile_nlet_as_nlet_eq.
+        simpl.
+        compile_step.
+        TODO: no R
+        simpl.
+        
+      let locals := lazymatch goal with
+                    | |- WeakestPrecondition.cmd _ _ _ _ ?l _ => l end in
+        simple eapply compile_downto with
+            (wcount := word.of_Z scalarbits)
+            (ginit := false)
+            (i_var := counter_var)
+            (ghost_step := downto_ghost_step K)
+          (*  (Inv :=
+               downto_inv
+                 _ x1_var z1_var x2_var z2_var _
+                 _ pK pX1 pZ1 pX2 pZ2
+                 _ pA pAA pB pBB pE pC pD pDA pCB);
+          [ .. | subst L | subst L ].*).
+      eapply compile_downto.
+      eapply
+      simple apply compile_nlet_as_nlet_eq.
+      compile_step.
+      repeat compile_step.
+      {
+        unfold pred_sep; simpl.
+        unfold Basics.flip; simpl.
+        repeat change (fun x => ?h x) with h.
+        unfold map.getmany_of_list.
+        simpl.
+        {
+          (*TODO: do in a better way*)
+          change (fun y => exists ws, @?P ws y) with (Lift1Prop.ex1 P).
+          repeat seprewrite FElem_from_bytes.
+          repeat (sepsimpl;
+                  match goal with
+                    [H : context [FElem ?p ?v] |- Lift1Prop.ex1 (fun h => FElem ?p h * _)%sep _] =>
+                    exists v
+                  end).
+          sepsimpl.
+          exists [].
+          cbv beta.
+          eapply Proper_sep_iff1.
+          2: reflexivity.
+          {
+            instantiate (1:=
+                           Lift1Prop.ex1 (fun OUT0 =>
+                                            feval OUT0 =
+        (let
+         '(X4, Z1, X3, Z2, swap) :=
+          downto (feval X, feval X0, feval X1, feval X2, false) (Z.to_nat scalarbits)
+            (fun (state : F M_pos * F M_pos * F M_pos * F M_pos * bool) (i : nat) =>
+             let
+             '(X4, Z1, X3, Z2, swap) := state in
+              let/n s_i as "s_i" := Z.testbit (F.to_Z (sceval K)) (Z.of_nat i) in
+              let/n swap0 as "swap" := xorb swap s_i in
+              let/n (X5, X6) as ("X1", "X2") := cswap swap0 X4 X3 in
+              let/n (Z0, Z3) as ("Z1", "Z2") := cswap swap0 Z1 Z2 in
+              nlet ["X1"; "Z1"; "X2"; "Z2"] (ladderstep_gallina (feval U) X5 Z0 X6 Z3)
+                (fun '(X8, Z5, X7, Z4) => let/n x as "swap" := s_i in
+                                          (X8, Z5, X7, Z4, x))) in
+          let/n (X5, _) as ("X1", "X2") := cswap swap X4 X3 in
+          let/n (Z0, _) as ("Z1", "Z2") := cswap swap Z1 Z2 in
+          let/n r as "r" := F.inv Z0 in
+          let/n r0 as "r" := (X5 * r)%F in
+          r0) /\ bounded_by tight_bounds OUT0 /\ (FElem pOUT OUT0 ⋆ Scalar pK K ⋆ FElem pU U ⋆ R) y)).
+            simpl.
+            instantiate (1:=
+                       (Lift1Prop.ex1 (fun X4 =>
+                        Lift1Prop.ex1 (fun Z4 =>
+                        Lift1Prop.ex1 (fun X5 =>
+                        Lift1Prop.ex1 (fun Z5 =>
+                        (emp ((feval out13, feval out16, feval out9, feval out12)
+                         = (feval X4, feval Z4, feval X5, feval Z5) /\
+                        bounded_by tight_bounds X4 /\
+                        bounded_by tight_bounds Z4 /\
+                        bounded_by tight_bounds X5 /\ bounded_by tight_bounds Z5))
+                        * (FElem pX1 X1 ⋆ FElem pX2 X4 ⋆ FElem pZ2 Z4 ⋆ FElem pX3 X5 ⋆ FElem pZ3 Z5 ⋆ R))))))%sep).
+        cbv [Lift1Prop.iff1 Lift1Prop.ex1].
+        intuition idtac.
+        {
+          destruct H33 as (?&?&?&?&?).
+          exists x0, x1, x2, x3.
+          intuition idtac.
+          eapply sep_emp_l.
+          intuition idtac.
+        }
+        {
+          destruct H28 as (?&?&?&?&?).
+          exists x0, x1, x2, x3.
+          eapply sep_emp_l in H28.
+          intuition idtac.
+        }
+      }
+      sepsimpl; eexists.
+      sepsimpl; eexists.
+      sepsimpl; eexists.
+      sepsimpl; eexists.
+      sepsimpl.
+      auto.
+      all: try assumption.
+      ecancel_assumption.
+    }
+  }
+  
+      TODO: need felem copy alloc
+      simple apply compile_nlet_as_nlet_eq.
+      eapply compile_felem_small_literal_alloc; eauto.
+      simple apply compile_nlet_as_nlet_eq.
+      eapply compile_felem_small_literal_alloc; eauto.
+      apply unsigned_of_Z_1.
+      apply unsigned_of_Z_0.
+      apply unsigned_of_Z_1.
+      eapply compile_point_assign.
 (* NOTE: the plan is to completely redo montladder after ladderstep is updated to use stackalloc *)
     Abort.
 (*

--- a/src/Bedrock/Specs/ScalarField.v
+++ b/src/Bedrock/Specs/ScalarField.v
@@ -37,17 +37,13 @@ Section FunctionSpecs.
   Context {scalar_representaton : ScalarRepresentation (word:=word) (mem:=mem)}.
 
   Definition spec_of_sctestbit : spec_of sctestbit :=
-    (forall! (x : scalar) (px wi : word)
-           (b:=Z.testbit (F.to_Z (sceval x)) (word.unsigned wi)),
-        (fun Rr mem =>
-           (exists Ra, (Scalar px x * Ra)%sep mem)
-           /\ Rr mem)
-          ===>
-          sctestbit @ [px; wi] returns rets
-          ===>
-          (liftexists r,
-           emp (rets = [r]
-                /\ r = word.of_Z (Z.b2z b)))).
+    fnspec! sctestbit (px wi: word) / (x: scalar) Ra Rr ~> r,
+    { requires tr mem :=
+        (Scalar px x * Ra)%sep mem /\ Rr mem;
+      ensures tr' mem' :=
+        tr = tr' /\ Rr mem' /\
+        let b := Z.testbit (F.to_Z (sceval x)) (word.unsigned wi) in
+        r = word.b2w b }.
 End FunctionSpecs.
 
 Section SpecProperties.


### PR DESCRIPTION
Updates the ladderstep function to generate stack allocations, and starts the process of updating the commented-out montladder function the same way. Also bumps rupicola to make stack allocation features available.