### PR TITLE
Partial compatibility with Haskell 9.2.1

### DIFF
--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -83,6 +83,7 @@ jobs:
       with:
         name: ExtractionOCaml-${{ matrix.env.COQ_VERSION }}
         path: src/ExtractionOCaml
+      if: always ()
     - name: standalone-haskell
       run: etc/ci/github-actions-make.sh -j1 standalone-haskell GHCFLAGS='+RTS -M5G -RTS'
     - name: upload Haskell files
@@ -90,6 +91,7 @@ jobs:
       with:
         name: ExtractionHaskell-${{ matrix.env.COQ_VERSION }}
         path: src/ExtractionHaskell
+      if: always ()
     - name: display timing info
       run: cat time-of-build-pretty.log
     - name: display per-line timing info

--- a/src/haskell.sed
+++ b/src/haskell.sed
@@ -1,3 +1,4 @@
 s/import qualified Prelude/import qualified Prelude\nimport qualified Data.Bits\nimport qualified Data.Char\nimport qualified Text.Printf\nimport qualified System.Environment\n/g
 s/import qualified GHC.Base/import qualified GHC.Base\n#if __GLASGOW_HASKELL__ >= 900\nimport qualified GHC.Exts\n#endif\n#if __GLASGOW_HASKELL__ >= 802\nimport qualified GHC.Types\n#endif/g
 s/unsafeCoerce = GHC.Base.unsafeCoerce#/#if __GLASGOW_HASKELL__ >= 900\nunsafeCoerce = GHC.Exts.unsafeCoerce#\n#else\nunsafeCoerce = GHC.Base.unsafeCoerce#\n#endif/g
+s/\(OPTIONS_GHC [^#]*\) /\1 -XNoPolyKinds /g


### PR DESCRIPTION
Unlike #1048, we don't test on Haskell 9.2.1, because we still have a heap overflow.  But we can at least pass typechecking, so here we do.