### PR TITLE
Parameterize over dereference_scalar in more places

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -400,6 +400,7 @@ src/Util/Tactics/PoseTermWithName.v
 src/Util/Tactics/PrintContext.v
 src/Util/Tactics/PrintGoal.v
 src/Util/Tactics/Revert.v
+src/Util/Tactics/RevertUntil.v
 src/Util/Tactics/RewriteHyp.v
 src/Util/Tactics/RunTacticAsConstr.v
 src/Util/Tactics/SetEvars.v

--- a/src/Util/Tactics.v
+++ b/src/Util/Tactics.v
@@ -38,6 +38,7 @@ Require Export Crypto.Util.Tactics.PoseTermWithName.
 Require Export Crypto.Util.Tactics.PrintContext.
 Require Export Crypto.Util.Tactics.PrintGoal.
 Require Export Crypto.Util.Tactics.Revert.
+Require Export Crypto.Util.Tactics.RevertUntil.
 Require Export Crypto.Util.Tactics.RewriteHyp.
 Require Export Crypto.Util.Tactics.RunTacticAsConstr.
 Require Export Crypto.Util.Tactics.SetEvars.

--- a/src/Util/Tactics/RevertUntil.v
+++ b/src/Util/Tactics/RevertUntil.v
@@ -1,0 +1,9 @@
+Require Export Crypto.Util.FixCoqMistakes.
+
+(** [revert_until H] reverts all hypotheses coming after [H] *)
+Ltac revert_until H :=
+  lazymatch goal with
+  | [ H' : _ |- _ ] => tryif constr_eq H' H
+                      then idtac
+                      else (revert H'; revert_until H)
+  end.


### PR DESCRIPTION
This will allow us to reuse the same code to load inputs and outputs,
when we want to enforce the spec of reading back and removing all of the
values and then saying that the resulting symbolic memory state is
empty.

Some of the proofs are not quite as complete as they were before, but I
hope to replace them soon with a more principled approach.

@andres-erbsen You might be interested in this change (this paves the way for returning scalars either in registers or by way of pointers; we could plausibly turn this into a list of bools if desired).