### PR TITLE
Trying out self-hosted runners

### DIFF
--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         if [ ! -z "$PPA" ]; then sudo add-apt-repository "$PPA" -y; fi
         sudo apt-get -o Acquire::Retries=30 update -q
-        sudo apt-get -o Acquire::Retries=30 install jq python-is-python3 ocaml-findlib $COQ_PACKAGE -y --allow-unauthenticated
+        sudo apt-get -o Acquire::Retries=30 install jq python-is-python3 ocaml-findlib libgmp3-dev $COQ_PACKAGE -y --allow-unauthenticated
     - uses: haskell/actions/setup@v1
       with:
         ghc-version: ${{ matrix.ghc }}


### PR DESCRIPTION
Do not merge, this branch runs *only* self-hosted runners as a test. I am hoping though that with the other changes here we could mix them by labeling our runners as `ubuntu-latest` (somewhat misleadingly). I started the two current runners using the following script:

```sh
#!/bin/bash -eux

# USAGE: 
# 1. get API token from  https://github.com/mit-plv/fiat-crypto/settings/actions/runners/new  or  https://docs.github.com/en/rest/reference/actions#create-a-registration-token-for-a-repository
# 2. edit --token below
# 3. https://horizon.csail.mit.edu/horizon/project/instances/ xl.2core ubuntu Post-Creation

su -s /bin/bash ubuntu -- -eux <<'EOF'
cd
mkdir actions-runner && cd actions-runner
curl -o actions-runner-linux-x64-2.283.1.tar.gz -L https://github.com/actions/runner/releases/download/v2.283.1/actions-runner-linux-x64-2.283.1.tar.gz
echo "aebaaf7c00f467584b921f432f9f9fb50abf06e1b6b226545fbcbdaa65ed3031  actions-runner-linux-x64-2.283.1.tar.gz" | shasum -a 256 -c
tar xzf ./actions-runner-linux-x64-2.283.1.tar.gz
./config.sh --unattended --labels ubuntu-upstream-latest --name "$(hostname)" --url https://github.com/mit-plv/fiat-crypto --token TODO_INSERT_TOKEN_HERE
./run.sh
EOF
```

I'm not sure whether this will work because github self-hosted runners do not have any of the isolation (and thus cleanup) functionality we've come to expect from public CI services. In particular, I'm curious to see what happens when the same runner gets assigned a job with a different coq version than before. But it might just work.