### PR TITLE
Finish assembly equivalence checker proof

### DIFF
--- a/src/Util/ListUtil/Filter.v
+++ b/src/Util/ListUtil/Filter.v
@@ -21,4 +21,17 @@ Module List.
     pose proof (filter_length_le f ls).
     lia.
   Qed.
+
+  Lemma Forall2_filter_same A B P f g lsA lsB
+    : @Forall2 A B (fun a b => match f a, g b with
+                               | true, true => P a b
+                               | false, false => True
+                               | true, false | false, true => False
+                               end)
+              lsA lsB
+      -> Forall2 P (filter f lsA) (filter g lsB).
+  Proof.
+    induction 1; cbn; [ constructor | ].
+    destruct f, g; try constructor; auto; try (exfalso; assumption).
+  Qed.
 End List.


### PR DESCRIPTION
The proof is slow and horrible due to my attempts to make it a bit less
slow, because there's no systematicness to the chaining of `Forall` and
`Forall2` implications, and it's way too slow to use the straightfoward
brute force approach.  But it's done!

It takes 287.14s on my laptop to run this file.  Interestingly, this is actually nearly 2 minutes faster than it previously took, maybe due to `Qed` doing less work than `Admitted`? (cf https://github.com/coq/coq/pull/15860)

<details><summary>Timing Diff</summary>
<p>

```
   After |   Peak Mem | File Name                      |   Before |   Peak Mem ||    Change || Change (mem) | % Change | % Change (mem)
---------------------------------------------------------------------------------------------------------------------------------------
3m12.47s | 2220284 ko | Total Time / Peak Mem          | 5m03.18s | 3114444 ko || -1m50.71s ||   -894160 ko |  -36.51% |        -28.71%
---------------------------------------------------------------------------------------------------------------------------------------
3m12.48s | 2220284 ko | Assembly/WithBedrock/Proofs.vo | 5m03.19s | 3114444 ko || -1m50.71s ||   -894160 ko |  -36.51% |        -28.71%

```
</p>
</details>

I want to wait to merge this PR until I finish debugging https://github.com/coq/coq/pull/15860, though