### PR TITLE
Add support for folding constants into and

### DIFF
--- a/fiat-amd64/8917_ratio11077_seed3401074160038646_sub_p224.asm
+++ b/fiat-amd64/8917_ratio11077_seed3401074160038646_sub_p224.asm
@@ -1,0 +1,56 @@
+SECTION .text
+	GLOBAL sub_p224
+sub_p224:
+sub rsp, 0x20
+mov rax, [ rsi + 0x0 ];x1, copying arg1[0] here, cause arg1[0] is needed in a reg. It has those deps: "x1--x2, size: 1"
+sub rax, [ rdx + 0x0 ]
+mov r10, [ rsi + 0x8 ];x3, copying arg1[1] here, cause arg1[1] is needed in a reg. It has those deps: "x3--x4, size: 1"
+sbb r10, [ rdx + 0x8 ]
+mov r11, [ rsi + 0x10 ];x5, copying arg1[2] here, cause arg1[2] is needed in a reg. It has those deps: "x5--x6, size: 1"
+sbb r11, [ rdx + 0x10 ]
+mov rcx, [ rsi + 0x18 ];x7, copying arg1[3] here, cause arg1[3] is needed in a reg. It has those deps: "x7--x8, size: 1"
+sbb rcx, [ rdx + 0x18 ]
+mov r8, 0x0 ; moving imm to reg
+mov r9, 0xffffffffffffffff ; moving imm to reg
+mov [ rsp + 0x0 ], r15; spilling callerSaver15 to mem
+mov r15, r8;x9, copying 0x0 here, cause 0x0 is needed in a reg. It has those deps: "x1--x2, x9, x10--x11, size: 3"
+cmovc r15, r9; if CF, x9<- 0xffffffffffffffff (nzVar)
+mov r8, 0x1 ; moving imm to reg
+mov [ rsp + 0x8 ], r14; spilling callerSaver14 to mem
+mov r14, r15;x10000, copying x9 here, cause x9 is needed in a reg. It has those deps: "x10002, x10001, x10000, x14--x15, size: 4"
+and r14, r8; x10000 <- x9&0x1
+mov r8, 0xffffffff ; moving imm to reg
+mov [ rsp + 0x10 ], r13; spilling callerSaver13 to mem
+mov r13, r15;x10002, copying x9 here, cause x9 is needed in a reg. It has those deps: "x10002, x10001, x14--x15, size: 3"
+and r13, r8; x10002 <- x9&0xffffffff
+adox r14, rax
+mov [ rdi + 0x0 ], r14; out1[0] = x10
+mov rax, 0xffffffff00000000 ; moving imm to reg
+seto r14b; spill OF x11 to reg (r14)
+mov [ rsp + 0x18 ], r12; spilling callerSaver12 to mem
+mov r12, r15;x10001, copying x9 here, cause x9 is needed in a reg. It has those deps: "x10001, x14--x15, size: 2"
+and r12, rax; x10001 <- x9&0xffffffff00000000
+add r14b, 0x7F; load flag from rm/8 into OF, clears other flag. NOTE, if operand1 is not a byte reg, this fails.
+seto r14b; since that has deps, restore it where ever it was
+adox r10, r12
+adox r15, r11
+adox rcx, r13
+mov [ rdi + 0x10 ], r15; out1[2] = x14
+mov [ rdi + 0x18 ], rcx; out1[3] = x16
+mov [ rdi + 0x8 ], r10; out1[1] = x12
+mov r15, [ rsp + 0x0 ] ; pop
+mov r14, [ rsp + 0x8 ] ; pop
+mov r13, [ rsp + 0x10 ] ; pop
+mov r12, [ rsp + 0x18 ] ; pop
+add rsp, 0x20 
+ret
+; cpu Intel(R) Core(TM) i5-8265U CPU @ 1.60GHz
+; ratio 1.1077
+; seed 3401074160038646 
+; CC / CFLAGS clang / -march=native -mtune=native -O3 
+; time needed: 18641 ms / 9500 evals=> 1.9622105263157894ms/eval
+; Time spent for assembling and measureing (initial batch_size=485, initial num_batches=31): 6977 ms
+; number of used evaluations: 9500
+; Ratio (time for assembling + measure)/(total runtime for 9500 evals): 0.3742824955742718
+; number reverted permutation/ tried permutation: 4377 / 4794 =91.302%
+; number reverted decision/ tried decision: 4323 / 4705 =91.881%

--- a/src/Assembly/Symbolic.v
+++ b/src/Assembly/Symbolic.v
@@ -944,6 +944,7 @@ Proof using Type.
   { rewrite !Z.mul_1_r, ?Z.land_ones; push_Zmod; pull_Zmod; Lia.lia. }
 Qed.
 
