### PR TITLE
Separate F_lia

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -39,6 +39,7 @@ src/Arithmetic/BaseConversion.v
 src/Arithmetic/Core.v
 src/Arithmetic/FancyMontgomeryReduction.v
 src/Arithmetic/Freeze.v
+src/Arithmetic/FLia.v
 src/Arithmetic/ModOps.v
 src/Arithmetic/ModularArithmeticPre.v
 src/Arithmetic/ModularArithmeticTheorems.v

--- a/src/Arithmetic/FLia.v
+++ b/src/Arithmetic/FLia.v
@@ -1,0 +1,121 @@
+Require Import ZArith.ZArith.
+Require Import Coq.micromega.Lia.
+Require Import Crypto.Arithmetic.PrimeFieldTheorems.
+
+Local Open Scope Z_scope.
+
+
+Section __.
+  Context {M_pos : positive}.
+
+  Lemma solve_F_equality_via_Z lhs' rhs' (lhs rhs : F M_pos)
+    : F.to_Z lhs = lhs' mod Z.pos M_pos ->
+      F.to_Z rhs = rhs' mod Z.pos M_pos ->
+      lhs' = rhs' ->
+      lhs = rhs.
+  Proof.
+    intros.
+    rewrite <- (F.of_Z_to_Z lhs).
+    rewrite <- (F.of_Z_to_Z rhs).
+    intuition congruence.
+  Qed.
+
+
+  (*TODO: add remaining homomorphisms.
+    To support additional operations, prove a lemma like the ones below
+    and then add it to the `F_convert_to_Z` tactic.
+   *)
+
+  Lemma F_mul_to_Z a a' b b'
+    : F.to_Z a = a' mod Z.pos M_pos ->
+      F.to_Z b = b' mod Z.pos M_pos ->
+      @F.to_Z M_pos (a * b) = (a' * b') mod Z.pos M_pos.
+  Proof.
+    intros H H0.
+    rewrite F.to_Z_mul.
+    rewrite H, H0.
+    rewrite <- PullPush.Z.mul_mod_l.
+    rewrite <- PullPush.Z.mul_mod_r.
+    congruence.
+  Qed.
+
+  Lemma F_add_to_Z a a' b b'
+    : F.to_Z a = a' mod Z.pos M_pos ->
+      F.to_Z b = b' mod Z.pos M_pos ->
+      @F.to_Z M_pos (a + b) = (a' + b') mod Z.pos M_pos.
+  Proof.
+    intros H H0.
+    rewrite F.to_Z_add.
+    rewrite H, H0.
+    rewrite <- PullPush.Z.add_mod_l.
+    rewrite <- PullPush.Z.add_mod_r.
+    congruence.
+  Qed.
+
+  
+  Lemma F_pow_to_Z a a' c
+    : F.to_Z a = a' mod Z.pos M_pos ->
+      @F.to_Z M_pos (a ^ c) = (a' ^ c) mod Z.pos M_pos.
+  Proof.
+    intros H.
+    rewrite F.to_Z_pow.
+    rewrite H.
+    rewrite <- PullPush.Z.pow_mod_full.
+    congruence.
+  Qed.
+
+  Lemma F_var_to_Z (x : F M_pos) : F.to_Z x = proj1_sig x mod Z.pos M_pos.
+  Proof.
+    destruct x; simpl; assumption.
+  Qed.
+
+  Lemma F_one_to_Z : @F.to_Z M_pos 1 = 1 mod Z.pos M_pos.
+  Proof.
+    reflexivity.
+  Qed.
+
+
+  Lemma F_const_to_Z c : F.to_Z (F.of_Z M_pos c) = c mod Z.pos M_pos.
+  Proof.
+    reflexivity.
+  Qed.
+
+End __.
+
+
+Ltac F_convert_to_Z :=
+  solve [repeat
+           let e := lazymatch goal with |- F.to_Z ?x = _ => x end in
+           first [ simple eapply F_mul_to_Z
+                 | simple eapply F_add_to_Z
+                 | simple eapply F_one_to_Z
+                 | simple eapply F_pow_to_Z
+                 | simple eapply F_const_to_Z
+                 (* must be last *)
+                 | simple eapply F_var_to_Z]].
+
+(*TODO: doesn't prepare hypotheses.
+  To support working with hypotheses will require a variation on `solve_F_equality_via_Z` 
+  that goes in the other direction.
+  Since Z->F isn't injective, it will require some thinking.
+ *)
+Ltac F_zify :=
+  intros;
+  lazymatch goal with
+  | [|- ?lhs = ?rhs] =>
+      simple eapply solve_F_equality_via_Z;
+      [F_convert_to_Z | F_convert_to_Z | ]
+  end.
+
+Ltac F_lia := F_zify; (lia || fail "F_lia failed; check that all necessary homomorphisms have been added").
+
+
+
+Section Example.
+  Context {M_pos : positive}.
+  
+  Goal forall (x : F M_pos), (x + F.of_Z  _ 4 * x)%F = ( x * F.of_Z  _ 2 + F.of_Z  _ 2 * x + 1 * 1 * x)%F.
+  Proof.
+    F_lia.
+  Qed.
+End Example.

--- a/src/Bedrock/Group/AdditionChains.v
+++ b/src/Bedrock/Group/AdditionChains.v
@@ -146,81 +146,6 @@ Section FElems.
       exp_from_encoding x (run_length_encoding n).
   End Impl.
 
-  Section FUtils.
-    Context (m : positive).
-    (* FIXME go over this section with Dustin to understand why the code below
-       is needed. *)
-    
-    Lemma solve_F_equality_via_Z lhs' rhs' (lhs rhs : F m)
-      : F.to_Z lhs = lhs' mod Z.pos m ->
-        F.to_Z rhs = rhs' mod Z.pos m ->
-        lhs' = rhs' ->
-        lhs = rhs.
-    Proof.
-      intros.
-      rewrite <- (F.of_Z_to_Z lhs).
-      rewrite <- (F.of_Z_to_Z rhs).
-      intuition congruence.
-    Qed.
-
-    Lemma F_mul_to_Z a a' b b'
-      : F.to_Z a = a' mod Z.pos m ->
-        F.to_Z b = b' mod Z.pos m ->
-        @F.to_Z m (a * b) = (a' * b') mod Z.pos m.
-    Proof.
-      intros H H0.
-      rewrite F.to_Z_mul.
-      rewrite H, H0.
-      rewrite <- PullPush.Z.mul_mod_l.
-      rewrite <- PullPush.Z.mul_mod_r.
-      congruence.
-    Qed.
-
-    Lemma F_add_to_Z a a' b b'
-      : F.to_Z a = a' mod Z.pos m ->
-        F.to_Z b = b' mod Z.pos m ->
-        @F.to_Z m (a + b) = (a' + b') mod Z.pos m.
-    Proof.
-      intros H H0.
-      rewrite F.to_Z_add.
-      rewrite H, H0.
-      rewrite <- PullPush.Z.add_mod_l.
-      rewrite <- PullPush.Z.add_mod_r.
-      congruence.
-    Qed.
-
-    Lemma F_exp_to_Z a a' n
-      : F.to_Z a = a' mod Z.pos m ->
-        @F.to_Z m (a ^ n) = (a' ^ n) mod Z.pos m.
-    Proof.
-      intros H.
-      rewrite F.to_Z_pow.
-      rewrite H.
-      rewrite <- PullPush.Z.mod_pow_full.
-      congruence.
-    Qed.
-
-    Lemma F_var_to_Z (x : F m) : F.to_Z x = proj1_sig x mod Z.pos m.    Proof.
-      destruct x; simpl; assumption.
-    Qed.
-
-    Lemma F_one_to_Z : @F.to_Z m 1 = 1 mod Z.pos m.
-    Proof.
-      reflexivity.
-    Qed.
-
-
-    Lemma F_const_to_Z c : F.to_Z (F.of_Z m c) = c mod Z.pos m.
-    Proof.
-      reflexivity.
-    Qed.
-
-
-    Definition Pos2N_pos_xI n : N.pos n~1 = (2 * N.pos n + 1)%N := eq_refl.
-    Definition Pos2N_pos_xO n : N.pos n~0 = (2 * N.pos n)%N := eq_refl.
-    
-  End FUtils.
-
   Section Proofs.
     Context (m : positive).
    
@@ -251,9 +176,13 @@ Section FElems.
       unfold nlet;
       autorewrite with F_pow;
       repeat rewrite F_mul_1_r;
-      repeat rewrite F_mul_1_l; 
+      repeat rewrite F_mul_1_l;
       try reflexivity;
       try F_lia.
+
+    
+    Definition Pos2N_pos_xI n : N.pos n~1 = (2 * N.pos n + 1)%N := eq_refl.
+    Definition Pos2N_pos_xO n : N.pos n~0 = (2 * N.pos n)%N := eq_refl.
 
      Lemma exp_by_squaring_correct :
       forall n x, exp_by_squaring m x n = (x ^ N.pos n)%F.

--- a/src/Bedrock/Group/AdditionChains.v
+++ b/src/Bedrock/Group/AdditionChains.v
@@ -2,6 +2,7 @@ Require Import Rupicola.Lib.Api.
 Require Import Rupicola.Lib.Loops.
 Require Import Rupicola.Lib.ControlFlow.DownTo.
 Require Import Crypto.Arithmetic.PrimeFieldTheorems.
+Require Import Crypto.Arithmetic.FLia.
 Require Import Crypto.Bedrock.Specs.Field.
 Require Import Crypto.Bedrock.Field.Interface.Compilation2.
 Require Import Crypto.Algebra.Hierarchy.
@@ -222,41 +223,7 @@ Section FElems.
 
   Section Proofs.
     Context (m : positive).
-    Ltac rewrite_Z :=
-      lazymatch goal with
-      | [|- ?a = ?b] =>
-        let H := fresh "H" in
-        let m := open_constr:(_) in
-        enough (F.of_Z m (F.to_Z a) = F.of_Z m (F.to_Z b)) as H;
-        [rewrite !F.of_Z_to_Z in H; assumption| f_equal]
-      end.
-
-    Ltac F_lia_orig :=
-      try rewrite_Z;
-      try rewrite !F.to_Z_mul;
-      try f_equal;
-      try lia.
-    
-    Ltac F_convert_to_Z :=
-      solve [repeat
-               let e := lazymatch goal with |- F.to_Z ?x = _ => x end in
-               tryif is_var e
-               then simple eapply F_var_to_Z
-               else first [ simple eapply F_exp_to_Z
-                          | simple eapply F_mul_to_Z
-                          | simple eapply F_add_to_Z
-                          | simple eapply F_one_to_Z
-                          | simple eapply F_const_to_Z]].
-
-    Ltac F_zify :=
-      intros;
-      lazymatch goal with
-      | [|- ?lhs = ?rhs] =>
-        simple eapply solve_F_equality_via_Z;
-        [F_convert_to_Z | F_convert_to_Z | ]
-      end.
-
-    Ltac F_lia := F_zify; lia.
+   
 
     Lemma F_mul_1_r : forall x : F m,
         (x * 1)%F = x.
@@ -322,7 +289,7 @@ Section FElems.
         + destruct p. destruct b.
           * rewrite <- IHn.
             cbn. replace (n0 + 1)%nat with (S n0) by lia.
-            unfold nlet; destruct n0; cbn; destruct n eqn : H'; unfold exp_square_and_multiply; unfold nlet; set (exp_from_encoding_simple _ x l) as expxl; try F_lia; F_lia_orig.
+            unfold nlet; destruct n0; cbn; destruct n eqn : H'; unfold exp_square_and_multiply; unfold nlet; set (exp_from_encoding_simple _ x l) as expxl; F_lia.
           * rewrite <- IHn.
             cbn.
             unfold nlet.
@@ -335,14 +302,14 @@ Section FElems.
           unfold nlet.
           cbn.
           unfold exp_square.
-          destruct n0; F_lia_orig.
+          destruct n0; cbv [nlet Nat.iter]; simpl; F_lia.
         * destruct (run_length_encoding p~0) as [|[[|] n0] t]; try reflexivity.
           simpl.
           replace (n0 + 1)% nat with (S n0) by lia.
           unfold nlet.
           simpl.
           unfold exp_square.
-          destruct n0; F_lia_orig.
+          destruct n0; cbv [nlet Nat.iter]; simpl; F_lia.
         * unfold run_length_encoding.
           unfold exp_from_encoding_simple.
           simplify_F.


### PR DESCRIPTION
Moves the `F_lia` tactic out of AdditionChains.v and replaces the outdated `F_lia_orig` tactic with calls to `F_lia`.