### PR TITLE
Friendlier GH Actions Queue

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -11,6 +11,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/coq-macos.yml
+++ b/.github/workflows/coq-macos.yml
@@ -13,6 +13,10 @@ jobs:
 
     runs-on: macOS-10.15
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
     env:
       NJOBS: "2"
       COQ_VERSION: "8.14.0"

--- a/.github/workflows/coq-windows.yml
+++ b/.github/workflows/coq-windows.yml
@@ -16,6 +16,10 @@ jobs:
 
     runs-on: windows-latest
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
     env:
       NJOBS: "2"
       COQ_VERSION: "8.12.0" # https://packages.debian.org/stable/coq

--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -24,6 +24,10 @@ jobs:
     env: ${{ matrix.env }}
     name: ${{ matrix.env.COQ_VERSION }}
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.env.COQ_VERSION }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,6 +11,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -11,6 +11,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -7,9 +7,13 @@ on:
     - cron: '0 0 1 * *'
 
 jobs:
-  test-go:
+  test-json:
 
     runs-on: ubuntu-latest
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
     steps:
     - uses: actions/checkout@v3
     - name: cargo build

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -10,6 +10,10 @@ jobs:
   test-zig:
     runs-on: ubuntu-latest
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
     steps:
       - name: Install Zig
         uses: goto-bus-stop/setup-zig@v1


### PR DESCRIPTION
We now cancel previous queued and in progress actions runs on PRs when a
PR is updated. Because [`github.head_ref` is only defined for PRs and
`github.run_id` is
unique-per-workflow](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value-1),
we won't cancel previous jobs on branches, meaning that we'll still see
a log of which commits succeeded and which ones failed.