### PR TITLE
[rust] Add conditional `no_std` to Cargo.toml

### DIFF
--- a/fiat-rust/Cargo.toml
+++ b/fiat-rust/Cargo.toml
@@ -12,3 +12,7 @@ license = "MIT OR Apache-2.0 OR BSD-1-Clause"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+
+[features]
+default = [ "std" ]
+std = []

--- a/fiat-rust/src/lib.rs
+++ b/fiat-rust/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 pub mod curve25519_64;
 pub mod curve25519_32;
 pub mod p521_64; // Zoe: Has assignments from u32 to u64


### PR DESCRIPTION
Adds `#![cfg_attr(not(feature = "std"), no_std)]` to the Rust library,
as suggested in https://github.com/mit-plv/fiat-crypto/issues/1067

Fixes #1067

@vlmutolo @brycx Does this look good?