+(** TODO: plausibly we want to define all associative operations in terms of some [make_associative_op] definition, so that we can separate out the binary operation reasoning from the fold and option reasoning *)
 (* is it okay for associative to imply identity? *)
 Lemma interp_op_associative_spec_fold o : associative o = true ->
   forall G xs, interp_op G o xs = fold_right (fun v acc => acc <- acc; interp_op G o [v; acc])%option (interp_op G o []) xs.

--- a/src/Assembly/Symbolic.v
+++ b/src/Assembly/Symbolic.v
@@ -1339,6 +1339,7 @@ Proof using Type.
   t; cbn [fold_right]. rewrite Z.lxor_0_r, Z.lxor_nilpotent; trivial.
 Qed.
 
+(** TODO: Add a pass that turns unary operations like [and], [add], etc into truncation *)
 Definition expr : expr -> expr :=
   List.fold_left (fun e f => f e)
   [constprop

--- a/src/Assembly/Symbolic.v
+++ b/src/Assembly/Symbolic.v
@@ -389,11 +389,11 @@ Definition gensym_dag_ok G d := gensym_ok G d /\ dag_ok G d.
 Lemma gensym_ok_length_Proper G d1 d2
       (H : List.length d1 <= List.length d2)
   : gensym_ok G d1 -> gensym_ok G d2.
-Proof. cbv [gensym_ok]; firstorder lia. Qed.
+Proof using Type. cbv [gensym_ok]; firstorder lia. Qed.
 
 Lemma gensym_ok_app G d1 d2
   : gensym_ok G d1 -> gensym_ok G (d1 ++ d2).
-Proof. apply gensym_ok_length_Proper; rewrite app_length; lia. Qed.
+Proof using Type. apply gensym_ok_length_Proper; rewrite app_length; lia. Qed.
 
 Lemma eval_merge_node :
   forall G d, gensym_dag_ok G d ->
@@ -908,7 +908,7 @@ Proof using Type. t. f_equal; eauto using eval_eval. Qed.
 
 Lemma interp_op_drop_identity o id : identity o = Some id ->
   forall G xs, interp_op G o xs = interp_op G o (List.filter (fun v => negb (Z.eqb v id)) xs).
-Proof.
+Proof using Type.
   destruct o; cbn [identity]; intro; inversion_option; subst; intros G xs; cbn [interp_op]; f_equal.
   all: induction xs as [|x xs IHxs]; cbn [fold_right List.filter]; try reflexivity.
   all: unfold negb at 1; break_innermost_match_step; reflect_hyps; subst; cbn [fold_right].
@@ -924,11 +924,13 @@ Qed.
 
 Lemma interp_op_nil_is_identity o i (Hi : identity o = Some i)
   G : interp_op G o [] = Some i.
-Proof.
+Proof using Type.
   destruct o; cbn [identity] in *; break_innermost_match_hyps; inversion_option; subst; cbn [interp_op fold_right]; f_equal.
   all: cbn [interp_op fold_right]; autorewrite with zsimplify_const; try reflexivity.
   { cbn [identity]; break_innermost_match; try reflexivity.
-    rewrite Z.land_ones by lia; Z.rewrite_mod_small; reflexivity. }
+    rewrite Z.land_ones by lia; Z.rewrite_mod_small; try reflexivity;
+      (* compat with older versions of Coq (needed for 8.11, not for 8.13) *)
+      rewrite Z.mod_small; rewrite ?Z.log2_lt_pow2; cbn [Z.log2]; try lia. }
 Qed.
 
 Lemma invert_interp_op_associative o : associative o = true ->


### PR DESCRIPTION
Supercedes and closes #1049

I got nerdsniped and wrote the rewrite rule myself.

The first commit of this PR is a reorganization of the associative-commutative machinery for operations, making more operations associative and commutative.  I tried to minimize the number of proofs in which we destruct the operation.  I decided on the following:

For an operation with identity, the spec is that if `identity o = Some id`, then:
- `interp_op G o xs = interp_op G o (List.filter (fun v => negb (v =? id)) xs)`
- `interp_op G o [] = Some id`

For an associative operation, the spec is:
- `interp_op G o xs = fold_right (fun v acc => acc <- acc; interp_op G o [v; acc])%option (interp_op G o []) xs`
- `interp_op G o [] = identity o`
- `interp_op G o ys = Some vys -> interp_op G o zs = Some vzs ->((xy <- interp_op G o [x; vys]; interp_op G o [xy; vzs]) = (yz <- interp_op G o [vys; vzs]; interp_op G o [x; yz]))%option` which is only used to prove `interp_op G o (List.concat xs) = (vxs <-- List.map (interp_op G o) xs; interp_op G o vxs)%option`, which is generally treated as the actual spec for this bullet point 

The third commit is @dderjoel 's test from #1049