### PR TITLE
Adapt to Coq PR #15434: even erasable subterms of fixpoints must be guarded

### DIFF
--- a/src/Stringification/Language.v
+++ b/src/Stringification/Language.v
@@ -703,32 +703,38 @@ Module Compilers.
           Context {var}
                   (of_string : forall t, string -> option (var t))
                   (k : forall t, @API.expr var t -> type.for_each_lhs_of_arrow (fun t => (Level -> string) * ZRange.type.option.interp t)%type t -> positive -> (positive * (Level -> list string)) * ZRange.type.base.option.interp (type.final_codomain t)).
+          Definition show_eta_abs_aux
+              (aux : forall t (idx : positive) (e : @API.expr var t),
+                     (positive * (list string * (Level -> list string))) * ZRange.type.base.option.interp (type.final_codomain t))
+              s d (idx : positive) (f : var s -> @API.expr var d)
+            : (positive * (list string * (Level -> list string))) * ZRange.type.base.option.interp (type.final_codomain d)
+            := let n := "x" ++ Decimal.Pos.to_string idx in
+               match of_string s n with
+               | Some n'
+                 => let '(_, (args, show_f), r) := aux d (Pos.succ idx) (f n') in
+                    (idx,
+                     (n :: args, show_f),
+                     r)
+               | None
+                 => (idx,
+                     ([n], (fun _ => ["λ_(" ++ show s ++ ")"])),
+                     ZRange.type.base.option.None)
+               end.
           Fixpoint show_eta_abs_cps' {t} (idx : positive) (e : @API.expr var t)
             : (positive * (list string * (Level -> list string))) * ZRange.type.base.option.interp (type.final_codomain t)
             := match e in expr.expr t return (unit -> _ * ZRange.type.base.option.interp (type.final_codomain t)) -> _ * ZRange.type.base.option.interp (type.final_codomain t) with
                | expr.Abs s d f
                  => fun _
-                    => let n := "x" ++ Decimal.Pos.to_string idx in
-                       match of_string s n with
-                       | Some n'
-                         => let '(_, (args, show_f), r) := @show_eta_abs_cps' d (Pos.succ idx) (f n') in
-                            (idx,
-                             (n :: args, show_f),
-                             r)
-                       | None
-                         => (idx,
-                             ([n], (fun _ => ["λ_(" ++ show t ++ ")"])),
-                             ZRange.type.base.option.None)
-                       end
+                    => show_eta_abs_aux (@show_eta_abs_cps') s d idx f
                | _
                  => fun default
                     => default tt
                end (fun _
                     => let '(args, (idx, show_f, r)) := get_eta_cps_args _ idx (@k _ e) in
                        ((idx, (args, show_f)), r)).
-          Definition show_eta_abs_cps (with_casts : bool) {t} (idx : positive) (e : @API.expr var t) (extraargs : type.for_each_lhs_of_arrow (fun t => (Level -> string) * ZRange.type.option.interp t)%type t)
-            : (positive * (Level -> list string)) * ZRange.type.base.option.interp (type.final_codomain t)
-            := let '(idx, (args, show_f), r) := @show_eta_abs_cps' t idx e in
+          Definition show_eta_abs_cps (with_casts : bool) {s d} (idx : positive) (f : var s -> @API.expr var d) (extraargs : type.for_each_lhs_of_arrow (fun t => (Level -> string) * ZRange.type.option.interp t)%type (s -> d))
+            : (positive * (Level -> list string)) * ZRange.type.base.option.interp (type.final_codomain d)
+            := let '(idx, (args, show_f), r) := show_eta_abs_aux (@show_eta_abs_cps') s d idx f in
                let argstr := String.concat " " args in
                (idx,
                 fun lvl
@@ -767,9 +773,9 @@ Module Compilers.
                               (idx, fun lvl => [v lvl], r)
              | expr.Var t v
                => fun args => (idx, fun lvl => [show_application with_casts (fun _ => to_string _ v) args lvl], ZRange.type.base.option.None)
-             | expr.Abs s d f as e
+             | expr.Abs s d f
                => fun args
-                  => show_eta_abs_cps of_string (fun t e args idx => let '(idx, v, r) := @show_expr_lines_gen with_casts var to_string of_string t e args idx in (idx, fun _ => v term_lvl, r)) with_casts idx e args
+                  => show_eta_abs_cps of_string (fun t e args idx => let '(idx, v, r) := @show_expr_lines_gen with_casts var to_string of_string t e args idx in (idx, fun _ => v term_lvl, r)) with_casts idx f args
              | expr.App s d f x
                => fun args
                   => let '(idx', x', xr) := show_eta_cps of_string (fun t e args idx => @show_expr_lines_gen with_casts var to_string of_string t e args idx) idx x in


### PR DESCRIPTION
Hi,

The fixpoint `show_expr_lines_gen` in file `Stringification/Language.v` has the following form once the helpers it depends on are unfolded:
```coq
Fixpoint show_expr_lines_gen ... e ... :=
  match e with
  | expr.Abs s d f =>
      fix show_eta_abs_cps' ... e ... :=
        match e with
        | expr.Abs s d f => ψ (show_eta_abs_cps' ... f ...)
        | _ => show_expr_lines_gen ... e ...
        end (expr.Abs s d f)
  | _ => ...
  end
```

This includes in the default case of `show_eta_abs_cps'` an erasable recursive call to `show_expr_lines_gen` which is not guarded and which thus may loop for a specific reduction strategy that unfolds `show_eta_abs_cps'` one step, then reduces the expression in the default case of the `match (expr.Abs s d f) with  ... end` before contracting the `match` itself. PR coq/coq#15434 forbids it.

This fiat-crypto PR reformulates `show_expr_lines_gen` by forcing the evaluation of the `match (expr.Abs s d f) with  ... end` in advance as in:
```coq
Fixpoint show_expr_lines_gen ... e ... :=
  match e with
  | expr.Abs s d f =>
      ψ (fix show_eta_abs_cps' ... e ... :=
        match e with
        | expr.Abs s d f => ψ (show_eta_abs_cps' ... f ...)
        | _ => show_expr_lines_gen ... e ...
        end f)
  | _ => ...
  end
```

If this reformulation is ok to you, it can be merged as soon as now.