### PR TITLE
Better equivalence-checker error messages

### DIFF
--- a/src/Assembly/Equivalence.v
+++ b/src/Assembly/Equivalence.v
@@ -1136,7 +1136,7 @@ Fixpoint symex_expr {descr:description} {t} (e : API.expr (var:=var) t) : symex_
           symex_T_bind_base ex ef
      | expr.LetIn (type.base _) _ x f
        => let ef v := symex_expr (f v) in
-          let ex := symex_expr (descr:=Some (fun 'tt => show x, false)) x in
+          let ex := symex_expr (descr:=Build_description (show x) false) x in
           symex_T_bind_base ex ef
      | expr.App (type.arrow _ _) _ f x
        => symex_T_error (Invalid_higher_order_application f x)
@@ -1151,7 +1151,7 @@ Definition symex_PHOAS_PHOAS {t} (expr : API.Expr t) (input_var_data : type.for_
   : ErrorT EquivalenceCheckingError (base_var (type.final_codomain t) * dag)
   := let ast : API.expr (type.base (type.final_codomain t))
          := invert_expr.smart_App_curried (expr _) input_var_data in
-     symex_expr (descr:=None) ast d.
+     symex_expr (descr:=no_description) ast d.
 
 (* takes and returns assembly/list style things *)
 Definition symex_PHOAS
@@ -1169,7 +1169,7 @@ Definition symex_PHOAS
      PHOAS_output <- simplify_base_var PHOAS_output;
      Success (PHOAS_output, d)).
 
-Definition init_symbolic_state_descr : description := Some (fun 'tt => "init_symbolic_state", true).
+Definition init_symbolic_state_descr : description := Build_description "init_symbolic_state" true.
 
 Definition init_symbolic_state (d : dag) : symbolic_state
   := let _ := init_symbolic_state_descr in
@@ -1242,22 +1242,22 @@ Definition symex_asm_func_M
            (output_types : type_spec) (stack_size : nat)
            (inputs : list (idx + list idx)) (reg_available : list REG) (asm : Lines)
   : M (ErrorT EquivalenceCheckingError (list (idx + list idx)))
-  := (output_placeholders <- lift_dag (build_inputs (descr:=Some (fun 'tt => "output_placeholders", true)) output_types);
+  := (output_placeholders <- lift_dag (build_inputs (descr:=Build_description "output_placeholders" true) output_types);
       let n_outputs := List.length output_placeholders in
       (* to make proofs easier, we merge addresses in reverse order from reading them *)
-      inputaddrs <- build_merge_base_addresses (descr:=Some (fun 'tt => "inputaddrs", true)) (dereference_scalar:=dereference_input_scalars) inputs (skipn n_outputs reg_available);
-      outputaddrs <- build_merge_base_addresses (descr:=Some (fun 'tt => "outputaddrs", true)) (dereference_scalar:=dereference_output_scalars) output_placeholders (firstn n_outputs reg_available);
-      stack_base <- build_merge_stack_placeholders (descr:=Some (fun 'tt => "stack_base", true)) stack_size;
-      initial_register_values <- mapM (GetReg (descr:=Some (fun 'tt => "initial_register_values", true))) callee_saved_registers;
+      inputaddrs <- build_merge_base_addresses (descr:=Build_description "inputaddrs" true) (dereference_scalar:=dereference_input_scalars) inputs (skipn n_outputs reg_available);
+      outputaddrs <- build_merge_base_addresses (descr:=Build_description "outputaddrs" true) (dereference_scalar:=dereference_output_scalars) output_placeholders (firstn n_outputs reg_available);
+      stack_base <- build_merge_stack_placeholders (descr:=Build_description "stack_base" true) stack_size;
+      initial_register_values <- mapM (GetReg (descr:=Build_description "initial_register_values" true)) callee_saved_registers;
       _ <- SymexLines asm;
-      final_register_values <- mapM (GetReg (descr:=Some (fun 'tt => "final_register_values", true))) callee_saved_registers;
-      _ <- LoadArray (descr:=Some (fun 'tt => "load final stack", true)) stack_base stack_size;
+      final_register_values <- mapM (GetReg (descr:=Build_description "final_register_values" true)) callee_saved_registers;
+      _ <- LoadArray (descr:=Build_description "load final stack" true) stack_base stack_size;
       let unsaved_registers : list (REG * (idx * idx)) := List.filter (fun '(r, (init, final)) => negb (init =? final)%N) (List.combine callee_saved_registers (List.combine initial_register_values final_register_values)) in
-      asm_output <- LoadOutputs (descr:=Some (fun 'tt => "asm_output", true)) (dereference_scalar:=dereference_output_scalars) outputaddrs output_types;
+      asm_output <- LoadOutputs (descr:=Build_description "asm_output" true) (dereference_scalar:=dereference_output_scalars) outputaddrs output_types;
       (* also load inputs, for the sake of the proof *)
       (* reconstruct input types *)
       let input_types := List.map (fun v => match v with inl _ => None | inr ls => Some (List.length ls) end) inputs in
-      asm_input <- LoadOutputs (descr:=Some (fun 'tt => "asm_input <- LoadOutputs", true)) (dereference_scalar:=dereference_input_scalars) inputaddrs input_types;
+      asm_input <- LoadOutputs (descr:=Build_description "asm_input <- LoadOutputs" true) (dereference_scalar:=dereference_input_scalars) inputaddrs input_types;
       (fun s => Success
                   (match asm_output, asm_input, unsaved_registers, s.(symbolic_mem_state) with
                    | Success asm_output, Success _, [], []
@@ -1337,7 +1337,7 @@ Section check_equivalence.
       let d := empty_dag in
       input_types <- map_err_None (simplify_input_type t arg_bounds);
       output_types <- map_err_None (simplify_base_type (type.final_codomain t) out_bounds);
-      let '(inputs, d) := build_inputs (descr:=Some (fun 'tt => "build_inputs", true)) input_types d in
+      let '(inputs, d) := build_inputs (descr:=Build_description "build_inputs" true ) input_types d in
 
       PHOAS_output <- map_err_None (symex_PHOAS expr inputs d);
       let '(PHOAS_output, d) := PHOAS_output in

--- a/src/Assembly/EquivalenceProofs.v
+++ b/src/Assembly/EquivalenceProofs.v
@@ -300,7 +300,7 @@ Local Ltac saturate_eval_merge_step :=
         | solve [ eauto 100 ] ].
 Local Ltac saturate_eval_merge := repeat saturate_eval_merge_step.
 
-Lemma App_correct n d (Hdag : gensym_dag_ok G d) i d' (H : App n d = Success (i, d'))
+Lemma App_correct {descr:description} n d (Hdag : gensym_dag_ok G d) i d' (H : App n d = Success (i, d'))
   v (Heval : eval_node G d n v)
   : eval G d' (ExprRef i) v /\ gensym_dag_ok G d' /\ (forall e n, eval G d e n -> eval G d' e n).
 Proof using Type.
@@ -321,6 +321,7 @@ Lemma unfold_symex_bind {A B} ma amb :
 Proof using Type. exact eq_refl. Qed.
 
 Theorem symex_ident_correct
+        {descr:description}
         {t} (idc : ident t)
         (d : dag)
         (input_var_data : type.for_each_lhs_of_arrow var t)
@@ -417,7 +418,9 @@ Proof using Type.
   all : match goal with H : Z.succ _=_|-_=> rewrite <-H, Z.add_1_r end; trivial.
   all : fail.
 Qed.
+
 Theorem symex_expr_correct
+        {descr:description}
         {t} (expr1 : API.expr (var:=var) t) (expr2 : API.expr (var:=API.interp_type) t)
         (d : dag)
         (input_var_data : type.for_each_lhs_of_arrow var t) (input_runtime_var : type.for_each_lhs_of_arrow API.interp_type t)
@@ -433,11 +436,11 @@ Theorem symex_expr_correct
     /\ gensym_dag_ok G d'
     /\ (forall e n, eval G d e n -> eval G d' e n).
 Proof using Type.
-  revert dependent d; revert dependent d'; revert dependent input_var_data; revert dependent input_runtime_var.
+  revert dependent descr; revert dependent d; revert dependent d'; revert dependent input_var_data; revert dependent input_runtime_var.
   induction Hwf; intros; cbn [symex_expr] in *.
   all: repeat first [ match goal with
                       (* ident case *)
-                      | [ |- context[expr.Ident] ] => eapply symex_ident_correct; eassumption
+                      | [ |- context[expr.Ident] ] => eapply @symex_ident_correct; eassumption
                       (* var case *)
                       | [ HIn : List.In (existT _ ?t (?v1, ?v2)) _ |- context[expr.Var] ]
                         => is_var t; specialize (HG t _ _ HIn); destruct t
@@ -446,66 +449,78 @@ Proof using Type.
                         => eapply H; try eassumption; clear H; []
                       end
                     | match goal with
-                      | [ H : Success _ = Success _ |- _ ] => inversion H; clear H
-                      | [ H : Error _ = Success _ |- _ ] => now inversion H
                       | [ H : symex_T_app_curried (symex_T_bind_base _ _) _ _ = Success _ |- _ ]
                         => apply symex_T_app_curried_symex_T_bind_base_split in H
-                      end
-                    | match goal with
-                      | [ IH : forall rets d' d, _ -> symex_expr ?x d = Success (rets, d') -> _, H : symex_expr ?x _ = Success (_, _) |- _ ]
-                        => specialize (fun H' => IH _ _ _ H' H)
-                      | [ IH : forall rets irv c ivd e d' d0, _ -> _ -> _ -> symex_T_app_curried (symex_expr ?f ivd) e d0 = Success (rets, d') -> _,
-                            H : symex_T_app_curried (symex_expr ?f _) _ _ = Success (_, _) |- _ ]
-                        => specialize (fun irv c H1 H2 H3 => IH _ irv c _ _ _ _ H1 H2 H3 H)
-                      | [ IH : forall v1 v2 rets irv ivd d' d, _ -> _ -> symex_T_app_curried (symex_expr (?f v1)) ivd d = Success (rets, d') -> _,
-                            H : symex_T_app_curried (symex_expr (?f _)) _ _ = Success (_, _) |- _ ]
-                        => specialize (fun v2 irv H1 H2 => IH _ v2 _ irv _ _ _ H1 H2 H)
-                      | [ IH : forall irv c, eval_base_var ?a ?b irv -> _, H : eval_base_var ?a ?b _ |- _ ]
-                        => specialize (fun c => IH _ c H)
-                      | [ IH : forall c, type.and_for_each_lhs_of_arrow ?x ?ivd c -> _, H : type.and_for_each_lhs_of_arrow ?y ?ivd ?cv |- _ ]
-                        => specialize (fun H' => IH cv ltac:(eapply Wf.Compilers.type.and_for_each_lhs_of_arrow_Proper_impl; [ .. | eexact H ]; try reflexivity; cbv [Morphisms.forall_relation Morphisms.pointwise_relation Basics.impl]; eapply lift_eval_var_impl; eassumption))
-                      | [ IH : forall v2 c, type.and_for_each_lhs_of_arrow ?x ?ivd c -> _, H : type.and_for_each_lhs_of_arrow ?y ?ivd ?cv |- _ ]
-                        => specialize (fun v2 H' => IH v2 cv ltac:(eapply Wf.Compilers.type.and_for_each_lhs_of_arrow_Proper_impl; [ .. | eexact H ]; try reflexivity; cbv [Morphisms.forall_relation Morphisms.pointwise_relation Basics.impl]; eapply lift_eval_var_impl; eassumption))
-                      | [ H : forall v, ?T -> (forall t v1 v2, existT _ _ _ = _ \/ _ -> _) -> _ |- _ ]
-                        => specialize (fun H1 H3 v H2 => H v H1 (fun t v1 v2 pf => match pf with
-                                                                                   | or_introl pf => H2 t v1 v2 pf
-                                                                                   | or_intror pf => H3 t v1 v2 pf
-                                                                                   end))
-                      | [ H : forall v, (forall t v1 v2, existT _ _ _ = existT _ t (v1, v2) -> _) -> _ |- _ ]
-                        => specialize (H _ ltac:(intros; inversion_sigma; subst; cbn [eq_rect] in *; inversion_prod; subst; eassumption))
-                      end
-                    | match goal with
-                      | [ H : forall a (b : unit), _ |- _ ] => specialize (fun a => H a tt)
-                      | [ H : forall a b, True -> _ |- _ ] => specialize (fun a b => H a b I)
-                      | [ H : forall a b c, True -> _ |- _ ] => specialize (fun a b c => H a b c I)
-                      | [ H : forall a (b : _ * _), _ |- _ ] => specialize (fun a b c => H a (b, c))
-                      | [ H : forall a b c (d : _ * _), _ |- _ ] => specialize (fun a b c d e => H a b c (d, e))
-                      | [ H : forall a b c d e f, _ /\ _ -> _ |- _ ] => specialize (fun a b c d e f g h => H a b c d e f (conj g h))
-                      | [ H : forall a b c d e f g, _ /\ _ -> _ |- _ ] => specialize (fun a b c d e f g h i => H a b c d e f g (conj h i))
+                      | [ H : forall v, (forall t v1 v2, existT _ _ _ = _ \/ _ -> _) -> _ |- _ ]
+                        => specialize (fun H3 v H2
+                                       => H v (fun t v1 v2 pf
+                                               => match pf with
+                                                  | or_introl pf => H2 t v1 v2 pf
+                                                  | or_intror pf => H3 t v1 v2 pf
+                                                  end))
                       end
                     | exfalso; assumption
                     | progress subst
-                    | progress destruct_head_hnf' unit
-                    | progress destruct_head_hnf' True
-                    | progress destruct_head_hnf' prod
                     | progress destruct_head'_and
                     | progress destruct_head'_ex
+                    | progress inversion_ErrorT
+                    | progress inversion_pair
                     | progress cbn [symex_T_app_curried symex_T_return eval_var type.app_curried] in *
                     | progress cbn [type.and_for_each_lhs_of_arrow type.for_each_lhs_of_arrow fst snd List.In eq_rect] in *
                     | progress cbn [type.final_codomain base_var] in *
                     | progress cbv [symex_return] in *
                     | rewrite @symex_T_app_curried_symex_T_error in *
                     | solve [ auto ]
-                    | progress inversion_sigma
-                    | progress inversion_prod
-                    | progress break_innermost_match_hyps
-                    | progress destruct_head'_or
-                    | progress intros
+                    | break_innermost_match_hyps_step
                     | progress specialize_by_assumption
-                    | progress specialize_by (eauto using lift_eval_var_impl) ].
+                    | progress
+                        guarded_specialize_dep_under_binders_by
+                        ltac:(idtac;
+                              lazymatch goal with
+                              | [ |- True ] => exact I
+                              | [ |- unit ] => exact tt
+                              | [ |- _ /\ _ ] => split
+                              | [ |- _ * _ ] => split
+                              end)
+                               ltac:(fun H => lazymatch type of H with
+                                              | context[forall x : True, _] => idtac
+                                              | context[forall x : unit, _] => idtac
+                                              | context[forall x : _ * _, _] => idtac
+                                              | context[forall x : _ /\ _, _] => idtac
+                                              end)
+                    | progress
+                        guarded_specialize_under_binders_by
+                        ltac:(idtac;
+                              match goal with
+                              | [ H : symex_T_app_curried _ _ _ = Success _ |- symex_T_app_curried _ _ _ = Success _ ]
+                                => exact H
+                              | [ H : symex_expr _ _ = Success _ |- symex_expr _ _ = Success _ ]
+                                => exact H
+                              end)
+                               ltac:(fun H => lazymatch type of H with
+                                              | context[symex_T_app_curried _ _ _ = Success _ -> _] => idtac
+                                              | context[symex_expr _ _ = Success _ -> _] => idtac
+                                              end)
+                    | progress
+                        guarded_specialize_under_binders_by
+                        ltac:(idtac;
+                              match goal with
+                              | [ H : type.and_for_each_lhs_of_arrow _ _ _ |- type.and_for_each_lhs_of_arrow _ _ _ ]
+                                => first [ exact H
+                                         | eapply Wf.Compilers.type.and_for_each_lhs_of_arrow_Proper_impl; [ cbv [forall_relation pointwise_relation Basics.impl] .. | exact H ]; try eapply lift_eval_var_impl; eauto ]
+                              | [ H : eval_base_var _ _ _ |- eval_base_var _ _ _ ] => exact H
+                              | [ |- forall t v1 v2, existT _ _ _ = existT _ t (v1, v2) -> _ ]
+                                => intros; inversion_sigma; subst; cbn [eq_rect] in *; inversion_prod; subst; eassumption
+                              end)
+                               ltac:(fun H => lazymatch type of H with
+                                              | context[type.and_for_each_lhs_of_arrow _ _ _ -> _] => idtac
+                                              | context[eval_base_var _ _ _ -> _] => idtac
+                                              | context[(forall t v1 v2, existT _ _ _ = existT _ t (v1, v2) -> _) -> _] => idtac
+                                              end)
+                    | progress specialize_under_binders_by eauto using lift_eval_var_impl ].
 Qed.
 
-Lemma symex_expr_App_curried {t} (e : API.expr t) input_var_data d
+Lemma symex_expr_App_curried {descr:description} {t} (e : API.expr t) input_var_data d
   : symex_expr (invert_expr.App_curried e (type.map_for_each_lhs_of_arrow (fun t v => ($v)%expr) input_var_data)) d
     = symex_T_app_curried (symex_expr e) input_var_data d.
 Proof using Type.
@@ -522,7 +537,7 @@ Proof using Type.
   all: destruct_head'_or; destruct_head'_ex; destruct_head'_and; congruence.
 Qed.
 
-Lemma symex_expr_smart_App_curried {t} (e : API.expr t) input_var_data d
+Lemma symex_expr_smart_App_curried {descr:description} {t} (e : API.expr t) input_var_data d
   : symex_expr (invert_expr.smart_App_curried e input_var_data) d
     = symex_T_app_curried (symex_expr e) input_var_data d.
 Proof using Type.
@@ -900,13 +915,13 @@ Module dagG.
   Definition M A := (symbol -> option Z) * dag -> A * ((symbol -> option Z) * dag).
 End dagG.
 
-Definition merge_fresh_symbol_G (v : Z) : dagG.M idx
+Definition merge_fresh_symbol_G {descr:description} (v : Z) : dagG.M idx
   := fun '(G, d) => let '(idx, d) := merge_fresh_symbol d in (idx, (ctx_set idx v G, d)).
 
-Definition build_inputarray_G (vals : list Z) : dagG.M (list idx)
+Definition build_inputarray_G {descr:description} (vals : list Z) : dagG.M (list idx)
   := List.foldmap merge_fresh_symbol_G vals.
 
-Fixpoint build_inputs_G (vals : list (Z + list Z))
+Fixpoint build_inputs_G {descr:description} (vals : list (Z + list Z))
   : dagG.M (list (idx + list idx))
   := match vals with
      | [] => fun st => ([], st)
@@ -922,7 +937,7 @@ Fixpoint build_inputs_G (vals : list (Z + list Z))
              (inl idx :: rest, st)
      end.
 
-Fixpoint dag_gensym_n_G (vals : list Z) : dagG.M (list idx)
+Fixpoint dag_gensym_n_G {descr:description} (vals : list Z) : dagG.M (list idx)
   := match vals with
      | nil => fun st => ([], st)
      | v :: vs
@@ -951,12 +966,13 @@ Definition lift_dag_G {A} (v : dagG.M A) : G.M A
   := fun '(G, s) => let '(v, (G, d)) := v (G, s.(dag_state)) in
                     Some (v, (G, update_dag_with s (fun _ => d))).
 
-Definition SetRegFresh_G (r : REG) (v : Z) : G.M idx
+Definition SetRegFresh_G {descr:description} (r : REG) (v : Z) : G.M idx
   := (idx <- lift_dag_G (merge_fresh_symbol_G v);
       _ <- G.lift (SetReg r idx);
       G.ret idx)%GM.
 
 Fixpoint build_merge_base_addresses_G
+         {descr:description}
          {dereference_scalar:bool}
          (items : list (idx + list idx)) (reg_available : list REG) (runtime_reg : list Z) {struct items}
   : G.M (list ((REG + idx) + idx))
@@ -981,13 +997,13 @@ Fixpoint build_merge_base_addresses_G
            G.ret (inl addr :: rest))
      end%GM%N%x86symex.
 
-Definition compute_stack_base_G (rsp_val : Z) (stack_size : nat)
+Definition compute_stack_base_G {descr:description} (rsp_val : Z) (stack_size : nat)
   : G.M idx
   := (rsp_idx <- SetRegFresh_G rsp rsp_val;
       stack_size <- G.lift (Symbolic.App (zconst 64 (-8 * Z.of_nat stack_size), []));
       G.lift (Symbolic.App (add 64%N, [rsp_idx; stack_size])))%GM.
 
-Definition build_merge_stack_placeholders_G (rsp_val : Z) (stack_vals : list Z)
+Definition build_merge_stack_placeholders_G {descr:description} (rsp_val : Z) (stack_vals : list Z)
   : G.M idx
   := (let stack_size := List.length stack_vals in
       stack_placeholders <- lift_dag_G (build_inputarray_G stack_vals);
@@ -1089,7 +1105,7 @@ Proof.
   all: intros; break_match; intuition.
 Qed.
 
-Lemma merge_fresh_symbol_eq_G G d v
+Lemma merge_fresh_symbol_eq_G {descr:description} G d v
       (res := merge_fresh_symbol_G v (G, d))
   : merge_fresh_symbol d = (fst res, snd (snd res)).
 Proof.
@@ -1097,33 +1113,33 @@ Proof.
 Qed.
 
 Lemma big_old_node_absent n d w args
-      (H : forall i r, nth_error d (N.to_nat i) = Some r -> node_ok i r)
+      (H : forall i r, dag_lookup d (N.to_nat i) = Some r -> node_ok i r)
       (Hn : (N.of_nat (List.length d) <= n)%N)
-  : List.indexof (node_beq N.eqb (old w n, args)) d = None.
+  : dag_reverse_lookup d (old w n, args) = None.
 Proof.
   revert dependent n; induction d as [|v d IHd] using List.rev_ind; [ reflexivity | ];
     rewrite ?app_length in *; cbn [List.indexof List.length] in *; intros.
-  rewrite List.indexof_app.
-  rewrite IHd; cbv [Crypto.Util.Option.sequence]; cbv [List.indexof option_map].
+  rewrite dag_reverse_lookup_app.
+  rewrite IHd; cbv [Crypto.Util.Option.sequence]; cbv [dag_reverse_lookup List.indexof option_map].
   { break_innermost_match; reflect_hyps; subst; try reflexivity.
     specialize (H (N.of_nat (List.length d))).
-    rewrite nth_error_app in H; break_innermost_match_hyps; try lia; [].
+    rewrite dag_lookup_app in H; break_innermost_match_hyps; try lia; [].
     rewrite Nat2N.id, Nat.sub_diag in H; specialize (H _ eq_refl _ _ _ eq_refl).
     lia. }
-  { intros ? ? Hi; apply H; rewrite nth_error_app, Hi; break_innermost_match; try reflexivity.
-    apply nth_error_value_length in Hi; tauto. }
+  { intros ? ? Hi; apply H; rewrite dag_lookup_app, Hi; break_innermost_match; try reflexivity.
+    apply dag_lookup_value_length in Hi; tauto. }
   { lia. }
 Qed.
 
 Lemma gensym_node_absent G d w args
       (H : gensym_dag_ok G d)
-  : List.indexof (node_beq N.eqb (old w (gensym d), args)) d = None.
+  : dag_reverse_lookup d (old w (gensym d), args) = None.
 Proof.
   apply big_old_node_absent; try apply H.
   cbv [gensym]; reflexivity.
 Qed.
 
-Lemma merge_fresh_symbol_G_ok G d v G' d' idx
+Lemma merge_fresh_symbol_G_ok {descr:description} G d v G' d' idx
       (Hd : gensym_dag_ok G d)
       (H : merge_fresh_symbol_G v (G, d) = (idx, (G', d')))
   : eval_idx_Z G' d' idx (Z.land v (Z.ones (Z.of_N 64)))
@@ -1139,20 +1155,20 @@ Proof.
                     | progress subst
                     | progress destruct_head'_and
                     | progress cbv [eval_idx_Z gensym_dag_ok gensym_ok ctx_set gensym dag_ok node_ok] in *
-                    | rewrite Nat2N.id, nth_error_app, Nat.sub_diag
+                    | rewrite Nat2N.id, dag_lookup_app, Nat.sub_diag
                     | progress break_innermost_match
                     | progress break_innermost_match_hyps
                     | progress inversion_option
                     | lia
-                    | progress cbn [nth_error List.map interp_op List.length fst snd] in *
+                    | progress cbn [List.map interp_op List.length fst snd] in *
                     | progress reflect_hyps
                     | reflexivity
                     | rewrite app_length
                     | progress intros
-                    | rewrite @nth_error_app in *
+                    | rewrite @dag_lookup_app in *
                     | match goal with
-                      | [ H : nth_error ?d ?i = Some _, H' : ~?i < List.length ?d |- _ ]
-                        => exfalso; apply nth_error_value_length in H; clear -H H'; tauto
+                      | [ H : dag_lookup ?d ?i = Some _, H' : ~?i < List.length ?d |- _ ]
+                        => exfalso; apply dag_lookup_value_length in H; clear -H H'; tauto
                       | [ H : interp_op _ ?op ?args = Some ?n |- interp_op _ ?op ?args = Some ?n ]
                         => revert H; destruct op; cbn [interp_op]; break_innermost_match
                       | [ H : forall s _v, ?G s = Some _v -> (s < ?v)%N, H' : ?G ?v = Some _ |- _ ]
@@ -1162,16 +1178,18 @@ Proof.
                       | [ |- Forall2 _ nil _ ] => constructor
                       | [ H : fst ?x = _ |- _ ] => is_var x; destruct x
                       | [ H : _ = snd ?x |- _ ] => is_var x; destruct x
-                      | [ H : nth_error (_ :: _) ?x = Some _ |- _ ] => destruct x eqn:?; cbn [nth_error] in H
-                      | [ H : nth_error nil ?x = Some _ |- _ ] => destruct x eqn:?; cbn [nth_error] in H
+                      | [ H : dag_lookup (_ :: _) ?x = Some _ |- _ ]
+                        => rewrite eta_dag_lookup in H; destruct x eqn:?; cbn [fst] in *
+                      | [ H : dag_lookup nil ?x = Some _ |- _ ]
+                        => rewrite eta_dag_lookup in H; destruct x eqn:?
                       | [ H : old _ _ = old _ _ |- _ ] => inversion H; clear H
                       | [ H : ?x - ?y = 0, H' : ~?x < ?y |- _ ] => assert (x = y) by lia; clear H H'
                       | [ H : N.to_nat ?x = ?y |- _ ] => is_var x; assert (x = N.of_nat y) by lia; clear H
                       | [ |- exists v, eval _ (?d ++ _) (ExprRef (N.of_nat (length ?d))) v ]
                         => eexists; econstructor
                       | [ H : Forall2 _ ?xs _ |- Forall2 _ ?xs _ ] => eapply Forall2_weaken; [ | eassumption ]; intuition tauto
-                      | [ H : forall i r, nth_error ?d (N.to_nat i) = Some r -> exists v, eval _ ?d (ExprRef i) v,
-                            H' : nth_error ?d (N.to_nat ?idx) = Some _
+                      | [ H : forall i r, dag_lookup ?d (N.to_nat i) = Some r -> exists v, eval _ ?d (ExprRef i) v,
+                            H' : dag_lookup ?d (N.to_nat ?idx) = Some _
                             |- exists v', eval _ (?d ++ _) (ExprRef ?idx) v' ]
                         => let v := fresh "v" in specialize (H _ _ H'); destruct H as [v H]; exists v
                       end
@@ -1188,7 +1206,7 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma merge_fresh_symbol_G_ok_bounded G d v G' d' idx
+Lemma merge_fresh_symbol_G_ok_bounded {descr:description} G d v G' d' idx
       (Hd : gensym_dag_ok G d)
       (H : merge_fresh_symbol_G v (G, d) = (idx, (G', d')))
       (Hv : (0 <= v < 2^64)%Z)
@@ -1200,7 +1218,7 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma build_inputarray_eq_G G d vals (len := List.length vals)
+Lemma build_inputarray_eq_G {descr:description} G d vals (len := List.length vals)
   : build_inputarray len d = (fst (build_inputarray_G vals (G, d)), snd (snd (build_inputarray_G vals (G, d)))).
 Proof.
   cbv [build_inputarray build_inputarray_G].
@@ -1215,7 +1233,7 @@ Proof.
 Qed.
 
 
-Lemma build_inputarray_G_ok G d vals G' d' ia
+Lemma build_inputarray_G_ok {descr:description} G d vals G' d' ia
       (Hd : gensym_dag_ok G d)
       (H : build_inputarray_G vals (G, d) = (ia, (G', d')))
       (Hbounds : Forall (fun v => (0 <= v < 2^64)%Z) vals)
@@ -1250,7 +1268,7 @@ Proof.
                    end ]. }
 Qed.
 
-Lemma build_inputarray_ok G d len idxs args d'
+Lemma build_inputarray_ok {descr:description} G d len idxs args d'
       (d_ok : gensym_dag_ok G d)
       (H : build_inputarray len d = (idxs, d'))
       (Hargs : List.length args = len)
@@ -1265,7 +1283,7 @@ Proof.
   repeat first [ eassumption | apply path_prod | reflexivity ].
 Qed.
 
-Lemma dag_gensym_n_eq_G G d vals (len := List.length vals)
+Lemma dag_gensym_n_eq_G {descr:description} G d vals (len := List.length vals)
   : dag_gensym_n len d = (fst (dag_gensym_n_G vals (G, d)), snd (snd (dag_gensym_n_G vals (G, d)))).
 Proof.
   subst len.
@@ -1274,7 +1292,7 @@ Proof.
   erewrite !@merge_fresh_symbol_eq_G, IHvals; cbn [fst snd]; eta_expand; reflexivity.
 Qed.
 
-Lemma dag_gensym_n_G_ok G d vals G' d' ia
+Lemma dag_gensym_n_G_ok {descr:description} G d vals G' d' ia
       (Hd : gensym_dag_ok G d)
       (H : dag_gensym_n_G vals (G, d) = (ia, (G', d')))
       (Hbounds : Forall (fun v => (0 <= v < 2^64)%Z) vals)
@@ -1306,7 +1324,7 @@ Proof.
                    end ]. }
 Qed.
 
-Lemma dag_gensym_n_ok G d len idxs args d'
+Lemma dag_gensym_n_ok {descr:description} G d len idxs args d'
       (d_ok : gensym_dag_ok G d)
       (H : dag_gensym_n len d = (idxs, d'))
       (Hargs : List.length args = len)
@@ -1333,7 +1351,7 @@ Proof.
     repeat (subst || cbn in * || destruct_head' option || break_innermost_match || intuition). }
 Qed.
 
-Lemma build_inputs_eq_G G d vals (types := type_spec_of_runtime vals)
+Lemma build_inputs_eq_G {descr:description} G d vals (types := type_spec_of_runtime vals)
   : build_inputs types d = (fst (build_inputs_G vals (G, d)), snd (snd (build_inputs_G vals (G, d)))).
 Proof.
   revert G d; subst types; induction vals as [|v vals IHvals]; [ reflexivity | ].
@@ -1350,7 +1368,7 @@ Proof.
                       end ].
 Qed.
 
-Lemma build_inputs_G_ok G d vals G' d' inputs
+Lemma build_inputs_G_ok {descr:description} G d vals G' d' inputs
       (Hd : gensym_dag_ok G d)
       (H : build_inputs_G vals (G, d) = (inputs, (G', d')))
       (Hbounds : Forall (fun v => match v with
@@ -1382,7 +1400,7 @@ Proof.
                       | progress cbv [eval_idx_or_list_idx] ]. }
 Qed.
 
-Lemma build_inputs_ok G d types inputs args d'
+Lemma build_inputs_ok {descr:description} G d types inputs args d'
       (d_ok : gensym_dag_ok G d)
       (H : build_inputs types d = (inputs, d'))
       (Hbounds : Forall (fun v => match v with
@@ -1413,7 +1431,7 @@ Proof.
   eexists; reflexivity.
 Qed.
 
-Lemma SetRegFresh_eq_G G r s v idx s'
+Lemma SetRegFresh_eq_G {descr:description} G r s v idx s'
       (H : SetRegFresh r s = Success (idx, s'))
   : exists G',
     SetRegFresh_G r v (G, s) = Some (idx, (G', s')).
@@ -1440,7 +1458,7 @@ Proof.
                | progress destruct_head'_prod ].
 Qed.
 
-Lemma build_merge_base_addresses_eq_G {dereference_scalar:bool}
+Lemma build_merge_base_addresses_eq_G {descr:description} {dereference_scalar:bool}
       G items reg_available runtime_reg s res s'
       (Hreg : Nat.min (List.length items) (List.length reg_available) <= List.length runtime_reg)
       (H : build_merge_base_addresses (dereference_scalar:=dereference_scalar) items reg_available s = Success (res, s'))
@@ -1475,7 +1493,7 @@ Proof.
                       | [ H : Forall2 _ [] _ |- _ ] => inversion H; clear H
                       | [ H : S ?x <= S ?y |- _ ] => assert (x <= y) by lia; clear H
                       | [ H : build_merge_base_addresses _ _ _ = _ |- _ ]
-                        => specialize (IH _ _ _ _ H)
+                        => specialize (IH _ _ _ _ _ H)
                       | [ IH : forall G rr, _ -> exists G', build_merge_base_addresses_G ?it ?ra rr (G, ?s) = _,
                             H' : build_merge_base_addresses_G ?it ?ra ?rrv (?Gv, ?s) = _ |- _ ]
                         => specialize (IH Gv rrv)
@@ -1486,7 +1504,7 @@ Proof.
                     | progress destruct_head'_prod ].
 Qed.
 
-Lemma compute_stack_base_eq_G G rsp_val stack_size s res s'
+Lemma compute_stack_base_eq_G {descr:description} G rsp_val stack_size s res s'
       (H : compute_stack_base stack_size s = Success (res, s'))
   : exists G',
     compute_stack_base_G rsp_val stack_size (G, s) = Some (res, (G', s')).
@@ -1512,7 +1530,7 @@ Proof.
                | break_innermost_match_step ].
 Qed.
 
-Lemma build_merge_stack_placeholders_eq_G G rsp_val stack_vals s res s'
+Lemma build_merge_stack_placeholders_eq_G {descr:description} G rsp_val stack_vals s res s'
       (H : build_merge_stack_placeholders (List.length stack_vals) s = Success (res, s'))
   : exists G',
     build_merge_stack_placeholders_G rsp_val stack_vals (G, s) = Some (res, (G', s')).
@@ -1543,7 +1561,7 @@ Proof.
                | break_innermost_match_step ].
 Qed.
 
-Lemma SetReg_ok G s s' reg idx rn lo sz v
+Lemma SetReg_ok {descr:description} G s s' reg idx rn lo sz v
       (Hreg : index_and_shift_and_bitcount_of_reg reg = (rn, lo, sz))
       (H64 : sz = 64%N)
       (H : SetReg reg idx s = Success (tt, s'))
@@ -1589,7 +1607,7 @@ Proof.
               [ solve [ repeat first [ eassumption | exactly_once econstructor ] ] | ];
               generalize dependent (simplify s n); intros
          | [ H : context[merge ?e ?d] |- _ ]
-           => pose proof (@eval_merge _ e _ d ltac:(eassumption) ltac:(eassumption));
+           => pose proof (@eval_merge _ _ e _ d ltac:(eassumption) ltac:(eassumption));
               generalize dependent (merge e d); intros
          end.
   repeat first [ progress inversion_ErrorT
@@ -1603,7 +1621,7 @@ Proof.
                | eapply ex_intro ].
 Qed.
 
-Lemma SetReg_ok_bounded G s s' reg idx rn lo sz v
+Lemma SetReg_ok_bounded {descr:description} G s s' reg idx rn lo sz v
       (Hreg : index_and_shift_and_bitcount_of_reg reg = (rn, lo, sz))
       (H64 : sz = 64%N)
       (H : SetReg reg idx s = Success (tt, s'))
@@ -1630,7 +1648,7 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma SetRegFresh_G_ok G G' s s' reg idx rn lo sz v
+Lemma SetRegFresh_G_ok {descr:description} G G' s s' reg idx rn lo sz v
       (Hreg : index_and_shift_and_bitcount_of_reg reg = (rn, lo, sz))
       (H64 : sz = 64%N)
       (H : SetRegFresh_G reg v (G, s) = Some (idx, (G', s')))
@@ -1676,7 +1694,7 @@ Proof.
                | eapply ex_intro ].
 Qed.
 
-Lemma SetRegFresh_G_ok_bounded G G' s s' reg idx rn lo sz v
+Lemma SetRegFresh_G_ok_bounded {descr:description} G G' s s' reg idx rn lo sz v
       (Hreg : index_and_shift_and_bitcount_of_reg reg = (rn, lo, sz))
       (H64 : sz = 64%N)
       (H : SetRegFresh_G reg v (G, s) = Some (idx, (G', s')))
@@ -1703,7 +1721,7 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma GetReg_ok G s s' reg idx rn lo sz v
+Lemma GetReg_ok {descr:description} G s s' reg idx rn lo sz v
       (Hreg : index_and_shift_and_bitcount_of_reg reg = (rn, lo, sz))
       (H64 : sz = 64%N)
       (H : GetReg reg s = Success (idx, s'))
@@ -1744,7 +1762,7 @@ Proof.
               [ solve [ repeat first [ eassumption | exactly_once econstructor ] ] | ];
               generalize dependent (simplify s n); intros
          | [ H : context[merge ?e ?d] |- _ ]
-           => pose proof (@eval_merge _ e _ d ltac:(eassumption) ltac:(eassumption));
+           => pose proof (@eval_merge _ _ e _ d ltac:(eassumption) ltac:(eassumption));
               generalize dependent (merge e d); intros
          end.
   all: repeat first [ progress inversion_ErrorT
@@ -1762,7 +1780,7 @@ Proof.
                     | eapply ex_intro ].
 Qed.
 
-Lemma GetReg_ok_bounded G s s' reg idx rn lo sz v
+Lemma GetReg_ok_bounded {descr:description} G s s' reg idx rn lo sz v
       (Hreg : index_and_shift_and_bitcount_of_reg reg = (rn, lo, sz))
       (H64 : sz = 64%N)
       (H : GetReg reg s = Success (idx, s'))
@@ -1879,7 +1897,7 @@ Proof.
   rewrite get_reg_set_reg_full; break_innermost_match; reflect_hyps; cbv beta in *; try reflexivity; lia.
 Qed.
 
-Lemma compute_array_address_ok G s s' base i idx base_val
+Lemma compute_array_address_ok {descr:description} G s s' base i idx base_val
       (H : compute_array_address base i s = Success (idx, s'))
       (d := s.(dag_state))
       (d' := s'.(dag_state))
@@ -1922,7 +1940,7 @@ Proof.
                       [ solve [ repeat first [ eassumption | solve [ eauto ] | exactly_once econstructor ] ] | ];
                       generalize dependent (simplify s n); intros
                  | [ H : context[merge ?e ?d] |- _ ]
-                   => pose proof (@eval_merge _ e _ d ltac:(eassumption) ltac:(eassumption));
+                   => pose proof (@eval_merge _ _ e _ d ltac:(eassumption) ltac:(eassumption));
                       generalize dependent (merge e d); intros
                  | [ H : (?x, ?y) = (?z, ?w) |- _ ] => is_var x; is_var z; is_var w; inversion H; clear H
                  end
@@ -1946,7 +1964,7 @@ Proof.
                     | progress (push_Zmod; pull_Zmod) ].
 Qed.
 
-Lemma compute_array_address_ok_bounded G s s' base i idx base_val
+Lemma compute_array_address_ok_bounded {descr:description} G s s' base i idx base_val
       (H : compute_array_address base i s = Success (idx, s'))
       (d := s.(dag_state))
       (d' := s'.(dag_state))
@@ -1971,7 +1989,7 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma build_merge_array_addresses_ok G s s'
+Lemma build_merge_array_addresses_ok {descr:description} G s s'
       base base_val items addrs
       (H : build_merge_array_addresses base items s = Success (addrs, s'))
       (d := s.(dag_state))
@@ -2043,7 +2061,7 @@ Proof.
     eauto 20. }
 Qed.
 
-Lemma compute_stack_base_G_ok G G' s s' rv
+Lemma compute_stack_base_G_ok {descr:description} G G' s s' rv
       (rsp_val : Z) (stack_size : nat)
       (H : compute_stack_base_G rsp_val stack_size (G, s) = Some (rv, (G', s')))
       (d := s.(dag_state))
@@ -2094,7 +2112,7 @@ Proof.
                            [ solve [ repeat first [ eassumption | solve [ eauto ] | exactly_once econstructor ] ] | ];
                            generalize dependent (simplify s n); intros
                       | [ H : context[merge ?e ?d] |- _ ]
-                        => pose proof (@eval_merge _ e _ d ltac:(eassumption) ltac:(eassumption));
+                        => pose proof (@eval_merge _ _ e _ d ltac:(eassumption) ltac:(eassumption));
                            generalize dependent (merge e d); intros
                       | [ H : SetRegFresh_G _ _ _ = _ |- _ ]
                         => eapply SetRegFresh_G_ok in H;
@@ -2117,7 +2135,7 @@ Proof.
                     | f_equal; lia ].
 Qed.
 
-Lemma build_merge_stack_placeholders_G_ok G G' s s'
+Lemma build_merge_stack_placeholders_G_ok {descr:description} G G' s s'
       (rsp_val : Z) (stack_vals : list Z) stack_base
       (H : build_merge_stack_placeholders_G rsp_val stack_vals (G, s) = Some (stack_base, (G', s')))
       (d := s.(dag_state))
@@ -2210,7 +2228,7 @@ Ltac handle_eval_eval :=
          end.
 
 Lemma build_merge_base_addresses_G_ok
-      {dereference_scalar:bool}
+      {descr:description} {dereference_scalar:bool}
   : forall (idxs : list (idx + list idx))
            (reg_available : list REG)
            (runtime_reg : list Z)
@@ -2432,7 +2450,7 @@ Proof.
                  end ].
 Qed.
 
-Lemma compute_stack_ok G s s' base
+Lemma compute_stack_ok {descr:description} G s s' base
       (rsp_val : Z) (stack_size : nat)
       (H : compute_stack_base stack_size s = Success (base, s'))
       (d := s.(dag_state))
@@ -2459,7 +2477,7 @@ Proof.
   eapply compute_stack_base_G_ok in H; try eassumption.
 Qed.
 
-Lemma build_merge_stack_placeholders_ok G s s'
+Lemma build_merge_stack_placeholders_ok {descr:description} G s s'
       (rsp_val : Z) (stack_vals : list Z) stack_base
       (H : build_merge_stack_placeholders (List.length stack_vals) s = Success (stack_base, s'))
       (d := s.(dag_state))
@@ -2492,7 +2510,7 @@ Proof.
 Qed.
 
 Lemma build_merge_base_addresses_ok
-      {dereference_scalar:bool}
+      {descr:description} {dereference_scalar:bool}
       (idxs : list (idx + list idx))
       (reg_available : list REG)
       (runtime_reg : list Z)
@@ -2612,7 +2630,7 @@ Proof.
 Qed.
 
 
-Lemma mapM_GetReg_ok_bounded G
+Lemma mapM_GetReg_ok_bounded {descr:description} G
   : forall regs idxs reg_vals s s'
            (H : mapM GetReg regs s = Success (idxs, s'))
            (d := s.(dag_state))
@@ -2783,23 +2801,23 @@ Local Ltac same_reg_some_of_success_t_step_unfold_go :=
 Local Ltac same_reg_some_of_success_t := repeat first [ same_reg_some_of_success_t_step_normal | same_reg_some_of_success_t_step_unfold ].
 
 (* TODO: move? *)
-Local Instance Merge_reg_same x : same_reg_some_of_success (Symbolic.Merge x).
+Local Instance Merge_reg_same {descr:description} x : same_reg_some_of_success (Symbolic.Merge x).
 Proof. same_reg_some_of_success_t. Qed.
 
 (* TODO: move? *)
-Local Instance App_reg_same x : same_reg_some_of_success (Symbolic.App x).
+Local Instance App_reg_same {descr:description} x : same_reg_some_of_success (Symbolic.App x).
 Proof. same_reg_some_of_success_t. Qed.
 
 (* TODO: move? *)
-Local Instance GetReg_reg_same r : same_reg_some_of_success (GetReg r).
+Local Instance GetReg_reg_same {descr:description} r : same_reg_some_of_success (GetReg r).
 Proof. same_reg_some_of_success_t. Qed.
 
 (* TODO: move? *)
-Local Instance Address_reg_same sa a : same_reg_some_of_success (@Address sa a).
+Local Instance Address_reg_same {descr:description} {sa:AddressSize} a : same_reg_some_of_success (Address a).
 Proof. same_reg_some_of_success_t. Qed.
 
 (* TODO: move? *)
-Local Instance GetOperand_reg_same sz sa arg : same_reg_some_of_success (@GetOperand sz sa arg).
+Local Instance GetOperand_reg_same {descr:description} {sz:OperationSize} {sa:AddressSize} arg : same_reg_some_of_success (GetOperand arg).
 Proof. same_reg_some_of_success_t. Qed.
 
 (* TODO: move? *)
@@ -2807,7 +2825,7 @@ Local Instance GetFlag_reg_same f : same_reg_some_of_success (GetFlag f).
 Proof. same_reg_some_of_success_t. Qed.
 
 (* TODO: move? *)
-Local Instance SetOperand_reg_same sz sa arg v : same_reg_some_of_success (@SetOperand sz sa arg v).
+Local Instance SetOperand_reg_same {descr:description} {sz:OperationSize} {sa:AddressSize} arg v : same_reg_some_of_success (SetOperand arg v).
 Proof. same_reg_some_of_success_t. Qed.
 
 (* TODO: move? *)
@@ -2847,7 +2865,7 @@ Proof.
 Defined.
 
 (* TODO: move? *)
-Fixpoint Symeval_reg_same sz sa args {struct args} : same_reg_some_of_success (@Symeval sz sa args).
+Fixpoint Symeval_reg_same descr sz sa args {struct args} : same_reg_some_of_success (@Symeval descr sz sa args).
 Proof.
   destruct args; cbn [Symeval] in *; typeclasses eauto.
 Qed.
@@ -2856,7 +2874,7 @@ Typeclasses Opaque Symeval.
 Typeclasses Transparent AddressSize OperationSize.
 
 (* TODO: move? *)
-Local Instance SymexNormalInstruction_reg_same instr : same_reg_some_of_success (SymexNormalInstruction instr).
+Local Instance SymexNormalInstruction_reg_same {descr:description} instr : same_reg_some_of_success (SymexNormalInstruction instr).
 Proof.
   destruct instr; cbv [SymexNormalInstruction err Symbolic.bind ret Syntax.op Syntax.args ErrorT.bind same_reg_some_of_success] in *; intros.
   same_reg_some_of_success_t.
@@ -2872,7 +2890,7 @@ Qed.
 Local Instance SymexLine_reg_same line : same_reg_some_of_success (SymexLine line).
 Proof.
   cbv [SymexLine SymexRawLine err ret] in *; break_innermost_match; try congruence.
-  typeclasses eauto.
+  apply SymexNormalInstruction_reg_same.
 Qed.
 
 (* TODO: move? *)
@@ -2943,23 +2961,23 @@ Local Ltac same_mem_addressed_of_success_t_step_unfold_go :=
 Local Ltac same_mem_addressed_of_success_t := repeat first [ same_mem_addressed_of_success_t_step_normal | same_mem_addressed_of_success_t_step_unfold ].
 
 (* TODO: move? *)
-Local Instance Merge_mem_same x : same_mem_addressed_of_success (Symbolic.Merge x).
+Local Instance Merge_mem_same {descr:description} x : same_mem_addressed_of_success (Symbolic.Merge x).
 Proof. same_mem_addressed_of_success_t. Qed.
 
 (* TODO: move? *)
-Local Instance App_mem_same x : same_mem_addressed_of_success (Symbolic.App x).
+Local Instance App_mem_same {descr:description} x : same_mem_addressed_of_success (Symbolic.App x).
 Proof. same_mem_addressed_of_success_t. Qed.
 
 (* TODO: move? *)
-Local Instance GetReg_mem_same r : same_mem_addressed_of_success (GetReg r).
+Local Instance GetReg_mem_same {descr:description} r : same_mem_addressed_of_success (GetReg r).
 Proof. same_mem_addressed_of_success_t. Qed.
 
 (* TODO: move? *)
-Local Instance Address_mem_same sa a : same_mem_addressed_of_success (@Address sa a).
+Local Instance Address_mem_same descr sa a : same_mem_addressed_of_success (@Address descr sa a).
 Proof. same_mem_addressed_of_success_t. Qed.
 
 (* TODO: move? *)
-Local Instance GetOperand_mem_same sz sa arg : same_mem_addressed_of_success (@GetOperand sz sa arg).
+Local Instance GetOperand_mem_same descr sz sa arg : same_mem_addressed_of_success (@GetOperand descr sz sa arg).
 Proof. same_mem_addressed_of_success_t. Qed.
 
 (* TODO: move? *)
@@ -2967,7 +2985,7 @@ Local Instance GetFlag_mem_same f : same_mem_addressed_of_success (GetFlag f).
 Proof. same_mem_addressed_of_success_t. Qed.
 
 (* TODO: move? *)
-Local Instance SetOperand_mem_same sz sa arg v : same_mem_addressed_of_success (@SetOperand sz sa arg v).
+Local Instance SetOperand_mem_same descr sz sa arg v : same_mem_addressed_of_success (@SetOperand descr sz sa arg v).
 Proof. same_mem_addressed_of_success_t. Qed.
 
 (* TODO: move? *)
@@ -3015,7 +3033,7 @@ Proof.
 Defined.
 
 (* TODO: move? *)
-Fixpoint Symeval_mem_same sz sa args {struct args} : same_mem_addressed_of_success (@Symeval sz sa args).
+Fixpoint Symeval_mem_same descr sz sa args {struct args} : same_mem_addressed_of_success (@Symeval descr sz sa args).
 Proof.
   destruct args; cbn [Symeval] in *; typeclasses eauto.
 Qed.
@@ -3024,7 +3042,7 @@ Typeclasses Opaque Symeval.
 Typeclasses Transparent AddressSize OperationSize.
 
 (* TODO: move? *)
-Local Instance SymexNormalInstruction_mem_same instr : same_mem_addressed_of_success (SymexNormalInstruction instr).
+Local Instance SymexNormalInstruction_mem_same {descr:description} instr : same_mem_addressed_of_success (SymexNormalInstruction instr).
 Proof.
   destruct instr; cbv [SymexNormalInstruction err Symbolic.bind ret Syntax.op Syntax.args ErrorT.bind same_mem_addressed_of_success] in *; intros.
   same_mem_addressed_of_success_t.
@@ -3034,7 +3052,7 @@ Qed.
 Local Instance SymexLine_mem_same line : same_mem_addressed_of_success (SymexLine line).
 Proof.
   cbv [SymexLine SymexRawLine err ret] in *; break_innermost_match; try congruence.
-  typeclasses eauto.
+  apply SymexNormalInstruction_mem_same.
 Qed.
 
 (* TODO: move? *)
@@ -3353,7 +3371,7 @@ Proof.
 Qed.
 
 Local Existing Instance Permutation_cons | 0.
-Lemma LoadArray_ok G s s' base base_val len idxs
+Lemma LoadArray_ok {descr:description} G s s' base base_val len idxs
       (H : LoadArray base len s = Success (idxs, s'))
       (d := s.(dag_state))
       (d' := s'.(dag_state))
@@ -3461,7 +3479,7 @@ Ltac saturate_lengths_step :=
   end.
 Ltac saturate_lengths := repeat saturate_lengths_step.
 
-Lemma LoadOutputs_ok {dereference_scalar:bool} G s s' outputaddrs output_types output_vals idxs
+Lemma LoadOutputs_ok {descr:description} {dereference_scalar:bool} G s s' outputaddrs output_types output_vals idxs
       (H : LoadOutputs (dereference_scalar:=dereference_scalar) outputaddrs output_types s = Success (Success idxs, s'))
       (d := s.(dag_state))
       (d' := s'.(dag_state))

--- a/src/Assembly/EquivalenceProofs.v
+++ b/src/Assembly/EquivalenceProofs.v
@@ -796,6 +796,7 @@ End WithFixedCtx.
 Lemma empty_gensym_dag_ok : gensym_dag_ok (fun _ => None) empty_dag.
 Proof using Type.
   cbv [empty_dag gensym_dag_ok gensym_ok dag_ok node_ok]; repeat split; try congruence;
+    cbv [dag_lookup option_map] in *; break_match_hyps; inversion_option; subst;
     exfalso; match goal with H : _ |- _ => apply nth_error_In in H; cbn in H end; assumption.
 Qed.
 

--- a/src/Assembly/Symbolic.v
+++ b/src/Assembly/Symbolic.v
@@ -221,19 +221,19 @@ Definition node_beq {A : Set} (arg_eqb : A -> A -> bool) : node A -> node A -> b
 Global Instance reflect_node_beq {A : Set} {arg_eqb} {H : reflect_rel (@eq A) arg_eqb}
   : reflect_rel eq (@node_beq A arg_eqb) | 10 := _.
 
-Class description := descr : unit (*option ((unit -> string) * bool (* always show *))*).
+Class description := descr : option ((unit -> string) * bool (* always show *)).
 Typeclasses Opaque description.
-Definition eager_description := unit (*option (string * bool)*).
-Notation Build_description descr always_show := (* (Some (fun 'tt => descr, always_show)) *) tt (only parsing).
-Notation no_description := (* None *) tt (only parsing).
+Definition eager_description := option (string * bool).
+Notation Build_description descr always_show := (Some (fun 'tt => descr, always_show)) (only parsing).
+Notation no_description := None (only parsing).
 Definition dag := list (node idx * description).
 Definition eager_dag := list (node idx * eager_description).
 Definition get_eager_description_description (d : eager_description) : option string
-  := None (* option_map fst d *).
+  := option_map fst d.
 Definition get_eager_description_always_show (d : eager_description) : bool
-:= false. (* match d with Some (_, always_show) => always_show | None => false end. *)
+:= match d with Some (_, always_show) => always_show | None => false end.
 Definition force_description : description -> eager_description
-  := fun 'tt => tt. (* option_map (fun '(descr, always_show) => (descr tt, always_show)) *)
+  := option_map (fun '(descr, always_show) => (descr tt, always_show)).
 Definition force_dag : dag -> eager_dag
   := List.map (fun '(n, descr) => (n, force_description descr)).
 Definition dag_lookup (d : dag) (i : nat) : option (node idx) := option_map fst (List.nth_error d i).

--- a/src/Assembly/WithBedrock/SymbolicProofs.v
+++ b/src/Assembly/WithBedrock/SymbolicProofs.v
@@ -383,7 +383,7 @@ Ltac step_GetFlag :=
 Ltac step_symex1 := first [step_symex0 | step_GetFlag].
 Ltac step_symex ::= step_symex1.
 
-Lemma Merge_R s m (HR : R s m) e v (H : eval s e v) :
+Lemma Merge_R {descr:description} s m (HR : R s m) e v (H : eval s e v) :
   forall i s', Merge e s = Success (i, s') ->
   R s' m /\ s :< s' /\ eval s' i v.
 Proof using Type.
@@ -406,7 +406,7 @@ Ltac step_Merge :=
 Ltac step_symex2 := first [step_symex1 | step_Merge].
 Ltac step_symex ::= step_symex2.
 
-Lemma App_R s m (HR : R s m) e v (H : eval_node G s e v) :
+Lemma App_R {descr:description} s m (HR : R s m) e v (H : eval_node G s e v) :
   forall i s', Symbolic.App e s = Success (i, s') ->
   R s' m /\ s :< s' /\ eval s' i v.
 Proof using Type.
@@ -468,8 +468,8 @@ Ltac step_SetFlag :=
     [eassumption|..|clear H]
   end.
 
-Lemma GetReg_R s m (HR: R s m) r i s'
-  (H : @GetReg r s = Success (i, s'))
+Lemma GetReg_R {descr:description} s m (HR: R s m) r i s'
+  (H : GetReg r s = Success (i, s'))
   : R s' m  /\ s :< s' /\ eval s' i (get_reg m r).
 Proof using Type.
   cbv [GetReg GetReg64 bind some_or get_reg index_and_shift_and_bitcount_of_reg] in *.
@@ -490,7 +490,7 @@ Ltac step_GetReg :=
     [eassumption|..|clear H]
   end.
 
-Lemma Address_R s m (HR : R s m) sa o a s' (H : @Symbolic.Address sa o s = Success (a, s'))
+Lemma Address_R {descr:description} s m (HR : R s m) (sa:AddressSize) o a s' (H : Symbolic.Address o s = Success (a, s'))
   : R s' m /\ s :< s' /\ exists v, eval s' a v /\ @DenoteAddress sa m o = v.
 Proof using Type.
   destruct o as [? ? ? ?]; cbv [Address DenoteAddress Syntax.mem_base_reg Syntax.mem_offset Syntax.mem_scale_reg err ret] in *; repeat step_symex.
@@ -704,8 +704,8 @@ Proof using Type.
 Qed.
 
 
-Lemma GetOperand_R s m (HR: R s m) so sa a i s'
-  (H : @GetOperand so sa a s = Success (i, s'))
+Lemma GetOperand_R {descr:description} s m (HR: R s m) (so:OperationSize) (sa:AddressSize) a i s'
+  (H : GetOperand a s = Success (i, s'))
   : R s' m /\ s :< s' /\ exists v, eval s' i v /\ DenoteOperand sa so m a = Some v.
 Proof using Type.
   cbv [GetOperand DenoteOperand err] in *; break_innermost_match; inversion_ErrorT.
@@ -759,8 +759,8 @@ Ltac step_GetOperand :=
   end.
 
 (* note: do the two SetOperand both truncate inputs or not?... *)
-Lemma R_SetOperand s m (HR : R s m)
-  sz sa a i _tt s' (H : @Symbolic.SetOperand sz sa a i s = Success (_tt, s'))
+Lemma R_SetOperand {descr:description} s m (HR : R s m)
+  (sz:OperationSize) (sa:AddressSize) a i _tt s' (H : Symbolic.SetOperand a i s = Success (_tt, s'))
   v (Hv : eval s i v)
   : exists m', SetOperand sa sz m a v = Some m' /\ R s' m' /\ s :< s'.
 Proof using Type.
@@ -1094,7 +1094,7 @@ Proof using Type.
 Qed.
 
 
-Lemma SymexNornalInstruction_R s m (HR : R s m) instr :
+Lemma SymexNornalInstruction_R {descr:description} s m (HR : R s m) instr :
   forall _tt s', Symbolic.SymexNormalInstruction instr s = Success (_tt, s') ->
   exists m', Semantics.DenoteNormalInstruction m instr = Some m' /\ R s' m' /\ s :< s'.
 Proof using Type.

--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -462,7 +462,10 @@ Module Pipeline.
               => (["Error while checking for equivalence of syntax tree and assembly:"]
                     ++ show_lines_Expr arg_bounds false (* don't re-print input bounds; they're not relevant *) e
                     ++ [""; "Assembly (in " ++ asm_fname ++ "):"]%string
-                    ++ show_lines asm
+                    ++ match Equivalence.symbolic_state_of_EquivalenceCheckingError err with
+                       | Some s => Equivalence.show_lines_AnnotatedLines (asm, s)
+                       | None => show_lines asm
+                       end
                     ++ [""; "Equivalence checking error:"]
                     ++ show_lines err)
             end%list.


### PR DESCRIPTION
The dag now prints out where some indices came from, and assembly lines
generating values that don't exist in PHOAS are annotated with the dag
indices they generate.

We also pave the way to display information about indices that appear
only in the assembly and not in the PHOAS.  I'm not sure what the right strategy here is.
One idea:
When we transition from an inequality that contains indices appearing only in assembly to an inequality containing indices that appear in both, recursively expand all indices appearing only in asm

Edit: performance is pretty terrible:
<details><summary>Timing Diff since <a href="https://github.com/JasonGross/fiat-crypto/commit/831d6114a2c4b13b51c5985a48185c7bd2d5a3a8">831d6114a2c4b13b51c5985a48185c7bd2d5a3a8</a></summary>
<p>

```
     After |  Peak Mem | File Name                                |     Before |  Peak Mem ||     Change || Change (mem) | % Change | % Change (mem)
----------------------------------------------------------------------------------------------------------------------------------------------------
122m52.12s | 302392 ko | Total Time / Peak Mem                    | 103m15.27s | 327788 ko || +19m36.84s ||    -25396 ko |  +18.99% |         -7.74%
----------------------------------------------------------------------------------------------------------------------------------------------------
 52m14.52s | 302392 ko | fiat-amd64/p434-mul.only-status          |  44m39.92s | 327788 ko ||  +7m34.59s ||    -25396 ko |  +16.96% |         -7.74%
 49m00.50s | 289860 ko | fiat-amd64/p434-square.only-status       |  41m46.12s | 280424 ko ||  +7m14.38s ||      9436 ko |  +17.33% |         +3.36%
  7m03.23s |  93856 ko | fiat-amd64/p384-mul.only-status          |   5m42.95s |  93804 ko ||  +1m20.28s ||        52 ko |  +23.40% |         +0.05%
  6m17.51s |  93864 ko | fiat-amd64/p384-square.only-status       |   5m09.63s |  84120 ko ||  +1m07.87s ||      9744 ko |  +21.92% |        +11.58%
  2m30.23s |  54948 ko | fiat-amd64/p448-mul.only-status          |   1m46.05s |  50276 ko ||  +0m44.17s ||      4672 ko |  +41.65% |         +9.29%
  1m47.63s |  50300 ko | fiat-amd64/p521-mul.only-status          |   1m10.69s |  45816 ko ||  +0m36.93s ||      4484 ko |  +52.25% |         +9.78%
  0m57.09s |  42144 ko | fiat-amd64/p448-square.only-status       |   0m41.84s |  42168 ko ||  +0m15.25s ||       -24 ko |  +36.44% |         -0.05%
  0m33.92s |  38808 ko | fiat-amd64/p224-square.only-status       |   0m21.42s |  38620 ko ||  +0m12.50s ||       188 ko |  +58.35% |         +0.48%
  0m33.25s |  36436 ko | fiat-amd64/p224-mul.only-status          |   0m22.94s |  36476 ko ||  +0m10.30s ||       -40 ko |  +44.94% |         -0.10%
  0m17.85s |  36252 ko | fiat-amd64/p256-mul.only-status          |   0m11.08s |  36188 ko ||  +0m06.77s ||        64 ko |  +61.10% |         +0.17%
  0m14.26s |  38104 ko | fiat-amd64/p256-square.only-status       |   0m09.72s |  37620 ko ||  +0m04.53s ||       484 ko |  +46.70% |         +1.28%
  0m24.48s |  38740 ko | fiat-amd64/secp256k1-mul.only-status     |   0m20.92s |  38780 ko ||  +0m03.55s ||       -40 ko |  +17.01% |         -0.10%
  0m23.26s |  36288 ko | fiat-amd64/p521-square.only-status       |   0m20.08s |  36152 ko ||  +0m03.18s ||       136 ko |  +15.83% |         +0.37%
  0m22.36s |  38900 ko | fiat-amd64/secp256k1-square.only-status  |   0m19.29s |  39028 ko ||  +0m03.07s ||      -128 ko |  +15.91% |         -0.32%
  0m04.70s |  26684 ko | fiat-amd64/curve25519-mul.only-status    |   0m05.02s |  25720 ko ||  -0m00.31s ||       964 ko |   -6.37% |         +3.74%
  0m03.60s |  26752 ko | fiat-amd64/curve25519-square.only-status |   0m03.85s |  25700 ko ||  -0m00.25s ||      1052 ko |   -6.49% |         +4.09%
  0m01.88s |  22584 ko | fiat-amd64/poly1305-mul.only-status      |   0m01.93s |  22620 ko ||  -0m00.05s ||       -36 ko |   -2.59% |         -0.15%
  0m01.66s |  22168 ko | fiat-amd64/poly1305-square.only-status   |   0m01.70s |  22296 ko ||  -0m00.04s ||      -128 ko |   -2.35% |         -0.57%
  0m00.19s |  21616 ko | fiat-amd64/p224-sub.only-status          |   0m00.13s |  21284 ko ||  +0m00.06s ||       332 ko |  +46.15% |         +1.55%

```
</p>
</details>