### PR TITLE
Automatically skip bedrock2 on older versions of Coq

### DIFF
--- a/.github/workflows/coq-windows.yml
+++ b/.github/workflows/coq-windows.yml
@@ -19,7 +19,6 @@ jobs:
     env:
       NJOBS: "2"
       COQ_VERSION: "8.12.0" # https://packages.debian.org/stable/coq
-      SKIP_BEDROCK2: "1"
       COQEXTRAFLAGS: "-async-proofs-j 1"
       COQCHKEXTRAFLAGS: ""
       OPAMYES: "true"

--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -15,9 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - env: { COQ_VERSION: "master"    , COQ_PACKAGE: "coq libcoq-ocaml-dev", SKIP_BEDROCK2: "" , SKIP_VALIDATE: "", COQCHKEXTRAFLAGS: "-bytecode-compiler yes", PPA: "ppa:jgross-h/coq-master-daily", EXTRA_GH_REPORTIFY: "--warnings" }
+        - env: { COQ_VERSION: "master"    , COQ_PACKAGE: "coq libcoq-ocaml-dev", SKIP_VALIDATE: "", COQCHKEXTRAFLAGS: "-bytecode-compiler yes", PPA: "ppa:jgross-h/coq-master-daily", EXTRA_GH_REPORTIFY: "--warnings" }
           os: 'ubuntu-latest'
-        - env: { COQ_VERSION: "Ubuntu LTS", COQ_PACKAGE: "coq libcoq-ocaml-dev", SKIP_BEDROCK2: "1", SKIP_VALIDATE: "", COQCHKEXTRAFLAGS: ""                      , PPA: "" }
+        - env: { COQ_VERSION: "Ubuntu LTS", COQ_PACKAGE: "coq libcoq-ocaml-dev", SKIP_VALIDATE: "", COQCHKEXTRAFLAGS: ""                      , PPA: "" }
           os: 'ubuntu-20.04'
 
     runs-on: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,23 @@ BEDROCK2_FILES_PATTERN := \
 	src/Assembly/WithBedrock/% \
 	src/Bedrock/% # it's important to catch not just the .vo files, but also the .glob files, etc, because this is used to filter FILESTOINSTALL
 EXCLUDE_PATTERN :=
+
+FORCE_BEDROCK2?=
+ifneq (,$(filter 8.11% 8.12% 8.13%,$(COQ_VERSION)))
+ifneq ($(SKIP_BEDROCK2),1)
+$(warning Coq version $(COQ_VERSION) is older than the minimum bedrock2 Coq version of 8.14)
+ifeq ($(FORCE_BEDROCK2),1)
+$(warning Building bedrock2 code anyway because FORCE_BEDROCK2=$(FORCE_BEDROCK2))
+else
+ifeq ($(SKIP_BEDROCK2),)
+SKIP_BEDROCK2=1
+else
+$(error Cannot build bedrock2! Pass FORCE_BEDROCK2=1 to override this error and build anyway, or pass SKIP_BEDROCK2=1 (instead of SKIP_BEDROCK2=$(SKIP_BEDROCK2)) to skip bedrock2)
+endif
+endif
+endif
+endif
+
 ifeq ($(SKIP_BEDROCK2),1)
 EXCLUDE_PATTERN += $(BEDROCK2_FILES_PATTERN)
 $(warning Skipping bedrock2)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Building
 This repository requires [Coq](https://coq.inria.fr/) [8.11](https://github.com/coq/coq/releases/tag/V8.11.0) or later.
 Note that if you install Coq from Ubuntu aptitude packages, you need `libcoq-ocaml-dev` in addition to `coq`.
 Note that in some cases (such as installing Coq via homebrew on Mac), you may also need to install `ocaml-findlib` (for `ocamlfind`).
-If you want to build the bedrock2 code, you need [Coq 8.13](https://github.com/coq/coq/releases/tag/V8.13.0) or later (otherwise you can pass `SKIP_BEDROCK2=1` to `make`).
+If you want to build the bedrock2 code, you need [Coq 8.14](https://github.com/coq/coq/releases/tag/V8.14.0) or later (otherwise this code will be skipped automatically; you can skip this code on newer versions of Coq by passing `SKIP_BEDROCK2=1` to `make`).
 We suggest downloading [the latest version of Coq](https://github.com/coq/coq/wiki#coq-installation).
 Generation of JSON code via the Makefile also requires `jq`.
 


### PR DESCRIPTION
It's confusing to have `make` not work by default on older versions of
Coq, I think, so instead when `SKIP_BEDROCK2` is unset we will set it by
default on old versions of Coq.

Fixes #1212