### PR TITLE
Add support for checking callee-saved registers

### DIFF
--- a/src/PushButtonSynthesis/BaseConversion.v
+++ b/src/PushButtonSynthesis/BaseConversion.v
@@ -100,11 +100,8 @@ Section __.
           {ignore_unique_asm_names : ignore_unique_asm_names_opt}
           {widen_carry : widen_carry_opt}
           {widen_bytes : widen_bytes_opt}
-          {assembly_calling_registers : assembly_calling_registers_opt}
-          {assembly_stack_size : assembly_stack_size_opt}
+          {assembly_conventions : assembly_conventions_opt}
           {error_on_unused_assembly_functions : error_on_unused_assembly_functions_opt}
-          {assembly_output_first : assembly_output_first_opt}
-          {assembly_argument_registers_left_to_right : assembly_argument_registers_left_to_right_opt}
           (s : Z) (c : list (Z * Z))
           (src_n : nat)
           (src_limbwidth : Q)

--- a/src/PushButtonSynthesis/Primitives.v
+++ b/src/PushButtonSynthesis/Primitives.v
@@ -801,11 +801,8 @@ Section __.
           {assembly_hints_lines : assembly_hints_lines_opt}
           {widen_carry : widen_carry_opt}
           {widen_bytes : widen_bytes_opt}
-          {assembly_calling_registers : assembly_calling_registers_opt}
-          {assembly_stack_size : assembly_stack_size_opt}
+          {assembly_conventions : assembly_conventions_opt}
           {error_on_unused_assembly_functions : error_on_unused_assembly_functions_opt}
-          {assembly_output_first : assembly_output_first_opt}
-          {assembly_argument_registers_left_to_right : assembly_argument_registers_left_to_right_opt}
           {ignore_unique_asm_names : ignore_unique_asm_names_opt}
           (n : nat)
           (machine_wordsize : machine_wordsize_opt).

--- a/src/PushButtonSynthesis/SaturatedSolinas.v
+++ b/src/PushButtonSynthesis/SaturatedSolinas.v
@@ -82,11 +82,8 @@ Section __.
           {ignore_unique_asm_names : ignore_unique_asm_names_opt}
           {widen_carry : widen_carry_opt}
           (widen_bytes : widen_bytes_opt := true) (* true, because we don't allow byte-sized things anyway, so we should not expect carries to be widened to byte-size when emitting C code *)
-          {assembly_calling_registers : assembly_calling_registers_opt}
-          {assembly_stack_size : assembly_stack_size_opt}
+          {assembly_conventions : assembly_conventions_opt}
           {error_on_unused_assembly_functions : error_on_unused_assembly_functions_opt}
-          {assembly_output_first : assembly_output_first_opt}
-          {assembly_argument_registers_left_to_right : assembly_argument_registers_left_to_right_opt}
           (s : Z)
           (c : list (Z * Z))
           (machine_wordsize : machine_wordsize_opt).

--- a/src/PushButtonSynthesis/UnsaturatedSolinas.v
+++ b/src/PushButtonSynthesis/UnsaturatedSolinas.v
@@ -104,11 +104,8 @@ Section __.
           {widen_carry : widen_carry_opt}
           {widen_bytes : widen_bytes_opt}
           {tight_upperbound_fraction : tight_upperbound_fraction_opt}
-          {assembly_calling_registers : assembly_calling_registers_opt}
-          {assembly_stack_size : assembly_stack_size_opt}
+          {assembly_conventions : assembly_conventions_opt}
           {error_on_unused_assembly_functions : error_on_unused_assembly_functions_opt}
-          {assembly_output_first : assembly_output_first_opt}
-          {assembly_argument_registers_left_to_right : assembly_argument_registers_left_to_right_opt}
           (n : nat)
           (s : Z)
           (c : list (Z * Z))

--- a/src/PushButtonSynthesis/WordByWordMontgomery.v
+++ b/src/PushButtonSynthesis/WordByWordMontgomery.v
@@ -117,11 +117,8 @@ Section __.
           {ignore_unique_asm_names : ignore_unique_asm_names_opt}
           {widen_carry : widen_carry_opt}
           {widen_bytes : widen_bytes_opt}
-          {assembly_calling_registers : assembly_calling_registers_opt}
-          {assembly_stack_size : assembly_stack_size_opt}
+          {assembly_conventions : assembly_conventions_opt}
           {error_on_unused_assembly_functions : error_on_unused_assembly_functions_opt}
-          {assembly_output_first : assembly_output_first_opt}
-          {assembly_argument_registers_left_to_right : assembly_argument_registers_left_to_right_opt}
           (m : Z)
           (machine_wordsize : machine_wordsize_opt).
 


### PR DESCRIPTION
Also check a couple of other sanity conditions in the equivalence
checker

@andres-erbsen I decided to allow both MS and System V conventions to be passed by name.  Feel free to review any part of this that you want; I plan to merge once CI passes