### PR TITLE
Attempt to fix windows build

### DIFF
--- a/.github/workflows/coq-macos.yml
+++ b/.github/workflows/coq-macos.yml
@@ -36,11 +36,10 @@ jobs:
         set -e
         eval $(opam env)
         opam update
-        opam install opam-depext
-        opam-depext coq
         opam pin add coq ${COQ_VERSION}
       env:
         OPAMYES: "true"
+        OPAMCONFIRMLEVEL: "unsafe-yes"
 
     - name: echo build params
       run: |

--- a/.github/workflows/coq-opam-package.yml
+++ b/.github/workflows/coq-opam-package.yml
@@ -40,6 +40,7 @@ jobs:
 
     env:
       OPAMYES: "true"
+      OPAMCONFIRMLEVEL: "unsafe-yes"
 
     steps:
     - name: Set up OCaml
@@ -106,8 +107,6 @@ jobs:
     - run: opam repo add coq-released https://coq.inria.fr/opam/released
     - run: opam repo add coq-extra-dev https://coq.inria.fr/opam/extra-dev
     - run: opam update
-    - run: opam install opam-depext
-    - run: opam exec -- opam-depext coq.${{ matrix.coq-version }}
     - run: opam pin --kind=version add coq ${{ matrix.coq-version }}
 
     - name: echo more build params
@@ -125,7 +124,6 @@ jobs:
         echo "" | opam exec -- coqtop
         echo ::endgroup::
 
-    - run: opam exec -- opam-depext coq-fiat-crypto
     - run: opam install coq-fiat-crypto ${{ matrix.opam-jobs-flag }}
       env:
         COQEXTRAFLAGS: ${{ matrix.coq-extra-flags }}

--- a/.github/workflows/coq-windows.yml
+++ b/.github/workflows/coq-windows.yml
@@ -21,6 +21,7 @@ jobs:
       COQ_VERSION: "8.12.0" # https://packages.debian.org/stable/coq
       SKIP_BEDROCK2: "1"
       OPAMYES: "true"
+      OPAMCONFIRMLEVEL: "unsafe-yes"
 
     steps:
     - uses: actions/checkout@v2
@@ -32,8 +33,6 @@ jobs:
       uses: ocaml/setup-ocaml@v2
       with:
         ocaml-compiler: 4.11.1
-    - run: opam install opam-depext
-    - run: opam exec -- opam-depext coq.${{ env.COQ_VERSION }}
     - run: opam pin add --kind=version coq ${{ env.COQ_VERSION }}
 
     - name: Install System Dependencies


### PR DESCRIPTION
Since opam 2.1, depext is integrated in install, so we try disabling it.
See https://opam.ocaml.org/blog/opam-2-1-0/