### PR TITLE
Add pretty-printer for asm error messages

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -363,6 +363,8 @@ src/Util/Strings/String.v
 src/Util/Strings/StringMap.v
 src/Util/Strings/String_as_OT.v
 src/Util/Strings/String_as_OT_old.v
+src/Util/Strings/Subscript.v
+src/Util/Strings/Superscript.v
 src/Util/Strings/Parse/Common.v
 src/Util/Structures/Orders.v
 src/Util/Structures/Equalities/Iso.v

--- a/src/Assembly/Equivalence.v
+++ b/src/Assembly/Equivalence.v
@@ -470,10 +470,16 @@ Definition iteratively_explain_array_unification_error_modulo_commutativity
           | Some op => "(" ++ show op ++ ", " ++ args ++ ")"
           | None => args
           end%string in
+     let show_array_pretty array
+       := match op with
+          | Some op => show_expr_pretty (ExprApp (op, array))
+          | None => @show_list _ show_expr_pretty array
+          end%string in
      List.map
        (fun '(asm_array, PHOAS_array)
         => (show_array asm_array ++ " ≠ " ++ show_array PHOAS_array)%string)
        reveals
+       ++ [show_array_pretty last_asm ++ " ≠ " ++ show_array_pretty last_PHOAS]%string
        ++ (List.flat_map
              describe_idx
              (indices_at_leaves_map (last_asm ++ last_PHOAS))).

--- a/src/Util/Strings/Subscript.v
+++ b/src/Util/Strings/Subscript.v
@@ -1,0 +1,36 @@
+Require Import Coq.Lists.List.
+Require Import Coq.Strings.Ascii.
+Require Import Coq.Strings.String.
+Require Import Crypto.Util.Strings.String.
+Import ListNotations.
+Local Open Scope list_scope.
+Local Open Scope char_scope.
+
+Definition subscript_map :=
+  Eval cbv in
+    List.combine
+      ["("; ")"; "+"; "-";
+       "0"; "1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9";
+       "=";
+       "a"; "e"; "h"; "i"; "j"; "k"; "l"; "m"; "n"; "o"; "p"; "r"; "s"; "t"; "u"; "v"; "x"; "y"]%char
+      ["₍"; "₎"; "₊"; "₋";
+       "₀"; "₁"; "₂"; "₃"; "₄"; "₅"; "₆"; "₇"; "₈"; "₉";
+       "₌";
+       "ₐ"; "ₑ"; "ₕ"; "ᵢ"; "ⱼ"; "ₖ"; "ₗ"; "ₘ"; "ₙ"; "ₒ"; "ₚ"; "ᵣ"; "ₛ"; "ₜ"; "ᵤ"; "ᵥ"; "ₓ"; "ᵧ"]%string.
+
+Module Ascii.
+  Definition to_subscript_opt (c : ascii) : option string
+    := option_map snd (find (fun '(ch, _) => Ascii.eqb c ch) subscript_map).
+  Definition to_subscript (c : ascii) : string
+    := match to_subscript_opt c with
+       | Some s => s
+       | None => String c EmptyString
+       end.
+End Ascii.
+
+Module Export WORKAROUND_EXTRACTION_DONT_SHADOW_OCAML_STRING.
+Module String.
+  Definition to_subscript (s : string) : string
+    := string_of_list_ascii (List.flat_map (fun a => list_ascii_of_string (Ascii.to_subscript a)) (list_ascii_of_string s)).
+End String.
+End WORKAROUND_EXTRACTION_DONT_SHADOW_OCAML_STRING.

--- a/src/Util/Strings/Superscript.v
+++ b/src/Util/Strings/Superscript.v
@@ -1,0 +1,38 @@
+Require Import Coq.Lists.List.
+Require Import Coq.Strings.Ascii.
+Require Import Coq.Strings.String.
+Require Import Crypto.Util.Strings.String.
+Import ListNotations.
+Local Open Scope list_scope.
+Local Open Scope char_scope.
+
+Definition superscript_map :=
+  Eval cbv in
+    List.combine
+      ["("; ")"; "+"; "-";
+       "0"; "1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9";
+       "=";
+       "A"; "B"; "C"; "D"; "E"; "F"; "G"; "H"; "I"; "J"; "K"; "L"; "M"; "N"; "O"; "P"; "R"; "S"; "T"; "U"; "V"; "W"; "X"; "Y"; "Z";
+       "a"; "b"; "c"; "d"; "e"; "f"; "g"; "h"; "i"; "j"; "k"; "l"; "m"; "n"; "o"; "p"; "r"; "s"; "t"; "u"; "v"; "w"; "x"; "y"; "z"]%char
+      ["⁽"; "⁾"; "⁺"; "⁻";
+       "⁰"; "¹"; "²"; "³"; "⁴"; "⁵"; "⁶"; "⁷"; "⁸"; "⁹";
+       "⁼";
+       "ᴬ"; "ᴮ"; "ᶜ"; "ᴰ"; "ᴱ"; "ᶠ"; "ᴳ"; "ᴴ"; "ᴵ"; "ᴶ"; "ᴷ"; "ᴸ"; "ᴹ"; "ᴺ"; "ᴼ"; "ᴾ"; "ᴿ"; "ˢ"; "ᵀ"; "ᵁ"; "ⱽ"; "ᵂ"; "ˣ"; "ʸ"; "ᶻ";
+       "ᵃ"; "ᵇ"; "ᶜ"; "ᵈ"; "ᵉ"; "ᶠ"; "ᵍ"; "ʰ"; "ᶦ"; "ʲ"; "ᵏ"; "ˡ"; "ᵐ"; "ⁿ"; "ᵒ"; "ᵖ"; "ʳ"; "ˢ"; "ᵗ"; "ᵘ"; "ᵛ"; "ʷ"; "ˣ"; "ʸ"; "ᶻ"]%string.
+
+Module Ascii.
+  Definition to_superscript_opt (c : ascii) : option string
+    := option_map snd (find (fun '(ch, _) => Ascii.eqb c ch) superscript_map).
+  Definition to_superscript (c : ascii) : string
+    := match to_superscript_opt c with
+       | Some s => s
+       | None => String c EmptyString
+       end.
+End Ascii.
+
+Module Export WORKAROUND_EXTRACTION_DONT_SHADOW_OCAML_STRING.
+Module String.
+  Definition to_superscript (s : string) : string
+    := string_of_list_ascii (List.flat_map (fun a => list_ascii_of_string (Ascii.to_superscript a)) (list_ascii_of_string s)).
+End String.
+End WORKAROUND_EXTRACTION_DONT_SHADOW_OCAML_STRING.


### PR DESCRIPTION
Prints things like
```
(addcarry₆₄, [((#15 >>₆₄ #10) +₆₄ (addcarry₆₄, [(#3 *₆₄ #5), ((#19 >>₆₄ #10) +₆₄ (addcarry₆₄, [#20, #26]))]))]) ≠ (addcarry₆₄, [(#15 >>₆₄ #10), (addcarry₆₄, [(#3 *₆₄ #5), (#19 >>₆₄ #10), (addcarry₆₄, [#20, #26])])])
```