### PR TITLE
Bump rupicola for bedrock2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -497,9 +497,7 @@ install-bedrock2:
 	$(MAKE) --no-print-directory -C $(BEDROCK2_ROOT_FOLDER) install_bedrock2
 
 bedrock2-compiler: bedrock2
-	# We have to build the compiler *including* examples to get compilerExamples/MMIO.v
 	$(MAKE) --no-print-directory -C $(BEDROCK2_ROOT_FOLDER) compiler_noex
-	$(MAKE) --no-print-directory -C $(BEDROCK2_ROOT_FOLDER) compiler_ex
 
 clean-bedrock2-compiler:
 	$(MAKE) --no-print-directory -C $(BEDROCK2_ROOT_FOLDER) clean_compiler


### PR DESCRIPTION
Now that https://github.com/mit-plv/bedrock2/pull/206 has been merged,
we no longer need to make the examples.

This is blocked on https://github.com/mit-plv/rupicola/pull/22, after which we'll need to make sure that we point to a commit that's actually on the master branch of rupicola.