### PR TITLE
Finish proving/using that SymexLines scribles only over known memory

### DIFF
--- a/src/Assembly/WithBedrock/Proofs.v
+++ b/src/Assembly/WithBedrock/Proofs.v
@@ -3709,7 +3709,7 @@ Proof.
   rewrite H.
   pose proof (split_combine l2) as H'.
   rewrite split_alt in H'.
-  eexists; split; [ eassumption | ].
+  eexists; split; [ now eauto | ].
   apply (f_equal (@List.length _)) in H.
   rewrite !map_length in *; congruence.
 Qed.
@@ -3744,7 +3744,7 @@ Proof.
   rewrite map_fst_combine in H.
   pose proof (split_combine l2) as H'.
   rewrite split_alt, <- H in H'.
-  assumption.
+  now eauto.
 Qed.
 
 Lemma same_mem_addressed_combine_ex_r l1a l1b l2


### PR DESCRIPTION
What remains is doing the reverse of the final symex goal to deal with
the different representations of memory specs, splitting apart input and
output values via `++` (not 100% sure how to do this yet), and showing
that the outputs are mapped to the right values (also need to figure out
how to do this).

on top of https://github.com/mit-plv/fiat-crypto/pull/1116