### PR TITLE
Use records in FMap structures

### DIFF
--- a/src/Util/FSets/FMapProd.v
+++ b/src/Util/FSets/FMapProd.v
@@ -75,12 +75,17 @@ Module ProdWSfun_gen (E1 : DecidableTypeOrig) (E2 : DecidableTypeOrig) (M1 : WSf
 
     Global Hint Transparent key : core.
 
-    Definition t elt := M1.t { m : M2.t elt | ~M2.Empty m }.
+    (* Create a record so that the normal form of the type isn't exponentially sized when we nest things, see COQBUG(https://github.com/coq/coq/issues/16172) *)
+    Local Set Primitive Projections.
+    Record M2_t_NonEmpty elt := { M2_m :> M2.t elt ; M2_NonEmpty :> ~M2.Empty M2_m }.
+    Global Arguments Build_M2_t_NonEmpty [elt] _ _.
+    Local Notation M2_mk := (@Build_M2_t_NonEmpty _).
+    Definition t elt := M1.t (M2_t_NonEmpty elt).
 
     Local Ltac t_obgl :=
       repeat first [ progress intros
                    | progress cbv [M2.Empty Option.value not option_map] in *
-                   | progress cbn [proj1_sig] in *
+                   | progress cbn [M2_m] in *
                    | reflexivity
                    | exfalso; assumption
                    | congruence
@@ -103,7 +108,7 @@ Module ProdWSfun_gen (E1 : DecidableTypeOrig) (E2 : DecidableTypeOrig) (M1 : WSf
                      end
                    | progress subst
                    | progress specialize_under_binders_by eapply M2.map_1
-                   | progress destruct_head'_sig
+                   | progress destruct_head' M2_t_NonEmpty
                    | progress destruct_head'_and
                    | progress destruct_head' option
                    | progress break_innermost_match_hyps
@@ -116,10 +121,10 @@ Module ProdWSfun_gen (E1 : DecidableTypeOrig) (E2 : DecidableTypeOrig) (M1 : WSf
     Definition empty elt : t elt := @M1.empty _.
     Definition is_empty elt : t elt -> bool := @M1.is_empty _.
     Program Definition add elt (k : key) (v : elt) (m : t elt) : t elt
-      := let m2 := M2.add (snd k) v (Option.value (option_map (@proj1_sig _ _) (M1.find (fst k) m)) (@M2.empty _)) in
-         M1.add (fst k) (exist _ m2 _) m.
+      := let m2 := M2.add (snd k) v (Option.value (option_map (@M2_m _) (M1.find (fst k) m)) (@M2.empty _)) in
+         M1.add (fst k) (M2_mk m2 _) m.
     Definition find elt (k : key) (m : t elt) : option elt
-      := m2 <- M1.find (fst k) m; M2.find (snd k) (`m2).
+      := m2 <- M1.find (fst k) m; M2.find (snd k) (M2_m m2).
     Program Definition remove elt (k : key) (m : t elt) : t elt
       := match M1.find (fst k) m with
          | None => m
@@ -127,15 +132,15 @@ Module ProdWSfun_gen (E1 : DecidableTypeOrig) (E2 : DecidableTypeOrig) (M1 : WSf
            => let m2 := M2.remove (snd k) m2 in
               match M2.is_empty m2 with
               | true => M1.remove (fst k) m
-              | false => M1.add (fst k) (exist _ m2 _) m
+              | false => M1.add (fst k) (M2_mk m2 _) m
               end
          end.
     Definition mem elt (k : key) (m : t elt) : bool
       := match find k m with Some _ => true | _ => false end.
     Program Definition map elt elt' (f : elt -> elt') : t elt -> t elt'
-      := M1.map (fun m => exist _ (M2.map f (`m)) _).
+      := M1.map (fun m => M2_mk (M2.map f (M2_m m)) _).
     Program Definition mapi elt elt' (f : key -> elt -> elt') : t elt -> t elt'
-      := M1.mapi (fun k1 m => exist _ (M2.mapi (fun k2 => f (k1, k2)) (`m)) _).
+      := M1.mapi (fun k1 m => M2_mk (M2.mapi (fun k2 => f (k1, k2)) (M2_m m)) _).
     Program Definition map2 elt elt' elt'' (f : option elt -> option elt' -> option elt'')
             (f' := match f None None with
                    | None => f
@@ -149,22 +154,22 @@ Module ProdWSfun_gen (E1 : DecidableTypeOrig) (E2 : DecidableTypeOrig) (M1 : WSf
                   => if match m1, m2 with None, None => true | _, _ => false end
                      then None
                      else
-                       let m1' := Option.value (option_map (@proj1_sig _ _) m1) (M2.empty _) in
-                       let m2' := Option.value (option_map (@proj1_sig _ _) m2) (M2.empty _) in
+                       let m1' := Option.value (option_map (@M2_m _) m1) (M2.empty _) in
+                       let m2' := Option.value (option_map (@M2_m _) m2) (M2.empty _) in
                        let m' := M2.map2 f' m1' m2' in
                        match M2.is_empty m' with
                        | true => None
-                       | false => Some (exist _ m' _)
+                       | false => Some (M2_mk m' _)
                        end).
     Definition elements elt (m : t elt) : list (key * elt)
-      := List.flat_map (fun '(k1, m) => List.map (fun '(k2, v) => ((k1, k2), v)) (M2.elements (`m))) (M1.elements m).
+      := List.flat_map (fun '(k1, m) => List.map (fun '(k2, v) => ((k1, k2), v)) (M2.elements (M2_m m))) (M1.elements m).
     Definition cardinal elt (m : t elt) : nat := List.length (elements m).
     Definition fold elt A (f : key -> elt -> A -> A) : t elt -> A -> A
-      := M1.fold (fun k1 m => M2.fold (fun k2 => f (k1, k2)) (`m)).
+      := M1.fold (fun k1 m => M2.fold (fun k2 => f (k1, k2)) (M2_m m)).
     Definition equal elt (eqb : elt -> elt -> bool) : t elt -> t elt -> bool
-      := M1.equal (fun m m' => M2.equal eqb (`m) (`m')).
+      := M1.equal (fun m m' => M2.equal eqb (M2_m m) (M2_m m')).
     Definition MapsTo elt (k : key) (v : elt) (m : t elt) : Prop
-      := exists m2, M1.MapsTo (fst k) m2 m /\ M2.MapsTo (snd k) v (`m2).
+      := exists m2, M1.MapsTo (fst k) m2 m /\ M2.MapsTo (snd k) v (M2_m m2).
     Definition eq_key elt (p p':key*elt) := E.eq (fst p) (fst p').
     Definition eq_key_elt elt (p p':key*elt) :=
       E.eq (fst p) (fst p') /\ (snd p) = (snd p').
@@ -190,7 +195,7 @@ Module ProdWSfun_gen (E1 : DecidableTypeOrig) (E2 : DecidableTypeOrig) (M1 : WSf
       Definition Empty_alt elt (m : t elt) : Prop := M1.Empty m.
       (*Definition In_alt elt (k : key) (m : t elt) : Prop := liftKT_ (@M1.In elt) (@M2.In elt).
     Definition Equal_alt elt (m m' : t elt) : Prop := M1.Equal (fst m) (fst m') /\ M2.Equal (snd m) (snd m').*)
-      Definition Equiv_alt elt (cmp : elt -> elt -> Prop) (m m' : t elt) : Prop := M1.Equiv (fun m m' => M2.Equiv cmp (`m) (`m')) m m'.
+      Definition Equiv_alt elt (cmp : elt -> elt -> Prop) (m m' : t elt) : Prop := M1.Equiv (fun m m' => M2.Equiv cmp (M2_m m) (M2_m m')) m m'.
       (*Definition Equivb_alt elt (cmp : elt -> elt -> bool) (m m' : t elt) : Prop := M1.Equivb cmp (fst m) (fst m') /\ M2.Equivb cmp (snd m) (snd m').
        *)
 
@@ -202,7 +207,7 @@ Module ProdWSfun_gen (E1 : DecidableTypeOrig) (E2 : DecidableTypeOrig) (M1 : WSf
       Proof.
         cbv [Empty Empty_alt MapsTo M1.Empty M2.Empty not M2.key key M1.key E.t].
         split; repeat intro.
-        all: repeat first [ progress destruct_head'_sig
+        all: repeat first [ progress destruct_head' M2_t_NonEmpty
                           | progress destruct_head'_ex
                           | progress destruct_head'_and
                           | progress specialize_dep_under_binders_by apply pair
@@ -217,13 +222,14 @@ Module ProdWSfun_gen (E1 : DecidableTypeOrig) (E2 : DecidableTypeOrig) (M1 : WSf
         setoid_rewrite M1'.find_mapsto_iff; setoid_rewrite M2'.find_mapsto_iff.
         split; [ pose I as FWD | pose I as BAK ].
         all: repeat first [ progress intros
-                          | progress destruct_head'_sig
+                          | progress destruct_head' M2_t_NonEmpty
                           | progress destruct_head'_ex
                           | progress destruct_head'_and
                           | progress split_iff
                           | progress specialize_dep_under_binders_by apply pair
                           | progress specialize_dep_under_binders_by eexists
-                          | progress cbn [fst snd proj1_sig] in *
+                          | progress cbn [fst snd ProdWSfun_gen.M2_m] in *
+                          | progress cbv [not] in *
                           | apply conj
                           | match goal with
                             | [ |- context[@M1.find ?a ?b ?c] ] => destruct (@M1.find a b c) eqn:?
@@ -250,7 +256,7 @@ Module ProdWSfun_gen (E1 : DecidableTypeOrig) (E2 : DecidableTypeOrig) (M1 : WSf
              end.
         all: repeat first [ progress cbv [M2.eq_key_elt] in *
                           | progress cbn [fst snd proj1_sig] in *
-                          | progress destruct_head'_sig
+                          | progress destruct_head' M2_t_NonEmpty
                           | progress destruct_head'_ex
                           | progress destruct_head'_and
                           | progress specialize_dep_under_binders_by apply conj
@@ -854,7 +860,7 @@ Module ProdWSfun_gen (E1 : DecidableTypeOrig) (E2 : DecidableTypeOrig) (M1 : WSf
       all: cbv [option_map Option.bind Option.value] in *.
       all: repeat first [ progress inversion_option
                         | progress subst
-                        | progress cbn [proj1_sig] in *
+                        | progress cbn [M2_m] in *
                         | progress break_match_hyps ].
       all: lazymatch goal with
            | [ H : context[M2.find _ (M2.map2 _ _ _)] |- _ ]

--- a/src/Util/FSets/FMapSum.v
+++ b/src/Util/FSets/FMapSum.v
@@ -73,7 +73,15 @@ Module SumWSfun_gen (E1 : DecidableTypeOrig) (E2 : DecidableTypeOrig) (M1 : WSfu
 
     Global Hint Transparent key : core.
 
-    Definition t elt := M1.t elt * M2.t elt.
+    (* Create a record so that the normal form of the type isn't exponentially sized when we nest things, see COQBUG(https://github.com/coq/coq/issues/16172) *)
+    Record underlying_map elt := { underlying :> M1.t elt * M2.t elt }.
+    Declare Scope underlying_map_scope.
+    Bind Scope underlying_map_scope with map.
+    Notation "( x , y , .. , z )" := {| underlying := (pair .. (pair x y) .. z) |} : underlying_map_scope.
+    Definition t := underlying_map.
+    Bind Scope underlying_map_scope with t.
+    Local Delimit Scope underlying_map_scope with t.
+    Local Open Scope underlying_map_scope.
 
     Module Import _Extra1.
       Definition liftK {A} (f1 : M1.key -> A) (f2 : M2.key -> A) : key -> A
@@ -161,8 +169,8 @@ Module SumWSfun_gen (E1 : DecidableTypeOrig) (E2 : DecidableTypeOrig) (M1 : WSfu
     Definition mapi elt elt' : (key -> elt -> elt') -> t elt -> t elt' := lifthoTT (@M1.mapi elt elt') (@M2.mapi elt elt').
     Definition map2 elt elt' elt'' : (option elt -> option elt' -> option elt'') -> t elt -> t elt' -> t elt'' := lift_TTT (@M1.map2 elt elt' elt'') (@M2.map2 elt elt' elt'').
     Definition elements elt (v : t elt) : list (key * elt)
-      := (List.map (fun kv => (inl (fst kv), snd kv)) (M1.elements (fst v)))
-           ++ List.map (fun kv => (inr (fst kv), snd kv)) (M2.elements (snd v)).
+      := (List.map (fun kv => (inl (fst kv), snd kv)%core) (M1.elements (fst v)))
+           ++ List.map (fun kv => (inr (fst kv), snd kv)%core) (M2.elements (snd v)).
     Definition cardinal elt (m : t elt) : nat := M1.cardinal (fst m) + M2.cardinal (snd m).
     Definition fold elt A (f : key -> elt -> A -> A) (m : t elt) (i : A) : A
       := M2.fold (fun k => f (inr k)) (snd m) (M1.fold (fun k => f (inl k)) (fst m) i).
@@ -365,7 +373,7 @@ Module SumWSfun_gen (E1 : DecidableTypeOrig) (E2 : DecidableTypeOrig) (M1 : WSfu
 
     Local Ltac spec_t_step_quick
       := first [ progress intros
-               | progress cbn [fst snd] in *
+               | progress cbn [fst snd underlying] in *
                | apply (f_equal2 (@pair _ _))
                | progress destruct_head'_False
                | rewrite <- andb_lazy_alt
@@ -435,13 +443,13 @@ Module SumWSfun_gen (E1 : DecidableTypeOrig) (E2 : DecidableTypeOrig) (M1 : WSfu
       Lemma find_2 : find x m = Some e -> MapsTo x e m.
       Proof using Type. clear; spec_t. Qed.
       Lemma elements_1 :
-        MapsTo x e m -> InA (@eq_key_elt _) (x,e) (elements m).
+        MapsTo x e m -> InA (@eq_key_elt _) (x,e)%core (elements m).
       Proof using Type.
         clear; spec_t.
         all: [ > left | right ]; rewrite InA_map_iff; spec_t.
       Qed.
       Lemma elements_2 :
-        InA (@eq_key_elt _) (x,e) (elements m) -> MapsTo x e m.
+        InA (@eq_key_elt _) (x,e)%core (elements m) -> MapsTo x e m.
       Proof using Type.
         clear; spec_t.
         all: try solve [ rewrite InA_map_iff in *; spec_t ].

--- a/src/Util/FSets/FMapTrie/ShapeEx.v
+++ b/src/Util/FSets/FMapTrie/ShapeEx.v
@@ -275,7 +275,7 @@ Module NMapTrieInd <: Trie NOrderedTypeBits NMap.
     induction m as [d m pf] using NMapTypFunctor.t_rect.
     specialize (H d m pf).
     apply H; clear H.
-    destruct m as [[m0 m]|]; [ | intros; exact I ].
+    destruct m as [[[m0 m]]|]; [ | intros; exact I ].
     intros [|k]; [ | revert k ].
     { cbn.
       destruct m0 as [m0|]; [ | clear; intros; inversion_option ].
@@ -437,7 +437,7 @@ Module ZMapTrieInd <: Trie ZOrderedTypeBits ZMap.
     induction m as [d m pf] using ZMapTypFunctor.t_rect.
     specialize (H d m pf).
     apply H; clear H.
-    destruct m as [[mn [m0 m]]|]; [ | intros; exact I ].
+    destruct m as [[[mn [[m0 m]]]]|]; [ | intros; exact I ].
     intros [|k|k]; [ | revert k | revert k ].
     all: cbv -[PositiveMap.find t].
     { destruct m0 as [m0|]; [ | clear; intros; inversion_option ].


### PR DESCRIPTION
This works around the issue with exponentially sized types in
extraction, COQBUG(https://github.com/coq/coq/issues/16172)