### PR TITLE
Fix issues in buf_append lemma and its usage, as well as memcpy lemma.

### DIFF
--- a/src/Bedrock/End2End/RupicolaCrypto/Derive.v
+++ b/src/Bedrock/End2End/RupicolaCrypto/Derive.v
@@ -116,20 +116,20 @@ Section Bedrock2.
     { subst v; unfold buf_backed_by. unfold buf_push. admit (*compile_step.*). }
 
     simple eapply compile_nlet_as_nlet_eq.
-    simple eapply compile_w32s_of_bytes; repeat compile_step.
+    simple eapply compile_w32s_of_bytes; [repeat compile_step..|].
 
-    simple eapply compile_nlet_as_nlet_eq.
-   
-
-    (*TODO: gensym*)
-    Ltac compile_buf_append:=
-    lazymatch goal with
-    | [ |- WeakestPrecondition.cmd _ _ _ _ ?locals (_ (nlet_eq [?var] ?v _)) ] =>
-        let arr_var_str := gensym locals constr:((var++"_app")%string) in
-        simple eapply compile_buf_append with (arr_var:=arr_var_str)
-    end; [shelve ..|].
-    compile_buf_append.
-
+    compile_step.
+    compile_step; [repeat compile_step ..|].
+    
+    eapply expr_compile_Z_literal with (z:= 4).
+    shelve.
+    compile_step.
+    (*TODO: need a compile words lemma comparable to compile_byte_memcpy.
+      Alternately, something generic over fixed-size elements (e.g. instances of Allocable).
+     *)
+    Fail simple eapply compile_byte_memcpy.
+    (*compile_step.
+      
     repeat compile_step. subst v4.
 
     simple eapply compile_w32s_of_bytes; repeat compile_step.
@@ -212,7 +212,7 @@ Section Bedrock2.
     4 : { simple eapply compile_nlet_as_nlet_eq.
           eapply compile_buf_push_word32; repeat compile_step.
 
-     *)
+     *)*)
     Abort.
   
 End Bedrock2.


### PR DESCRIPTION
Fixes some inconveniences and poor ergonomics around using `compile_buf_append`, making it more appropriate for automatic compilation.