### PR TITLE
More assembly equivalence WIP

### DIFF
--- a/src/Assembly/WithBedrock/SymbolicProofs.v
+++ b/src/Assembly/WithBedrock/SymbolicProofs.v
@@ -304,26 +304,33 @@ Proof using Type.
   2: { epose proof Properties.word.eqb_spec. exact H. }
 Qed.
 
-Lemma get_reg_R s m (HR : R s m) ri :
+Lemma get_reg_R_regs d s m (HR : R_regs d s m) ri :
   forall i, Symbolic.get_reg s ri = Some i ->
-  exists v, eval s i v /\ Tuple.nth_default 0 ri (m : reg_state) = v.
+  exists v, eval d i v /\ Tuple.nth_default 0 ri m = v.
 Proof using Type.
   cbv [Symbolic.get_reg]; intros.
   rewrite <-Tuple.nth_default_to_list in H.
   cbv [nth_default] in H; BreakMatch.break_match_hyps; subst; [|solve[congruence] ].
-  destruct s,m; cbn in *; destruct HR as (_&?&_); cbv [R_regs R_reg] in *.
-  eapply Tuple.fieldwise_to_list_iff in H.
-  eapply Forall.Forall2_forall_iff_nth_error in H; cbv [Crypto.Util.Option.option_eq] in H.
+  destruct s,m; cbn in *; cbv [R_regs R_reg] in *.
+  eapply Tuple.fieldwise_to_list_iff in HR.
+  eapply Forall.Forall2_forall_iff_nth_error in HR; cbv [Crypto.Util.Option.option_eq] in HR.
 
-  rewrite Heqo in H.
+  rewrite Heqo in HR.
   BreakMatch.break_match_hyps; [|solve[contradiction]].
-  specialize (proj1 H _ eq_refl).
+  specialize (proj1 HR _ eq_refl).
   eexists; split; [eassumption|].
 
   rewrite <-Tuple.nth_default_to_list.
   cbv [nth_default].
   rewrite Heqo0.
   trivial.
+Qed.
+
+Lemma get_reg_R s m (HR : R s m) ri :
+  forall i, Symbolic.get_reg s ri = Some i ->
+  exists v, eval s i v /\ Tuple.nth_default 0 ri (m : reg_state) = v.
+Proof using Type.
+  destruct s, m; apply get_reg_R_regs, HR.
 Qed.
 
 Lemma bind_assoc {A B C} (v:M A) (k1:A->M B) (k2:B->M C) s


### PR DESCRIPTION
Only two subgoals remain:
```coq
  R_runtime_output frame runtime_rets
    (type_spec_of_runtime (word_args_to_Z_args word_runtime_inputs))
    (Datatypes.length x) stack_base asm_args_out asm_args_in callee_saved_registers
    runtime_callee_saved_registers m'
```
and
```coq
 R
   (frame ⋆ R_list_scalar_or_array x0 asm_args_out
    ⋆ R_list_scalar_or_array (word_args_to_Z_args word_runtime_inputs)
        asm_args_in ⋆ array cell64 (word.of_Z 8) stack_base x)%sep x1
   (update_dag_with (init_symbolic_state d) (fun _ : dag => d0)) m
 ->
 R_mem frame G_final dag_state1
   (rev (List.combine x4 x5) ++
    rev
      (flat_map
         (fun pat : (idx + idx * list idx) * (idx + list idx) =>
          match pat with
          | (inl _, _) => []
          | (inr (_, addrs'), inl _) => []
          | (inr (_, addrs'), inr items) => List.combine addrs' items
          end) (List.combine x3 (l4 ++ inputs))) ++ init_symbolic_state d) m
```

The first goal is that we must connect everything from the final
symbolic evaluation with our output spec.

The second goal is that we must connect the memory predicate from before
SymexLines (post-initialization) with the desired memory predicate, by
showing that we've updated symbolic memory as desired.

Note that we'll probably want some `iff` statements around `R_mem`,
because what we do in one direction in the first goal we do in the other
direction in the second goal.