### PR TITLE
Make rupicola depend on bedrock2-compiler as an order-only dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -563,7 +563,7 @@ clean-bedrock2-compiler:
 install-bedrock2-compiler:
 	$(MAKE) --no-print-directory -C $(BEDROCK2_ROOT_FOLDER) install_compiler
 
-rupicola: bedrock2
+rupicola: bedrock2 | bedrock2-compiler
 	$(MAKE) --no-print-directory -C $(RUPICOLA_FOLDER) all
 
 clean-rupicola:


### PR DESCRIPTION
When rupicola depends on bedrock2 and `make -j` is run, both fiat-crypto
and rupicola race to build bedrock2 (rupicola on the noex part and
fiat-crypto on the compiler part).  This results in a race where two
processes are deleting and recreating bedrock2 makefile dependencies,
resulting in frequent errors of parallel make.  We avoid this issue by
declaring that rupicola is not allowed to start building until
bedrock2-compiler is done, whenever both are targets for building.

We could instead have rupicola just depend directly on
bedrock2-compiler?  Not sure if it matters that much.

cc @andres-erbsen @jadephilipoom for visibility 