### PR TITLE
Move ScalarMult.ECC to AdditionChains

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -135,9 +135,9 @@ src/Bedrock/Field/Translation/Proofs/VarnameSet.v
 src/Bedrock/Field/Translation/Proofs/ValidComputable/Cmd.v
 src/Bedrock/Field/Translation/Proofs/ValidComputable/Expr.v
 src/Bedrock/Field/Translation/Proofs/ValidComputable/Func.v
+src/Bedrock/Group/AdditionChains.v
 src/Bedrock/Group/Loops.v
 src/Bedrock/Group/Point.v
-src/Bedrock/Group/ScalarMult/ECC.v
 src/Bedrock/Group/ScalarMult/LadderStep.v
 src/Bedrock/Group/ScalarMult/MontgomeryEquivalence.v
 src/Bedrock/Group/ScalarMult/MontgomeryLadder.v

--- a/src/Bedrock/End2End/X25519/MontgomeryLadder.v
+++ b/src/Bedrock/End2End/X25519/MontgomeryLadder.v
@@ -1,13 +1,14 @@
 Require Import Coq.Strings.String.
 Require Import Coq.Lists.List.
 Require Import Coq.ZArith.ZArith.
+Require Import Crypto.Spec.Curve25519.
 Require Import bedrock2.Syntax.
 Require Import compiler.Pipeline.
 Require Import compiler.MMIO.
 Require Import Crypto.Arithmetic.PrimeFieldTheorems.
 Require Import Crypto.Bedrock.End2End.X25519.Field25519.
 Require Import Crypto.Bedrock.Field.Synthesis.New.UnsaturatedSolinas.
-Require Import Crypto.Bedrock.Group.ScalarMult.ECC.
+Require Import Crypto.Bedrock.Group.AdditionChains.
 Require Import Crypto.Bedrock.Group.ScalarMult.LadderStep.
 Require Import Crypto.Bedrock.Group.ScalarMult.MontgomeryLadder.
 Require Import Crypto.Bedrock.Specs.ScalarField.
@@ -18,10 +19,7 @@ Print ScalarFieldParameters.
 
 (* TODO: move to a separate file? *)
 Local Instance scalar_field_parameters : ScalarFieldParameters :=
-  {  L_pos := 7237005577332262213973186563042994240857116359379907606001950938285454250989%positive;
-     scalarbits := 253;
-     sctestbit := "sc25519_testbit";
-  }.
+  { L_pos := Curve25519.l; scalarbits := 253; sctestbit := "sc25519_testbit" }.
 
 Definition ladderstep : func :=
   Eval vm_compute in


### PR DESCRIPTION
On top of #1071; to me merged to master instead.

@ashley-lin @DIJamner note the file rename, also code that uses `F` but does not use any representation of `F` as machine words should not depend on `field_parameters` (so no use of the projection `M_pos`). And `2^255-17` really should have been `2^255-21` all along, I subtracted 2 the wrong way first.

@DIJamner https://github.com/mit-plv/fiat-crypto/compare/scpock...move-additionchains?expand=1#diff-f2db6df85cc061aa2022d43cf5477cd150fb16d01b23c7b293e07526412ae30bR567-R568 is where I got when trying to remove dependence on `word.unsigned` in generated code; I don't think it's worth prioritizing but just FYI.