### PR TITLE
Work around coq/coq#7954

### DIFF
--- a/src/Util/FSets/FMapOption.v
+++ b/src/Util/FSets/FMapOption.v
@@ -151,7 +151,7 @@ Module OptionWSfun_gen (E2 : DecidableTypeOrig) (M2 : WSfun E2).
                         f2 (fun k => f (Some k)) (snd m)).
     End _Extra1.
 
-    Definition empty elt : t elt := liftT (@M1.empty _) (@M2.empty _).
+    Definition empty elt : t elt := Eval hnf in liftT (@M1.empty _) (@M2.empty _).
     Definition is_empty elt (m : t elt) : bool := M1.is_empty (fst m) &&& M2.is_empty (snd m).
     Definition add elt : key -> elt -> t elt -> t elt := liftK_TT (@M1.add elt) (@M2.add elt).
     Definition find elt : key -> t elt -> option elt := liftKT_ (@M1.find elt) (@M2.find elt).

--- a/src/Util/FSets/FMapSum.v
+++ b/src/Util/FSets/FMapSum.v
@@ -151,7 +151,7 @@ Module SumWSfun_gen (E1 : DecidableTypeOrig) (E2 : DecidableTypeOrig) (M1 : WSfu
                         f2 (fun k => f (inr k)) (snd m)).
     End _Extra1.
 
-    Definition empty elt : t elt := liftT (@M1.empty _) (@M2.empty _).
+    Definition empty elt : t elt := Eval hnf in liftT (@M1.empty _) (@M2.empty _).
     Definition is_empty elt (m : t elt) : bool := M1.is_empty (fst m) &&& M2.is_empty (snd m).
     Definition add elt : key -> elt -> t elt -> t elt := liftK_TT (@M1.add elt) (@M2.add elt).
     Definition find elt : key -> t elt -> option elt := liftKT_ (@M1.find elt) (@M2.find elt).


### PR DESCRIPTION
This fixes errors like those of coq/coq#7954, e.g.,:
```
File "src/ExtractionOCaml/unsaturated_solinas.ml", line 1:
Error: The implementation src/ExtractionOCaml/unsaturated_solinas.ml
       does not match the interface src/ExtractionOCaml/unsaturated_solinas.cmi:
        ... ... ... ... ... ... ... ... In module SumWSfun_gen.SumWSfun_gen:
       Values do not match:
         val empty : '_weak1 M1.t * '_weak2 M2.t
       is not included in
         val empty : 'a1 t
       File "src/ExtractionOCaml/unsaturated_solinas.mli", line 5958, characters 4-21:
         Expected declaration
       File "src/ExtractionOCaml/unsaturated_solinas.ml", line 16856, characters 8-13:
         Actual declaration
```