### PR TITLE
Zig: use @import("builtin") instead of the deprecated reexport

### DIFF
--- a/fiat-zig/src/curve25519_32.zig
+++ b/fiat-zig/src/curve25519_32.zig
@@ -13,7 +13,7 @@
 //   balance = [0x7ffffda, 0x3fffffe, 0x7fffffe, 0x3fffffe, 0x7fffffe, 0x3fffffe, 0x7fffffe, 0x3fffffe, 0x7fffffe, 0x3fffffe]
 
 const std = @import("std");
-const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 inline fn cast(comptime DestType: type, target: anytype) DestType {
     if (@typeInfo(@TypeOf(target)) == .Int) {

--- a/fiat-zig/src/curve25519_64.zig
+++ b/fiat-zig/src/curve25519_64.zig
@@ -13,7 +13,7 @@
 //   balance = [0xfffffffffffda, 0xffffffffffffe, 0xffffffffffffe, 0xffffffffffffe, 0xffffffffffffe]
 
 const std = @import("std");
-const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 inline fn cast(comptime DestType: type, target: anytype) DestType {
     if (@typeInfo(@TypeOf(target)) == .Int) {

--- a/fiat-zig/src/p224_32.zig
+++ b/fiat-zig/src/p224_32.zig
@@ -18,7 +18,7 @@
 //                            if x1 & (2^224-1) < 2^223 then x1 & (2^224-1) else (x1 & (2^224-1)) - 2^224
 
 const std = @import("std");
-const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 inline fn cast(comptime DestType: type, target: anytype) DestType {
     if (@typeInfo(@TypeOf(target)) == .Int) {

--- a/fiat-zig/src/p224_64.zig
+++ b/fiat-zig/src/p224_64.zig
@@ -18,7 +18,7 @@
 //                            if x1 & (2^256-1) < 2^255 then x1 & (2^256-1) else (x1 & (2^256-1)) - 2^256
 
 const std = @import("std");
-const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 inline fn cast(comptime DestType: type, target: anytype) DestType {
     if (@typeInfo(@TypeOf(target)) == .Int) {

--- a/fiat-zig/src/p256_32.zig
+++ b/fiat-zig/src/p256_32.zig
@@ -18,7 +18,7 @@
 //                            if x1 & (2^256-1) < 2^255 then x1 & (2^256-1) else (x1 & (2^256-1)) - 2^256
 
 const std = @import("std");
-const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 inline fn cast(comptime DestType: type, target: anytype) DestType {
     if (@typeInfo(@TypeOf(target)) == .Int) {

--- a/fiat-zig/src/p256_64.zig
+++ b/fiat-zig/src/p256_64.zig
@@ -18,7 +18,7 @@
 //                            if x1 & (2^256-1) < 2^255 then x1 & (2^256-1) else (x1 & (2^256-1)) - 2^256
 
 const std = @import("std");
-const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 inline fn cast(comptime DestType: type, target: anytype) DestType {
     if (@typeInfo(@TypeOf(target)) == .Int) {

--- a/fiat-zig/src/p384_32.zig
+++ b/fiat-zig/src/p384_32.zig
@@ -18,7 +18,7 @@
 //                            if x1 & (2^384-1) < 2^383 then x1 & (2^384-1) else (x1 & (2^384-1)) - 2^384
 
 const std = @import("std");
-const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 inline fn cast(comptime DestType: type, target: anytype) DestType {
     if (@typeInfo(@TypeOf(target)) == .Int) {

--- a/fiat-zig/src/p384_64.zig
+++ b/fiat-zig/src/p384_64.zig
@@ -18,7 +18,7 @@
 //                            if x1 & (2^384-1) < 2^383 then x1 & (2^384-1) else (x1 & (2^384-1)) - 2^384
 
 const std = @import("std");
-const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 inline fn cast(comptime DestType: type, target: anytype) DestType {
     if (@typeInfo(@TypeOf(target)) == .Int) {

--- a/fiat-zig/src/p434_64.zig
+++ b/fiat-zig/src/p434_64.zig
@@ -18,7 +18,7 @@
 //                            if x1 & (2^448-1) < 2^447 then x1 & (2^448-1) else (x1 & (2^448-1)) - 2^448
 
 const std = @import("std");
-const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 inline fn cast(comptime DestType: type, target: anytype) DestType {
     if (@typeInfo(@TypeOf(target)) == .Int) {

--- a/fiat-zig/src/p448_solinas_32.zig
+++ b/fiat-zig/src/p448_solinas_32.zig
@@ -13,7 +13,7 @@
 //   balance = [0x1ffffffe, 0x1ffffffe, 0x1ffffffe, 0x1ffffffe, 0x1ffffffe, 0x1ffffffe, 0x1ffffffe, 0x1ffffffe, 0x1ffffffc, 0x1ffffffe, 0x1ffffffe, 0x1ffffffe, 0x1ffffffe, 0x1ffffffe, 0x1ffffffe, 0x1ffffffe]
 
 const std = @import("std");
-const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 inline fn cast(comptime DestType: type, target: anytype) DestType {
     if (@typeInfo(@TypeOf(target)) == .Int) {

--- a/fiat-zig/src/p448_solinas_64.zig
+++ b/fiat-zig/src/p448_solinas_64.zig
@@ -13,7 +13,7 @@
 //   balance = [0x1fffffffffffffe, 0x1fffffffffffffe, 0x1fffffffffffffe, 0x1fffffffffffffe, 0x1fffffffffffffc, 0x1fffffffffffffe, 0x1fffffffffffffe, 0x1fffffffffffffe]
 
 const std = @import("std");
-const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 inline fn cast(comptime DestType: type, target: anytype) DestType {
     if (@typeInfo(@TypeOf(target)) == .Int) {

--- a/fiat-zig/src/p521_64.zig
+++ b/fiat-zig/src/p521_64.zig
@@ -13,7 +13,7 @@
 //   balance = [0x7fffffffffffffe, 0x7fffffffffffffe, 0x7fffffffffffffe, 0x7fffffffffffffe, 0x7fffffffffffffe, 0x7fffffffffffffe, 0x7fffffffffffffe, 0x7fffffffffffffe, 0x3fffffffffffffe]
 
 const std = @import("std");
-const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 inline fn cast(comptime DestType: type, target: anytype) DestType {
     if (@typeInfo(@TypeOf(target)) == .Int) {

--- a/fiat-zig/src/poly1305_32.zig
+++ b/fiat-zig/src/poly1305_32.zig
@@ -13,7 +13,7 @@
 //   balance = [0x7fffff6, 0x7fffffe, 0x7fffffe, 0x7fffffe, 0x7fffffe]
 
 const std = @import("std");
-const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 inline fn cast(comptime DestType: type, target: anytype) DestType {
     if (@typeInfo(@TypeOf(target)) == .Int) {

--- a/fiat-zig/src/poly1305_64.zig
+++ b/fiat-zig/src/poly1305_64.zig
@@ -13,7 +13,7 @@
 //   balance = [0x1ffffffffff6, 0xffffffffffe, 0xffffffffffe]
 
 const std = @import("std");
-const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 inline fn cast(comptime DestType: type, target: anytype) DestType {
     if (@typeInfo(@TypeOf(target)) == .Int) {

--- a/fiat-zig/src/secp256k1_32.zig
+++ b/fiat-zig/src/secp256k1_32.zig
@@ -18,7 +18,7 @@
 //                            if x1 & (2^256-1) < 2^255 then x1 & (2^256-1) else (x1 & (2^256-1)) - 2^256
 
 const std = @import("std");
-const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 inline fn cast(comptime DestType: type, target: anytype) DestType {
     if (@typeInfo(@TypeOf(target)) == .Int) {

--- a/fiat-zig/src/secp256k1_64.zig
+++ b/fiat-zig/src/secp256k1_64.zig
@@ -18,7 +18,7 @@
 //                            if x1 & (2^256-1) < 2^255 then x1 & (2^256-1) else (x1 & (2^256-1)) - 2^256
 
 const std = @import("std");
-const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
+const mode = @import("builtin").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels
 
 inline fn cast(comptime DestType: type, target: anytype) DestType {
     if (@typeInfo(@TypeOf(target)) == .Int) {

--- a/src/Stringification/Zig.v
+++ b/src/Stringification/Zig.v
@@ -96,7 +96,7 @@ Module Zig.
     : list string
     := (["";
          "const std = @import(""std"");";
-         "const mode = std.builtin.mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels";
+         "const mode = @import(""builtin"").mode; // Checked arithmetic is disabled in non-debug modes to avoid side channels";
          "";
          "inline fn cast(comptime DestType: type, target: anytype) DestType {";
          "    if (@typeInfo(@TypeOf(target)) == .Int) {";


### PR DESCRIPTION
Fixes #1029