### PR TITLE
`List.rev l` -> `List.rev_append l []`

### DIFF
--- a/src/StandaloneOCamlMain.v
+++ b/src/StandaloneOCamlMain.v
@@ -155,7 +155,7 @@ Global Instance OCamlIODriver : ForExtraction.IODriverAPI unit
        ; ForExtraction.ret := fun 'tt => tt
        ; ForExtraction.with_read_stdin k
          := seq (fun 'tt => read_channel_rev stdin)
-                (fun rev_lines => k (List.map string_to_Coq_string (List.rev rev_lines)))
+                (fun rev_lines => k (List.map string_to_Coq_string (List.rev_append rev_lines nil)))
        ; ForExtraction.write_stdout_then lines k
          := seq (fun _ => fprintf_list_string stdout lines)
                 k
@@ -164,7 +164,7 @@ Global Instance OCamlIODriver : ForExtraction.IODriverAPI unit
                 (fun chan
                  => seq (fun 'tt => read_channel_rev chan)
                         (fun rev_lines => seq (fun 'tt => close_in chan)
-                                              (fun 'tt => k (List.map string_to_Coq_string (List.rev rev_lines)))))
+                                              (fun 'tt => k (List.map string_to_Coq_string (List.rev_append rev_lines nil)))))
        ; ForExtraction.write_file_then fname lines k
          := seq (fun 'tt => open_out (string_of_Coq_string fname))
                 (fun chan

--- a/src/Util/Strings/String.v
+++ b/src/Util/Strings/String.v
@@ -61,8 +61,9 @@ Definition to_upper (s : string) : string := map Ascii.to_upper s.
 
 (** *** string reversal *)
 (** [rev s] reverses the string [s] *)
+(** Note that we use [rev_append . []] for non-quadratic behavior *)
 Definition rev : string -> string
-  := lift_list_function (@List.rev _).
+  := lift_list_function (fun s => List.rev_append s nil).
 
 Lemma rev_step s
   : rev s
@@ -70,7 +71,7 @@ Lemma rev_step s
       | EmptyString => EmptyString
       | String x xs => rev xs ++ String x EmptyString
       end.
-Proof. destruct s; cbn; rewrite ?string_of_list_ascii_app; reflexivity. Qed.
+Proof. destruct s; cbn; rewrite ?List.rev_append_rev, ?List.app_nil_r, ?string_of_list_ascii_app; reflexivity. Qed.
 
 Fixpoint take_while_drop_while (f : ascii -> bool) (s : string) : string * string
   := match s with
@@ -190,7 +191,7 @@ Section strip_prefix_cps.
   Lemma strip_prefix_cps_found sepch sep s2 s2'
         (Hfound : String sepch sep ++ s2' = s2)
     : strip_prefix_cps sepch sep s2 = found s2'.
-  Proof.
+  Proof using Type.
     revert sepch sep Hfound; induction s2 as [|ch s2 IHs2]; intros; cbn in Hfound; inversion Hfound; clear Hfound; subst.
     destruct sep; cbn [strip_prefix_cps]; now rewrite Ascii.eqb_refl; auto.
   Qed.
@@ -409,4 +410,4 @@ Fixpoint strip_leading_newlines (s : list string) : list string
      end.
 
 Definition strip_trailing_newlines (s : list string) : list string
-  := List.rev (strip_leading_newlines (List.rev s)).
+  := List.rev_append (strip_leading_newlines (List.rev_append s nil)) nil.


### PR DESCRIPTION
Unfortunately, `List.rev` is quadratic in the length of the list.  This
is a bottleneck in some generated code, so we use the linear-time
`List.rev_append _ []`.

<details><summary>Timing Diff</summary>
<p>

```
    After |   Peak Mem | File Name                                                   |     Before |   Peak Mem ||    Change || Change (mem) | % Change | % Change (mem)
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
97m13.31s | 2628008 ko | Total Time / Peak Mem                                       | 100m32.50s | 2631112 ko || -3m19.19s ||     -3104 ko |   -3.30% |         -0.11%
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 6m33.67s | 1081244 ko | fiat-bedrock2/src/p384_32.c                                 |   7m46.00s | 1001716 ko || -1m12.32s ||     79528 ko |  -15.52% |         +7.93%
 7m53.66s | 1051572 ko | fiat-json/src/p384_32.json                                  |   8m25.80s | 1142468 ko || -0m32.14s ||    -90896 ko |   -6.35% |         -7.95%
 0m08.23s |   51328 ko | fiat-json/src/p448_solinas_32.json                          |   0m32.16s |   66288 ko || -0m23.92s ||    -14960 ko |  -74.40% |        -22.56%
 0m30.86s |  230648 ko | fiat-json/src/secp256k1_32.json                             |   0m49.78s |  181408 ko || -0m18.92s ||     49240 ko |  -38.00% |        +27.14%
 8m10.16s | 1128908 ko | fiat-rust/src/p384_32.rs                                    |   7m55.11s | 1143724 ko || +0m15.05s ||    -14816 ko |   +3.16% |         -1.29%
 0m27.89s |  200292 ko | fiat-json/src/p256_32.json                                  |   0m43.79s |  194596 ko || -0m15.89s ||      5696 ko |  -36.30% |         +2.92%
 0m10.99s | 1081948 ko | Assembly/Parse/TestAsm.vo                                   |   0m26.40s | 1154020 ko || -0m15.40s ||    -72072 ko |  -58.37% |         -6.24%
 8m05.89s | 1016344 ko | fiat-go/32/p384/p384.go                                     |   7m52.52s | 1019884 ko || +0m13.37s ||     -3540 ko |   +2.82% |         -0.34%
 0m22.99s |  143656 ko | fiat-json/src/p434_64.json                                  |   0m34.91s |  161632 ko || -0m11.91s ||    -17976 ko |  -34.14% |        -11.12%
 6m49.10s |  925644 ko | fiat-zig/src/p384_32.zig                                    |   6m40.11s | 1017248 ko || +0m08.99s ||    -91604 ko |   +2.24% |         -9.00%
 0m13.53s |  147208 ko | fiat-json/src/p224_32.json                                  |   0m21.45s |  142152 ko || -0m07.92s ||      5056 ko |  -36.92% |         +3.55%
 0m33.74s |  213812 ko | fiat-bedrock2/src/secp256k1_32.c                            |   0m39.30s |  211076 ko || -0m05.55s ||      2736 ko |  -14.14% |         +1.29%
 0m10.54s |   97136 ko | fiat-json/src/p384_64.json                                  |   0m16.26s |   98252 ko || -0m05.72s ||     -1116 ko |  -35.17% |         -1.13%
 0m32.51s |  227552 ko | fiat-bedrock2/src/p256_32.c                                 |   0m35.24s |  215936 ko || -0m02.73s ||     11616 ko |   -7.74% |         +5.37%
 0m21.41s |  150904 ko | fiat-go/64/p434/p434.go                                     |   0m23.83s |  153580 ko || -0m02.41s ||     -2676 ko |  -10.15% |         -1.74%
 0m03.31s |   28980 ko | fiat-json/src/p521_64.json                                  |   0m05.45s |   30756 ko || -0m02.14s ||     -1776 ko |  -39.26% |         -5.77%
 0m01.80s |   27284 ko | fiat-json/src/curve25519_32.json                            |   0m04.25s |   30760 ko || -0m02.45s ||     -3476 ko |  -57.64% |        -11.30%
 0m30.95s | 1725368 ko | ExtractionOCaml/unsaturated_solinas                         |   0m32.28s | 1730696 ko || -0m01.33s ||     -5328 ko |   -4.12% |         -0.30%
 0m15.34s |  144072 ko | fiat-bedrock2/src/p224_32.c                                 |   0m17.24s |  134840 ko || -0m01.89s ||      9232 ko |  -11.02% |         +6.84%
 0m12.71s |  135076 ko | fiat-zig/src/p224_32.zig                                    |   0m14.00s |  132136 ko || -0m01.28s ||      2940 ko |   -9.21% |         +2.22%
 0m12.15s |   94228 ko | fiat-bedrock2/src/p384_64.c                                 |   0m13.15s |  105940 ko || -0m01.00s ||    -11712 ko |   -7.60% |        -11.05%
 0m02.59s |   41680 ko | fiat-json/src/secp256k1_64.json                             |   0m04.23s |   44748 ko || -0m01.64s ||     -3068 ko |  -38.77% |         -6.85%
 0m01.96s |   27332 ko | fiat-json/src/p448_solinas_64.json                          |   0m03.91s |   28960 ko || -0m01.95s ||     -1628 ko |  -49.87% |         -5.62%
 0m01.88s |   42944 ko | fiat-json/src/p256_64.json                                  |   0m03.19s |   40536 ko || -0m01.31s ||      2408 ko |  -41.06% |         +5.94%
 0m01.83s |   39792 ko | fiat-json/src/p224_64.json                                  |   0m03.27s |   42840 ko || -0m01.43s ||     -3048 ko |  -44.03% |         -7.11%
 8m01.73s | 1084084 ko | fiat-c/src/p384_32.c                                        |   8m00.81s | 1012692 ko || +0m00.92s ||     71392 ko |   +0.19% |         +7.04%
 7m43.65s |  919980 ko | fiat-java/src/FiatP384.java                                 |   7m43.61s |  990208 ko || +0m00.03s ||    -70228 ko |   +0.00% |         -7.09%
 1m46.30s | 1376280 ko | Fancy/Barrett256.vo                                         |   1m47.03s | 1376168 ko || -0m00.73s ||       112 ko |   -0.68% |         +0.00%
 1m41.27s | 1058136 ko | Bedrock/Field/Synthesis/Examples/X25519_64.vo               |   1m41.38s | 1057976 ko || -0m00.10s ||       160 ko |   -0.10% |         +0.01%
 1m39.42s | 1534200 ko | SlowPrimeSynthesisExamples.vo                               |   1m39.28s | 1595764 ko || +0m00.14s ||    -61564 ko |   +0.14% |         -3.85%
 1m15.10s | 1131812 ko | UnsaturatedSolinasHeuristics/Tests.vo                       |   1m14.96s | 1131736 ko || +0m00.13s ||        76 ko |   +0.18% |         +0.00%
 1m13.46s | 1185228 ko | Bedrock/End2End/X25519/Field25519.vo                        |   1m13.07s | 1184996 ko || +0m00.39s ||       232 ko |   +0.53% |         +0.01%
 1m01.05s | 1328624 ko | Bedrock/Field/Synthesis/Examples/p224_64.vo                 |   1m00.88s | 1328812 ko || +0m00.16s ||      -188 ko |   +0.27% |         -0.01%
 0m59.23s | 1301292 ko | Bedrock/Field/Synthesis/Examples/p256_64.vo                 |   0m59.13s | 1301396 ko || +0m00.09s ||      -104 ko |   +0.16% |         -0.00%
 0m52.97s | 2462464 ko | ExtractionOCaml/bedrock2_word_by_word_montgomery            |   0m52.36s | 2462316 ko || +0m00.60s ||       148 ko |   +1.16% |         +0.00%
 0m49.34s | 2628008 ko | ExtractionOCaml/word_by_word_montgomery                     |   0m49.66s | 2631112 ko || -0m00.31s ||     -3104 ko |   -0.64% |         -0.11%
 0m46.76s | 1277196 ko | Fancy/Montgomery256.vo                                      |   0m47.13s | 1277420 ko || -0m00.37s ||      -224 ko |   -0.78% |         -0.01%
 0m44.90s |  939548 ko | Assembly/WithBedrock/SymbolicProofs.vo                      |   0m45.17s |  939488 ko || -0m00.27s ||        60 ko |   -0.59% |         +0.00%
 0m40.16s | 2333444 ko | ExtractionOCaml/bedrock2_word_by_word_montgomery.ml         |   0m39.57s | 2331288 ko || +0m00.58s ||      2156 ko |   +1.49% |         +0.09%
 0m39.05s | 2217188 ko | ExtractionOCaml/word_by_word_montgomery.ml                  |   0m38.82s | 2217536 ko || +0m00.22s ||      -348 ko |   +0.59% |         -0.01%
 0m34.61s | 1739412 ko | ExtractionOCaml/bedrock2_unsaturated_solinas                |   0m35.07s | 1741292 ko || -0m00.46s ||     -1880 ko |   -1.31% |         -0.10%
 0m33.06s |  913448 ko | Assembly/WithBedrock/Proofs.vo                              |   0m32.97s |  913500 ko || +0m00.09s ||       -52 ko |   +0.27% |         -0.00%
 0m32.88s | 1145092 ko | Bedrock/Field/Synthesis/Generic/UnsaturatedSolinas.vo       |   0m32.94s | 1145040 ko || -0m00.05s ||        52 ko |   -0.18% |         +0.00%
 0m32.59s | 1407024 ko | ExtractionOCaml/bedrock2_saturated_solinas                  |   0m32.54s | 1420004 ko || +0m00.05s ||    -12980 ko |   +0.15% |         -0.91%
 0m32.16s | 1402252 ko | ExtractionOCaml/bedrock2_base_conversion                    |   0m32.49s | 1402328 ko || -0m00.33s ||       -76 ko |   -1.01% |         -0.00%
 0m31.85s | 1088792 ko | Bedrock/Field/Synthesis/Generic/WordByWordMontgomery.vo     |   0m31.77s | 1089044 ko || +0m00.08s ||      -252 ko |   +0.25% |         -0.02%
 0m31.59s |  192420 ko | fiat-zig/src/secp256k1_32.zig                               |   0m31.35s |  220292 ko || +0m00.23s ||    -27872 ko |   +0.76% |        -12.65%
 0m31.50s |  215508 ko | fiat-java/src/FiatSecp256K1.java                            |   0m31.26s |  232040 ko || +0m00.23s ||    -16532 ko |   +0.76% |         -7.12%
 0m30.70s |  216860 ko | fiat-go/32/secp256k1/secp256k1.go                           |   0m31.56s |  211696 ko || -0m00.85s ||      5164 ko |   -2.72% |         +2.43%
 0m30.47s |  205812 ko | fiat-rust/src/secp256k1_32.rs                               |   0m30.43s |  214660 ko || +0m00.03s ||     -8848 ko |   +0.13% |         -4.12%
 0m30.23s |  211036 ko | fiat-zig/src/p256_32.zig                                    |   0m30.04s |  232456 ko || +0m00.19s ||    -21420 ko |   +0.63% |         -9.21%
 0m30.08s |  217912 ko | fiat-c/src/secp256k1_32.c                                   |   0m30.41s |  213544 ko || -0m00.33s ||      4368 ko |   -1.08% |         +2.04%
 0m29.98s | 1240368 ko | ExtractionOCaml/base_conversion                             |   0m29.40s | 1223744 ko || +0m00.58s ||     16624 ko |   +1.97% |         +1.35%
 0m29.59s |  218024 ko | fiat-rust/src/p256_32.rs                                    |   0m29.56s |  223756 ko || +0m00.03s ||     -5732 ko |   +0.10% |         -2.56%
 0m29.54s |  212092 ko | fiat-go/32/p256/p256.go                                     |   0m30.22s |  218336 ko || -0m00.67s ||     -6244 ko |   -2.25% |         -2.85%
 0m29.36s | 1233276 ko | ExtractionOCaml/perf_word_by_word_montgomery                |   0m29.42s | 1233416 ko || -0m00.06s ||      -140 ko |   -0.20% |         -0.01%
 0m29.32s |  192216 ko | fiat-c/src/p256_32.c                                        |   0m29.30s |  181852 ko || +0m00.01s ||     10364 ko |   +0.06% |         +5.69%
 0m28.94s | 1233756 ko | ExtractionOCaml/saturated_solinas                           |   0m29.66s | 1280124 ko || -0m00.71s ||    -46368 ko |   -2.42% |         -3.62%
 0m27.65s |  231692 ko | fiat-java/src/FiatP256.java                                 |   0m28.29s |  221764 ko || -0m00.64s ||      9928 ko |   -2.26% |         +4.47%
 0m27.53s |  843616 ko | PushButtonSynthesis/UnsaturatedSolinas.vo                   |   0m27.54s |  843840 ko || -0m00.00s ||      -224 ko |   -0.03% |         -0.02%
 0m26.69s | 1233172 ko | ExtractionOCaml/perf_unsaturated_solinas                    |   0m26.77s | 1233276 ko || -0m00.07s ||      -104 ko |   -0.29% |         -0.00%
 0m25.44s | 1707472 ko | ExtractionOCaml/bedrock2_unsaturated_solinas.ml             |   0m25.16s | 1707444 ko || +0m00.28s ||        28 ko |   +1.11% |         +0.00%
 0m24.76s |  156092 ko | fiat-bedrock2/src/p434_64.c                                 |   0m25.18s |  150240 ko || -0m00.41s ||      5852 ko |   -1.66% |         +3.89%
 0m24.68s |  865452 ko | Bedrock/Field/Synthesis/Examples/LadderStep.vo              |   0m24.80s |  865464 ko || -0m00.12s ||       -12 ko |   -0.48% |         -0.00%
 0m24.15s | 1693768 ko | ExtractionOCaml/unsaturated_solinas.ml                      |   0m24.08s | 1693724 ko || +0m00.07s ||        44 ko |   +0.29% |         +0.00%
 0m23.32s |  162920 ko | fiat-rust/src/p434_64.rs                                    |   0m23.09s |  136092 ko || +0m00.23s ||     26828 ko |   +0.99% |        +19.71%
 0m23.05s |  136500 ko | fiat-zig/src/p434_64.zig                                    |   0m22.86s |  143812 ko || +0m00.19s ||     -7312 ko |   +0.83% |         -5.08%
 0m22.57s |  145960 ko | fiat-c/src/p434_64.c                                        |   0m22.61s |  160852 ko || -0m00.03s ||    -14892 ko |   -0.17% |         -9.25%
 0m21.52s |  841508 ko | PushButtonSynthesis/WordByWordMontgomery.vo                 |   0m21.49s |  841584 ko || +0m00.03s ||       -76 ko |   +0.13% |         -0.00%
 0m20.98s | 1666096 ko | ExtractionOCaml/bedrock2_base_conversion.ml                 |   0m21.08s | 1666132 ko || -0m00.09s ||       -36 ko |   -0.47% |         -0.00%
 0m20.79s | 1670640 ko | ExtractionOCaml/bedrock2_saturated_solinas.ml               |   0m20.88s | 1670448 ko || -0m00.08s ||       192 ko |   -0.43% |         +0.01%
 0m20.07s | 1841684 ko | ExtractionOCaml/perf_word_by_word_montgomery.ml             |   0m19.96s | 1843676 ko || +0m00.10s ||     -1992 ko |   +0.55% |         -0.10%
 0m19.78s | 1614952 ko | ExtractionOCaml/base_conversion.ml                          |   0m19.85s | 1614764 ko || -0m00.07s ||       188 ko |   -0.35% |         +0.01%
 0m19.41s | 1604808 ko | ExtractionOCaml/saturated_solinas.ml                        |   0m19.52s | 1604704 ko || -0m00.10s ||       104 ko |   -0.56% |         +0.00%
 0m18.86s |  824252 ko | Bedrock/Field/Synthesis/Examples/X1305_32.vo                |   0m18.87s |  824340 ko || -0m00.01s ||       -88 ko |   -0.05% |         -0.01%
 0m18.55s | 1941360 ko | ExtractionHaskell/bedrock2_word_by_word_montgomery.hs       |   0m18.62s | 1941136 ko || -0m00.07s ||       224 ko |   -0.37% |         +0.01%
 0m18.54s | 1740824 ko | ExtractionOCaml/perf_unsaturated_solinas.ml                 |   0m18.69s | 1740444 ko || -0m00.15s ||       380 ko |   -0.80% |         +0.02%
 0m17.96s | 1778524 ko | ExtractionHaskell/word_by_word_montgomery.hs                |   0m17.95s | 1778672 ko || +0m00.01s ||      -148 ko |   +0.05% |         -0.00%
 0m16.64s |  780392 ko | Bedrock/Field/Translation/Proofs/Func.vo                    |   0m16.67s |  780456 ko || -0m00.03s ||       -64 ko |   -0.17% |         -0.00%
 0m16.30s |  802308 ko | Bedrock/Field/Translation/Proofs/Cmd.vo                     |   0m16.30s |  802372 ko || +0m00.00s ||       -64 ko |   +0.00% |         -0.00%
 0m15.68s |  910168 ko | StandaloneDebuggingExamples.vo                              |   0m15.87s |  910920 ko || -0m00.18s ||      -752 ko |   -1.19% |         -0.08%
 0m14.46s |  794764 ko | Bedrock/End2End/Poly1305/Field1305.vo                       |   0m14.47s |  794656 ko || -0m00.00s ||       108 ko |   -0.06% |         +0.01%
 0m14.44s |  127640 ko | fiat-java/src/FiatP224.java                                 |   0m13.88s |  143460 ko || +0m00.55s ||    -15820 ko |   +4.03% |        -11.02%
 0m14.17s | 1492216 ko | ExtractionHaskell/bedrock2_unsaturated_solinas.hs           |   0m13.98s | 1492216 ko || +0m00.18s ||         0 ko |   +1.35% |         +0.00%
 0m14.17s |  139556 ko | fiat-rust/src/p224_32.rs                                    |   0m13.88s |  147852 ko || +0m00.28s ||     -8296 ko |   +2.08% |         -5.61%
 0m13.79s |  129584 ko | fiat-go/32/p224/p224.go                                     |   0m14.05s |  133732 ko || -0m00.26s ||     -4148 ko |   -1.85% |         -3.10%
 0m13.65s |  132008 ko | fiat-c/src/p224_32.c                                        |   0m13.94s |  138228 ko || -0m00.28s ||     -6220 ko |   -2.08% |         -4.49%
 0m13.11s | 1430580 ko | ExtractionHaskell/unsaturated_solinas.hs                    |   0m13.26s | 1430484 ko || -0m00.15s ||        96 ko |   -1.13% |         +0.00%
 0m12.66s | 1379452 ko | ExtractionHaskell/bedrock2_base_conversion.hs               |   0m12.59s | 1379652 ko || +0m00.07s ||      -200 ko |   +0.55% |         -0.01%
 0m12.57s | 1385972 ko | ExtractionHaskell/bedrock2_saturated_solinas.hs             |   0m12.71s | 1385880 ko || -0m00.14s ||        92 ko |   -1.10% |         +0.00%
 0m12.26s | 1352904 ko | ExtractionHaskell/base_conversion.hs                        |   0m12.37s | 1352756 ko || -0m00.10s ||       148 ko |   -0.88% |         +0.01%
 0m12.06s | 1381888 ko | ExtractionHaskell/saturated_solinas.hs                      |   0m11.40s | 1381992 ko || +0m00.66s ||      -104 ko |   +5.78% |         -0.00%
 0m11.68s |  857572 ko | PushButtonSynthesis/SmallExamples.vo                        |   0m11.73s |  857624 ko || -0m00.05s ||       -52 ko |   -0.42% |         -0.00%
 0m11.53s |  608184 ko | Assembly/Symbolic.vo                                        |   0m11.60s |  608320 ko || -0m00.07s ||      -136 ko |   -0.60% |         -0.02%
 0m10.88s |  589096 ko | Stringification/IR.vo                                       |   0m10.90s |  589004 ko || -0m00.01s ||        92 ko |   -0.18% |         +0.01%
 0m10.86s |   87512 ko | fiat-go/64/p384/p384.go                                     |   0m10.82s |   90840 ko || +0m00.03s ||     -3328 ko |   +0.36% |         -3.66%
 0m10.76s |  772068 ko | Bedrock/Field/Synthesis/New/Signature.vo                    |   0m10.84s |  771972 ko || -0m00.08s ||        96 ko |   -0.73% |         +0.01%
 0m10.72s |  103140 ko | fiat-rust/src/p384_64.rs                                    |   0m10.67s |   91100 ko || +0m00.05s ||     12040 ko |   +0.46% |        +13.21%
 0m10.71s |   97196 ko | fiat-zig/src/p384_64.zig                                    |   0m10.75s |   94688 ko || -0m00.03s ||      2508 ko |   -0.37% |         +2.64%
 0m10.49s |   96236 ko | fiat-c/src/p384_64.c                                        |   0m10.59s |   96520 ko || -0m00.09s ||      -284 ko |   -0.94% |         -0.29%
 0m08.33s |  750552 ko | Bedrock/End2End/X25519/MontgomeryLadder.vo                  |   0m08.29s |  750608 ko || +0m00.04s ||       -56 ko |   +0.48% |         -0.00%
 0m08.31s |   47320 ko | fiat-c/src/p448_solinas_32.c                                |   0m08.42s |   47668 ko || -0m00.10s ||      -348 ko |   -1.30% |         -0.73%
 0m08.20s |   46316 ko | fiat-zig/src/p448_solinas_32.zig                            |   0m08.14s |   46484 ko || +0m00.05s ||      -168 ko |   +0.73% |         -0.36%
 0m08.17s |  688468 ko | PushButtonSynthesis/BaseConversion.vo                       |   0m08.18s |  688300 ko || -0m00.00s ||       168 ko |   -0.12% |         +0.02%
 0m08.16s |   46276 ko | fiat-rust/src/p448_solinas_32.rs                            |   0m08.10s |   44208 ko || +0m00.06s ||      2068 ko |   +0.74% |         +4.67%
 0m06.62s |  688800 ko | PushButtonSynthesis/Primitives.vo                           |   0m06.72s |  688680 ko || -0m00.09s ||       120 ko |   -1.48% |         +0.01%
 0m05.42s |  733912 ko | Bedrock/Field/Synthesis/Examples/EncodeDecode.vo            |   0m05.44s |  734144 ko || -0m00.02s ||      -232 ko |   -0.36% |         -0.03%
 0m05.17s |  638172 ko | BoundsPipeline.vo                                           |   0m05.40s |  638088 ko || -0m00.23s ||        84 ko |   -4.25% |         +0.01%
 0m04.80s |  679740 ko | PushButtonSynthesis/BarrettReduction.vo                     |   0m04.71s |  679500 ko || +0m00.08s ||       240 ko |   +1.91% |         +0.03%
 0m03.93s |   39472 ko | fiat-bedrock2/src/p521_64.c                                 |   0m04.04s |   39720 ko || -0m00.10s ||      -248 ko |   -2.72% |         -0.62%
 0m03.74s |  740320 ko | Bedrock/Field/Synthesis/New/UnsaturatedSolinas.vo           |   0m03.73s |  740560 ko || +0m00.01s ||      -240 ko |   +0.26% |         -0.03%
 0m03.67s |   32888 ko | fiat-go/64/p521/p521.go                                     |   0m04.16s |   33012 ko || -0m00.49s ||      -124 ko |  -11.77% |         -0.37%
 0m03.46s |  721284 ko | Bedrock/Field/Synthesis/Examples/MulTwice.vo                |   0m03.55s |  721488 ko || -0m00.08s ||      -204 ko |   -2.53% |         -0.02%
 0m03.18s |   26784 ko | fiat-c/src/p521_64.c                                        |   0m02.89s |   25464 ko || +0m00.29s ||      1320 ko |  +10.03% |         +5.18%
 0m03.15s |   26756 ko | fiat-rust/src/p521_64.rs                                    |   0m02.92s |   26776 ko || +0m00.23s ||       -20 ko |   +7.87% |         -0.07%
 0m03.11s |  688320 ko | PushButtonSynthesis/FancyMontgomeryReduction.vo             |   0m03.18s |  688624 ko || -0m00.07s ||      -304 ko |   -2.20% |         -0.04%
 0m03.09s |   46776 ko | fiat-bedrock2/src/secp256k1_64.c                            |   0m03.32s |   43576 ko || -0m00.23s ||      3200 ko |   -6.92% |         +7.34%
 0m03.01s |  705260 ko | Bedrock/Field/Translation/Proofs/ValidComputable/Cmd.vo     |   0m02.97s |  705228 ko || +0m00.03s ||        32 ko |   +1.34% |         +0.00%
 0m02.86s |  710548 ko | CLI.vo                                                      |   0m02.77s |  710484 ko || +0m00.08s ||        64 ko |   +3.24% |         +0.00%
 0m02.82s |   26760 ko | fiat-zig/src/p521_64.zig                                    |   0m02.90s |   25500 ko || -0m00.08s ||      1260 ko |   -2.75% |         +4.94%
 0m02.79s |  686496 ko | PushButtonSynthesis/SaturatedSolinas.vo                     |   0m02.85s |  686600 ko || -0m00.06s ||      -104 ko |   -2.10% |         -0.01%
 0m02.78s |   41652 ko | fiat-bedrock2/src/p448_solinas_64.c                         |   0m02.94s |   42496 ko || -0m00.16s ||      -844 ko |   -5.44% |         -1.98%
 0m02.70s |   44612 ko | fiat-go/64/secp256k1/secp256k1.go                           |   0m02.72s |   45080 ko || -0m00.02s ||      -468 ko |   -0.73% |         -1.03%
 0m02.66s |   37188 ko | fiat-bedrock2/src/curve25519_32.c                           |   0m02.81s |   38160 ko || -0m00.14s ||      -972 ko |   -5.33% |         -2.54%
 0m02.63s |   41296 ko | fiat-zig/src/secp256k1_64.zig                               |   0m02.58s |   40992 ko || +0m00.04s ||       304 ko |   +1.93% |         +0.74%
 0m02.58s |   39944 ko | fiat-rust/src/secp256k1_64.rs                               |   0m02.60s |   44500 ko || -0m00.02s ||     -4556 ko |   -0.76% |        -10.23%
 0m02.55s |   40488 ko | fiat-c/src/secp256k1_64.c                                   |   0m02.61s |   41436 ko || -0m00.06s ||      -948 ko |   -2.29% |         -2.28%
 0m02.55s |   35304 ko | fiat-go/64/p448solinas/p448solinas.go                       |   0m02.77s |   33140 ko || -0m00.22s ||      2164 ko |   -7.94% |         +6.52%
 0m02.41s |   42840 ko | fiat-bedrock2/src/p224_64.c                                 |   0m02.61s |   41404 ko || -0m00.19s ||      1436 ko |   -7.66% |         +3.46%
 0m02.31s |   43652 ko | fiat-bedrock2/src/p256_64.c                                 |   0m02.46s |   46180 ko || -0m00.14s ||     -2528 ko |   -6.09% |         -5.47%
 0m02.14s |   25184 ko | fiat-go/32/curve25519/curve25519.go                         |   0m02.16s |   24720 ko || -0m00.02s ||       464 ko |   -0.92% |         +1.87%
 0m02.05s |   39216 ko | fiat-go/64/p224/p224.go                                     |   0m02.09s |   41476 ko || -0m00.04s ||     -2260 ko |   -1.91% |         -5.44%
 0m02.03s |   43028 ko | fiat-go/64/p256/p256.go                                     |   0m02.00s |   41476 ko || +0m00.02s ||      1552 ko |   +1.49% |         +3.74%
 0m01.97s |   26788 ko | fiat-c/src/p448_solinas_64.c                                |   0m02.01s |   25484 ko || -0m00.03s ||      1304 ko |   -1.99% |         +5.11%
 0m01.96s |   42060 ko | fiat-c/src/p224_64.c                                        |   0m01.98s |   41180 ko || -0m00.02s ||       880 ko |   -1.01% |         +2.13%
 0m01.96s |   25428 ko | fiat-rust/src/p448_solinas_64.rs                            |   0m02.00s |   25584 ko || -0m00.04s ||      -156 ko |   -2.00% |         -0.60%
 0m01.94s |   43456 ko | fiat-rust/src/p224_64.rs                                    |   0m01.98s |   44756 ko || -0m00.04s ||     -1300 ko |   -2.02% |         -2.90%
 0m01.88s |   42792 ko | fiat-c/src/p256_64.c                                        |   0m01.95s |   42096 ko || -0m00.07s ||       696 ko |   -3.58% |         +1.65%
 0m01.88s |   44288 ko | fiat-rust/src/p256_64.rs                                    |   0m01.81s |   37416 ko || +0m00.06s ||      6872 ko |   +3.86% |        +18.36%
 0m01.88s |   44600 ko | fiat-zig/src/p224_64.zig                                    |   0m01.95s |   43472 ko || -0m00.07s ||      1128 ko |   -3.58% |         +2.59%
 0m01.88s |   25624 ko | fiat-zig/src/p448_solinas_64.zig                            |   0m02.00s |   24608 ko || -0m00.12s ||      1016 ko |   -6.00% |         +4.12%
 0m01.82s |  639300 ko | Bedrock/Field/Translation/Cmd.vo                            |   0m01.85s |  639372 ko || -0m00.03s ||       -72 ko |   -1.62% |         -0.01%
 0m01.81s |   38076 ko | fiat-zig/src/p256_64.zig                                    |   0m01.93s |   43296 ko || -0m00.11s ||     -5220 ko |   -6.21% |        -12.05%
 0m01.79s |   23716 ko | fiat-rust/src/curve25519_32.rs                              |   0m01.79s |   24644 ko || +0m00.00s ||      -928 ko |   +0.00% |         -3.76%
 0m01.78s |   24432 ko | fiat-c/src/curve25519_32.c                                  |   0m01.85s |   24132 ko || -0m00.07s ||       300 ko |   -3.78% |         +1.24%
 0m01.77s |   25356 ko | fiat-java/src/FiatCurve25519.java                           |   0m01.85s |   24648 ko || -0m00.08s ||       708 ko |   -4.32% |         +2.87%
 0m01.77s |   25340 ko | fiat-zig/src/curve25519_32.zig                              |   0m01.84s |   25944 ko || -0m00.07s ||      -604 ko |   -3.80% |         -2.32%
 0m01.76s |  532812 ko | Stringification/Language.vo                                 |   0m01.66s |  533108 ko || +0m00.10s ||      -296 ko |   +6.02% |         -0.05%
 0m01.75s |  589800 ko | CompilersTestCases.vo                                       |   0m01.78s |  589528 ko || -0m00.03s ||       272 ko |   -1.68% |         +0.04%
 0m01.50s |  633952 ko | Bedrock/Field/Translation/Func.vo                           |   0m01.50s |  633716 ko || +0m00.00s ||       236 ko |   +0.00% |         +0.03%
 0m01.50s |  718848 ko | Rewriter/PerfTesting/Core.vo                                |   0m01.49s |  718916 ko || +0m00.01s ||       -68 ko |   +0.67% |         -0.00%
 0m01.42s |  468988 ko | Assembly/Parse.vo                                           |   0m01.43s |  468876 ko || -0m00.01s ||       112 ko |   -0.69% |         +0.02%
 0m01.27s |  527636 ko | Stringification/Go.vo                                       |   0m01.28s |  527480 ko || -0m00.01s ||       156 ko |   -0.78% |         +0.02%
 0m01.22s |  688684 ko | Bedrock/Field/Stringification/Stringification.vo            |   0m01.24s |  688568 ko || -0m00.02s ||       116 ko |   -1.61% |         +0.01%
 0m01.19s |  581076 ko | Assembly/Equivalence.vo                                     |   0m01.22s |  581008 ko || -0m00.03s ||        68 ko |   -2.45% |         +0.01%
 0m01.13s |  743416 ko | Bedrock/Standalone/StandaloneHaskellMain.vo                 |   0m01.06s |  743444 ko || +0m00.06s ||       -28 ko |   +6.60% |         -0.00%
 0m01.11s |  711800 ko | Bedrock/Field/Synthesis/Specialized/UnsaturatedSolinas.vo   |   0m01.18s |  711860 ko || -0m00.06s ||       -60 ko |   -5.93% |         -0.00%
 0m01.10s |  730332 ko | Rewriter/PerfTesting/StandaloneOCamlMain.vo                 |   0m01.12s |  730484 ko || -0m00.02s ||      -152 ko |   -1.78% |         -0.02%
 0m01.09s |  694460 ko | Bedrock/Field/Synthesis/Generic/Operation.vo                |   0m01.07s |  694264 ko || +0m00.02s ||       196 ko |   +1.86% |         +0.02%
 0m01.09s |  725344 ko | Bedrock/Field/Synthesis/Specialized/WordByWordMontgomery.vo |   0m01.16s |  725412 ko || -0m00.06s ||       -68 ko |   -6.03% |         -0.00%
 0m01.08s |  743680 ko | Bedrock/Standalone/StandaloneOCamlMain.vo                   |   0m01.12s |  743404 ko || -0m00.04s ||       276 ko |   -3.57% |         +0.03%
 0m01.07s |  693280 ko | Bedrock/Field/Synthesis/Generic/Tactics.vo                  |   0m01.07s |  692968 ko || +0m00.00s ||       312 ko |   +0.00% |         +0.04%
 0m01.04s |  699028 ko | Bedrock/Field/Synthesis/Specialized/ReifiedOperation.vo     |   0m01.08s |  699152 ko || -0m00.04s ||      -124 ko |   -3.70% |         -0.01%
 0m01.04s |  706628 ko | StandaloneOCamlMain.vo                                      |   0m01.12s |  706540 ko || -0m00.08s ||        88 ko |   -7.14% |         +0.01%
 0m01.02s |  697000 ko | Bedrock/Field/Translation/Proofs/ValidComputable/Func.vo    |   0m01.13s |  697012 ko || -0m00.10s ||       -12 ko |   -9.73% |         -0.00%
 0m01.00s |  707464 ko | Bedrock/Field/Synthesis/New/ComputedOp.vo                   |   0m01.13s |  707508 ko || -0m00.12s ||       -44 ko |  -11.50% |         -0.00%
 0m01.00s |  692764 ko | Bedrock/Field/Synthesis/Specialized/Tactics.vo              |   0m00.85s |  693076 ko || +0m00.15s ||      -312 ko |  +17.64% |         -0.04%
 0m01.00s |  706284 ko | StandaloneHaskellMain.vo                                    |   0m01.01s |  706196 ko || -0m00.01s ||        88 ko |   -0.99% |         +0.01%
 0m00.95s |  649016 ko | Bedrock/Field/Translation/Parameters/Defaults32.vo          |   0m00.88s |  649052 ko || +0m00.06s ||       -36 ko |   +7.95% |         -0.00%
 0m00.95s |  525208 ko | Stringification/JSON.vo                                     |   0m00.94s |  525212 ko || +0m00.01s ||        -4 ko |   +1.06% |         -0.00%
 0m00.89s |  649240 ko | Bedrock/Field/Translation/Parameters/Defaults64.vo          |   0m00.95s |  649268 ko || -0m00.05s ||       -28 ko |   -6.31% |         -0.00%
 0m00.86s |  528164 ko | Stringification/C.vo                                        |   0m00.94s |  528260 ko || -0m00.07s ||       -96 ko |   -8.51% |         -0.01%
 0m00.83s |  644608 ko | Bedrock/Field/Translation/Parameters/Defaults.vo            |   0m00.94s |  644528 ko || -0m00.10s ||        80 ko |  -11.70% |         +0.01%
 0m00.82s |  524472 ko | Stringification/Java.vo                                     |   0m00.81s |  524636 ko || +0m00.00s ||      -164 ko |   +1.23% |         -0.03%
 0m00.78s |  524652 ko | Stringification/Rust.vo                                     |   0m00.83s |  524508 ko || -0m00.04s ||       144 ko |   -6.02% |         +0.02%
 0m00.78s |  525028 ko | Stringification/Zig.vo                                      |   0m00.89s |  525024 ko || -0m00.10s ||         4 ko |  -12.35% |         +0.00%
 0m00.73s |  536444 ko | Bedrock/Field/Stringification/FlattenVarData.vo             |   0m00.72s |  536220 ko || +0m00.01s ||       224 ko |   +1.38% |         +0.04%
 0m00.68s |  531384 ko | Bedrock/Field/Stringification/LoadStoreListVarData.vo       |   0m00.68s |  531412 ko || +0m00.00s ||       -28 ko |   +0.00% |         -0.00%
 0m00.64s |   26312 ko | fiat-bedrock2/src/curve25519_64.c                           |   0m00.66s |   26228 ko || -0m00.02s ||        84 ko |   -3.03% |         +0.32%
 0m00.62s |   23372 ko | fiat-go/64/curve25519/curve25519.go                         |   0m00.66s |   23228 ko || -0m00.04s ||       144 ko |   -6.06% |         +0.61%
 0m00.59s |  420680 ko | Util/Strings/ParseArithmetic.vo                             |   0m00.61s |  420668 ko || -0m00.02s ||        12 ko |   -3.27% |         +0.00%
 0m00.56s |  432300 ko | Util/Arg.vo                                                 |   0m00.60s |  432416 ko || -0m00.03s ||      -116 ko |   -6.66% |         -0.02%
 0m00.47s |   20296 ko | fiat-c/src/curve25519_64.c                                  |   0m00.48s |   20956 ko || -0m00.01s ||      -660 ko |   -2.08% |         -3.14%
 0m00.47s |   21536 ko | fiat-rust/src/curve25519_64.rs                              |   0m00.49s |   21004 ko || -0m00.02s ||       532 ko |   -4.08% |         +2.53%
 0m00.47s |   21208 ko | fiat-zig/src/curve25519_64.zig                              |   0m00.48s |   21280 ko || -0m00.01s ||       -72 ko |   -2.08% |         -0.33%
 0m00.46s |   23068 ko | fiat-json/src/curve25519_64.json                            |   0m00.90s |   23324 ko || -0m00.44s ||      -256 ko |  -48.88% |         -1.09%
 0m00.45s |  431200 ko | Util/Strings/NamingConventions.vo                           |   0m00.45s |  431132 ko || +0m00.00s ||        68 ko |   +0.00% |         +0.01%
 0m00.44s |  455136 ko | Util/MSetPositive/Show.vo                                   |   0m00.43s |  455088 ko || +0m00.01s ||        48 ko |   +2.32% |         +0.01%
 0m00.40s |  415744 ko | Util/Strings/ParseArithmeticToTaps.vo                       |   0m00.51s |  415732 ko || -0m00.10s ||        12 ko |  -21.56% |         +0.00%
 0m00.40s |  430304 ko | Util/Strings/Show.vo                                        |   0m00.42s |  430256 ko || -0m00.01s ||        48 ko |   -4.76% |         +0.01%
 0m00.34s |   24848 ko | fiat-bedrock2/src/poly1305_32.c                             |   0m00.39s |   24072 ko || -0m00.04s ||       776 ko |  -12.82% |         +3.22%
 0m00.30s |  411096 ko | Util/Strings/String.vo                                      |   0m00.24s |  411196 ko || +0m00.06s ||      -100 ko |  +25.00% |         -0.02%
 0m00.29s |   20520 ko | fiat-go/32/poly1305/poly1305.go                             |   0m00.31s |   20192 ko || -0m00.02s ||       328 ko |   -6.45% |         +1.62%
 0m00.23s |  317528 ko | Util/ZRange/Show.vo                                         |   0m00.18s |  317392 ko || +0m00.05s ||       136 ko |  +27.77% |         +0.04%
 0m00.22s |  319836 ko | Util/MSets/Show.vo                                          |   0m00.25s |  319960 ko || -0m00.03s ||      -124 ko |  -12.00% |         -0.03%
 0m00.22s |   19892 ko | fiat-java/src/FiatPoly1305.java                             |   0m00.23s |   19668 ko || -0m00.01s ||       224 ko |   -4.34% |         +1.13%
 0m00.21s |  299052 ko | Bedrock/Field/Common/Names/VarnameGenerator.vo              |   0m00.23s |  298832 ko || -0m00.02s ||       220 ko |   -8.69% |         +0.07%
 0m00.21s |  285648 ko | Util/Strings/Parse/Common.vo                                |   0m00.22s |  285692 ko || -0m00.01s ||       -44 ko |   -4.54% |         -0.01%
 0m00.21s |   20636 ko | fiat-json/src/poly1305_32.json                              |   0m00.43s |   21280 ko || -0m00.22s ||      -644 ko |  -51.16% |         -3.02%
 0m00.21s |   19288 ko | fiat-zig/src/poly1305_32.zig                                |   0m00.21s |   19852 ko || +0m00.00s ||      -564 ko |   +0.00% |         -2.84%
 0m00.20s |   19908 ko | fiat-rust/src/poly1305_32.rs                                |   0m00.23s |   19872 ko || -0m00.03s ||        36 ko |  -13.04% |         +0.18%
 0m00.18s |  319112 ko | Util/ErrorT/Show.vo                                         |   0m00.19s |  319084 ko || -0m00.01s ||        28 ko |   -5.26% |         +0.00%
 0m00.18s |   20536 ko | fiat-go/64/poly1305/poly1305.go                             |   0m00.18s |   20384 ko || +0m00.00s ||       152 ko |   +0.00% |         +0.74%
 0m00.17s |   22008 ko | fiat-bedrock2/src/poly1305_64.c                             |   0m00.17s |   21912 ko || +0m00.00s ||        96 ko |   +0.00% |         +0.43%
 0m00.17s |   19884 ko | fiat-c/src/poly1305_32.c                                    |   0m00.21s |   19936 ko || -0m00.03s ||       -52 ko |  -19.04% |         -0.26%
 0m00.13s |   19356 ko | fiat-c/src/poly1305_64.c                                    |   0m00.14s |   19152 ko || -0m00.01s ||       204 ko |   -7.14% |         +1.06%
 0m00.12s |   18760 ko | fiat-rust/src/poly1305_64.rs                                |   0m00.12s |   19184 ko || +0m00.00s ||      -424 ko |   +0.00% |         -2.21%
 0m00.11s |   19024 ko | fiat-zig/src/poly1305_64.zig                                |   0m00.13s |   18752 ko || -0m00.02s ||       272 ko |  -15.38% |         +1.45%
 0m00.10s |   20380 ko | fiat-json/src/poly1305_64.json                              |   0m00.21s |   20240 ko || -0m00.10s ||       140 ko |  -52.38% |         +0.69%

```
</p>
</details>