### PR TITLE
Name the jobs in coq.yml

### DIFF
--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -22,6 +22,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     env: ${{ matrix.env }}
+    name: ${{ matrix.env.COQ_VERSION }}
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This way when we change the build params the job names won't change, so
we don't have to keep updating the list of required checks.