### PR TITLE
Remove some pesky FMap hints

### DIFF
--- a/src/Util/FSets/FMapFacts.v
+++ b/src/Util/FSets/FMapFacts.v
@@ -19,6 +19,57 @@ Require Import Crypto.Util.Tactics.UniquePose.
 
 Local Set Keyed Unification.
 
+
+Module Type WFacts_funT (E:DecidableTypeOrig)(M:WSfun E) := Nop <+ WFacts_fun E M.
+Module WFacts_fun_RemoveHints (E:DecidableTypeOrig)(M:WSfun E) (F : WFacts_funT E M).
+  Global Remove Hints
+         F.Empty_m_Proper
+         F.EqualSetoid
+         F.EqualSetoid_Reflexive
+         F.EqualSetoid_Symmetric
+         F.EqualSetoid_Transitive
+         F.EqualSetoid_relation
+         F.In_m_Proper
+         F.KeySetoid
+         F.KeySetoid_Reflexive
+         F.KeySetoid_Symmetric
+         F.KeySetoid_Transitive
+         F.KeySetoid_relation
+         F.MapsTo_m_Proper
+         F.add_m_Proper
+         F.find_m_Proper
+         F.is_empty_m_Proper
+         F.map_m_Proper
+         F.mem_m_Proper
+         F.remove_m_Proper
+    : typeclass_instances.
+End WFacts_fun_RemoveHints.
+Module WFacts_RemoveHints (M:WS) (F:WFacts_funT M.E M) := WFacts_fun_RemoveHints M.E M F.
+Module Facts_RemoveHints := WFacts_RemoveHints.
+
+Module Type WProperties_funT (E:DecidableTypeOrig)(M:WSfun E) := Nop <+ WProperties_fun E M.
+Module WProperties_fun_RemoveHints (E:DecidableTypeOrig)(M:WSfun E) (F : WProperties_funT E M).
+  Include WFacts_fun_RemoveHints E M F.F.
+  Global Remove Hints
+         F.Disjoint_m_Proper
+         F.Partition_m_Proper
+         F.cardinal_m_Proper
+         F.diff_m_Proper
+         F.restrict_m_Proper
+         F.update_m_Proper
+    : typeclass_instances.
+End WProperties_fun_RemoveHints.
+Module WProperties_RemoveHints (M:WS) (F:WProperties_funT M.E M) := WProperties_fun_RemoveHints M.E M F.
+Module Properties_RemoveHints := WProperties_RemoveHints.
+
+Module Type OrdPropertiesT (M:S) := Nop <+ OrdProperties M.
+Module OrdProperties_RemoveHints (M:S) (P:OrdPropertiesT M).
+  Include OrderedTypeOrigFacts_RemoveHints M.E P.ME.
+  Include KeyOrderedType_RemoveHints M.E P.O.
+  Include Properties_RemoveHints M P.P.
+End OrdProperties_RemoveHints.
+
+
 Local Ltac t_destr_conj_step :=
   first [ progress subst
         | progress destruct_head'_False
@@ -63,11 +114,32 @@ Local Ltac t_destr_step :=
 
 Module WAdditionalFacts_fun (E:DecidableTypeOrig)(Import M:WSfun E).
   Module Import _WAdditionalFacts_fun.
-    Module WFacts := WFacts_fun E M.
-    Module WProperties := WProperties_fun E M.
+    Module WFacts := WFacts_fun E M <+ WFacts_fun_RemoveHints E M.
+    Module WProperties := WProperties_fun E M <+ WProperties_fun_RemoveHints E M.
   End _WAdditionalFacts_fun.
   Import _WAdditionalFacts_fun.WFacts.
   Import _WAdditionalFacts_fun.WProperties.
+  Local Existing Instances
+        Empty_m_Proper
+        EqualSetoid
+        EqualSetoid_Reflexive
+        EqualSetoid_Symmetric
+        EqualSetoid_Transitive
+        EqualSetoid_relation
+        In_m_Proper
+        KeySetoid
+        KeySetoid_Reflexive
+        KeySetoid_Symmetric
+        KeySetoid_Transitive
+        KeySetoid_relation
+        MapsTo_m_Proper
+        add_m_Proper
+        find_m_Proper
+        is_empty_m_Proper
+        map_m_Proper
+        mem_m_Proper
+        remove_m_Proper
+  .
 
   Local Instance Proper_eq_key_elt_iff elt
     : Proper (eq ==> RelationPairs.RelProd E.eq eq ==> iff) (@M.eq_key_elt elt).

--- a/src/Util/FSets/FMapOption.v
+++ b/src/Util/FSets/FMapOption.v
@@ -49,8 +49,12 @@ Module OptionWSfun_gen (E2 : DecidableTypeOrig) (M2 : WSfun E2).
   Module E2 <: DecidableTypeBoth := E2 <+ UpdateEq.
   Global Remove Hints E2.eq_refl E2.eq_sym E2.eq_trans : core.
   Module M1 <: WSfun E1 := UnitMap.
-  Module M1' := M1 <+ WFacts_fun E1 <+ WAdditionalFacts_fun E1.
-  Module M2' := M2 <+ WFacts_fun E2 <+ WAdditionalFacts_fun E2.
+  Module M1' := M1 <+ WFacts_fun E1 <+ WFacts_fun_RemoveHints E1 <+ WAdditionalFacts_fun E1.
+  Module M2' := M2 <+ WFacts_fun E2 <+ WFacts_fun_RemoveHints E2 <+ WAdditionalFacts_fun E2.
+  Local Existing Instances
+        M1'.Empty_m_Proper M1'.In_m_Proper M1'.MapsTo_m_Proper M1'.add_m_Proper M1'.find_m_Proper M1'.is_empty_m_Proper M1'.map_m_Proper M1'.mem_m_Proper M1'.remove_m_Proper
+        M2'.Empty_m_Proper M2'.In_m_Proper M2'.MapsTo_m_Proper M2'.add_m_Proper M2'.find_m_Proper M2'.is_empty_m_Proper M2'.map_m_Proper M2'.mem_m_Proper M2'.remove_m_Proper
+  | 10.
   Local Existing Instances
         M1'.eq_key_equiv M1'.eq_key_elt_equiv M1'.Equal_Equivalence
         M2'.eq_key_equiv M2'.eq_key_elt_equiv M2'.Equal_Equivalence

--- a/src/Util/FSets/FMapProd.v
+++ b/src/Util/FSets/FMapProd.v
@@ -49,8 +49,12 @@ Module ProdWSfun_gen (E1 : DecidableTypeOrig) (E2 : DecidableTypeOrig) (M1 : WSf
   Global Remove Hints E1.eq_refl E1.eq_sym E1.eq_trans : core.
   Module E2 <: DecidableTypeBoth := E2 <+ UpdateEq.
   Global Remove Hints E2.eq_refl E2.eq_sym E2.eq_trans : core.
-  Module M1' := M1 <+ WFacts_fun E1 <+ WAdditionalFacts_fun E1.
-  Module M2' := M2 <+ WFacts_fun E2 <+ WAdditionalFacts_fun E2.
+  Module M1' := M1 <+ WFacts_fun E1 <+ WFacts_fun_RemoveHints E1 <+ WAdditionalFacts_fun E1.
+  Module M2' := M2 <+ WFacts_fun E2 <+ WFacts_fun_RemoveHints E2 <+ WAdditionalFacts_fun E2.
+  Local Existing Instances
+        M1'.Empty_m_Proper M1'.In_m_Proper M1'.MapsTo_m_Proper M1'.add_m_Proper M1'.find_m_Proper M1'.is_empty_m_Proper M1'.map_m_Proper M1'.mem_m_Proper M1'.remove_m_Proper
+        M2'.Empty_m_Proper M2'.In_m_Proper M2'.MapsTo_m_Proper M2'.add_m_Proper M2'.find_m_Proper M2'.is_empty_m_Proper M2'.map_m_Proper M2'.mem_m_Proper M2'.remove_m_Proper
+  | 10.
   Local Existing Instances
         M1'.eq_key_equiv M1'.eq_key_elt_equiv M1'.Equal_Equivalence
         M2'.eq_key_equiv M2'.eq_key_elt_equiv M2'.Equal_Equivalence

--- a/src/Util/FSets/FMapSum.v
+++ b/src/Util/FSets/FMapSum.v
@@ -47,8 +47,12 @@ Module SumWSfun_gen (E1 : DecidableTypeOrig) (E2 : DecidableTypeOrig) (M1 : WSfu
   Global Remove Hints E1.eq_refl E1.eq_sym E1.eq_trans : core.
   Module E2 <: DecidableTypeBoth := E2 <+ UpdateEq.
   Global Remove Hints E2.eq_refl E2.eq_sym E2.eq_trans : core.
-  Module M1' := M1 <+ WFacts_fun E1 <+ WAdditionalFacts_fun E1.
-  Module M2' := M2 <+ WFacts_fun E2 <+ WAdditionalFacts_fun E2.
+  Module M1' := M1 <+ WFacts_fun E1 <+ WFacts_fun_RemoveHints E1 <+ WAdditionalFacts_fun E1.
+  Module M2' := M2 <+ WFacts_fun E2 <+ WFacts_fun_RemoveHints E2 <+ WAdditionalFacts_fun E2.
+  Local Existing Instances
+        M1'.Empty_m_Proper M1'.In_m_Proper M1'.MapsTo_m_Proper M1'.add_m_Proper M1'.find_m_Proper M1'.is_empty_m_Proper M1'.map_m_Proper M1'.mem_m_Proper M1'.remove_m_Proper
+        M2'.Empty_m_Proper M2'.In_m_Proper M2'.MapsTo_m_Proper M2'.add_m_Proper M2'.find_m_Proper M2'.is_empty_m_Proper M2'.map_m_Proper M2'.mem_m_Proper M2'.remove_m_Proper
+  | 10.
   Local Existing Instances
         M1'.eq_key_equiv M1'.eq_key_elt_equiv M1'.Equal_Equivalence
         M2'.eq_key_equiv M2'.eq_key_elt_equiv M2'.Equal_Equivalence

--- a/src/Util/FSets/FMapTrie.v
+++ b/src/Util/FSets/FMapTrie.v
@@ -1814,7 +1814,7 @@ Module ListWSfun_gen (Y : DecidableTypeOrig) (M : WSfun Y) (Import T : Trie Y M)
   End ESigCompat.
   Module Y' <: DecidableTypeBoth := Y <+ UpdateEq.
   Global Remove Hints Y'.eq_refl Y'.eq_sym Y'.eq_trans : core.
-  Module M' := WFacts_fun Y M <+ WAdditionalFacts_fun Y M.
+  Module M' := WFacts_fun Y M <+ WFacts_fun_RemoveHints Y M <+ WAdditionalFacts_fun Y M.
   Local Existing Instances
         M'.eq_key_equiv M'.eq_key_elt_equiv M'.Equal_Equivalence
   | 10.

--- a/src/Util/Structures/Orders.v
+++ b/src/Util/Structures/Orders.v
@@ -265,3 +265,25 @@ Module UsualOT_of_UsualOrig (Import O : UsualMiniOrderedType) <: UsualOrderedTyp
   Include UpdateCompare O O.
   Include HasEqDec_DecStrOrder.
 End UsualOT_of_UsualOrig.
+
+Module OrderedTypeOrigFacts (O:OrderedTypeOrig) := OrderedType.OrderedTypeFacts O.
+Module Type OrderedTypeOrigFactsT (O:OrderedTypeOrig) := Nop <+ OrderedTypeOrigFacts O.
+Module OrderedTypeOrigFacts_RemoveHints (O:OrderedTypeOrig) (F:OrderedTypeOrigFactsT O).
+  Global Remove Hints
+         F.eq_equiv
+         F.lt_compat
+         F.lt_strorder
+    : typeclass_instances.
+End OrderedTypeOrigFacts_RemoveHints.
+
+Module Type KeyOrderedTypeT (O:OrderedType) := Nop <+ KeyOrderedType O.
+Module KeyOrderedType_RemoveHints (O:OrderedTypeOrig) (F:KeyOrderedTypeT O).
+  Include OrderedTypeOrigFacts_RemoveHints O F.MO.
+  Global Remove Hints
+         F.eqk_equiv
+         F.eqke_equiv
+         F.ltk_strorder
+         F.ltk_compat
+         F.ltk_compat'
+    : typeclass_instances.
+End KeyOrderedType_RemoveHints.


### PR DESCRIPTION
I was finding that `reflexivity` was taking a long time to fail because
tc/conversion decided to try to unify FMap `Equal` with the relation I
was using.  So we eagerly remove most of the extraneous hints.

Timing coming soon, on top of <strike>#1290</strike>