### PR TITLE
[sp2019latest] Adaptation w.r.t. coq/coq#16004

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,5 +1,6 @@
 -R src Crypto
 -R bbv/src/bbv bbv
+-arg -w -arg -deprecated-hint-rewrite-without-locality,+deprecated-hint-without-locality,+deprecated-instance-without-locality
 bbv/src/bbv/BinNotation.v
 bbv/src/bbv/BinNotationZ.v
 bbv/src/bbv/DepEq.v

--- a/src/Algebra/Field.v
+++ b/src/Algebra/Field.v
@@ -5,6 +5,10 @@ Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Mor
 Require Import Crypto.Algebra.Hierarchy Crypto.Algebra.Monoid Crypto.Algebra.Ring Crypto.Algebra.IntegralDomain.
 Require Coq.setoid_ring.Field_theory.
 Module Export Hints1.
+  Export Crypto.Algebra.Monoid.Hints.
+  Export Crypto.Algebra.Hierarchy.Hints.
+  Export Crypto.Algebra.Ring.Hints.
+  Export Crypto.Algebra.IntegralDomain.Hints.
   Global Existing Instances
          Ncring_tac.Ifind0
          Ncring_tac.Iclosed_nil
@@ -33,7 +37,6 @@ Module Export Hints1.
          Ncring_tac.reifyZneg
   | 11.
   Global Existing Instance Ncring_tac.reify_var | 100.
-  Global Existing Instance IntegralDomain.Integral_domain.
 End Hints1.
 
 Section Field.
@@ -363,33 +366,6 @@ Module Export Hints.
   Export Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
   Export Hints1.
   Global Existing Instances is_mul_nonzero_nonzero integral_domain.
-  Global Existing Instance monoid_is_associative.
-  Global Existing Instance monoid_is_left_identity.
-  Global Existing Instance monoid_is_right_identity.
-  Global Existing Instance monoid_Equivalence.
-  Global Existing Instance monoid_op_Proper.
-  Global Existing Instance group_monoid.
-  Global Existing Instance group_is_left_inverse.
-  Global Existing Instance group_is_right_inverse.
-  Global Existing Instance group_inv_Proper.
-  Global Existing Instance commutative_group_group.
-  Global Existing Instance commutative_group_is_commutative.
-  Global Existing Instance ring_commutative_group_add.
-  Global Existing Instance ring_monoid_mul.
-  Global Existing Instance ring_is_left_distributive.
-  Global Existing Instance ring_is_right_distributive.
-  Global Existing Instance ring_mul_Proper.
-  Global Existing Instance ring_sub_Proper.
-  Global Existing Instance commutative_ring_ring.
-  Global Existing Instance commutative_ring_is_commutative.
-  Global Existing Instance integral_domain_commutative_ring.
-  Global Existing Instance integral_domain_is_zero_product_zero_factor.
-  Global Existing Instance integral_domain_is_zero_neq_one.
-  Global Existing Instance field_commutative_ring.
-  Global Existing Instance field_is_left_multiplicative_inverse.
-  Global Existing Instance field_is_zero_neq_one.
-  Global Existing Instance field_inv_Proper.
-  Global Existing Instance field_div_Proper.
   Global Existing Instances
          Ncring.zero_notation
          Ncring.one_notation
@@ -404,18 +380,5 @@ Module Export Hints.
          Ncring.ring_sub_comp
          Ncring.ring_opp_comp
          Ncring.power_ring
-         Ring.is_left_distributive_sub
-         Ring.is_right_distributive_sub
-         Ring.Ncring_Ring_ops
-         Ring.Ncring_Ring
-         Ring.homomorphism_is_homomorphism
-         Ring.monoid_homomorphism_mul
-         Ring.Cring_Cring_commutative_ring
-         Ring.ring_Z
-         Ring.commutative_ring_Z
-         Ring.integral_domain_Z
-         Ring.homomorphism_of_Z
-         Ring.integral_domain_Z
-         Ring.homomorphism_of_Z
   .
 End Hints.

--- a/src/Algebra/Field.v
+++ b/src/Algebra/Field.v
@@ -1,9 +1,40 @@
 Require Import Crypto.Util.Relations Crypto.Util.Notations.
 Require Import Crypto.Util.Tactics.UniquePose.
 Require Import Crypto.Util.Tactics.DebugPrint.
-Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms.
-Require Import Crypto.Algebra.Hierarchy Crypto.Algebra.Ring Crypto.Algebra.IntegralDomain.
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
+Require Import Crypto.Algebra.Hierarchy Crypto.Algebra.Monoid Crypto.Algebra.Ring Crypto.Algebra.IntegralDomain.
 Require Coq.setoid_ring.Field_theory.
+Module Export Hints1.
+  Global Existing Instances
+         Ncring_tac.Ifind0
+         Ncring_tac.Iclosed_nil
+         Ncring_tac.Iclosed_cons
+         Ncring_tac.reify_zero
+         Ncring_tac.reify_one
+         Ncring_tac.reify_add
+         Ncring_tac.reify_sub
+         Ncring_tac.reify_opp
+         Ncring_tac.reify_nil
+         Ncring_tac.reify_cons
+  .
+  Global Existing Instances
+         Ncring_tac.IfindS
+         Ncring_tac.reify_pow
+  | 1.
+  Global Existing Instances
+         Ncring_tac.reify_mul_ext
+  | 9.
+  Global Existing Instances
+         Ncring_tac.reify_mul
+  | 10.
+  Global Existing Instances
+         Ncring_tac.reifyZ0
+         Ncring_tac.reifyZpos
+         Ncring_tac.reifyZneg
+  | 11.
+  Global Existing Instance Ncring_tac.reify_var | 100.
+  Global Existing Instance IntegralDomain.Integral_domain.
+End Hints1.
 
 Section Field.
   Context {T eq zero one opp add mul sub inv div} `{@field T eq zero one opp add sub mul inv div}.
@@ -327,3 +358,64 @@ Section FieldSquareRoot.
     fsatz.
   Qed.
 End FieldSquareRoot.
+
+Module Export Hints.
+  Export Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
+  Export Hints1.
+  Global Existing Instances is_mul_nonzero_nonzero integral_domain.
+  Global Existing Instance monoid_is_associative.
+  Global Existing Instance monoid_is_left_identity.
+  Global Existing Instance monoid_is_right_identity.
+  Global Existing Instance monoid_Equivalence.
+  Global Existing Instance monoid_op_Proper.
+  Global Existing Instance group_monoid.
+  Global Existing Instance group_is_left_inverse.
+  Global Existing Instance group_is_right_inverse.
+  Global Existing Instance group_inv_Proper.
+  Global Existing Instance commutative_group_group.
+  Global Existing Instance commutative_group_is_commutative.
+  Global Existing Instance ring_commutative_group_add.
+  Global Existing Instance ring_monoid_mul.
+  Global Existing Instance ring_is_left_distributive.
+  Global Existing Instance ring_is_right_distributive.
+  Global Existing Instance ring_mul_Proper.
+  Global Existing Instance ring_sub_Proper.
+  Global Existing Instance commutative_ring_ring.
+  Global Existing Instance commutative_ring_is_commutative.
+  Global Existing Instance integral_domain_commutative_ring.
+  Global Existing Instance integral_domain_is_zero_product_zero_factor.
+  Global Existing Instance integral_domain_is_zero_neq_one.
+  Global Existing Instance field_commutative_ring.
+  Global Existing Instance field_is_left_multiplicative_inverse.
+  Global Existing Instance field_is_zero_neq_one.
+  Global Existing Instance field_inv_Proper.
+  Global Existing Instance field_div_Proper.
+  Global Existing Instances
+         Ncring.zero_notation
+         Ncring.one_notation
+         Ncring.add_notation
+         Ncring.mul_notation
+         Ncring.sub_notation
+         Ncring.opp_notation
+         Ncring.eq_notation
+         Ncring.ring_setoid
+         Ncring.ring_plus_comp
+         Ncring.ring_mult_comp
+         Ncring.ring_sub_comp
+         Ncring.ring_opp_comp
+         Ncring.power_ring
+         Ring.is_left_distributive_sub
+         Ring.is_right_distributive_sub
+         Ring.Ncring_Ring_ops
+         Ring.Ncring_Ring
+         Ring.homomorphism_is_homomorphism
+         Ring.monoid_homomorphism_mul
+         Ring.Cring_Cring_commutative_ring
+         Ring.ring_Z
+         Ring.commutative_ring_Z
+         Ring.integral_domain_Z
+         Ring.homomorphism_of_Z
+         Ring.integral_domain_Z
+         Ring.homomorphism_of_Z
+  .
+End Hints.

--- a/src/Algebra/Group.v
+++ b/src/Algebra/Group.v
@@ -1,5 +1,6 @@
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Crypto.Util.Relations (*Crypto.Util.Tactics*).
 Require Import Crypto.Algebra.Hierarchy Crypto.Algebra.Monoid.
+Export Hierarchy.Hints Monoid.Hints.
 
 Section BasicProperties.
   Context {T eq op id inv} `{@group T eq op id inv}.
@@ -181,3 +182,17 @@ Section CommutativeGroupByIsomorphism.
            end.
   Qed.
 End CommutativeGroupByIsomorphism.
+
+Module Export Hints.
+  Export Hierarchy.Hints Monoid.Hints.
+  Global Existing Instances
+           isomorphic_groups_group_G
+           isomorphic_groups_group_H
+           isomorphic_groups_hom_GH
+           isomorphic_groups_hom_HG
+           isomorphic_commutative_groups_group_G
+           isomorphic_commutative_groups_group_H
+           isomorphic_commutative_groups_hom_GH
+           isomorphic_commutative_groups_hom_HG
+  .
+End Hints.

--- a/src/Algebra/Group.v
+++ b/src/Algebra/Group.v
@@ -1,4 +1,4 @@
-Require Import Coq.Classes.Morphisms Crypto.Util.Relations (*Crypto.Util.Tactics*).
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Crypto.Util.Relations (*Crypto.Util.Tactics*).
 Require Import Crypto.Algebra.Hierarchy Crypto.Algebra.Monoid.
 
 Section BasicProperties.

--- a/src/Algebra/Hierarchy.v
+++ b/src/Algebra/Hierarchy.v
@@ -2,7 +2,7 @@ Require Export Crypto.Util.FixCoqMistakes.
 Require Export Crypto.Util.Decidable.
 
 Require Coq.PArith.BinPos.
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 
 Require Coq.Numbers.Natural.Peano.NPeano.
 Require Coq.Lists.List.

--- a/src/Algebra/Hierarchy.v
+++ b/src/Algebra/Hierarchy.v
@@ -1,3 +1,4 @@
+Require Import Coq.Classes.Equivalence Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Export Crypto.Util.FixCoqMistakes.
 Require Export Crypto.Util.Decidable.
 
@@ -159,3 +160,36 @@ Section ZeroNeqOne.
     intro HH; symmetry in HH. auto using zero_neq_one.
   Qed.
 End ZeroNeqOne.
+
+Module Export Hints.
+  Export Coq.Classes.Equivalence Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
+  Export Crypto.Util.FixCoqMistakes.
+  Export Crypto.Util.Decidable.
+  Global Existing Instance monoid_is_associative.
+  Global Existing Instance monoid_is_left_identity.
+  Global Existing Instance monoid_is_right_identity.
+  Global Existing Instance monoid_Equivalence.
+  Global Existing Instance monoid_op_Proper.
+  Global Existing Instance group_monoid.
+  Global Existing Instance group_is_left_inverse.
+  Global Existing Instance group_is_right_inverse.
+  Global Existing Instance group_inv_Proper.
+  Global Existing Instance commutative_group_group.
+  Global Existing Instance commutative_group_is_commutative.
+  Global Existing Instance ring_commutative_group_add.
+  Global Existing Instance ring_monoid_mul.
+  Global Existing Instance ring_is_left_distributive.
+  Global Existing Instance ring_is_right_distributive.
+  Global Existing Instance ring_mul_Proper.
+  Global Existing Instance ring_sub_Proper.
+  Global Existing Instance commutative_ring_ring.
+  Global Existing Instance commutative_ring_is_commutative.
+  Global Existing Instance integral_domain_commutative_ring.
+  Global Existing Instance integral_domain_is_zero_product_zero_factor.
+  Global Existing Instance integral_domain_is_zero_neq_one.
+  Global Existing Instance field_commutative_ring.
+  Global Existing Instance field_is_left_multiplicative_inverse.
+  Global Existing Instance field_is_zero_neq_one.
+  Global Existing Instance field_inv_Proper.
+  Global Existing Instance field_div_Proper.
+End Hints.

--- a/src/Algebra/IntegralDomain.v
+++ b/src/Algebra/IntegralDomain.v
@@ -200,3 +200,10 @@ Ltac dropRingSyntax :=
         Ncring.eq_notation
     ] in *.
 Ltac nsatz := Algebra.Nsatz.nsatz; dropRingSyntax.
+
+Module Export Hints.
+  Export Crypto.Algebra.Nsatz.Hints.
+  Export Crypto.Algebra.Hierarchy.Hints.
+  Export Crypto.Algebra.Ring.Hints.
+  Global Existing Instance IntegralDomain.Integral_domain.
+End Hints.

--- a/src/Algebra/IntegralDomain.v
+++ b/src/Algebra/IntegralDomain.v
@@ -1,5 +1,6 @@
 Require Coq.setoid_ring.Integral_domain.
 Require Crypto.Algebra.Nsatz.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.Factorize.
 Require Import Crypto.Algebra.Hierarchy Crypto.Algebra.Ring.
 Require Import Crypto.Util.Tactics.RewriteHyp.

--- a/src/Algebra/Monoid.v
+++ b/src/Algebra/Monoid.v
@@ -1,6 +1,6 @@
-Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.Tactics.RewriteHyp.
 Require Import Crypto.Algebra.Hierarchy.
+Import Crypto.Algebra.Hierarchy.Hints.
 
 Section Monoid.
   Context {T eq op id} {monoid:@monoid T eq op id}.
@@ -80,3 +80,9 @@ Section HomomorphismComposition.
     : @is_homomorphism G EQ OP K eqK opK (fun x => phi' (phi x))
     := is_homomorphism_compose (fun x => reflexivity _).
 End HomomorphismComposition.
+
+Module Export Hints.
+  Export Crypto.Algebra.Hierarchy.Hints.
+  Global Existing Instance is_homomorphism_phi_proper.
+  Global Existing Instance is_homomorphism_compose_refl.
+End Hints.

--- a/src/Algebra/Monoid.v
+++ b/src/Algebra/Monoid.v
@@ -1,4 +1,4 @@
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.Tactics.RewriteHyp.
 Require Import Crypto.Algebra.Hierarchy.
 

--- a/src/Algebra/Nsatz.v
+++ b/src/Algebra/Nsatz.v
@@ -4,7 +4,7 @@
 
 Require Coq.nsatz.Nsatz.
 Require Import Coq.Lists.List.
-Require Export Crypto.Util.GlobalSettings.
+Require Export Crypto.Util.FixCoqMistakes.
 
 (** For compat with https://github.com/coq/coq/pull/12073 *)
 Module Nsatz.
@@ -174,6 +174,7 @@ Ltac nsatz_contradict :=
       end).
 
 Module Export Hints.
+  Export Crypto.Util.FixCoqMistakes.
   Global Existing Instances
          Ncring_tac.Ifind0
          Ncring_tac.Iclosed_nil

--- a/src/Algebra/Nsatz.v
+++ b/src/Algebra/Nsatz.v
@@ -4,6 +4,7 @@
 
 Require Coq.nsatz.Nsatz.
 Require Import Coq.Lists.List.
+Require Export Crypto.Util.GlobalSettings.
 
 (** For compat with https://github.com/coq/coq/pull/12073 *)
 Module Nsatz.
@@ -171,3 +172,49 @@ Ltac nsatz_contradict :=
         [nsatz; nsatz_nonzero
         |destruct (Integral_domain.integral_domain_one_zero (Integral_domain:=domain) Hbad)]
       end).
+
+Module Export Hints.
+  Global Existing Instances
+         Ncring_tac.Ifind0
+         Ncring_tac.Iclosed_nil
+         Ncring_tac.Iclosed_cons
+         Ncring_tac.reify_zero
+         Ncring_tac.reify_one
+         Ncring_tac.reify_add
+         Ncring_tac.reify_sub
+         Ncring_tac.reify_opp
+         Ncring_tac.reify_nil
+         Ncring_tac.reify_cons
+  .
+  Global Existing Instances
+         Ncring_tac.IfindS
+         Ncring_tac.reify_pow
+  | 1.
+  Global Existing Instances
+         Ncring_tac.reify_mul_ext
+  | 9.
+  Global Existing Instances
+         Ncring_tac.reify_mul
+  | 10.
+  Global Existing Instances
+         Ncring_tac.reifyZ0
+         Ncring_tac.reifyZpos
+         Ncring_tac.reifyZneg
+  | 11.
+  Global Existing Instance Ncring_tac.reify_var | 100.
+  Global Existing Instances
+         Ncring_initial.Zops
+         Ncring_initial.Zr
+         Ncring_initial.gen_phiZ_morph
+         Ncring_initial.multiplication_phi_ring
+  .
+  Import nsatz.Nsatz.
+  Global Existing Instances
+         Qops
+         Qri
+         Qcri
+         Qdi
+         Zcri
+         Zdi
+  .
+End Hints.

--- a/src/Algebra/Ring.v
+++ b/src/Algebra/Ring.v
@@ -1,6 +1,6 @@
 Require Coq.setoid_ring.Ncring.
 Require Coq.setoid_ring.Cring.
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.micromega.Lia.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.Tactics.OnSubterms.
@@ -443,6 +443,6 @@ Ltac ring_simplify_subterms_in_all :=
 Create HintDb ring_simplify discriminated.
 Create HintDb ring_simplify_subterms discriminated.
 Create HintDb ring_simplify_subterms_in_all discriminated.
-Hint Extern 1 => progress ring_simplify : ring_simplify.
-Hint Extern 1 => progress ring_simplify_subterms : ring_simplify_subterms.
-Hint Extern 1 => progress ring_simplify_subterms_in_all : ring_simplify_subterms_in_all.
+Global Hint Extern 1 => progress ring_simplify : ring_simplify.
+Global Hint Extern 1 => progress ring_simplify_subterms : ring_simplify_subterms.
+Global Hint Extern 1 => progress ring_simplify_subterms_in_all : ring_simplify_subterms_in_all.

--- a/src/Algebra/Ring.v
+++ b/src/Algebra/Ring.v
@@ -1,14 +1,14 @@
 Require Coq.setoid_ring.Ncring.
 Require Coq.setoid_ring.Cring.
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.Tactics.OnSubterms.
 Require Import Crypto.Util.Tactics.Revert.
 Require Import Crypto.Util.Tactics.RewriteHyp.
 Require Import Crypto.Algebra.Hierarchy Crypto.Algebra.Group Crypto.Algebra.Monoid.
 Require Coq.ZArith.ZArith Coq.PArith.PArith.
-
+Export Crypto.Algebra.Hierarchy.Hints Crypto.Algebra.Group.Hints Crypto.Algebra.Monoid.Hints.
 
 Section Ring.
   Context {T eq zero one opp add sub mul} `{@ring T eq zero one opp add sub mul}.
@@ -443,6 +443,23 @@ Ltac ring_simplify_subterms_in_all :=
 Create HintDb ring_simplify discriminated.
 Create HintDb ring_simplify_subterms discriminated.
 Create HintDb ring_simplify_subterms_in_all discriminated.
-Global Hint Extern 1 => progress ring_simplify : ring_simplify.
-Global Hint Extern 1 => progress ring_simplify_subterms : ring_simplify_subterms.
-Global Hint Extern 1 => progress ring_simplify_subterms_in_all : ring_simplify_subterms_in_all.
+
+Module Export Hints.
+  Export Crypto.Algebra.Hierarchy.Hints Crypto.Algebra.Group.Hints Crypto.Algebra.Monoid.Hints.
+  Global Existing Instances
+         is_left_distributive_sub
+         is_right_distributive_sub
+         Ncring_Ring_ops
+         Ncring_Ring
+         homomorphism_is_homomorphism
+         monoid_homomorphism_mul
+         Cring_Cring_commutative_ring
+         ring_Z
+         commutative_ring_Z
+         integral_domain_Z
+         homomorphism_of_Z
+  .
+  Global Hint Extern 1 => progress ring_simplify : ring_simplify.
+  Global Hint Extern 1 => progress ring_simplify_subterms : ring_simplify_subterms.
+  Global Hint Extern 1 => progress ring_simplify_subterms_in_all : ring_simplify_subterms_in_all.
+End Hints.

--- a/src/Algebra/ScalarMult.v
+++ b/src/Algebra/ScalarMult.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt Coq.ZArith.ZArith Coq.micromega.Lia Crypto.Util.ZUtil.Peano.
+Require Import Coq.ZArith.BinInt Coq.ZArith.ZArith Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Crypto.Util.ZUtil.Peano.
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Algebra.Monoid Crypto.Algebra.Hierarchy Crypto.Algebra.Group.
@@ -165,3 +165,10 @@ Proof.
     rewrite <-?Z.succ'_succ, <-?Z.pred'_pred, ?Z.peano_rect_succ, ?Z.peano_rect_pred in * by lia;
     reflexivity.
 Qed.
+
+Module Export Hints.
+  Export Crypto.Algebra.Monoid.Hints Crypto.Algebra.Hierarchy.Hints Crypto.Algebra.Group.Hints.
+  Global Existing Instance scalarmult_Proper.
+  Global Existing Instance Proper_scalarmult_ref.
+  Global Existing Instance scalarmult_ref_is_scalarmult.
+End Hints.

--- a/src/Algebra/ScalarMult.v
+++ b/src/Algebra/ScalarMult.v
@@ -1,7 +1,7 @@
 Require Import Coq.ZArith.BinInt Coq.ZArith.ZArith Coq.micromega.Lia Crypto.Util.ZUtil.Peano.
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.Tactics.BreakMatch.
-Require Import Crypto.Algebra.Hierarchy Crypto.Algebra.Group.
+Require Import Crypto.Algebra.Monoid Crypto.Algebra.Hierarchy Crypto.Algebra.Group.
 Local Open Scope Z_scope.
 
 Section ScalarMultProperties.
@@ -21,7 +21,7 @@ Section ScalarMultProperties.
   Context `{mul_is_scalarmult:is_scalarmult}.
 
   Lemma scalarmult_succ_l n P : Z.succ n * P = P + n * P.
-  Proof.
+  Proof using groupG mul_is_scalarmult.
     induction n using Z.peano_rect_strong; intros; rewrite ?Z.succ'_succ, ?Z.pred'_pred in * by lia;
       repeat (rewrite ?scalarmult_0_l, ?scalarmult_succ_l_nn, ?scalarmult_pred_l_np, ?left_identity, ?right_identity, ?Z.succ_pred, ?Z.pred_succ, ?associative, ?right_inverse, ?left_inverse by lia); reflexivity.
   Qed.

--- a/src/Algebra/SubsetoidRing.v
+++ b/src/Algebra/SubsetoidRing.v
@@ -1,6 +1,6 @@
 Require Coq.setoid_ring.Ncring.
 Require Coq.setoid_ring.Cring.
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.Tactics.OnSubterms.
 Require Import Crypto.Util.Tactics.Revert.

--- a/src/Arithmetic/BarrettReduction/Generalized.v
+++ b/src/Arithmetic/BarrettReduction/Generalized.v
@@ -17,6 +17,7 @@ Require Import Crypto.Util.ZUtil.Tactics.SimplifyFractionsLe.
 Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
 Require Import Crypto.Util.ZUtil.Tactics.DivModToQuotRem.
 Require Import Crypto.Util.ZUtil.ZSimplify.
+Require Import Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.Tactics.BreakMatch.
 
 Local Open Scope Z_scope.
@@ -149,7 +150,7 @@ Section barrett.
       Context (n_good : b ^ offset * (b^(2*k) mod n) <= b ^ (k+offset) - m) (a_good : a < n * b ^ k).
 
       Lemma helper_1 : b ^ (2 * k) * ((a / n) - 1) <= m * (n * (a / n) - b ^ (k - offset)).
-      Proof.
+      Proof using a_good a_small base_good k_big_enough k_good m_good n_good n_large n_pos n_reasonable offset_nonneg.
         pose proof (Z.mod_pos_bound (b ^ (2*k)) n).
         assert (0 < b ^ (k - offset)) by auto with zarith.
         assert (a/n < b ^ k) by auto using Z.div_lt_upper_bound with zarith.
@@ -158,7 +159,7 @@ Section barrett.
       Qed.
 
       Lemma helper_2 : n * (a / n) - b ^ (k - offset) < b ^ (k - offset) * (a / b ^ (k - offset)).
-      Proof.
+      Proof using base_good k_big_enough n_pos n_reasonable offset_nonneg r.
         pose proof (Z.mod_pos_bound a n).
         pose proof (Z.mod_pos_bound a (b ^ (k - offset))).
         assert (0 < b ^ (k - offset)) by auto with zarith.
@@ -168,13 +169,13 @@ Section barrett.
       Let epsilon := (a / n) * b ^ (k+offset) - (a / b ^ (k - offset)) * m.
 
       Lemma q_epsilon : q = (a / n) + (- epsilon) / b ^ (k + offset).
-      Proof.
+      Proof using a_small base_good k_big_enough m_good n_good n_large n_pos n_reasonable offset_nonneg r.
         subst q epsilon.
         autorewrite with push_Zpow in *; do 2 Z.div_mod_to_quot_rem_in_goal; nia.
       Qed.
 
       Lemma epsilon_lower : - b ^ (k + offset) < epsilon.
-      Proof.
+      Proof using a_good a_nonneg a_small base_good k_big_enough k_good m_good n_good n_large n_pos n_reasonable offset_nonneg r.
         pose proof q_epsilon as Hq_epsilon.
         rewrite (proj2_sig q_nice) in Hq_epsilon.
         cut (- epsilon / b ^ (k + offset) <= 0);
@@ -182,13 +183,13 @@ Section barrett.
       Qed.
 
       Lemma m_pos : 0 < m.
-      Proof.
+      Proof using a_good a_nonneg a_small base_good k_big_enough k_good m_good n_good n_large n_pos n_reasonable offset_nonneg.
         subst m. Z.zero_bounds; autorewrite with push_Zpow in *; nia.
       Qed.
 
       Lemma epsilon_bound : epsilon < b ^ (k + offset).
-      Proof.
-        subst epsilon. pose proof helper_1. pose proof helper_2. pose proof m_pos.
+      Proof using a_good a_nonneg a_small base_good k_big_enough k_good m_good n_good n_large n_pos n_reasonable offset_nonneg r.
+        pose proof helper_1. pose proof helper_2. pose proof m_pos. subst epsilon.
         replace (b ^ (2 * k)) with (b^(k - offset) * b ^ (k + offset)) in *
           by (rewrite <-Z.pow_add_r; auto with zarith).
         apply Z.mul_lt_mono_pos_l with (p:=b^(k-offset)); auto with zarith.
@@ -196,7 +197,7 @@ Section barrett.
       Qed.
 
       Lemma q_nice_strong : { b : bool | q = a / n + if b then -1 else 0}.
-      Proof.
+      Proof using a_good a_nonneg a_small base_good epsilon k_big_enough k_good m_good n_good n_large n_pos n_reasonable offset_nonneg r.
         exists (0 <? epsilon).
         rewrite q_epsilon.
         pose proof epsilon_bound. pose proof epsilon_lower.
@@ -204,13 +205,13 @@ Section barrett.
       Qed.
 
       Lemma q_bound : a / n - 1 <= q.
-      Proof.
+      Proof using a_good a_nonneg a_small base_good epsilon k_big_enough k_good m_good n_good n_large n_pos n_reasonable offset_nonneg r.
         rewrite (proj2_sig q_nice_strong).
         break_match; lia.
       Qed.
 
       Lemma r_small_strong : r < 2 * n.
-      Proof.
+      Proof using a_good a_nonneg a_small base_good epsilon k_big_enough k_good m_good n_good n_large n_pos n_reasonable offset_nonneg q.
         Hint Rewrite (Z.mul_div_eq' a n) using lia : zstrip_div.
         assert (a mod n < n) by auto with zarith lia.
         unfold r.

--- a/src/Arithmetic/BarrettReduction/Generalized.v
+++ b/src/Arithmetic/BarrettReduction/Generalized.v
@@ -8,7 +8,7 @@
     ± 1] to [k ± offset]).  This leads to weaker conditions on the
     base ([b]), exponent ([k]), and the [offset] than those given in
     the HAC. *)
-Require Import Coq.ZArith.ZArith Coq.micromega.Psatz.
+Require Import Coq.ZArith.ZArith Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Div.
 Require Import Crypto.Util.ZUtil.Modulo.
 Require Import Crypto.Util.ZUtil.Pow.
@@ -151,6 +151,7 @@ Section barrett.
 
       Lemma helper_1 : b ^ (2 * k) * ((a / n) - 1) <= m * (n * (a / n) - b ^ (k - offset)).
       Proof using a_good a_small base_good k_big_enough k_good m_good n_good n_large n_pos n_reasonable offset_nonneg.
+        clear -a_good a_small base_good k_big_enough k_good m_good n_good n_large n_pos n_reasonable offset_nonneg.
         pose proof (Z.mod_pos_bound (b ^ (2*k)) n).
         assert (0 < b ^ (k - offset)) by auto with zarith.
         assert (a/n < b ^ k) by auto using Z.div_lt_upper_bound with zarith.
@@ -169,8 +170,9 @@ Section barrett.
       Let epsilon := (a / n) * b ^ (k+offset) - (a / b ^ (k - offset)) * m.
 
       Lemma q_epsilon : q = (a / n) + (- epsilon) / b ^ (k + offset).
-      Proof using a_small base_good k_big_enough m_good n_good n_large n_pos n_reasonable offset_nonneg r.
+      Proof using a_small base_good k_big_enough m_good n_good n_large n_pos n_reasonable offset_nonneg r k_good.
         subst q epsilon.
+        clear a_good a_nonneg.
         autorewrite with push_Zpow in *; do 2 Z.div_mod_to_quot_rem_in_goal; nia.
       Qed.
 

--- a/src/Arithmetic/BarrettReduction/HAC.v
+++ b/src/Arithmetic/BarrettReduction/HAC.v
@@ -8,7 +8,7 @@
     does reduction modulo [b^(k+offset)] early (ensuring that we don't
     have to carry around extra precision), but requires more stringint
     conditions on the base ([b]), exponent ([k]), and the [offset]. *)
-Require Import Coq.ZArith.ZArith Coq.micromega.Psatz.
+Require Import Coq.ZArith.ZArith Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
 Require Import Crypto.Util.ZUtil.Tactics.ZeroBounds.

--- a/src/Arithmetic/BarrettReduction/RidiculousFish.v
+++ b/src/Arithmetic/BarrettReduction/RidiculousFish.v
@@ -2,7 +2,7 @@ Require Import Crypto.Util.Notations.
 Require Import Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.ZUtil.Tactics.DivModToQuotRem.
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 
 Open Scope Z_scope.
 

--- a/src/Arithmetic/BarrettReduction/Wikipedia.v
+++ b/src/Arithmetic/BarrettReduction/Wikipedia.v
@@ -1,6 +1,6 @@
 (*** Barrett Reduction *)
 (** This file implements Barrett Reduction on [Z].  We follow Wikipedia. *)
-Require Import Coq.ZArith.ZArith Coq.micromega.Psatz.
+Require Import Coq.ZArith.ZArith Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.ZUtil.Tactics.ZeroBounds.
 Require Import Crypto.Util.ZUtil.Tactics.SimplifyFractionsLe.

--- a/src/Arithmetic/BarrettReduction/Wikipedia.v
+++ b/src/Arithmetic/BarrettReduction/Wikipedia.v
@@ -1,6 +1,7 @@
 (*** Barrett Reduction *)
 (** This file implements Barrett Reduction on [Z].  We follow Wikipedia. *)
 Require Import Coq.ZArith.ZArith Coq.micromega.Psatz.
+Require Import Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.ZUtil.Tactics.ZeroBounds.
 Require Import Crypto.Util.ZUtil.Tactics.SimplifyFractionsLe.
 Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.

--- a/src/Arithmetic/Core.v
+++ b/src/Arithmetic/Core.v
@@ -240,7 +240,7 @@ reasonable time, so this is not really an option.
 
 *****)
 
-Require Import Coq.ZArith.ZArith Coq.micromega.Psatz Coq.micromega.Lia.
+Require Import Coq.ZArith.ZArith Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.BinIntDef.
 Local Open Scope Z_scope.
 

--- a/src/Arithmetic/Core.v
+++ b/src/Arithmetic/Core.v
@@ -347,7 +347,7 @@ Module B.
     Definition mul (p q:list limb) := mul_cps p q id.
     Lemma mul_cps_id p q: forall {T} f, @mul_cps p q T f = f (mul p q).
     Proof. cbv [mul_cps mul]; prove_id. Qed.
-    Hint Opaque mul : uncps.
+    Local Hint Opaque mul : uncps.
     Hint Rewrite mul_cps_id : uncps.
 
     Lemma eval_mul p q: eval (mul p q) = eval p * eval q.
@@ -382,7 +382,7 @@ Module B.
                | _ => progress (cbv [split]; prove_id)
                end.
     Qed.
-    Hint Opaque split : uncps.
+    Local Hint Opaque split : uncps.
     Hint Rewrite split_cps_id : uncps.
 
     Lemma eval_split s p (s_nonzero:s<>0):
@@ -405,7 +405,7 @@ Module B.
     Lemma reduce_cps_id s c p {T} f:
       @reduce_cps s c p T f = f (reduce s c p).
     Proof. cbv [reduce_cps reduce]; prove_id. Qed.
-    Hint Opaque reduce : uncps.
+    Local Hint Opaque reduce : uncps.
     Hint Rewrite reduce_cps_id : uncps.
 
     Lemma reduction_rule a b s c m (m_eq:Z.pos m = s - c):
@@ -432,7 +432,7 @@ Module B.
     Definition negate_snd p := negate_snd_cps p id.
     Lemma negate_snd_id p {T} f : @negate_snd_cps p T f = f (negate_snd p).
     Proof. cbv [negate_snd_cps negate_snd]; prove_id. Qed.
-    Hint Opaque negate_snd : uncps.
+    Local Hint Opaque negate_snd : uncps.
     Hint Rewrite negate_snd_id : uncps.
 
     Lemma eval_negate_snd p : eval (negate_snd p) = - eval p.
@@ -468,7 +468,7 @@ Module B.
       Proof using div_cps_id modulo_cps_id.
         cbv [carryterm_cps carryterm Let_In]; prove_id.
       Qed.
-      Hint Opaque carryterm : uncps.
+      Local Hint Opaque carryterm : uncps.
       Hint Rewrite carryterm_cps_id : uncps.
 
 
@@ -489,7 +489,7 @@ Module B.
       Proof using div_cps_id modulo_cps_id.
         cbv [carry_cps carry]; prove_id.
       Qed.
-      Hint Opaque carry : uncps.
+      Local Hint Opaque carry : uncps.
       Hint Rewrite carry_cps_id : uncps.
 
       Lemma eval_carry w fw p (fw_nonzero:fw<>0):
@@ -532,17 +532,17 @@ Module B.
       Lemma to_associational_cps_id {n} x {T} f:
         @to_associational_cps n x T f = f (to_associational x).
       Proof using Type. cbv [to_associational_cps to_associational]; prove_id. Qed.
-      Hint Opaque to_associational : uncps.
+      Local Hint Opaque to_associational : uncps.
       Hint Rewrite @to_associational_cps_id : uncps.
 
       Definition eval {n} x :=
         @to_associational_cps n x _ Associational.eval.
 
       Lemma eval_single (x:Z) : eval (n:=1) x = weight 0%nat * x.
-      Proof. cbv - [Z.mul Z.add]. ring. Qed.
+      Proof using Type. cbv - [Z.mul Z.add]. ring. Qed.
 
       Lemma eval_unit : eval (n:=0) tt = 0.
-      Proof. reflexivity. Qed.
+      Proof using Type. reflexivity. Qed.
       Hint Rewrite eval_unit eval_single : push_basesystem_eval.
 
       Lemma eval_to_associational {n} x :
@@ -583,7 +583,7 @@ Module B.
         Unshelve.
         intros; subst. autorewrite with uncps push_id. distr_length.
       Qed.
-      Hint Opaque add_to_nth : uncps.
+      Local Hint Opaque add_to_nth : uncps.
       Hint Rewrite @add_to_nth_cps_id : uncps.
 
       Lemma eval_add_to_nth {n} (i:nat) (x:Z) (H:(i<n)%nat) (xs:tuple Z n):
@@ -621,7 +621,7 @@ Module B.
       Lemma place_cps_id t i {T} f :
         @place_cps T t i f = f (place t i).
       Proof using Type. cbv [place]; induction i; prove_id. Qed.
-      Hint Opaque place : uncps.
+      Local Hint Opaque place : uncps.
       Hint Rewrite place_cps_id : uncps.
 
       Lemma place_cps_in_range (t:limb) (n:nat)
@@ -652,7 +652,7 @@ Module B.
       Proof using Type.
         cbv [from_associational_cps from_associational]; prove_id.
       Qed.
-      Hint Opaque from_associational : uncps.
+      Local Hint Opaque from_associational : uncps.
       Hint Rewrite @from_associational_cps_id : uncps.
 
       Lemma eval_from_associational {n} p (n_nonzero:n<>O):
@@ -753,15 +753,15 @@ Module B.
         Definition carry {n m} i p := @carry_cps n m i p _ id.
         Lemma carry_cps_id {n m} i p {T} f:
           @carry_cps n m i p T f = f (carry i p).
-        Proof.
+        Proof using div_cps_id modulo_cps_id.
           cbv [carry_cps carry]; prove_id; rewrite carry_cps_id; reflexivity.
         Qed.
-        Hint Opaque carry : uncps. Hint Rewrite @carry_cps_id : uncps.
+        Local Hint Opaque carry : uncps. Hint Rewrite @carry_cps_id : uncps.
 
         Lemma eval_carry {n m} i p: (n <> 0%nat) -> (m <> 0%nat) ->
                                   weight (S i) / weight i <> 0 ->
           eval (carry (n:=n) (m:=m) i p) = eval p.
-        Proof.
+        Proof using div_cps_id div_mod modulo_cps_id weight_0 weight_nonzero.
           cbv [carry_cps carry]; intros. prove_eval.
           rewrite @eval_carry by eauto.
           apply eval_to_associational.
@@ -773,7 +773,7 @@ Module B.
                    {T} (f: tuple Z n ->T) :=
           carry_cps (n:=n) (m:=S n) (pred n) p
             (fun r => reduce_cps (m:=S n) (n:=n) s c r f).
-        Hint Unfold carry_reduce_cps.
+        Local Hint Unfold carry_reduce_cps.
 
         (* N.B. It is important to reverse [idxs] here. Like
         [fold_right], [fold_right_cps2] is written such that the first
@@ -793,7 +793,7 @@ Module B.
         Proof using modulo_cps_id div_cps_id.
           cbv [chained_carries_cps chained_carries]; prove_id.
         Qed.
-        Hint Opaque chained_carries : uncps.
+        Local Hint Opaque chained_carries : uncps.
         Hint Rewrite @chained_carries_id : uncps.
 
         Lemma eval_chained_carries {n} (p:tuple Z n) idxs :
@@ -845,7 +845,7 @@ Module B.
                      (fun r => carry_reduce_cps (n:=n) s c r
                      (fun r' => chained_carries_reduce_cps s c r' carry_chains f))
               end.
-        Proof.
+        Proof using Type.
           destruct carry_chains; reflexivity.
         Qed.
 
@@ -856,7 +856,7 @@ Module B.
         Lemma chained_carries_reduce_id {n} s c {T} p carry_chains f
           : @chained_carries_reduce_cps n s c T p carry_chains f
             = f (@chained_carries_reduce n s c p carry_chains).
-        Proof.
+        Proof using div_cps_id modulo_cps_id.
           destruct carry_chains as [|carry_chain carry_chains]; [ reflexivity | ].
           cbv [chained_carries_reduce].
           revert p carry_chain; induction carry_chains as [|? carry_chains IHcarry_chains]; intros.
@@ -867,7 +867,7 @@ Module B.
             rewrite !IHcarry_chains.
             reflexivity. }
         Qed.
-        Hint Opaque chained_carries_reduce : uncps.
+        Local Hint Opaque chained_carries_reduce : uncps.
         Hint Rewrite @chained_carries_reduce_id : uncps.
 
         Lemma eval_chained_carries_reduce {n} (s:Z) (c:list limb) (p:tuple Z n) carry_chains
@@ -909,7 +909,7 @@ Module B.
         Hint Rewrite @eval_encode : push_basesystem_eval.
 
       End Carries.
-      Hint Unfold carry_reduce_cps.
+      Local Hint Unfold carry_reduce_cps.
 
       Section Subtraction.
         Context {m n} {coef : tuple Z n}
@@ -923,7 +923,7 @@ Module B.
         Definition sub p q := sub_cps p q id.
         Lemma sub_id p q {T} f : @sub_cps p q T f = f (sub p q).
         Proof using Type. cbv [sub_cps sub]; autounfold; prove_id. Qed.
-        Hint Opaque sub : uncps.
+        Local Hint Opaque sub : uncps.
         Hint Rewrite sub_id : uncps.
 
         Lemma eval_sub p q : mod_eq m (eval (sub p q)) (eval p - eval q).
@@ -1023,14 +1023,14 @@ Module B.
       Definition select {n} mask cond p := @select_cps n mask cond p _ id.
       Lemma select_id {n} mask cond p T f :
         @select_cps n mask cond p T f = f (select mask cond p).
-      Proof.
+      Proof using Type.
         cbv [select select_cps Let_In]; autorewrite with uncps push_id;
           reflexivity.
       Qed.
-      Hint Opaque select : uncps.
+      Local Hint Opaque select : uncps.
 
       Lemma map_and_0 {n} (p:tuple Z n) : Tuple.map (Z.land 0) p = zeros n.
-      Proof.
+      Proof using Type.
         induction n as [|n IHn]; [destruct p; reflexivity | ].
         rewrite (Tuple.subst_append p), Tuple.map_append, Z.land_0_l, IHn.
         reflexivity.
@@ -1039,7 +1039,7 @@ Module B.
       Lemma eval_select {n} mask cond x (H:Tuple.map (Z.land mask) x = x) :
         B.Positional.eval weight (@select n mask cond x) =
         if dec (cond = 0) then 0 else  B.Positional.eval weight x.
-      Proof.
+      Proof using Type.
         cbv [select select_cps Let_In].
         autorewrite with uncps push_id.
         rewrite Z.zselect_correct; break_match.
@@ -1051,7 +1051,7 @@ Module B.
 
   End Positional.
 
-  Hint Unfold
+  Global Hint Unfold
       Positional.add_cps
       Positional.mul_cps
       Positional.reduce_cps
@@ -1121,13 +1121,13 @@ Section DivMod.
   Lemma modulo_id {T} a b f
     : @modulo_cps T a b f = f (modulo a b).
   Proof. cbv [modulo_cps modulo]; autorewrite with uncps; break_match; reflexivity. Qed.
-  Hint Opaque modulo : uncps.
+  Local Hint Opaque modulo : uncps.
   Hint Rewrite @modulo_id : uncps.
 
   Lemma div_id {T} a b f
     : @div_cps T a b f = f (div a b).
   Proof. cbv [div_cps div]; autorewrite with uncps; break_match; reflexivity. Qed.
-  Hint Opaque div : uncps.
+  Local Hint Opaque div : uncps.
   Hint Rewrite @div_id : uncps.
 
   Lemma div_cps_correct {T} a b f : @div_cps T a b f = f (Z.div a b).
@@ -1153,14 +1153,14 @@ Section DivMod.
   Qed.
 End DivMod.
 
-Hint Opaque div modulo : uncps.
+Global Hint Opaque div modulo : uncps.
 Hint Rewrite @div_id @modulo_id : uncps.
 
 Import B.
 
 Create HintDb basesystem_partial_evaluation_unfolder.
 
-Hint Unfold
+Global Hint Unfold
      id
      Associational.eval
      Associational.multerm
@@ -1215,7 +1215,7 @@ Hint Unfold
      Z.add_get_carry_full Z.add_get_carry_full_cps
   : basesystem_partial_evaluation_unfolder.
 
-Hint Unfold
+Global Hint Unfold
      B.limb ListUtil.sum ListUtil.sum_firstn
      CPSUtil.Tuple.mapi_with_cps CPSUtil.Tuple.mapi_with'_cps CPSUtil.flat_map_cps CPSUtil.on_tuple_cps CPSUtil.fold_right_cps2
      Decidable.dec Decidable.dec_eq_Z

--- a/src/Arithmetic/CoreUnfolder.v
+++ b/src/Arithmetic/CoreUnfolder.v
@@ -9,7 +9,7 @@ Require Import Crypto.Util.Tactics.VM.
 
 Create HintDb arithmetic_cps_unfolder.
 
-Hint Unfold Core.div Core.modulo : arithmetic_cps_unfolder.
+Global Hint Unfold Core.div Core.modulo : arithmetic_cps_unfolder.
 
 Ltac make_parameterized_sig t :=
   refine (_ : { v : _ | v = t });
@@ -85,85 +85,85 @@ done
     Definition eval_sig := parameterize_sig (@Core.B.Associational.eval).
     Definition eval := parameterize_from_sig eval_sig.
     Definition eval_eq := parameterize_eq eval eval_sig.
-    Hint Unfold eval : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold eval : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- eval_eq : pattern_runtime.
 
     Definition multerm_sig := parameterize_sig (@Core.B.Associational.multerm).
     Definition multerm := parameterize_from_sig multerm_sig.
     Definition multerm_eq := parameterize_eq multerm multerm_sig.
-    Hint Unfold multerm : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold multerm : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- multerm_eq : pattern_runtime.
 
     Definition mul_cps_sig := parameterize_sig (@Core.B.Associational.mul_cps).
     Definition mul_cps := parameterize_from_sig mul_cps_sig.
     Definition mul_cps_eq := parameterize_eq mul_cps mul_cps_sig.
-    Hint Unfold mul_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold mul_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- mul_cps_eq : pattern_runtime.
 
     Definition mul_sig := parameterize_sig (@Core.B.Associational.mul).
     Definition mul := parameterize_from_sig mul_sig.
     Definition mul_eq := parameterize_eq mul mul_sig.
-    Hint Unfold mul : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold mul : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- mul_eq : pattern_runtime.
 
     Definition split_cps_sig := parameterize_sig (@Core.B.Associational.split_cps).
     Definition split_cps := parameterize_from_sig split_cps_sig.
     Definition split_cps_eq := parameterize_eq split_cps split_cps_sig.
-    Hint Unfold split_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold split_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- split_cps_eq : pattern_runtime.
 
     Definition split_sig := parameterize_sig (@Core.B.Associational.split).
     Definition split := parameterize_from_sig split_sig.
     Definition split_eq := parameterize_eq split split_sig.
-    Hint Unfold split : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold split : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- split_eq : pattern_runtime.
 
     Definition reduce_cps_sig := parameterize_sig (@Core.B.Associational.reduce_cps).
     Definition reduce_cps := parameterize_from_sig reduce_cps_sig.
     Definition reduce_cps_eq := parameterize_eq reduce_cps reduce_cps_sig.
-    Hint Unfold reduce_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold reduce_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- reduce_cps_eq : pattern_runtime.
 
     Definition reduce_sig := parameterize_sig (@Core.B.Associational.reduce).
     Definition reduce := parameterize_from_sig reduce_sig.
     Definition reduce_eq := parameterize_eq reduce reduce_sig.
-    Hint Unfold reduce : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold reduce : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- reduce_eq : pattern_runtime.
 
     Definition negate_snd_cps_sig := parameterize_sig (@Core.B.Associational.negate_snd_cps).
     Definition negate_snd_cps := parameterize_from_sig negate_snd_cps_sig.
     Definition negate_snd_cps_eq := parameterize_eq negate_snd_cps negate_snd_cps_sig.
-    Hint Unfold negate_snd_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold negate_snd_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- negate_snd_cps_eq : pattern_runtime.
 
     Definition negate_snd_sig := parameterize_sig (@Core.B.Associational.negate_snd).
     Definition negate_snd := parameterize_from_sig negate_snd_sig.
     Definition negate_snd_eq := parameterize_eq negate_snd negate_snd_sig.
-    Hint Unfold negate_snd : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold negate_snd : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- negate_snd_eq : pattern_runtime.
 
     Definition carryterm_cps_sig := parameterize_sig (@Core.B.Associational.carryterm_cps).
     Definition carryterm_cps := parameterize_from_sig carryterm_cps_sig.
     Definition carryterm_cps_eq := parameterize_eq carryterm_cps carryterm_cps_sig.
-    Hint Unfold carryterm_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold carryterm_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- carryterm_cps_eq : pattern_runtime.
 
     Definition carryterm_sig := parameterize_sig (@Core.B.Associational.carryterm).
     Definition carryterm := parameterize_from_sig carryterm_sig.
     Definition carryterm_eq := parameterize_eq carryterm carryterm_sig.
-    Hint Unfold carryterm : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold carryterm : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- carryterm_eq : pattern_runtime.
 
     Definition carry_cps_sig := parameterize_sig (@Core.B.Associational.carry_cps).
     Definition carry_cps := parameterize_from_sig carry_cps_sig.
     Definition carry_cps_eq := parameterize_eq carry_cps carry_cps_sig.
-    Hint Unfold carry_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold carry_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- carry_cps_eq : pattern_runtime.
 
     Definition carry_sig := parameterize_sig (@Core.B.Associational.carry).
     Definition carry := parameterize_from_sig carry_sig.
     Definition carry_eq := parameterize_eq carry carry_sig.
-    Hint Unfold carry : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold carry : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- carry_eq : pattern_runtime.
 
   End Associational.
@@ -171,205 +171,205 @@ done
     Definition to_associational_cps_sig := parameterize_sig (@Core.B.Positional.to_associational_cps).
     Definition to_associational_cps := parameterize_from_sig to_associational_cps_sig.
     Definition to_associational_cps_eq := parameterize_eq to_associational_cps to_associational_cps_sig.
-    Hint Unfold to_associational_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold to_associational_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- to_associational_cps_eq : pattern_runtime.
 
     Definition to_associational_sig := parameterize_sig (@Core.B.Positional.to_associational).
     Definition to_associational := parameterize_from_sig to_associational_sig.
     Definition to_associational_eq := parameterize_eq to_associational to_associational_sig.
-    Hint Unfold to_associational : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold to_associational : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- to_associational_eq : pattern_runtime.
 
     Definition eval_sig := parameterize_sig (@Core.B.Positional.eval).
     Definition eval := parameterize_from_sig eval_sig.
     Definition eval_eq := parameterize_eq eval eval_sig.
-    Hint Unfold eval : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold eval : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- eval_eq : pattern_runtime.
 
     Definition zeros_sig := parameterize_sig (@Core.B.Positional.zeros).
     Definition zeros := parameterize_from_sig zeros_sig.
     Definition zeros_eq := parameterize_eq zeros zeros_sig.
-    Hint Unfold zeros : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold zeros : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- zeros_eq : pattern_runtime.
 
     Definition add_to_nth_cps_sig := parameterize_sig (@Core.B.Positional.add_to_nth_cps).
     Definition add_to_nth_cps := parameterize_from_sig add_to_nth_cps_sig.
     Definition add_to_nth_cps_eq := parameterize_eq add_to_nth_cps add_to_nth_cps_sig.
-    Hint Unfold add_to_nth_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold add_to_nth_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- add_to_nth_cps_eq : pattern_runtime.
 
     Definition add_to_nth_sig := parameterize_sig (@Core.B.Positional.add_to_nth).
     Definition add_to_nth := parameterize_from_sig add_to_nth_sig.
     Definition add_to_nth_eq := parameterize_eq add_to_nth add_to_nth_sig.
-    Hint Unfold add_to_nth : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold add_to_nth : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- add_to_nth_eq : pattern_runtime.
 
     Definition place_cps_sig := parameterize_sig (@Core.B.Positional.place_cps).
     Definition place_cps := parameterize_from_sig place_cps_sig.
     Definition place_cps_eq := parameterize_eq place_cps place_cps_sig.
-    Hint Unfold place_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold place_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- place_cps_eq : pattern_runtime.
 
     Definition place_sig := parameterize_sig (@Core.B.Positional.place).
     Definition place := parameterize_from_sig place_sig.
     Definition place_eq := parameterize_eq place place_sig.
-    Hint Unfold place : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold place : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- place_eq : pattern_runtime.
 
     Definition from_associational_cps_sig := parameterize_sig (@Core.B.Positional.from_associational_cps).
     Definition from_associational_cps := parameterize_from_sig from_associational_cps_sig.
     Definition from_associational_cps_eq := parameterize_eq from_associational_cps from_associational_cps_sig.
-    Hint Unfold from_associational_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold from_associational_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- from_associational_cps_eq : pattern_runtime.
 
     Definition from_associational_sig := parameterize_sig (@Core.B.Positional.from_associational).
     Definition from_associational := parameterize_from_sig from_associational_sig.
     Definition from_associational_eq := parameterize_eq from_associational from_associational_sig.
-    Hint Unfold from_associational : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold from_associational : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- from_associational_eq : pattern_runtime.
 
     Definition carry_cps_sig := parameterize_sig (@Core.B.Positional.carry_cps).
     Definition carry_cps := parameterize_from_sig carry_cps_sig.
     Definition carry_cps_eq := parameterize_eq carry_cps carry_cps_sig.
-    Hint Unfold carry_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold carry_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- carry_cps_eq : pattern_runtime.
 
     Definition carry_sig := parameterize_sig (@Core.B.Positional.carry).
     Definition carry := parameterize_from_sig carry_sig.
     Definition carry_eq := parameterize_eq carry carry_sig.
-    Hint Unfold carry : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold carry : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- carry_eq : pattern_runtime.
 
     Definition chained_carries_cps_sig := parameterize_sig (@Core.B.Positional.chained_carries_cps).
     Definition chained_carries_cps := parameterize_from_sig chained_carries_cps_sig.
     Definition chained_carries_cps_eq := parameterize_eq chained_carries_cps chained_carries_cps_sig.
-    Hint Unfold chained_carries_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold chained_carries_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- chained_carries_cps_eq : pattern_runtime.
 
     Definition chained_carries_sig := parameterize_sig (@Core.B.Positional.chained_carries).
     Definition chained_carries := parameterize_from_sig chained_carries_sig.
     Definition chained_carries_eq := parameterize_eq chained_carries chained_carries_sig.
-    Hint Unfold chained_carries : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold chained_carries : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- chained_carries_eq : pattern_runtime.
 
     Definition encode_sig := parameterize_sig (@Core.B.Positional.encode).
     Definition encode := parameterize_from_sig encode_sig.
     Definition encode_eq := parameterize_eq encode encode_sig.
-    Hint Unfold encode : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold encode : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- encode_eq : pattern_runtime.
 
     Definition add_cps_sig := parameterize_sig (@Core.B.Positional.add_cps).
     Definition add_cps := parameterize_from_sig add_cps_sig.
     Definition add_cps_eq := parameterize_eq add_cps add_cps_sig.
-    Hint Unfold add_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold add_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- add_cps_eq : pattern_runtime.
 
     Definition mul_cps_sig := parameterize_sig (@Core.B.Positional.mul_cps).
     Definition mul_cps := parameterize_from_sig mul_cps_sig.
     Definition mul_cps_eq := parameterize_eq mul_cps mul_cps_sig.
-    Hint Unfold mul_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold mul_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- mul_cps_eq : pattern_runtime.
 
     Definition reduce_cps_sig := parameterize_sig (@Core.B.Positional.reduce_cps).
     Definition reduce_cps := parameterize_from_sig reduce_cps_sig.
     Definition reduce_cps_eq := parameterize_eq reduce_cps reduce_cps_sig.
-    Hint Unfold reduce_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold reduce_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- reduce_cps_eq : pattern_runtime.
 
     Definition carry_reduce_cps_sig := parameterize_sig (@Core.B.Positional.carry_reduce_cps).
     Definition carry_reduce_cps := parameterize_from_sig carry_reduce_cps_sig.
     Definition carry_reduce_cps_eq := parameterize_eq carry_reduce_cps carry_reduce_cps_sig.
-    Hint Unfold carry_reduce_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold carry_reduce_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- carry_reduce_cps_eq : pattern_runtime.
 
     Definition chained_carries_reduce_cps_step_sig := parameterize_sig (@Core.B.Positional.chained_carries_reduce_cps_step).
     Definition chained_carries_reduce_cps_step := parameterize_from_sig chained_carries_reduce_cps_step_sig.
     Definition chained_carries_reduce_cps_step_eq := parameterize_eq chained_carries_reduce_cps_step chained_carries_reduce_cps_step_sig.
-    Hint Unfold chained_carries_reduce_cps_step : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold chained_carries_reduce_cps_step : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- chained_carries_reduce_cps_step_eq : pattern_runtime.
 
     Definition chained_carries_reduce_cps_sig := parameterize_sig (@Core.B.Positional.chained_carries_reduce_cps).
     Definition chained_carries_reduce_cps := parameterize_from_sig chained_carries_reduce_cps_sig.
     Definition chained_carries_reduce_cps_eq := parameterize_eq chained_carries_reduce_cps chained_carries_reduce_cps_sig.
-    Hint Unfold chained_carries_reduce_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold chained_carries_reduce_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- chained_carries_reduce_cps_eq : pattern_runtime.
 
     Definition chained_carries_reduce_sig := parameterize_sig (@Core.B.Positional.chained_carries_reduce).
     Definition chained_carries_reduce := parameterize_from_sig chained_carries_reduce_sig.
     Definition chained_carries_reduce_eq := parameterize_eq chained_carries_reduce chained_carries_reduce_sig.
-    Hint Unfold chained_carries_reduce : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold chained_carries_reduce : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- chained_carries_reduce_eq : pattern_runtime.
 
     Definition negate_snd_cps_sig := parameterize_sig (@Core.B.Positional.negate_snd_cps).
     Definition negate_snd_cps := parameterize_from_sig negate_snd_cps_sig.
     Definition negate_snd_cps_eq := parameterize_eq negate_snd_cps negate_snd_cps_sig.
-    Hint Unfold negate_snd_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold negate_snd_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- negate_snd_cps_eq : pattern_runtime.
 
     Definition split_cps_sig := parameterize_sig (@Core.B.Positional.split_cps).
     Definition split_cps := parameterize_from_sig split_cps_sig.
     Definition split_cps_eq := parameterize_eq split_cps split_cps_sig.
-    Hint Unfold split_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold split_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- split_cps_eq : pattern_runtime.
 
     Definition scmul_cps_sig := parameterize_sig (@Core.B.Positional.scmul_cps).
     Definition scmul_cps := parameterize_from_sig scmul_cps_sig.
     Definition scmul_cps_eq := parameterize_eq scmul_cps scmul_cps_sig.
-    Hint Unfold scmul_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold scmul_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- scmul_cps_eq : pattern_runtime.
 
     Definition unbalanced_sub_cps_sig := parameterize_sig (@Core.B.Positional.unbalanced_sub_cps).
     Definition unbalanced_sub_cps := parameterize_from_sig unbalanced_sub_cps_sig.
     Definition unbalanced_sub_cps_eq := parameterize_eq unbalanced_sub_cps unbalanced_sub_cps_sig.
-    Hint Unfold unbalanced_sub_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold unbalanced_sub_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- unbalanced_sub_cps_eq : pattern_runtime.
 
     Definition sub_cps_sig := parameterize_sig (@Core.B.Positional.sub_cps).
     Definition sub_cps := parameterize_from_sig sub_cps_sig.
     Definition sub_cps_eq := parameterize_eq sub_cps sub_cps_sig.
-    Hint Unfold sub_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold sub_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- sub_cps_eq : pattern_runtime.
 
     Definition sub_sig := parameterize_sig (@Core.B.Positional.sub).
     Definition sub := parameterize_from_sig sub_sig.
     Definition sub_eq := parameterize_eq sub sub_sig.
-    Hint Unfold sub : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold sub : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- sub_eq : pattern_runtime.
 
     Definition opp_cps_sig := parameterize_sig (@Core.B.Positional.opp_cps).
     Definition opp_cps := parameterize_from_sig opp_cps_sig.
     Definition opp_cps_eq := parameterize_eq opp_cps opp_cps_sig.
-    Hint Unfold opp_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold opp_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- opp_cps_eq : pattern_runtime.
 
     Definition Fencode_sig := parameterize_sig (@Core.B.Positional.Fencode).
     Definition Fencode := parameterize_from_sig Fencode_sig.
     Definition Fencode_eq := parameterize_eq Fencode Fencode_sig.
-    Hint Unfold Fencode : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold Fencode : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- Fencode_eq : pattern_runtime.
 
     Definition Fdecode_sig := parameterize_sig (@Core.B.Positional.Fdecode).
     Definition Fdecode := parameterize_from_sig Fdecode_sig.
     Definition Fdecode_eq := parameterize_eq Fdecode Fdecode_sig.
-    Hint Unfold Fdecode : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold Fdecode : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- Fdecode_eq : pattern_runtime.
 
     Definition eval_from_sig := parameterize_sig (@Core.B.Positional.eval_from).
     Definition eval_from := parameterize_from_sig eval_from_sig.
     Definition eval_from_eq := parameterize_eq eval_from eval_from_sig.
-    Hint Unfold eval_from : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold eval_from : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- eval_from_eq : pattern_runtime.
 
     Definition select_cps_sig := parameterize_sig (@Core.B.Positional.select_cps).
     Definition select_cps := parameterize_from_sig select_cps_sig.
     Definition select_cps_eq := parameterize_eq select_cps select_cps_sig.
-    Hint Unfold select_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold select_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- select_cps_eq : pattern_runtime.
 
     Definition select_sig := parameterize_sig (@Core.B.Positional.select).
     Definition select := parameterize_from_sig select_sig.
     Definition select_eq := parameterize_eq select select_sig.
-    Hint Unfold select : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold select : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- select_eq : pattern_runtime.
 
   End Positional.
@@ -378,23 +378,23 @@ End B.
 Definition modulo_cps_sig := parameterize_sig (@Core.modulo_cps).
 Definition modulo_cps := parameterize_from_sig modulo_cps_sig.
 Definition modulo_cps_eq := parameterize_eq modulo_cps modulo_cps_sig.
-Hint Unfold modulo_cps : basesystem_partial_evaluation_unfolder.
+Global Hint Unfold modulo_cps : basesystem_partial_evaluation_unfolder.
 Hint Rewrite <- modulo_cps_eq : pattern_runtime.
 
 Definition div_cps_sig := parameterize_sig (@Core.div_cps).
 Definition div_cps := parameterize_from_sig div_cps_sig.
 Definition div_cps_eq := parameterize_eq div_cps div_cps_sig.
-Hint Unfold div_cps : basesystem_partial_evaluation_unfolder.
+Global Hint Unfold div_cps : basesystem_partial_evaluation_unfolder.
 Hint Rewrite <- div_cps_eq : pattern_runtime.
 
 Definition modulo_sig := parameterize_sig (@Core.modulo).
 Definition modulo := parameterize_from_sig modulo_sig.
 Definition modulo_eq := parameterize_eq modulo modulo_sig.
-Hint Unfold modulo : basesystem_partial_evaluation_unfolder.
+Global Hint Unfold modulo : basesystem_partial_evaluation_unfolder.
 Hint Rewrite <- modulo_eq : pattern_runtime.
 
 Definition div_sig := parameterize_sig (@Core.div).
 Definition div := parameterize_from_sig div_sig.
 Definition div_eq := parameterize_eq div div_sig.
-Hint Unfold div : basesystem_partial_evaluation_unfolder.
+Global Hint Unfold div : basesystem_partial_evaluation_unfolder.
 Hint Rewrite <- div_eq : pattern_runtime.

--- a/src/Arithmetic/Karatsuba.v
+++ b/src/Arithmetic/Karatsuba.v
@@ -51,7 +51,7 @@ Context (weight : nat -> Z)
   Definition karatsuba_mul s x y := @karatsuba_mul_cps s x y _ id.
   Lemma karatsuba_mul_id s x y R f :
     @karatsuba_mul_cps s x y R f = f (karatsuba_mul s x y).
-  Proof.
+  Proof using Type.
     cbv [karatsuba_mul karatsuba_mul_cps].
     repeat autounfold.
     autorewrite with cancel_pair push_id uncps.
@@ -62,7 +62,7 @@ Context (weight : nat -> Z)
 
   Lemma eval_karatsuba_mul s x y (s_nonzero:s <> 0) :
     eval weight (karatsuba_mul s x y) = eval weight x * eval weight y.
-  Proof.
+  Proof using n2_nonzero n_nonzero weight_0 weight_nonzero.
     cbv [karatsuba_mul karatsuba_mul_cps]; repeat autounfold.
     autorewrite with cancel_pair push_id uncps push_basesystem_eval.
     repeat match goal with
@@ -158,7 +158,7 @@ Context (weight : nat -> Z)
   Definition goldilocks_mul s xs ys := goldilocks_mul_cps s xs ys id.
   Lemma goldilocks_mul_id s xs ys R f :
     @goldilocks_mul_cps s xs ys R f = f (goldilocks_mul s xs ys).
-  Proof.
+  Proof using Type.
     cbv [goldilocks_mul goldilocks_mul_cps Let_In].
     repeat autounfold. autorewrite with uncps push_id.
     reflexivity.
@@ -173,7 +173,7 @@ Context (weight : nat -> Z)
 
   Lemma goldilocks_mul_correct (p : Z) (p_nonzero : p <> 0) s (s_nonzero : s <> 0) (s2_modp : (s^2) mod p = (s+1) mod p) xs ys :
     (eval weight (goldilocks_mul s xs ys)) mod p = (eval weight xs * eval weight ys) mod p.
-  Proof.
+  Proof using n2_nonzero n_nonzero weight_0 weight_nonzero.
     cbv [goldilocks_mul_cps goldilocks_mul Let_In].
     Zmod_to_equiv_modulo.
     progress autounfold.
@@ -206,11 +206,11 @@ Context (weight : nat -> Z)
 
   Lemma eval_goldilocks_mul (p : positive) s (s_nonzero : s <> 0) (s2_modp : mod_eq p (s^2) (s+1)) xs ys :
     mod_eq p (eval weight (goldilocks_mul s xs ys)) (eval weight xs * eval weight ys).
-  Proof.
+  Proof using n2_nonzero n_nonzero weight_0 weight_nonzero.
     apply goldilocks_mul_correct; auto; lia.
   Qed.
 End Karatsuba.
-Hint Opaque karatsuba_mul goldilocks_mul : uncps.
+Global Hint Opaque karatsuba_mul goldilocks_mul : uncps.
 Hint Rewrite karatsuba_mul_id goldilocks_mul_id : uncps.
 
 Hint Rewrite

--- a/src/Arithmetic/Karatsuba.v
+++ b/src/Arithmetic/Karatsuba.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Algebra.Nsatz.
 Require Import Crypto.Util.LetIn Crypto.Util.CPSUtil.
 Require Import Crypto.Arithmetic.Core. Import B. Import Positional.

--- a/src/Arithmetic/ModularArithmeticPre.v
+++ b/src/Arithmetic/ModularArithmeticPre.v
@@ -1,7 +1,7 @@
 Require Import Coq.ZArith.BinInt Coq.NArith.BinNat Coq.Numbers.BinNums Coq.ZArith.Zdiv Coq.ZArith.Znumtheory.
 Require Import Coq.Logic.Eqdep_dec.
 Require Import Coq.Logic.EqdepFacts.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 From Coq Require Import ZArith.
 Require Import Crypto.Util.NumTheoryUtil.
 Require Export Crypto.Util.FixCoqMistakes.

--- a/src/Arithmetic/ModularArithmeticTheorems.v
+++ b/src/Arithmetic/ModularArithmeticTheorems.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Spec.ModularArithmetic.
 Require Import Crypto.Arithmetic.ModularArithmeticPre.
 

--- a/src/Arithmetic/ModularArithmeticTheorems.v
+++ b/src/Arithmetic/ModularArithmeticTheorems.v
@@ -3,7 +3,7 @@ Require Import Crypto.Spec.ModularArithmetic.
 Require Import Crypto.Arithmetic.ModularArithmeticPre.
 
 Require Import Coq.ZArith.BinInt Coq.ZArith.Zdiv Coq.ZArith.Znumtheory Coq.NArith.NArith. (* import Zdiv before Znumtheory *)
-Require Import Coq.Classes.Morphisms Coq.Setoids.Setoid.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.Setoids.Setoid.
 Require Export Coq.setoid_ring.Ring_theory Coq.setoid_ring.Ring_tac.
 
 Require Import Crypto.Algebra.Hierarchy Crypto.Algebra.ScalarMult.
@@ -336,7 +336,7 @@ Module F.
 
     Lemma pow_succ_r (x:F m) n : x^(N.succ n) = x * x^n.
     Proof using Type.
-      rewrite <-N.add_1_l; 
+      rewrite <-N.add_1_l;
         destruct (F.pow_spec x); auto.
     Qed.
 
@@ -387,4 +387,9 @@ Module F.
       change 1%N with (N.succ (N.succ (N.succ 0))); repeat rewrite ?pow_succ_r, ?pow_0_r; ring.
     Qed.
   End Pow.
+  Module Export Instances.
+    Export Field.Hints.
+    Global Existing Instances eq_dec commutative_ring_modulo char_gt.
+  End Instances.
 End F.
+Export F.Instances.

--- a/src/Arithmetic/MontgomeryReduction/Proofs.v
+++ b/src/Arithmetic/MontgomeryReduction/Proofs.v
@@ -4,6 +4,7 @@
     Wikipedia. *)
 Require Import Coq.ZArith.ZArith Coq.micromega.Psatz Coq.Structures.Equalities.
 Require Import Crypto.Arithmetic.MontgomeryReduction.Definition.
+Require Import Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.ZUtil.EquivModulo.
 Require Import Crypto.Util.ZUtil.Tactics.PullPush.Modulo.
 Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
@@ -126,7 +127,7 @@ Section montgomery.
         break_match; rewrite partial_reduce_correct; t_fin_correct.
       Qed.
 
-      Let m_small : 0 <= m < R. Proof. auto with zarith. Qed.
+      Let m_small : 0 <= m < R. Proof using N'_in_range. auto with zarith. Qed.
 
       Section generic.
         Lemma prereduce_in_range_gen B
@@ -246,7 +247,7 @@ Section montgomery.
         Qed.
 
         Lemma reduce_via_partial_alt_eq : reduce_via_partial_alt N R N' T = reduce_via_partial N R N' T.
-        Proof.
+        Proof using N_in_range N_reasonable T_representable m_small.
             cbv [reduce_via_partial_alt reduce_via_partial].
             rewrite partial_reduce_alt_eq by lia. reflexivity.
         Qed.

--- a/src/Arithmetic/MontgomeryReduction/Proofs.v
+++ b/src/Arithmetic/MontgomeryReduction/Proofs.v
@@ -2,7 +2,7 @@
 (** This file implements the proofs for Montgomery Form, Montgomery
     Reduction, and Montgomery Multiplication on [Z].  We follow
     Wikipedia. *)
-Require Import Coq.ZArith.ZArith Coq.micromega.Psatz Coq.Structures.Equalities.
+Require Import Coq.ZArith.ZArith Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.Structures.Equalities.
 Require Import Crypto.Arithmetic.MontgomeryReduction.Definition.
 Require Import Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.ZUtil.EquivModulo.

--- a/src/Arithmetic/MontgomeryReduction/WordByWord/Abstract/Definition.v
+++ b/src/Arithmetic/MontgomeryReduction/WordByWord/Abstract/Definition.v
@@ -58,4 +58,4 @@ Section WordByWordMontgomery.
 End WordByWordMontgomery.
 
 Create HintDb word_by_word_montgomery.
-Hint Unfold S4 S3 S2 q s S1 a A' A_a Let_In : word_by_word_montgomery.
+Global Hint Unfold S4 S3 S2 q s S1 a A' A_a Let_In : word_by_word_montgomery.

--- a/src/Arithmetic/MontgomeryReduction/WordByWord/Abstract/Dependent/Definition.v
+++ b/src/Arithmetic/MontgomeryReduction/WordByWord/Abstract/Dependent/Definition.v
@@ -86,4 +86,4 @@ Section WordByWordMontgomery.
 End WordByWordMontgomery.
 
 Create HintDb word_by_word_montgomery.
-Hint Unfold S4 S3 S2 q s S1 a A' A_a Let_In : word_by_word_montgomery.
+Global Hint Unfold S4 S3 S2 q s S1 a A' A_a Let_In : word_by_word_montgomery.

--- a/src/Arithmetic/MontgomeryReduction/WordByWord/Abstract/Dependent/Proofs.v
+++ b/src/Arithmetic/MontgomeryReduction/WordByWord/Abstract/Dependent/Proofs.v
@@ -1,6 +1,6 @@
 (*** Word-By-Word Montgomery Multiplication Proofs *)
 Require Import Coq.Arith.Arith.
-Require Import Coq.ZArith.BinInt Coq.ZArith.ZArith Coq.ZArith.Zdiv Coq.micromega.Lia.
+Require Import Coq.ZArith.BinInt Coq.ZArith.ZArith Coq.ZArith.Zdiv Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.LetIn.
 Require Import Crypto.Util.Prod.
 Require Import Crypto.Util.NatUtil.
@@ -487,6 +487,7 @@ Section WordByWordMontgomery.
         (small_A : small A)
     : 0 <= eval (redc A) < eval N + eval B + if eval N <=? eval (pre_redc A) then -eval N else 0.
   Proof using B_bounds N_lt_R Npos_correct R_correct eval_addT eval_addT' eval_conditional_sub eval_div eval_drop_high eval_mod eval_scmul eval_zero r_big small_B small_N small_addT small_addT' small_div small_drop_high small_scmul small_zero.
+    clear -B_bounds N_lt_R Npos_correct R_correct eval_addT eval_addT' eval_conditional_sub eval_div eval_drop_high eval_mod eval_scmul eval_zero r_big small_B small_N small_addT small_addT' small_div small_drop_high small_scmul small_zero small_A.
     pose proof (@small_pre_redc _ A small_A).
     pose proof (@pre_redc_bound _ A small_A).
     unfold redc.

--- a/src/Arithmetic/MontgomeryReduction/WordByWord/Abstract/Dependent/Proofs.v
+++ b/src/Arithmetic/MontgomeryReduction/WordByWord/Abstract/Dependent/Proofs.v
@@ -7,6 +7,7 @@ Require Import Crypto.Util.NatUtil.
 Require Import Crypto.Arithmetic.ModularArithmeticTheorems Crypto.Spec.ModularArithmetic.
 Require Import Crypto.Arithmetic.MontgomeryReduction.WordByWord.Abstract.Dependent.Definition.
 Require Import Crypto.Algebra.Ring.
+Require Import Crypto.Util.Decidable.
 Require Import Crypto.Util.ZUtil.MulSplit.
 Require Import Crypto.Util.ZUtil.Div.
 Require Import Crypto.Util.ZUtil.EquivModulo.
@@ -130,7 +131,7 @@ Section WordByWordMontgomery.
     Lemma S3_bound
       : eval S < eval N + eval B
         -> eval S3 < eval N + eval B.
-    Proof.
+    Proof using B_bounds N_lt_R Npos_correct eval_addT eval_addT' eval_div eval_mod eval_scmul r_big small_A small_B small_N small_S small_addT small_addT' small_scmul.
       assert (Hmod : forall a b, 0 < b -> a mod b <= b - 1)
         by (intros x y; pose proof (Z_mod_lt x y); lia).
       intro HS.
@@ -151,28 +152,28 @@ Section WordByWordMontgomery.
 
     Lemma small_A'
       : small A'.
-    Proof.
+    Proof using small_A small_div.
       repeat autounfold with word_by_word_montgomery; auto.
     Qed.
 
     Lemma small_S3
       : small S3.
-    Proof. repeat autounfold with word_by_word_montgomery; t_small. Qed.
+    Proof using B_bounds N_lt_R Npos_correct eval_mod r_big small_A small_B small_N small_S small_addT small_addT' small_div small_scmul. repeat autounfold with word_by_word_montgomery; t_small. Qed.
 
     Lemma S3_nonneg : 0 <= eval S3.
-    Proof.
+    Proof using B_bounds N_lt_R Npos_correct S_nonneg eval_addT eval_addT' eval_div eval_mod eval_scmul r_big small_A small_B small_N small_S small_addT small_addT' small_scmul.
       repeat autounfold with word_by_word_montgomery; rewrite ?Z.mul_split_mod;
         autorewrite with push_eval; [].
       rewrite ?Npos_correct; Z.zero_bounds; lia.
     Qed.
 
     Lemma S4_nonneg : 0 <= eval S4.
-    Proof. unfold S4; rewrite eval_drop_high by apply small_S3; Z.zero_bounds. Qed.
+    Proof using B_bounds N_lt_R Npos_correct eval_drop_high eval_mod r_big small_A small_B small_N small_S small_addT small_addT' small_div small_scmul. unfold S4; rewrite eval_drop_high by apply small_S3; Z.zero_bounds. Qed.
 
     Lemma S4_bound
       : eval S < eval N + eval B
         -> eval S4 < eval N + eval B.
-    Proof.
+    Proof using B_bounds N_lt_R Npos_correct R_correct S_nonneg eval_addT eval_addT' eval_div eval_drop_high eval_mod eval_scmul r_big small_A small_B small_N small_S small_addT small_addT' small_div small_scmul.
       intro H; pose proof (S3_bound H); pose proof S3_nonneg.
       unfold S4.
       rewrite eval_drop_high by apply small_S3.
@@ -182,22 +183,22 @@ Section WordByWordMontgomery.
 
     Lemma small_S4
       : small S4.
-    Proof. repeat autounfold with word_by_word_montgomery; t_small. Qed.
+    Proof using B_bounds N_lt_R Npos_correct eval_mod r_big small_A small_B small_N small_S small_addT small_addT' small_div small_drop_high small_scmul. repeat autounfold with word_by_word_montgomery; t_small. Qed.
 
     Lemma S1_eq : eval S1 = S + a*B.
-    Proof.
+    Proof using B_bounds eval_addT eval_mod eval_scmul small_A small_B.
       cbv [S1 a A'].
       repeat autorewrite with push_eval.
       reflexivity.
     Qed.
 
     Lemma S2_mod_N : (eval S2) mod N = (S + a*B) mod N.
-    Proof.
+    Proof using B_bounds N_lt_R Npos_correct eval_addT eval_addT' eval_mod eval_scmul r_big small_A small_B small_N.
       cbv [S2]; autorewrite with push_eval zsimplify. rewrite S1_eq. reflexivity.
     Qed.
 
     Lemma S2_mod_r : S2 mod r = 0.
-    Proof.
+    Proof using B_bounds N_lt_R Npos_correct eval_addT' eval_mod eval_scmul k_correct r_big small_A small_B small_N small_S small_addT small_scmul.
       cbv [S2 q s]; autorewrite with push_eval.
       assert (r > 0) by lia.
       assert (Hr : (-(1 mod r)) mod r = r - 1 /\ (-(1)) mod r = r - 1).
@@ -228,7 +229,7 @@ Section WordByWordMontgomery.
 
     Lemma S3_mod_N
       : S3 mod N = (S + a*B)*ri mod N.
-    Proof.
+    Proof using B_bounds N_lt_R Npos_correct eval_addT eval_addT' eval_div eval_mod eval_scmul k_correct r_big ri_correct small_A small_B small_N small_S small_addT small_addT' small_scmul.
       cbv [S3]; autorewrite with push_eval cancel_pair.
       pose proof fun a => Z.div_to_inv_modulo N a r ri eq_refl ri_correct as HH;
                             cbv [Z.equiv_modulo] in HH; rewrite HH; clear HH.
@@ -244,7 +245,7 @@ Section WordByWordMontgomery.
     Lemma S4_mod_N
           (Hbound : eval S < eval N + eval B)
       : S4 mod N = (S + a*B)*ri mod N.
-    Proof.
+    Proof using B_bounds N_lt_R Npos_correct R_correct S_nonneg eval_addT eval_addT' eval_div eval_drop_high eval_mod eval_scmul k_correct r_big ri_correct small_A small_B small_N small_S small_addT small_addT' small_div small_scmul.
       pose proof (S3_bound Hbound); pose proof S3_nonneg.
       unfold S4; autorewrite with push_eval.
       rewrite (Z.mod_small _ (r * _)) by nia.
@@ -269,19 +270,19 @@ Section WordByWordMontgomery.
             (S_bound : 0 <= eval S < eval N + eval B).
 
     Lemma small_fst_redc_body : small (fst (redc_body A_S)).
-    Proof. destruct A_S; apply small_A'; assumption. Qed.
+    Proof using S_bound small_A small_S small_div. destruct A_S; apply small_A'; assumption. Qed.
     Lemma small_snd_redc_body : small (snd (redc_body A_S)).
-    Proof. destruct A_S; unfold redc_body; apply small_S4; assumption. Qed.
+    Proof using B_bounds N_lt_R Npos_correct S_bound eval_mod r_big small_A small_B small_N small_S small_addT small_addT' small_div small_drop_high small_scmul. destruct A_S; unfold redc_body; apply small_S4; assumption. Qed.
     Lemma snd_redc_body_nonneg : 0 <= eval (snd (redc_body A_S)).
-    Proof. destruct A_S; apply S4_nonneg; assumption. Qed.
+    Proof using B_bounds N_lt_R Npos_correct S_bound eval_drop_high eval_mod r_big small_A small_B small_N small_S small_addT small_addT' small_div small_scmul. destruct A_S; apply S4_nonneg; assumption. Qed.
 
     Lemma snd_redc_body_mod_N
       : (eval (snd (redc_body A_S))) mod (eval N) = (eval S + a*eval B)*ri mod (eval N).
-    Proof. destruct A_S; apply S4_mod_N; auto; lia. Qed.
+    Proof using B_bounds N_lt_R Npos_correct R_correct S_bound eval_addT eval_addT' eval_div eval_drop_high eval_mod eval_scmul k_correct r_big ri_correct small_A small_B small_N small_S small_addT small_addT' small_div small_scmul. destruct A_S; apply S4_mod_N; auto; lia. Qed.
 
     Lemma fst_redc_body
       : (eval (fst (redc_body A_S))) = eval (fst A_S) / r.
-    Proof.
+    Proof using S_bound eval_div small_A small_S.
       destruct A_S; simpl; repeat autounfold with word_by_word_montgomery; simpl.
       autorewrite with push_eval.
       reflexivity.
@@ -289,7 +290,7 @@ Section WordByWordMontgomery.
 
     Lemma fst_redc_body_mod_N
       : (eval (fst (redc_body A_S))) mod (eval N) = ((eval (fst A_S) - a)*ri) mod (eval N).
-    Proof.
+    Proof using Npos R S_bound eval_div eval_mod r_big ri_correct small_A small_S.
       rewrite fst_redc_body.
       etransitivity; [ eapply Z.div_to_inv_modulo; try eassumption; lia | ].
       unfold a, A_a, A.
@@ -300,7 +301,7 @@ Section WordByWordMontgomery.
     Lemma redc_body_bound
       : eval S < eval N + eval B
         -> eval (snd (redc_body A_S)) < eval N + eval B.
-    Proof.
+    Proof using B_bounds N_lt_R Npos_correct R_correct S_bound eval_addT eval_addT' eval_div eval_drop_high eval_mod eval_scmul r_big small_A small_B small_N small_S small_addT small_addT' small_div small_scmul.
       destruct A_S; apply S4_bound; unfold S in *; cbn [snd] in *; try assumption; try lia.
     Qed.
   End body.
@@ -314,7 +315,7 @@ Section WordByWordMontgomery.
         (Hbound : 0 <= eval (snd A_S) < eval N + eval B)
     : (small (fst (redc_loop count A_S)) /\ small (snd (redc_loop count A_S)))
       /\ 0 <= eval (snd (redc_loop count A_S)) < eval N + eval B.
-  Proof.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_addT eval_addT' eval_div eval_drop_high eval_mod eval_scmul r_big small_B small_N small_addT small_addT' small_div small_drop_high small_scmul.
     induction_loop count IHcount; auto; [].
     change (id (0 <= eval B < R)) in B_bounds (* don't let [destruct_head'_and] loop *).
     destruct_head'_and.
@@ -331,13 +332,13 @@ Section WordByWordMontgomery.
         (Hsmall : small (fst A_S) /\ small (snd A_S))
         (Hbound : 0 <= eval (snd A_S) < eval N + eval B)
     : small (fst (redc_loop count A_S)) /\ small (snd (redc_loop count A_S)).
-  Proof. apply redc_loop_good; assumption. Qed.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_addT eval_addT' eval_div eval_drop_high eval_mod eval_scmul r_big small_B small_N small_addT small_addT' small_div small_drop_high small_scmul. apply redc_loop_good; assumption. Qed.
 
   Lemma redc_loop_bound count A_S
         (Hsmall : small (fst A_S) /\ small (snd A_S))
         (Hbound : 0 <= eval (snd A_S) < eval N + eval B)
     : 0 <= eval (snd (redc_loop count A_S)) < eval N + eval B.
-  Proof. apply redc_loop_good; assumption. Qed.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_addT eval_addT' eval_div eval_drop_high eval_mod eval_scmul r_big small_B small_N small_addT small_addT' small_div small_drop_high small_scmul. apply redc_loop_good; assumption. Qed.
 
   Local Ltac handle_IH_small :=
     repeat first [ apply redc_loop_good
@@ -354,7 +355,7 @@ Section WordByWordMontgomery.
         (Hsmall : small (fst A_S) /\ small (snd A_S))
         (Hbound : 0 <= eval (snd A_S) < eval N + eval B)
     : eval (fst (redc_loop count A_S)) = eval (fst A_S) / r^(Z.of_nat count).
-  Proof.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_addT eval_addT' eval_div eval_drop_high eval_mod eval_scmul r_big small_B small_N small_addT small_addT' small_div small_drop_high small_scmul.
     induction_loop count IHcount.
     { simpl; autorewrite with zsimplify; reflexivity. }
     { rewrite IHcount, fst_redc_body by handle_IH_small.
@@ -372,7 +373,7 @@ Section WordByWordMontgomery.
     : eval (fst (redc_loop count A_S)) mod (eval N)
       = (eval (fst A_S) - eval (fst A_S) mod r^Z.of_nat count)
         * ri^(Z.of_nat count) mod (eval N).
-  Proof.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_addT eval_addT' eval_div eval_drop_high eval_mod eval_scmul r_big ri_correct small_B small_N small_addT small_addT' small_div small_drop_high small_scmul.
     rewrite fst_redc_loop by assumption.
     destruct count.
     { simpl; autorewrite with zsimplify; reflexivity. }
@@ -393,7 +394,7 @@ Section WordByWordMontgomery.
         (Hbound : 0 <= eval (snd A_S) < eval N + eval B)
     : (eval (snd (redc_loop count A_S))) mod (eval N)
       = ((eval (snd A_S) + (eval (fst A_S) mod r^(Z.of_nat count))*eval B)*ri^(Z.of_nat count)) mod (eval N).
-  Proof.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_addT eval_addT' eval_div eval_drop_high eval_mod eval_scmul k_correct r_big ri_correct small_B small_N small_addT small_addT' small_div small_drop_high small_scmul.
     induction_loop count IHcount.
     { simpl; autorewrite with zsimplify; reflexivity. }
     { rewrite IHcount by handle_IH_small.
@@ -443,7 +444,7 @@ Section WordByWordMontgomery.
   Lemma pre_redc_bound A_numlimbs (A : T A_numlimbs)
         (small_A : small A)
     : 0 <= eval (pre_redc A) < eval N + eval B.
-  Proof.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_addT eval_addT' eval_div eval_drop_high eval_mod eval_scmul eval_zero r_big small_B small_N small_addT small_addT' small_div small_drop_high small_scmul small_zero.
     unfold pre_redc.
     apply redc_loop_good; simpl; autorewrite with push_eval;
       rewrite ?Npos_correct; auto; lia.
@@ -452,7 +453,7 @@ Section WordByWordMontgomery.
   Lemma small_pre_redc A_numlimbs (A : T A_numlimbs)
         (small_A : small A)
     : small (pre_redc A).
-  Proof.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_addT eval_addT' eval_div eval_drop_high eval_mod eval_scmul eval_zero r_big small_B small_N small_addT small_addT' small_div small_drop_high small_scmul small_zero.
     unfold pre_redc.
     apply redc_loop_good; simpl; autorewrite with push_eval;
       rewrite ?Npos_correct; auto; lia.
@@ -460,7 +461,7 @@ Section WordByWordMontgomery.
 
   Lemma pre_redc_mod_N A_numlimbs (A : T A_numlimbs) (small_A : small A) (A_bound : 0 <= eval A < r ^ Z.of_nat A_numlimbs)
     : (eval (pre_redc A)) mod (eval N) = (eval A * eval B * ri^(Z.of_nat A_numlimbs)) mod (eval N).
-  Proof.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_addT eval_addT' eval_div eval_drop_high eval_mod eval_scmul eval_zero k_correct r_big ri_correct small_B small_N small_addT small_addT' small_div small_drop_high small_scmul small_zero.
     unfold pre_redc.
     rewrite snd_redc_loop_mod_N; cbn [fst snd];
       autorewrite with push_eval zsimplify;
@@ -471,7 +472,7 @@ Section WordByWordMontgomery.
 
   Lemma redc_mod_N A_numlimbs (A : T A_numlimbs) (small_A : small A) (A_bound : 0 <= eval A < r ^ Z.of_nat A_numlimbs)
     : (eval (redc A)) mod (eval N) = (eval A * eval B * ri^(Z.of_nat A_numlimbs)) mod (eval N).
-  Proof.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_addT eval_addT' eval_conditional_sub eval_div eval_drop_high eval_mod eval_scmul eval_zero k_correct r_big ri_correct small_B small_N small_addT small_addT' small_div small_drop_high small_scmul small_zero.
     pose proof (@small_pre_redc _ A small_A).
     pose proof (@pre_redc_bound _ A small_A).
     unfold redc.
@@ -485,7 +486,7 @@ Section WordByWordMontgomery.
   Lemma redc_bound_tight A_numlimbs (A : T A_numlimbs)
         (small_A : small A)
     : 0 <= eval (redc A) < eval N + eval B + if eval N <=? eval (pre_redc A) then -eval N else 0.
-  Proof.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_addT eval_addT' eval_conditional_sub eval_div eval_drop_high eval_mod eval_scmul eval_zero r_big small_B small_N small_addT small_addT' small_div small_drop_high small_scmul small_zero.
     pose proof (@small_pre_redc _ A small_A).
     pose proof (@pre_redc_bound _ A small_A).
     unfold redc.
@@ -496,7 +497,7 @@ Section WordByWordMontgomery.
   Lemma redc_bound_N A_numlimbs (A : T A_numlimbs)
         (small_A : small A)
     : eval B < eval N -> 0 <= eval (redc A) < eval N.
-  Proof.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_addT eval_addT' eval_conditional_sub eval_div eval_drop_high eval_mod eval_scmul eval_zero r_big small_B small_N small_addT small_addT' small_div small_drop_high small_scmul small_zero.
     clear dependent ri.
     pose proof (@small_pre_redc _ A small_A).
     pose proof (@pre_redc_bound _ A small_A).
@@ -509,7 +510,7 @@ Section WordByWordMontgomery.
         (small_A : small A)
         (A_bound : 0 <= eval A < r ^ Z.of_nat A_numlimbs)
     : 0 <= eval (redc A) < R.
-  Proof.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_addT eval_addT' eval_conditional_sub eval_div eval_drop_high eval_mod eval_scmul eval_zero r_big small_B small_N small_addT small_addT' small_div small_drop_high small_scmul small_zero.
     clear dependent ri.
     pose proof (@small_pre_redc _ A small_A).
     pose proof (@pre_redc_bound _ A small_A).
@@ -522,7 +523,7 @@ Section WordByWordMontgomery.
         (small_A : small A)
         (A_bound : 0 <= eval A < r ^ Z.of_nat A_numlimbs)
     : small (redc A).
-  Proof.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_addT eval_addT' eval_div eval_drop_high eval_mod eval_scmul eval_zero r_big small_B small_N small_addT small_addT' small_conditional_sub small_div small_drop_high small_scmul small_zero.
     clear dependent ri.
     pose proof (@small_pre_redc _ A small_A).
     pose proof (@pre_redc_bound _ A small_A).
@@ -545,18 +546,18 @@ Section WordByWordMontgomery.
       clear dependent B; clear dependent k; clear dependent ri; clear dependent Npos.
 
     Lemma small_add : small (add Av Bv).
-    Proof. clear R_correct; do_clear; unfold add; t_small. Qed.
+    Proof using Av_bound Bv_bound N_lt_R eval_addT r small_Av small_Bv small_addT small_conditional_sub. clear R_correct; do_clear; unfold add; t_small. Qed.
     Lemma small_sub : small (sub Av Bv).
-    Proof. clear R_correct; do_clear; unfold sub; t_small. Qed.
+    Proof using small_sub_then_maybe_add. clear R_correct; do_clear; unfold sub; t_small. Qed.
     Lemma small_opp : small (opp Av).
-    Proof. clear R_correct; clear dependent Bv; do_clear; unfold opp, sub; t_small. Qed.
+    Proof using small_sub_then_maybe_add. clear R_correct; clear dependent Bv; do_clear; unfold opp, sub; t_small. Qed.
 
     Lemma eval_add : eval (add Av Bv) = eval Av + eval Bv + if (eval N <=? eval Av + eval Bv) then -eval N else 0.
-    Proof. clear R_correct. do_clear; unfold add; autorewrite with push_eval; reflexivity. Qed.
+    Proof using Av_bound Bv_bound N_lt_R eval_addT eval_conditional_sub r small_Av small_Bv small_addT. clear R_correct. do_clear; unfold add; autorewrite with push_eval; reflexivity. Qed.
     Lemma eval_sub : eval (sub Av Bv) = eval Av - eval Bv + if (eval Av - eval Bv <? 0) then eval N else 0.
-    Proof. clear R_correct. do_clear; unfold sub; autorewrite with push_eval; reflexivity. Qed.
+    Proof using Av_bound Bv_bound eval_sub_then_maybe_add small_Av small_Bv. clear R_correct. do_clear; unfold sub; autorewrite with push_eval; reflexivity. Qed.
     Lemma eval_opp : eval (opp Av) = (if (eval Av =? 0) then 0 else eval N) - eval Av.
-    Proof.
+    Proof using Av_bound R eval_sub_then_maybe_add eval_zero r small_Av small_zero.
       clear R_correct.
       clear dependent Bv; do_clear; unfold opp, sub; autorewrite with push_eval.
       break_innermost_match; Z.ltb_to_lt; lia.
@@ -571,17 +572,17 @@ Section WordByWordMontgomery.
                    | progress (push_Zmod; pull_Zmod) ].
 
     Lemma eval_add_mod_N : eval (add Av Bv) mod eval N = (eval Av + eval Bv) mod eval N.
-    Proof. generalize eval_add; clear. t_mod_N. Qed.
+    Proof using Av_bound Bv_bound N_lt_R eval_addT eval_conditional_sub r small_Av small_Bv small_addT. generalize eval_add; clear. t_mod_N. Qed.
     Lemma eval_sub_mod_N : eval (sub Av Bv) mod eval N = (eval Av - eval Bv) mod eval N.
-    Proof. generalize eval_sub; clear. t_mod_N. Qed.
+    Proof using Av_bound Bv_bound eval_sub_then_maybe_add small_Av small_Bv. generalize eval_sub; clear. t_mod_N. Qed.
     Lemma eval_opp_mod_N : eval (opp Av) mod eval N = (-eval Av) mod eval N.
-    Proof. generalize eval_opp; clear; t_mod_N. Qed.
+    Proof using Av_bound R eval_sub_then_maybe_add eval_zero r small_Av small_zero. generalize eval_opp; clear; t_mod_N. Qed.
 
     Lemma add_bound : 0 <= eval (add Av Bv) < eval N.
-    Proof. generalize eval_add; clear -Av_bound Bv_bound; break_innermost_match; Z.ltb_to_lt; lia. Qed.
+    Proof using Av_bound Bv_bound N_lt_R eval_addT eval_conditional_sub r small_Av small_Bv small_addT. generalize eval_add; clear -Av_bound Bv_bound; break_innermost_match; Z.ltb_to_lt; lia. Qed.
     Lemma sub_bound : 0 <= eval (sub Av Bv) < eval N.
-    Proof. do_clear; generalize eval_sub; clear -Av_bound Bv_bound; break_innermost_match; Z.ltb_to_lt; lia. Qed.
+    Proof using Av_bound Bv_bound eval_sub_then_maybe_add small_Av small_Bv. do_clear; generalize eval_sub; clear -Av_bound Bv_bound; break_innermost_match; Z.ltb_to_lt; lia. Qed.
     Lemma opp_bound : 0 <= eval (opp Av) < eval N.
-    Proof. clear dependent Bv; do_clear; generalize eval_opp; clear -Av_bound; break_innermost_match; Z.ltb_to_lt; lia. Qed.
+    Proof using Av_bound R eval_sub_then_maybe_add eval_zero r small_Av small_zero. clear dependent Bv; do_clear; generalize eval_opp; clear -Av_bound; break_innermost_match; Z.ltb_to_lt; lia. Qed.
   End add_sub.
 End WordByWordMontgomery.

--- a/src/Arithmetic/MontgomeryReduction/WordByWord/Abstract/Proofs.v
+++ b/src/Arithmetic/MontgomeryReduction/WordByWord/Abstract/Proofs.v
@@ -7,6 +7,7 @@ Require Import Crypto.Util.NatUtil.
 Require Import Crypto.Arithmetic.ModularArithmeticTheorems Crypto.Spec.ModularArithmetic.
 Require Import Crypto.Arithmetic.MontgomeryReduction.WordByWord.Abstract.Definition.
 Require Import Crypto.Algebra.Ring.
+Require Import Crypto.Util.Decidable.
 Require Import Crypto.Util.ZUtil.MulSplit.
 Require Import Crypto.Util.ZUtil.Div.
 Require Import Crypto.Util.ZUtil.EquivModulo.
@@ -110,7 +111,7 @@ Section WordByWordMontgomery.
     Lemma S3_bound
       : eval S < eval N + eval B
         -> eval S3 < eval N + eval B.
-    Proof.
+    Proof using B_bounds N_lt_R Npos_correct R_numlimbs eval_add eval_div eval_mod eval_scmul r_big small_A small_add.
       assert (Hmod : forall a b, 0 < b -> a mod b <= b - 1)
         by (intros x y; pose proof (Z_mod_lt x y); lia).
       intro HS.
@@ -131,28 +132,28 @@ Section WordByWordMontgomery.
 
     Lemma small_A'
       : small A'.
-    Proof.
+    Proof using small_A small_div.
       repeat autounfold with word_by_word_montgomery; auto.
     Qed.
 
     Lemma small_S3
       : small S3.
-    Proof. repeat autounfold with word_by_word_montgomery; t_small. Qed.
+    Proof using small_add small_div. repeat autounfold with word_by_word_montgomery; t_small. Qed.
 
     Lemma S3_nonneg : 0 <= eval S3.
-    Proof.
+    Proof using B_bounds N_lt_R Npos_correct R_numlimbs S_nonneg eval_add eval_div eval_mod eval_scmul r_big small_A small_add.
       repeat autounfold with word_by_word_montgomery; rewrite Z.mul_split_mod;
         autorewrite with push_eval; [].
       rewrite ?Npos_correct; Z.zero_bounds; lia.
     Qed.
 
     Lemma S4_nonneg : 0 <= eval S4.
-    Proof. unfold S4; rewrite eval_drop_high by apply small_S3; Z.zero_bounds. Qed.
+    Proof using Npos R eval_drop_high r_big small_add small_div. unfold S4; rewrite eval_drop_high by apply small_S3; Z.zero_bounds. Qed.
 
     Lemma S4_bound
       : eval S < eval N + eval B
         -> eval S4 < eval N + eval B.
-    Proof.
+    Proof using B_bounds N_lt_R Npos_correct R_correct S_nonneg eval_add eval_div eval_drop_high eval_mod eval_scmul r_big small_A small_add small_div.
       intro H; pose proof (S3_bound H); pose proof S3_nonneg.
       unfold S4.
       rewrite eval_drop_high by apply small_S3.
@@ -161,7 +162,7 @@ Section WordByWordMontgomery.
     Qed.
 
     Lemma numlimbs_S4 : numlimbs S4 = min (max (1 + numlimbs S) (1 + max (1 + numlimbs B) (numlimbs N))) (1 + R_numlimbs).
-    Proof.
+    Proof using eval_mod numlimbs_add numlimbs_div numlimbs_drop_high numlimbs_scmul small_A.
       cbn [plus].
       repeat autounfold with word_by_word_montgomery; rewrite Z.mul_split_mod.
       repeat autorewrite with push_numlimbs.
@@ -171,14 +172,14 @@ Section WordByWordMontgomery.
     Qed.
 
     Lemma S1_eq : eval S1 = S + a*B.
-    Proof.
+    Proof using B_bounds eval_add eval_mod eval_scmul small_A.
       cbv [S1 a WordByWord.Abstract.Definition.A'].
       repeat autorewrite with push_eval.
       reflexivity.
     Qed.
 
     Lemma S2_mod_N : (eval S2) mod N = (S + a*B) mod N.
-    Proof.
+    Proof using B_bounds N_lt_R Npos_correct R_numlimbs eval_add eval_mod eval_scmul r_big small_A small_add.
       cbv [S2 WordByWord.Abstract.Definition.q WordByWord.Abstract.Definition.s]; autorewrite with push_eval zsimplify. rewrite S1_eq. reflexivity.
     Qed.
 
@@ -213,7 +214,7 @@ Section WordByWordMontgomery.
 
     Lemma S3_mod_N
       : S3 mod N = (S + a*B)*ri mod N.
-    Proof.
+    Proof using B_bounds N_lt_R Npos_correct R_numlimbs eval_add eval_div eval_mod eval_scmul k_correct r_big ri_correct small_A small_add.
       cbv [S3]; autorewrite with push_eval cancel_pair.
       pose proof fun a => Z.div_to_inv_modulo N a r ri eq_refl ri_correct as HH;
                             cbv [Z.equiv_modulo] in HH; rewrite HH; clear HH.
@@ -229,7 +230,7 @@ Section WordByWordMontgomery.
     Lemma S4_mod_N
           (Hbound : eval S < eval N + eval B)
       : S4 mod N = (S + a*B)*ri mod N.
-    Proof.
+    Proof using B_bounds N_lt_R Npos_correct R_correct S_nonneg eval_add eval_div eval_drop_high eval_mod eval_scmul k_correct r_big ri_correct small_A small_add small_div.
       pose proof (S3_bound Hbound); pose proof S3_nonneg.
       unfold S4; autorewrite with push_eval.
       rewrite (Z.mod_small _ (r * _)) by nia.
@@ -243,7 +244,7 @@ Section WordByWordMontgomery.
 
   Lemma redc_loop_comm_body count
     : forall A_S, redc_loop count (redc_body A_S) = redc_body (redc_loop count A_S).
-  Proof.
+  Proof using Type.
     induction count as [|count IHcount]; try reflexivity.
     simpl; intro; rewrite IHcount; reflexivity.
   Qed.
@@ -258,17 +259,17 @@ Section WordByWordMontgomery.
             (S_bound : 0 <= eval S < eval N + eval B).
 
     Lemma small_fst_redc_body : small (fst (redc_body A_S)).
-    Proof. destruct A_S; apply small_A'; assumption. Qed.
+    Proof using S_bound small_A small_div. destruct A_S; apply small_A'; assumption. Qed.
     Lemma snd_redc_body_nonneg : 0 <= eval (snd (redc_body A_S)).
-    Proof. destruct A_S; apply S4_nonneg; assumption. Qed.
+    Proof using Npos R S_bound eval_drop_high r_big small_A small_add small_div. destruct A_S; apply S4_nonneg; assumption. Qed.
 
     Lemma snd_redc_body_mod_N
       : (eval (snd (redc_body A_S))) mod (eval N) = (eval S + a*eval B)*ri mod (eval N).
-    Proof. destruct A_S; apply S4_mod_N; auto; lia. Qed.
+    Proof using B_bounds N_lt_R Npos_correct R_correct S_bound eval_add eval_div eval_drop_high eval_mod eval_scmul k_correct r_big ri_correct small_A small_add small_div. destruct A_S; apply S4_mod_N; auto; lia. Qed.
 
     Lemma fst_redc_body
       : (eval (fst (redc_body A_S))) = eval (fst A_S) / r.
-    Proof.
+    Proof using S_bound eval_div small_A.
       destruct A_S; simpl; unfold WordByWord.Abstract.Definition.A', WordByWord.Abstract.Definition.A_a, Let_In, a, A_a, A; simpl.
       autorewrite with push_eval.
       reflexivity.
@@ -276,7 +277,7 @@ Section WordByWordMontgomery.
 
     Lemma fst_redc_body_mod_N
       : (eval (fst (redc_body A_S))) mod (eval N) = ((eval (fst A_S) - a)*ri) mod (eval N).
-    Proof.
+    Proof using Npos R R_numlimbs S_bound eval_div eval_mod r_big ri_correct small_A.
       rewrite fst_redc_body.
       etransitivity; [ eapply Z.div_to_inv_modulo; try eassumption; lia | ].
       unfold a, A_a, A.
@@ -287,13 +288,13 @@ Section WordByWordMontgomery.
     Lemma redc_body_bound
       : eval S < eval N + eval B
         -> eval (snd (redc_body A_S)) < eval N + eval B.
-    Proof.
+    Proof using B_bounds N_lt_R Npos_correct R_correct S_bound eval_add eval_div eval_drop_high eval_mod eval_scmul r_big small_A small_add small_div.
       destruct A_S; apply S4_bound; unfold S in *; cbn [snd] in *; try assumption; try lia.
     Qed.
 
     Lemma numlimbs_redc_body : numlimbs (snd (redc_body A_S))
                                = min (max (1 + numlimbs (snd A_S)) (1 + max (1 + numlimbs B) (numlimbs N))) (1 + R_numlimbs).
-    Proof. destruct A_S; apply numlimbs_S4; assumption. Qed.
+    Proof using S_bound eval_mod numlimbs_add numlimbs_div numlimbs_drop_high numlimbs_scmul small_A. destruct A_S; apply numlimbs_S4; assumption. Qed.
   End body.
 
   Local Arguments Z.pow !_ !_.
@@ -305,7 +306,7 @@ Section WordByWordMontgomery.
         (Hbound : 0 <= eval (snd A_S) < eval N + eval B)
     : small (fst (redc_loop count A_S))
       /\ 0 <= eval (snd (redc_loop count A_S)) < eval N + eval B.
-  Proof.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_add eval_div eval_drop_high eval_mod eval_scmul r_big small_add small_div.
     induction_loop count IHcount; auto; [].
     change (id (0 <= eval B < R)) in B_bounds (* don't let [destruct_head'_and] loop *).
     destruct_head'_and.
@@ -320,7 +321,7 @@ Section WordByWordMontgomery.
         (Hsmall : small (fst A_S))
         (Hbound : 0 <= eval (snd A_S) < eval N + eval B)
     : 0 <= eval (snd (redc_loop count A_S)) < eval N + eval B.
-  Proof. apply redc_loop_good; assumption. Qed.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_add eval_div eval_drop_high eval_mod eval_scmul r_big small_add small_div. apply redc_loop_good; assumption. Qed.
 
   Local Ltac t_min_max_step _ :=
     match goal with
@@ -343,7 +344,7 @@ Section WordByWordMontgomery.
         | O => numlimbs (snd A_S)
         | S _ => 1 + R_numlimbs
         end%nat.
-  Proof.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_add eval_div eval_drop_high eval_mod eval_scmul numlimbs_add numlimbs_div numlimbs_drop_high numlimbs_scmul r_big small_add small_div.
     assert (Hgen
             : numlimbs (snd (redc_loop count A_S))
               = match count with
@@ -371,7 +372,7 @@ Section WordByWordMontgomery.
         (Hsmall : small (fst A_S))
         (Hbound : 0 <= eval (snd A_S) < eval N + eval B)
     : eval (fst (redc_loop count A_S)) = eval (fst A_S) / r^(Z.of_nat count).
-  Proof.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_add eval_div eval_drop_high eval_mod eval_scmul r_big small_add small_div.
     induction_loop count IHcount.
     { simpl; autorewrite with zsimplify; reflexivity. }
     { rewrite fst_redc_body, IHcount
@@ -389,7 +390,7 @@ Section WordByWordMontgomery.
     : eval (fst (redc_loop count A_S)) mod (eval N)
       = (eval (fst A_S) - eval (fst A_S) mod r^Z.of_nat count)
         * ri^(Z.of_nat count) mod (eval N).
-  Proof.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_add eval_div eval_drop_high eval_mod eval_scmul r_big ri_correct small_add small_div.
     rewrite fst_redc_loop by assumption.
     destruct count.
     { simpl; autorewrite with zsimplify; reflexivity. }
@@ -410,7 +411,7 @@ Section WordByWordMontgomery.
         (Hbound : 0 <= eval (snd A_S) < eval N + eval B)
     : (eval (snd (redc_loop count A_S))) mod (eval N)
       = ((eval (snd A_S) + (eval (fst A_S) mod r^(Z.of_nat count))*eval B)*ri^(Z.of_nat count)) mod (eval N).
-  Proof.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_add eval_div eval_drop_high eval_mod eval_scmul k_correct r_big ri_correct small_add small_div.
     induction_loop count IHcount.
     { simpl; autorewrite with zsimplify; reflexivity. }
     { simpl; rewrite snd_redc_body_mod_N
@@ -463,7 +464,7 @@ Section WordByWordMontgomery.
   Lemma redc_bound A
         (small_A : small A)
     : 0 <= eval (redc A) < eval N + eval B.
-  Proof.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_add eval_div eval_drop_high eval_mod eval_scmul eval_zero r_big small_add small_div.
     unfold redc.
     apply redc_loop_good; simpl; autorewrite with push_eval;
       rewrite ?Npos_correct; auto; lia.
@@ -475,18 +476,18 @@ Section WordByWordMontgomery.
         | O => S (numlimbs B)
         | _ => S R_numlimbs
         end.
-  Proof.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_add eval_div eval_drop_high eval_mod eval_scmul eval_zero numlimbs_add numlimbs_div numlimbs_drop_high numlimbs_scmul numlimbs_zero r_big small_add small_div.
     unfold redc; rewrite numlimbs_redc_loop by (cbn [fst snd]; t_small);
       cbn [snd]; rewrite ?numlimbs_zero.
     reflexivity.
   Qed.
   Lemma numlimbs_redc A (small_A : small A) (Hnumlimbs : R_numlimbs = numlimbs B)
     : numlimbs (redc A) = S (numlimbs B).
-  Proof. rewrite numlimbs_redc_gen; subst; auto; destruct (numlimbs A); reflexivity. Qed.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_add eval_div eval_drop_high eval_mod eval_scmul eval_zero numlimbs_add numlimbs_div numlimbs_drop_high numlimbs_scmul numlimbs_zero r_big small_add small_div. rewrite numlimbs_redc_gen; subst; auto; destruct (numlimbs A); reflexivity. Qed.
 
   Lemma redc_mod_N A (small_A : small A) (A_bound : 0 <= eval A < r ^ Z.of_nat (numlimbs A))
     : (eval (redc A)) mod (eval N) = (eval A * eval B * ri^(Z.of_nat (numlimbs A))) mod (eval N).
-  Proof.
+  Proof using B_bounds N_lt_R Npos_correct R_correct eval_add eval_div eval_drop_high eval_mod eval_scmul eval_zero k_correct r_big ri_correct small_add small_div.
     unfold redc.
     rewrite snd_redc_loop_mod_N; cbn [fst snd];
       autorewrite with push_eval zsimplify;

--- a/src/Arithmetic/MontgomeryReduction/WordByWord/Abstract/Proofs.v
+++ b/src/Arithmetic/MontgomeryReduction/WordByWord/Abstract/Proofs.v
@@ -1,6 +1,6 @@
 (*** Word-By-Word Montgomery Multiplication Proofs *)
 Require Import Coq.Arith.Arith.
-Require Import Coq.ZArith.BinInt Coq.ZArith.ZArith Coq.ZArith.Zdiv Coq.micromega.Lia.
+Require Import Coq.ZArith.BinInt Coq.ZArith.ZArith Coq.ZArith.Zdiv Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.LetIn.
 Require Import Crypto.Util.Prod.
 Require Import Crypto.Util.NatUtil.

--- a/src/Arithmetic/MontgomeryReduction/WordByWord/Definition.v
+++ b/src/Arithmetic/MontgomeryReduction/WordByWord/Definition.v
@@ -105,4 +105,4 @@ Section WordByWordMontgomery.
     := nonzero_cps A id.
 End WordByWordMontgomery.
 
-Hint Opaque redc pre_redc redc_body redc_loop add sub opp nonzero : uncps.
+Global Hint Opaque redc pre_redc redc_body redc_loop add sub opp nonzero : uncps.

--- a/src/Arithmetic/MontgomeryReduction/WordByWord/Proofs.v
+++ b/src/Arithmetic/MontgomeryReduction/WordByWord/Proofs.v
@@ -1,6 +1,6 @@
 (*** Word-By-Word Montgomery Multiplication Proofs *)
 Require Import Coq.ZArith.BinInt.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Arithmetic.Saturated.UniformWeight.
 Require Import Crypto.Arithmetic.Saturated.MontgomeryAPI.
 Require Import Crypto.Arithmetic.MontgomeryReduction.WordByWord.Abstract.Dependent.Definition.

--- a/src/Arithmetic/PrimeFieldTheorems.v
+++ b/src/Arithmetic/PrimeFieldTheorems.v
@@ -3,7 +3,7 @@ Require Export Crypto.Arithmetic.ModularArithmeticTheorems.
 Require Export Coq.setoid_ring.Ring_theory Coq.setoid_ring.Field_theory Coq.setoid_ring.Field_tac.
 
 Require Import Coq.nsatz.Nsatz.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Arithmetic.ModularArithmeticPre.
 Require Import Crypto.Util.NumTheoryUtil.
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.Setoids.Setoid.

--- a/src/Arithmetic/PrimeFieldTheorems.v
+++ b/src/Arithmetic/PrimeFieldTheorems.v
@@ -6,7 +6,7 @@ Require Import Coq.nsatz.Nsatz.
 Require Import Coq.micromega.Lia.
 Require Import Crypto.Arithmetic.ModularArithmeticPre.
 Require Import Crypto.Util.NumTheoryUtil.
-Require Import Coq.Classes.Morphisms Coq.Setoids.Setoid.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.Setoids.Setoid.
 Require Import Coq.ZArith.BinInt Coq.NArith.BinNat Coq.ZArith.ZArith Coq.ZArith.Znumtheory Coq.NArith.NArith. (* import Zdiv before Znumtheory *)
 Require Import Coq.Logic.Eqdep_dec.
 Require Import Crypto.Util.NumTheoryUtil.
@@ -18,6 +18,7 @@ Require Import Crypto.Util.Decidable.
 Require Export Crypto.Util.FixCoqMistakes.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Crypto.Algebra.Hierarchy Crypto.Algebra.Field.
+Export Field.Hints.
 
 Existing Class prime.
 Local Open Scope F_scope.
@@ -296,4 +297,9 @@ Module F.
       *)
     End IsomorphicRings.
   End Iso.
+  Module Export Instances.
+    Export Field.Hints.
+    Global Existing Instance field_modulo.
+  End Instances.
 End F.
+Export F.Instances.

--- a/src/Arithmetic/Saturated/AddSub.v
+++ b/src/Arithmetic/Saturated/AddSub.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.Lists.List.
 Local Open Scope Z_scope.

--- a/src/Arithmetic/Saturated/AddSub.v
+++ b/src/Arithmetic/Saturated/AddSub.v
@@ -59,7 +59,7 @@ Module B.
 
         Lemma chain_op'_id {n} : forall c p q T f,
           @chain_op'_cps T n c p q f = f (chain_op' c p q).
-        Proof.
+        Proof using op_get_carry_id op_with_carry_id.
           cbv [chain_op']; induction n; intros; destruct c;
             simpl chain_op'_cps; cbv [Let_In]; try reflexivity;
               autorewrite with uncps.
@@ -69,7 +69,7 @@ Module B.
 
         Lemma chain_op_id {n} p q T f :
           @chain_op_cps n p q T f = f (chain_op p q).
-        Proof. apply (@chain_op'_id n None). Qed.
+        Proof using op_get_carry_id op_with_carry_id. apply (@chain_op'_id n None). Qed.
       End GenericOp.
       Hint Opaque chain_op chain_op' : uncps.
       Hint Rewrite @chain_op_id @chain_op'_id using (assumption || (intros; autorewrite with uncps; reflexivity)) : uncps.
@@ -96,12 +96,12 @@ Module B.
 
         Lemma sat_add_id n p q T f :
           @sat_add_cps n p q T f = f (sat_add p q).
-        Proof. cbv [sat_add sat_add_cps]. autorewrite with uncps. reflexivity. Qed.
+        Proof using Type. cbv [sat_add sat_add_cps]. autorewrite with uncps. reflexivity. Qed.
 
         Lemma sat_add_mod_step n c d :
           c mod s + s * ((d + c / s) mod (uweight s n))
           = (s * d + c) mod (s * uweight s n).
-        Proof.
+        Proof using s_pos.
           assert (0 < uweight s n) as wt_pos
               by auto using Z.lt_gt, Z.gt_lt, uweight_positive.
           rewrite <-(Columns.compact_mod_step s (uweight s n) c d s_pos wt_pos).
@@ -110,7 +110,7 @@ Module B.
 
         Lemma sat_add_div_step n c d :
           (d + c / s) / uweight s n =  (s * d + c) / (s * uweight s n).
-        Proof.
+        Proof using s_pos.
           assert (0 < uweight s n) as wt_pos
               by auto using Z.lt_gt, Z.gt_lt, uweight_positive.
           rewrite <-(Columns.compact_div_step s (uweight s n) c d s_pos wt_pos).
@@ -120,7 +120,7 @@ Module B.
         Lemma sat_add_divmod n p q :
           eval (snd (@sat_add n p q)) = (eval p + eval q) mod (uweight s n)
           /\ fst (@sat_add n p q) = (eval p + eval q) / (uweight s n).
-        Proof.
+        Proof using s_pos.
           cbv [sat_add sat_add_cps chain_op_cps].
           remember None as c.
           replace (eval p + eval q) with
@@ -148,14 +148,14 @@ Module B.
 
         Lemma sat_add_mod n p q :
           eval (snd (@sat_add n p q)) = (eval p + eval q) mod (uweight s n).
-        Proof. exact (proj1 (sat_add_divmod n p q)). Qed.
+        Proof using s_pos. exact (proj1 (sat_add_divmod n p q)). Qed.
 
         Lemma sat_add_div n p q :
           fst (@sat_add n p q) = (eval p + eval q) / (uweight s n).
-        Proof. exact (proj2 (sat_add_divmod n p q)). Qed.
+        Proof using s_pos. exact (proj2 (sat_add_divmod n p q)). Qed.
 
         Lemma small_sat_add n p q : small (snd (@sat_add n p q)).
-        Proof.
+        Proof using s_pos.
           cbv [small UniformWeight.small sat_add sat_add_cps chain_op_cps].
           remember None as c. destruct Heqc. revert c.
           induction n; intros;
@@ -186,11 +186,11 @@ Module B.
 
         Lemma sat_sub_id n p q T f :
           @sat_sub_cps n p q T f = f (sat_sub p q).
-        Proof. cbv [sat_sub sat_sub_cps]. autorewrite with uncps. reflexivity. Qed.
+        Proof using Type. cbv [sat_sub sat_sub_cps]. autorewrite with uncps. reflexivity. Qed.
         Lemma sat_sub_divmod n p q :
           eval (snd (@sat_sub n p q)) = (eval p - eval q) mod (uweight s n)
           /\ fst (@sat_sub n p q) = - ((eval p - eval q) / (uweight s n)).
-        Proof.
+        Proof using s_pos.
           cbv [sat_sub sat_sub_cps chain_op_cps].
           remember None as c.
           replace (eval p - eval q) with
@@ -218,14 +218,14 @@ Module B.
 
         Lemma sat_sub_mod n p q :
           eval (snd (@sat_sub n p q)) = (eval p - eval q) mod (uweight s n).
-        Proof. exact (proj1 (sat_sub_divmod n p q)). Qed.
+        Proof using s_pos. exact (proj1 (sat_sub_divmod n p q)). Qed.
 
         Lemma sat_sub_div n p q :
           fst (@sat_sub n p q) = - ((eval p - eval q) / uweight s n).
-        Proof. exact (proj2 (sat_sub_divmod n p q)). Qed.
+        Proof using s_pos. exact (proj2 (sat_sub_divmod n p q)). Qed.
 
         Lemma small_sat_sub n p q : small (snd (@sat_sub n p q)).
-        Proof.
+        Proof using s_pos.
           cbv [small UniformWeight.small sat_sub sat_sub_cps chain_op_cps].
           remember None as c. destruct Heqc. revert c.
           induction n; intros;
@@ -251,12 +251,12 @@ Module B.
     End Positional.
   End Positional.
 End B.
-Hint Opaque B.Positional.sat_sub B.Positional.sat_add B.Positional.chain_op B.Positional.chain_op' : uncps.
+Global Hint Opaque B.Positional.sat_sub B.Positional.sat_add B.Positional.chain_op B.Positional.chain_op' : uncps.
 Hint Rewrite @B.Positional.sat_sub_id @B.Positional.sat_add_id : uncps.
 Hint Rewrite @B.Positional.chain_op_id @B.Positional.chain_op' using (assumption || (intros; autorewrite with uncps; reflexivity)) : uncps.
 Hint Rewrite @B.Positional.sat_sub_mod @B.Positional.sat_sub_div @B.Positional.sat_add_mod @B.Positional.sat_add_div using (lia || assumption) : push_basesystem_eval.
 
-Hint Unfold
+Global Hint Unfold
      B.Positional.chain_op'_cps
      B.Positional.chain_op'
      B.Positional.chain_op_cps

--- a/src/Arithmetic/Saturated/Core.v
+++ b/src/Arithmetic/Saturated/Core.v
@@ -17,6 +17,7 @@ Require Import Crypto.Util.ZUtil.Div.
 Require Import Crypto.Util.ZUtil.Tactics.ZeroBounds.
 Require Import Crypto.Util.NatUtil.
 Require Import Crypto.Util.Tactics.SpecializeBy.
+Import Field.Hints.
 Local Notation "A ^ n" := (tuple A n) : type_scope.
 
 (***
@@ -142,11 +143,11 @@ Module Columns.
       B.Positional.eval weight (Tuple.map sum x).
 
     Lemma eval_unit (x:unit) : eval (n:=0) x = 0.
-    Proof. reflexivity. Qed.
+    Proof using Type. reflexivity. Qed.
     Hint Rewrite eval_unit : push_basesystem_eval.
 
     Lemma eval_single (x:list Z) : eval (n:=1) x = sum x.
-    Proof.
+    Proof using weight_0.
       cbv [eval]. simpl map. cbv - [Z.mul Z.add sum].
       rewrite weight_0; ring.
     Qed. Hint Rewrite eval_single : push_basesystem_eval.
@@ -263,12 +264,12 @@ Module Columns.
     Qed.
 
     Lemma small_mod_eq a b n: a mod n = b mod n -> 0 <= a < n -> a = b mod n.
-    Proof. intros; rewrite <-(Z.mod_small a n); auto. Qed.
+    Proof using Type. intros; rewrite <-(Z.mod_small a n); auto. Qed.
 
     (* helper for some of the modular logic in compact *)
     Lemma compact_mod_step a b c d: 0 < a -> 0 < b ->
       a * ((c / a + d) mod b) + c mod a = (a * d + c) mod (a * b).
-    Proof.
+    Proof using Type.
       clear.
       intros Ha Hb. assert (a <= a * b) by (apply Z.le_mul_diag_r; lia).
       pose proof (Z.mod_pos_bound c a Ha).
@@ -285,7 +286,7 @@ Module Columns.
 
     Lemma compact_div_step a b c d : 0 < a -> 0 < b ->
       (c / a + d) / b = (a * d + c) / (a * b).
-    Proof.
+    Proof using Type.
       clear. intros Ha Hb.
       rewrite <-Z.div_div by lia.
       rewrite Z.div_add_l' by lia.
@@ -296,7 +297,7 @@ Module Columns.
       (B.Positional.eval weight (snd (compact inp))
        = (eval inp) mod (weight n))
         /\ (fst (compact inp) = eval (n:=n) inp / weight n).
-    Proof.
+    Proof using add_get_carry_cps_id add_get_carry_div add_get_carry_mod div_correct div_cps_id modulo_correct modulo_cps_id weight_0 weight_divides weight_multiples weight_positive.
       cbv [compact compact_cps compact_step compact_step_cps];
         autorewrite with uncps push_id.
       change (fun i s a => compact_digit_cps i (s :: a) id)
@@ -332,17 +333,17 @@ Module Columns.
     Lemma compact_mod {n} inp :
       (B.Positional.eval weight (snd (compact inp))
        = (eval (n:=n) inp) mod (weight n)).
-    Proof. apply (proj1 (compact_div_mod inp)). Qed.
+    Proof using add_get_carry_cps_id add_get_carry_div add_get_carry_mod div_correct div_cps_id modulo_correct modulo_cps_id weight_0 weight_divides weight_multiples weight_positive. apply (proj1 (compact_div_mod inp)). Qed.
     Hint Rewrite @compact_mod : push_basesystem_eval.
 
     Lemma compact_div {n} inp :
       fst (compact inp) = eval (n:=n) inp / weight n.
-    Proof. apply (proj2 (compact_div_mod inp)). Qed.
+    Proof using add_get_carry_cps_id add_get_carry_div add_get_carry_mod div_correct div_cps_id modulo_correct modulo_cps_id weight_0 weight_divides weight_multiples weight_positive. apply (proj2 (compact_div_mod inp)). Qed.
     Hint Rewrite @compact_div : push_basesystem_eval.
 
     (* TODO : move to tuple *)
     Lemma hd_to_list {A n} a (t : A^(S n)) : List.hd a (to_list (S n) t) = hd t.
-    Proof.
+    Proof using Type.
       rewrite (subst_append t), to_list_append, hd_append. reflexivity.
     Qed.
 
@@ -454,7 +455,7 @@ Hint Rewrite
      @Columns.eval_nils
   using (assumption || lia): push_basesystem_eval.
 
-Hint Unfold
+Global Hint Unfold
      Columns.eval Columns.eval_from
      Columns.compact_digit_cps Columns.compact_digit
      Columns.compact_step_cps Columns.compact_step

--- a/src/Arithmetic/Saturated/Core.v
+++ b/src/Arithmetic/Saturated/Core.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Init.Nat.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.Lists.List.

--- a/src/Arithmetic/Saturated/CoreUnfolder.v
+++ b/src/Arithmetic/Saturated/CoreUnfolder.v
@@ -1,7 +1,7 @@
 Require Import Crypto.Arithmetic.CoreUnfolder.
 Require Import Crypto.Arithmetic.Saturated.Core.
 
-Hint Unfold Core.Columns.compact_digit_cps Core.Columns.compact_step_cps Core.Columns.compact_cps : arithmetic_cps_unfolder.
+Global Hint Unfold Core.Columns.compact_digit_cps Core.Columns.compact_step_cps Core.Columns.compact_cps : arithmetic_cps_unfolder.
 
 Module Columns.
   (**
@@ -19,79 +19,79 @@ echo "End Columns."
   Definition eval_sig := parameterize_sig (@Core.Columns.eval).
   Definition eval := parameterize_from_sig eval_sig.
   Definition eval_eq := parameterize_eq eval eval_sig.
-  Hint Unfold eval : basesystem_partial_evaluation_unfolder.
+  Global Hint Unfold eval : basesystem_partial_evaluation_unfolder.
   Hint Rewrite <- eval_eq : pattern_runtime.
 
   Definition eval_from_sig := parameterize_sig (@Core.Columns.eval_from).
   Definition eval_from := parameterize_from_sig eval_from_sig.
   Definition eval_from_eq := parameterize_eq eval_from eval_from_sig.
-  Hint Unfold eval_from : basesystem_partial_evaluation_unfolder.
+  Global Hint Unfold eval_from : basesystem_partial_evaluation_unfolder.
   Hint Rewrite <- eval_from_eq : pattern_runtime.
 
   Definition compact_digit_cps_sig := parameterize_sig (@Core.Columns.compact_digit_cps).
   Definition compact_digit_cps := parameterize_from_sig compact_digit_cps_sig.
   Definition compact_digit_cps_eq := parameterize_eq compact_digit_cps compact_digit_cps_sig.
-  Hint Unfold compact_digit_cps : basesystem_partial_evaluation_unfolder.
+  Global Hint Unfold compact_digit_cps : basesystem_partial_evaluation_unfolder.
   Hint Rewrite <- compact_digit_cps_eq : pattern_runtime.
 
   Definition compact_digit_sig := parameterize_sig (@Core.Columns.compact_digit).
   Definition compact_digit := parameterize_from_sig compact_digit_sig.
   Definition compact_digit_eq := parameterize_eq compact_digit compact_digit_sig.
-  Hint Unfold compact_digit : basesystem_partial_evaluation_unfolder.
+  Global Hint Unfold compact_digit : basesystem_partial_evaluation_unfolder.
   Hint Rewrite <- compact_digit_eq : pattern_runtime.
 
   Definition compact_step_cps_sig := parameterize_sig (@Core.Columns.compact_step_cps).
   Definition compact_step_cps := parameterize_from_sig compact_step_cps_sig.
   Definition compact_step_cps_eq := parameterize_eq compact_step_cps compact_step_cps_sig.
-  Hint Unfold compact_step_cps : basesystem_partial_evaluation_unfolder.
+  Global Hint Unfold compact_step_cps : basesystem_partial_evaluation_unfolder.
   Hint Rewrite <- compact_step_cps_eq : pattern_runtime.
 
   Definition compact_step_sig := parameterize_sig (@Core.Columns.compact_step).
   Definition compact_step := parameterize_from_sig compact_step_sig.
   Definition compact_step_eq := parameterize_eq compact_step compact_step_sig.
-  Hint Unfold compact_step : basesystem_partial_evaluation_unfolder.
+  Global Hint Unfold compact_step : basesystem_partial_evaluation_unfolder.
   Hint Rewrite <- compact_step_eq : pattern_runtime.
 
   Definition compact_cps_sig := parameterize_sig (@Core.Columns.compact_cps).
   Definition compact_cps := parameterize_from_sig compact_cps_sig.
   Definition compact_cps_eq := parameterize_eq compact_cps compact_cps_sig.
-  Hint Unfold compact_cps : basesystem_partial_evaluation_unfolder.
+  Global Hint Unfold compact_cps : basesystem_partial_evaluation_unfolder.
   Hint Rewrite <- compact_cps_eq : pattern_runtime.
 
   Definition compact_sig := parameterize_sig (@Core.Columns.compact).
   Definition compact := parameterize_from_sig compact_sig.
   Definition compact_eq := parameterize_eq compact compact_sig.
-  Hint Unfold compact : basesystem_partial_evaluation_unfolder.
+  Global Hint Unfold compact : basesystem_partial_evaluation_unfolder.
   Hint Rewrite <- compact_eq : pattern_runtime.
 
   Definition cons_to_nth_cps_sig := parameterize_sig (@Core.Columns.cons_to_nth_cps).
   Definition cons_to_nth_cps := parameterize_from_sig cons_to_nth_cps_sig.
   Definition cons_to_nth_cps_eq := parameterize_eq cons_to_nth_cps cons_to_nth_cps_sig.
-  Hint Unfold cons_to_nth_cps : basesystem_partial_evaluation_unfolder.
+  Global Hint Unfold cons_to_nth_cps : basesystem_partial_evaluation_unfolder.
   Hint Rewrite <- cons_to_nth_cps_eq : pattern_runtime.
 
   Definition cons_to_nth_sig := parameterize_sig (@Core.Columns.cons_to_nth).
   Definition cons_to_nth := parameterize_from_sig cons_to_nth_sig.
   Definition cons_to_nth_eq := parameterize_eq cons_to_nth cons_to_nth_sig.
-  Hint Unfold cons_to_nth : basesystem_partial_evaluation_unfolder.
+  Global Hint Unfold cons_to_nth : basesystem_partial_evaluation_unfolder.
   Hint Rewrite <- cons_to_nth_eq : pattern_runtime.
 
   Definition nils_sig := parameterize_sig (@Core.Columns.nils).
   Definition nils := parameterize_from_sig nils_sig.
   Definition nils_eq := parameterize_eq nils nils_sig.
-  Hint Unfold nils : basesystem_partial_evaluation_unfolder.
+  Global Hint Unfold nils : basesystem_partial_evaluation_unfolder.
   Hint Rewrite <- nils_eq : pattern_runtime.
 
   Definition from_associational_cps_sig := parameterize_sig (@Core.Columns.from_associational_cps).
   Definition from_associational_cps := parameterize_from_sig from_associational_cps_sig.
   Definition from_associational_cps_eq := parameterize_eq from_associational_cps from_associational_cps_sig.
-  Hint Unfold from_associational_cps : basesystem_partial_evaluation_unfolder.
+  Global Hint Unfold from_associational_cps : basesystem_partial_evaluation_unfolder.
   Hint Rewrite <- from_associational_cps_eq : pattern_runtime.
 
   Definition from_associational_sig := parameterize_sig (@Core.Columns.from_associational).
   Definition from_associational := parameterize_from_sig from_associational_sig.
   Definition from_associational_eq := parameterize_eq from_associational from_associational_sig.
-  Hint Unfold from_associational : basesystem_partial_evaluation_unfolder.
+  Global Hint Unfold from_associational : basesystem_partial_evaluation_unfolder.
   Hint Rewrite <- from_associational_eq : pattern_runtime.
 
 End Columns.

--- a/src/Arithmetic/Saturated/Freeze.v
+++ b/src/Arithmetic/Saturated/Freeze.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.Lists.List.
 Require Import Coq.Classes.RelationClasses.

--- a/src/Arithmetic/Saturated/Freeze.v
+++ b/src/Arithmetic/Saturated/Freeze.v
@@ -1,6 +1,7 @@
 Require Import Coq.micromega.Lia.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.Lists.List.
+Require Import Coq.Classes.RelationClasses.
 Local Open Scope Z_scope.
 
 Require Import Crypto.Arithmetic.Core.
@@ -54,7 +55,7 @@ Section Freeze.
     @freeze_cps n mask m p _ id.
   Lemma freeze_id {n} mask m p T f:
     @freeze_cps n mask m p T f = f (freeze mask m p).
-  Proof.
+  Proof using Type.
     cbv [freeze_cps freeze]; repeat progress autounfold;
       autorewrite with uncps push_id; reflexivity.
   Qed.
@@ -72,7 +73,7 @@ Section Freeze.
     z0 = z + (if (dec (c0 = 0)) then 0 else m) ->
     a = z0 mod s ->
     a mod m = y0 mod m.
-  Proof.
+  Proof using Type.
     clear. intros. subst. break_match.
     { rewrite Z.add_0_r, Z.mod_mod by lia.
       assert (-(s-c) <= y - (s-c) < s-c) by lia.
@@ -99,7 +100,7 @@ Section Freeze.
       mod_eq modulus
              (B.Positional.eval weight (@freeze n mask m p))
              (B.Positional.eval weight p).
-  Proof.
+  Proof using weight_0 weight_divides weight_multiples weight_nonzero weight_positive.
     cbv [freeze_cps freeze].
     repeat progress autounfold.
     pose proof Z.add_get_carry_full_mod.
@@ -126,12 +127,12 @@ Section Freeze.
       reflexivity. }
   Qed.
 End Freeze.
-Hint Opaque freeze_cps : uncps.
+Global Hint Opaque freeze_cps : uncps.
 Hint Rewrite @freeze_id : uncps.
 Hint Rewrite @eval_freeze
      using (assumption || reflexivity || auto || eassumption || lia) : push_basesystem_eval.
 
-Hint Unfold
+Global Hint Unfold
      freeze freeze_cps
   : basesystem_partial_evaluation_unfolder.
 

--- a/src/Arithmetic/Saturated/FreezeUnfolder.v
+++ b/src/Arithmetic/Saturated/FreezeUnfolder.v
@@ -17,11 +17,11 @@ done
 Definition freeze_cps_sig := parameterize_sig (@Freeze.freeze_cps).
 Definition freeze_cps := parameterize_from_sig freeze_cps_sig.
 Definition freeze_cps_eq := parameterize_eq freeze_cps freeze_cps_sig.
-Hint Unfold freeze_cps : basesystem_partial_evaluation_unfolder.
+Global Hint Unfold freeze_cps : basesystem_partial_evaluation_unfolder.
 Hint Rewrite <- freeze_cps_eq : pattern_runtime.
 
 Definition freeze_sig := parameterize_sig (@Freeze.freeze).
 Definition freeze := parameterize_from_sig freeze_sig.
 Definition freeze_eq := parameterize_eq freeze freeze_sig.
-Hint Unfold freeze : basesystem_partial_evaluation_unfolder.
+Global Hint Unfold freeze : basesystem_partial_evaluation_unfolder.
 Hint Rewrite <- freeze_eq : pattern_runtime.

--- a/src/Arithmetic/Saturated/MontgomeryAPI.v
+++ b/src/Arithmetic/Saturated/MontgomeryAPI.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Lists.List.
 Local Open Scope Z_scope.
 

--- a/src/Arithmetic/Saturated/MontgomeryAPI.v
+++ b/src/Arithmetic/Saturated/MontgomeryAPI.v
@@ -643,7 +643,7 @@ Section API.
 End API.
 Hint Rewrite nonzero_id join0_id divmod_id drop_high_id scmul_id add_id add_S1_id add_S2_id sub_then_maybe_add_id conditional_sub_id : uncps.
 
-Hint Unfold
+Global Hint Unfold
      nonzero_cps
      nonzero
      scmul_cps

--- a/src/Arithmetic/Saturated/MulSplit.v
+++ b/src/Arithmetic/Saturated/MulSplit.v
@@ -25,7 +25,7 @@ Module B.
 
       Local Lemma mul_split_cps_correct {T} s x y f
         : @mul_split_cps T s x y f = f ((x * y) mod s, (x * y) / s).
-      Proof.
+      Proof using mul_split_cps_id mul_split_div mul_split_mod.
         now rewrite mul_split_cps_id, <- mul_split_mod, <- mul_split_div, <- surjective_pairing.
       Qed.
       Hint Rewrite @mul_split_cps_correct : uncps.
@@ -38,7 +38,7 @@ Module B.
       Definition sat_multerm s t t' := sat_multerm_cps s t t' id.
       Lemma sat_multerm_id s t t' T f :
       @sat_multerm_cps s t t' T f = f (sat_multerm s t t').
-      Proof.
+      Proof using mul_split_cps_id.
         unfold sat_multerm, sat_multerm_cps;
           etransitivity; rewrite mul_split_cps_id; reflexivity.
       Qed.
@@ -50,13 +50,13 @@ Module B.
 
       Definition sat_mul s p q := sat_mul_cps s p q id.
       Lemma sat_mul_id s p q T f : @sat_mul_cps s p q T f = f (sat_mul s p q).
-      Proof. cbv [sat_mul sat_mul_cps]. autorewrite with uncps. reflexivity. Qed.
+      Proof using mul_split_cps_id. cbv [sat_mul sat_mul_cps]. autorewrite with uncps. reflexivity. Qed.
       Hint Opaque sat_mul : uncps.
       Hint Rewrite sat_mul_id : uncps.
 
       Lemma eval_map_sat_multerm s a q (s_nonzero:s<>0):
       B.Associational.eval (flat_map (sat_multerm s a) q) = fst a * snd a * B.Associational.eval q.
-      Proof.
+      Proof using mul_split_cps_id mul_split_div mul_split_mod.
         cbv [sat_multerm sat_multerm_cps Let_In]; induction q;
           repeat match goal with
                  | _ => progress autorewrite with uncps push_id cancel_pair push_basesystem_eval in *
@@ -74,7 +74,7 @@ Module B.
 
       Lemma eval_sat_mul s p q (s_nonzero:s<>0):
       B.Associational.eval (sat_mul s p q) = B.Associational.eval p * B.Associational.eval q.
-      Proof.
+      Proof using mul_split_cps_id mul_split_div mul_split_mod.
       cbv [sat_mul sat_mul_cps]; induction p; [reflexivity|].
       repeat match goal with
               | _ => progress (autorewrite with uncps push_id push_basesystem_eval in * )
@@ -88,11 +88,11 @@ Module B.
     End Associational.
   End Associational.
 End B.
-Hint Opaque B.Associational.sat_mul B.Associational.sat_multerm : uncps.
+Global Hint Opaque B.Associational.sat_mul B.Associational.sat_multerm : uncps.
 Hint Rewrite @B.Associational.sat_mul_id @B.Associational.sat_multerm_id using (assumption || (intros; autorewrite with uncps; reflexivity)) : uncps.
 Hint Rewrite @B.Associational.eval_sat_mul @B.Associational.eval_map_sat_multerm using (lia || assumption) : push_basesystem_eval.
 
-Hint Unfold
+Global Hint Unfold
      B.Associational.sat_multerm_cps B.Associational.sat_multerm B.Associational.sat_mul_cps B.Associational.sat_mul
   : basesystem_partial_evaluation_unfolder.
 

--- a/src/Arithmetic/Saturated/MulSplit.v
+++ b/src/Arithmetic/Saturated/MulSplit.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.Lists.List.
 Local Open Scope Z_scope.

--- a/src/Arithmetic/Saturated/MulSplitUnfolder.v
+++ b/src/Arithmetic/Saturated/MulSplitUnfolder.v
@@ -20,25 +20,25 @@ echo "End B."
     Definition sat_multerm_cps_sig := parameterize_sig (@MulSplit.B.Associational.sat_multerm_cps).
     Definition sat_multerm_cps := parameterize_from_sig sat_multerm_cps_sig.
     Definition sat_multerm_cps_eq := parameterize_eq sat_multerm_cps sat_multerm_cps_sig.
-    Hint Unfold sat_multerm_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold sat_multerm_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- sat_multerm_cps_eq : pattern_runtime.
 
     Definition sat_multerm_sig := parameterize_sig (@MulSplit.B.Associational.sat_multerm).
     Definition sat_multerm := parameterize_from_sig sat_multerm_sig.
     Definition sat_multerm_eq := parameterize_eq sat_multerm sat_multerm_sig.
-    Hint Unfold sat_multerm : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold sat_multerm : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- sat_multerm_eq : pattern_runtime.
 
     Definition sat_mul_cps_sig := parameterize_sig (@MulSplit.B.Associational.sat_mul_cps).
     Definition sat_mul_cps := parameterize_from_sig sat_mul_cps_sig.
     Definition sat_mul_cps_eq := parameterize_eq sat_mul_cps sat_mul_cps_sig.
-    Hint Unfold sat_mul_cps : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold sat_mul_cps : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- sat_mul_cps_eq : pattern_runtime.
 
     Definition sat_mul_sig := parameterize_sig (@MulSplit.B.Associational.sat_mul).
     Definition sat_mul := parameterize_from_sig sat_mul_sig.
     Definition sat_mul_eq := parameterize_eq sat_mul sat_mul_sig.
-    Hint Unfold sat_mul : basesystem_partial_evaluation_unfolder.
+    Global Hint Unfold sat_mul : basesystem_partial_evaluation_unfolder.
     Hint Rewrite <- sat_mul_eq : pattern_runtime.
 
   End Associational.

--- a/src/Arithmetic/Saturated/UniformWeight.v
+++ b/src/Arithmetic/Saturated/UniformWeight.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.Lists.List.
 Local Open Scope Z_scope.

--- a/src/Arithmetic/Saturated/Wrappers.v
+++ b/src/Arithmetic/Saturated/Wrappers.v
@@ -47,13 +47,13 @@ Module Columns.
 
   End Wrappers.
 End Columns.
-Hint Unfold
+Global Hint Unfold
      Columns.conditional_add_cps
      Columns.add_cps
      Columns.unbalanced_sub_cps
      Columns.mul_cps.
 
-Hint Unfold
+Global Hint Unfold
      Columns.add_cps Columns.unbalanced_sub_cps Columns.mul_cps Columns.conditional_add_cps
   : basesystem_partial_evaluation_unfolder.
 

--- a/src/Arithmetic/Saturated/WrappersUnfolder.v
+++ b/src/Arithmetic/Saturated/WrappersUnfolder.v
@@ -3,7 +3,7 @@ Require Import Crypto.Arithmetic.Saturated.CoreUnfolder.
 Require Import Crypto.Arithmetic.Saturated.MulSplitUnfolder.
 Require Import Crypto.Arithmetic.Saturated.Wrappers.
 
-Hint Unfold Wrappers.Columns.add_cps Wrappers.Columns.unbalanced_sub_cps Wrappers.Columns.mul_cps : arithmetic_cps_unfolder.
+Global Hint Unfold Wrappers.Columns.add_cps Wrappers.Columns.unbalanced_sub_cps Wrappers.Columns.mul_cps : arithmetic_cps_unfolder.
 
 Module Columns.
   (**
@@ -21,25 +21,25 @@ echo "End Columns."
   Definition add_cps_sig := parameterize_sig (@Wrappers.Columns.add_cps).
   Definition add_cps := parameterize_from_sig add_cps_sig.
   Definition add_cps_eq := parameterize_eq add_cps add_cps_sig.
-  Hint Unfold add_cps : basesystem_partial_evaluation_unfolder.
+  Global Hint Unfold add_cps : basesystem_partial_evaluation_unfolder.
   Hint Rewrite <- add_cps_eq : pattern_runtime.
 
   Definition unbalanced_sub_cps_sig := parameterize_sig (@Wrappers.Columns.unbalanced_sub_cps).
   Definition unbalanced_sub_cps := parameterize_from_sig unbalanced_sub_cps_sig.
   Definition unbalanced_sub_cps_eq := parameterize_eq unbalanced_sub_cps unbalanced_sub_cps_sig.
-  Hint Unfold unbalanced_sub_cps : basesystem_partial_evaluation_unfolder.
+  Global Hint Unfold unbalanced_sub_cps : basesystem_partial_evaluation_unfolder.
   Hint Rewrite <- unbalanced_sub_cps_eq : pattern_runtime.
 
   Definition mul_cps_sig := parameterize_sig (@Wrappers.Columns.mul_cps).
   Definition mul_cps := parameterize_from_sig mul_cps_sig.
   Definition mul_cps_eq := parameterize_eq mul_cps mul_cps_sig.
-  Hint Unfold mul_cps : basesystem_partial_evaluation_unfolder.
+  Global Hint Unfold mul_cps : basesystem_partial_evaluation_unfolder.
   Hint Rewrite <- mul_cps_eq : pattern_runtime.
 
   Definition conditional_add_cps_sig := parameterize_sig (@Wrappers.Columns.conditional_add_cps).
   Definition conditional_add_cps := parameterize_from_sig conditional_add_cps_sig.
   Definition conditional_add_cps_eq := parameterize_eq conditional_add_cps conditional_add_cps_sig.
-  Hint Unfold conditional_add_cps : basesystem_partial_evaluation_unfolder.
+  Global Hint Unfold conditional_add_cps : basesystem_partial_evaluation_unfolder.
   Hint Rewrite <- conditional_add_cps_eq : pattern_runtime.
 
 End Columns.

--- a/src/Compilers/CommonSubexpressionEliminationInterp.v
+++ b/src/Compilers/CommonSubexpressionEliminationInterp.v
@@ -1,4 +1,5 @@
 (** * Common Subexpression Elimination for PHOAS Syntax *)
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Lists.List.
 Require Import Crypto.Compilers.Named.Context.
 Require Import Crypto.Compilers.Named.AListContext.
@@ -75,7 +76,7 @@ Section symbolic.
   Lemma interpf_flatten_binding_list T t x y v s
         (H : List.In (existT _ t (x, y)) (flatten_binding_list (var2:=interp_base_type) (t:=T) (symbolicify_smart_var v s) v))
     : fst x = y.
-  Proof.
+  Proof using Type.
     revert dependent s; induction T;
       repeat first [ progress simpl in *
                    | reflexivity
@@ -183,7 +184,7 @@ Section symbolic.
 
   Lemma interpf_prepend_prefix t e prefix
     : interpf interp_op (@prepend_prefix _ t e prefix) = interpf interp_op e.
-  Proof.
+  Proof using Type.
     induction prefix; simpl; [ reflexivity | unfold LetIn.Let_In; assumption ].
   Qed.
 
@@ -210,7 +211,7 @@ Section symbolic.
             -> exists pf : t1 = t2, wff nil (eq_rect _ exprf e1 _ pf) e2)*)
         (Hwf : Wf e)
     : forall x, Interp interp_op (@CSE t e prefix) x = Interp interp_op e x.
-  Proof.
+  Proof using base_type_code_lb denote_op op_code_bl op_code_lb.
     apply interp_cse; auto.
   Qed.
 End symbolic.

--- a/src/Compilers/CommonSubexpressionEliminationProperties.v
+++ b/src/Compilers/CommonSubexpressionEliminationProperties.v
@@ -1,5 +1,5 @@
 (** * Common Subexpression Elimination for PHOAS Syntax *)
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Lists.List.
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.FSets.FMapInterface.

--- a/src/Compilers/CommonSubexpressionEliminationProperties.v
+++ b/src/Compilers/CommonSubexpressionEliminationProperties.v
@@ -1,6 +1,7 @@
 (** * Common Subexpression Elimination for PHOAS Syntax *)
 Require Import Coq.micromega.Lia.
 Require Import Coq.Lists.List.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.FSets.FMapInterface.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.Equality.

--- a/src/Compilers/CommonSubexpressionEliminationWf.v
+++ b/src/Compilers/CommonSubexpressionEliminationWf.v
@@ -1,4 +1,5 @@
 (** * Common Subexpression Elimination for PHOAS Syntax *)
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Lists.List.
 Require Import Crypto.Compilers.Named.Context.
 Require Import Crypto.Compilers.Named.AListContext.
@@ -65,7 +66,7 @@ Section symbolic.
           (HG : forall t x y, List.In (existT _ t (x, y)) G -> snd x = snd y)
           (Hwf : wff G e1 e2)
       : @symbolize_exprf var1 t e1 = @symbolize_exprf var2 t e2.
-    Proof.
+    Proof using Type.
       induction Hwf; simpl; erewrite_hyp ?* by eassumption; reflexivity.
     Qed.
 
@@ -73,7 +74,7 @@ Section symbolic.
           (HG : forall t x y, List.In (existT _ t (x, y)) G -> snd x = snd y)
           (Hwf : wff G e1 e2)
       : @norm_symbolize_exprf var1 t e1 = @norm_symbolize_exprf var2 t e2.
-    Proof.
+    Proof using Type.
       unfold norm_symbolize_exprf; erewrite wff_symbolize_exprf by eassumption; reflexivity.
     Qed.
 
@@ -169,7 +170,7 @@ Section symbolic.
               -> exists pf : t1 = t2, wff nil (eq_rect _ exprf e1 _ pf) e2)
           (Hwf : wff G e1 e2)
       : wff G (@prepend_prefix var1' t e1 prefix1) (@prepend_prefix var2' t e2 prefix2).
-    Proof.
+    Proof using Type.
       revert dependent G; revert dependent prefix2; induction prefix1, prefix2; simpl; intros Hlen Hprefix G Hwf; try congruence.
       { pose proof (Hprefix 0) as H0; specialize (fun n => Hprefix (S n)).
         destruct_head sigT; simpl in *.
@@ -188,7 +189,7 @@ Section symbolic.
               -> nth_error prefix2 n = Some (existT _ t2 e2)
               -> exists pf : t1 = t2, wff nil (eq_rect _ exprf e1 _ pf) e2)
       : wf (@cse var1 prefix1 t e1 empty) (@cse var2 prefix2 t e2 empty).
-    Proof.
+    Proof using base_type_code_lb op_code_bl op_code_lb.
       destruct Hwf; simpl; constructor; intros.
       lazymatch goal with
       | [ |- wff (flatten_binding_list (t:=?src) ?x ?y) (csef _ (extendb _ ?n ?v)) (csef _ (extendb _ ?n' ?v')) ]
@@ -215,9 +216,9 @@ Section symbolic.
             -> exists pf : t1 = t2, wff nil (eq_rect _ exprf e1 _ pf) e2)
         (Hwf : Wf e)
     : Wf (@CSE t e prefix).
-  Proof.
+  Proof using base_type_code_lb op_code_bl op_code_lb.
     intros var1 var2; apply wf_cse; eauto.
   Qed.
 End symbolic.
 
-Hint Resolve Wf_CSE : wf.
+Global Hint Resolve Wf_CSE : wf.

--- a/src/Compilers/Equality.v
+++ b/src/Compilers/Equality.v
@@ -79,12 +79,12 @@ Lemma dec_eq_flat_type {base_type_code} `{DecidableRel (@eq base_type_code)}
 Proof.
   repeat intro; hnf; decide equality; apply dec; auto.
 Defined.
-Hint Extern 1 (Decidable (@eq (flat_type ?base_type_code) ?x ?y))
+Global Hint Extern 1 (Decidable (@eq (flat_type ?base_type_code) ?x ?y))
 => simple apply (@dec_eq_flat_type base_type_code) : typeclass_instances.
 Lemma dec_eq_type {base_type_code} `{DecidableRel (@eq base_type_code)}
   : DecidableRel (@eq (type base_type_code)).
 Proof.
   repeat intro; hnf; decide equality; apply dec; typeclasses eauto.
 Defined.
-Hint Extern 1 (Decidable (@eq (type ?base_type_code) ?x ?y))
+Global Hint Extern 1 (Decidable (@eq (type ?base_type_code) ?x ?y))
 => simple apply (@dec_eq_type base_type_code) : typeclass_instances.

--- a/src/Compilers/EtaWf.v
+++ b/src/Compilers/EtaWf.v
@@ -1,3 +1,4 @@
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.Wf.
 Require Import Crypto.Compilers.Eta.
@@ -119,4 +120,4 @@ Section language.
   Definition Wf_ExprEta' {t e} : Wf e -> Wf (ExprEta' e) := proj2 (@Wf_ExprEta'_iff t e).
 End language.
 
-Hint Resolve Wf_ExprEta Wf_ExprEta' : wf.
+Global Hint Resolve Wf_ExprEta Wf_ExprEta' : wf.

--- a/src/Compilers/GeneralizeVarInterp.v
+++ b/src/Compilers/GeneralizeVarInterp.v
@@ -1,3 +1,4 @@
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.SmartMap.
 Require Import Crypto.Compilers.Wf.
 Require Import Crypto.Compilers.Relations.

--- a/src/Compilers/GeneralizeVarWf.v
+++ b/src/Compilers/GeneralizeVarWf.v
@@ -74,4 +74,4 @@ Section language.
   Proof using base_type_code_lb. eapply Wf_GeneralizeVar; eassumption. Qed.
 End language.
 
-Hint Resolve Wf_GeneralizeVar Wf_GeneralizeVar_arrow : wf.
+Global Hint Resolve Wf_GeneralizeVar Wf_GeneralizeVar_arrow : wf.

--- a/src/Compilers/InlineConstAndOpByRewriteInterp.v
+++ b/src/Compilers/InlineConstAndOpByRewriteInterp.v
@@ -1,4 +1,5 @@
 (** * Inline: Remove some [Let] expressions, inline constants, interpret constant operations *)
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.SmartMap.
 Require Import Crypto.Compilers.ExprInversion.
@@ -51,7 +52,7 @@ Module Export Rewrite.
             {t} e
         : interpf interp_op (inline_const_and_op_genf (t:=t) interp_op invert_Const Const e)
           = interpf interp_op e.
-      Proof.
+      Proof using Hinvert_Const interpf_Const.
         unfold inline_const_and_op_genf;
           eapply interpf_rewrite_opf; eauto using interpf_rewrite_for_const_and_op.
       Qed.
@@ -61,7 +62,7 @@ Module Export Rewrite.
         : forall x,
           interp interp_op (inline_const_and_op_gen (t:=t) interp_op invert_Const Const e) x
           = interp interp_op e x.
-      Proof.
+      Proof using Hinvert_Const interpf_Const.
         unfold inline_const_and_op_gen;
           eapply interp_rewrite_op; eauto using interpf_rewrite_for_const_and_op.
       Qed.
@@ -89,7 +90,7 @@ Module Export Rewrite.
             {t} e
         : interpf interp_op (inline_const_and_opf (t:=t) interp_op OpConst e)
           = interpf interp_op e.
-      Proof.
+      Proof using interp_op_OpConst.
         unfold inline_const_and_opf;
           eapply interpf_rewrite_opf; eauto using interpf_rewrite_for_const_and_op, interpf_invert_ConstUnit, interpf_Const.
       Qed.
@@ -99,7 +100,7 @@ Module Export Rewrite.
         : forall x,
           interp interp_op (inline_const_and_op (t:=t) interp_op OpConst e) x
           = interp interp_op e x.
-      Proof.
+      Proof using interp_op_OpConst.
         unfold inline_const_and_op;
           eapply interp_rewrite_op; eauto using interpf_rewrite_for_const_and_op, interpf_invert_ConstUnit, interpf_Const.
       Qed.

--- a/src/Compilers/InlineConstAndOpByRewriteWf.v
+++ b/src/Compilers/InlineConstAndOpByRewriteWf.v
@@ -167,5 +167,5 @@ Module Export Rewrite.
     Qed.
   End language.
 
-  Hint Resolve Wf_InlineConstAndOpGen Wf_InlineConstAndOp : wf.
+  Global Hint Resolve Wf_InlineConstAndOpGen Wf_InlineConstAndOp : wf.
 End Rewrite.

--- a/src/Compilers/InlineConstAndOpInterp.v
+++ b/src/Compilers/InlineConstAndOpInterp.v
@@ -1,4 +1,5 @@
 (** * Inline: Remove some [Let] expressions, inline constants, interpret constant operations *)
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.Wf.
 Require Import Crypto.Compilers.SmartMap.
@@ -41,7 +42,7 @@ Section language.
                 (exprf_of_inline_directive
                    (postprocess_for_const_and_op interp_op invert_Const Const e))
         = interpf interp_op e.
-    Proof.
+    Proof using Hinvert_Const interpf_Const.
       induction e; try reflexivity; simpl in *.
       all:repeat first [ reflexivity
                        | break_innermost_match_step
@@ -67,7 +68,7 @@ Section language.
               -> interpf interp_op x = x')
       : interpf interp_op (inline_const_and_op_genf (t:=t) interp_op invert_Const Const e1)
         = interpf interp_op e2.
-    Proof.
+    Proof using Hinvert_Const interpf_Const.
       unfold inline_const_and_op_genf;
         eapply interpf_inline_const_genf; eauto using interpf_postprocess_for_const_and_op.
     Qed.
@@ -78,7 +79,7 @@ Section language.
       : forall x,
         interp interp_op (inline_const_and_op_gen (t:=t) interp_op invert_Const Const e1) x
         = interp interp_op e2 x.
-    Proof.
+    Proof using Hinvert_Const interpf_Const.
       unfold inline_const_and_op_gen;
         eapply interp_inline_const_gen; eauto using interpf_postprocess_for_const_and_op.
     Qed.
@@ -112,7 +113,7 @@ Section language.
               -> interpf interp_op x = x')
       : interpf interp_op (inline_const_and_opf (t:=t) interp_op OpConst e1)
         = interpf interp_op e2.
-    Proof.
+    Proof using interp_op_OpConst.
       unfold inline_const_and_opf;
         eapply interpf_inline_const_genf; eauto using interpf_postprocess_for_const_and_op, interpf_invert_ConstUnit, interpf_Const.
     Qed.
@@ -123,7 +124,7 @@ Section language.
       : forall x,
         interp interp_op (inline_const_and_op (t:=t) interp_op OpConst e1) x
         = interp interp_op e2 x.
-    Proof.
+    Proof using interp_op_OpConst.
       unfold inline_const_and_op;
         eapply interp_inline_const_gen; eauto using interpf_postprocess_for_const_and_op, interpf_invert_ConstUnit, interpf_Const.
     Qed.

--- a/src/Compilers/InlineConstAndOpWf.v
+++ b/src/Compilers/InlineConstAndOpWf.v
@@ -1,4 +1,5 @@
 (** * Inline: Remove some [Let] expressions, inline constants, interpret constant operations *)
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.Wf.
 Require Import Crypto.Compilers.ExprInversion.
@@ -216,4 +217,4 @@ Section language.
   Qed.
 End language.
 
-Hint Resolve Wf_InlineConstAndOpGen Wf_InlineConstAndOp : wf.
+Global Hint Resolve Wf_InlineConstAndOpGen Wf_InlineConstAndOp : wf.

--- a/src/Compilers/InlineInterp.v
+++ b/src/Compilers/InlineInterp.v
@@ -1,4 +1,5 @@
 (** * Inline: Remove some [Let] expressions *)
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.Wf.
 Require Import Crypto.Compilers.Relations.

--- a/src/Compilers/InlineWf.v
+++ b/src/Compilers/InlineWf.v
@@ -1,4 +1,5 @@
 (** * Inline: Remove some [Let] expressions *)
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.Wf.
 Require Import Crypto.Compilers.TypeInversion.
@@ -228,4 +229,4 @@ Section language.
   Qed.
 End language.
 
-Hint Resolve Wf_InlineConstGen Wf_InlineConst : wf.
+Global Hint Resolve Wf_InlineConstGen Wf_InlineConst : wf.

--- a/src/Compilers/InterpByIsoProofs.v
+++ b/src/Compilers/InterpByIsoProofs.v
@@ -1,4 +1,5 @@
 (** * PHOAS interpretation function for any retract of [var:=interp_base_type] *)
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.InterpByIso.
 Require Import Crypto.Compilers.Relations.

--- a/src/Compilers/InterpWf.v
+++ b/src/Compilers/InterpWf.v
@@ -1,4 +1,5 @@
 Require Import Coq.Strings.String Coq.Classes.RelationClasses.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.Wf.
 Require Import Crypto.Compilers.Relations.

--- a/src/Compilers/InterpWfRel.v
+++ b/src/Compilers/InterpWfRel.v
@@ -1,4 +1,5 @@
 Require Import Coq.Strings.String Coq.Classes.RelationClasses.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.Wf.
 Require Import Crypto.Compilers.Relations.

--- a/src/Compilers/LinearizeWf.v
+++ b/src/Compilers/LinearizeWf.v
@@ -1,4 +1,5 @@
 (** * Linearize: Place all and only operations in let binders *)
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.Wf.
 Require Import Crypto.Compilers.ExprInversion.
@@ -176,4 +177,4 @@ Section language.
     := Wf_Linearize_gen _ e.
 End language.
 
-Hint Resolve Wf_Linearize_gen Wf_Linearize Wf_ANormal : wf.
+Global Hint Resolve Wf_Linearize_gen Wf_Linearize Wf_ANormal : wf.

--- a/src/Compilers/MapBaseTypeWf.v
+++ b/src/Compilers/MapBaseTypeWf.v
@@ -1,3 +1,4 @@
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Bool.Sumbool.
 Require Import Crypto.Compilers.SmartMap.
 Require Import Crypto.Compilers.Syntax.
@@ -55,7 +56,7 @@ Section language.
       : wff G'
             (mapf_base_type f_var12 f_var21 failb e)
             (mapf_base_type f_var'12 f_var'21 failb' e').
-    Proof.
+    Proof using Hvar'12 Hvar12 Hwf_f_op Hwf_failb.
       revert dependent G'; induction Hwf;
         repeat first [ progress simpl in *
                      | progress intros
@@ -81,7 +82,7 @@ Section language.
       : wf
           (map_base_type f_var12 f_var21 failb e)
           (map_base_type f_var'12 f_var'21 failb' e').
-    Proof.
+    Proof using Hvar'12 Hvar12 Hwf_f_op Hwf_failb.
       destruct Hwf; constructor; simpl; intros.
       eapply wff_mapf_base_type; [ | eauto ].
       eauto using In_flatten_binding_list_untransfer_interp_flat_type.
@@ -114,4 +115,4 @@ Section language.
   End MapBaseType.
 End language.
 
-Hint Resolve @Wf_MapBaseType' : wf.
+Global Hint Resolve @Wf_MapBaseType' : wf.

--- a/src/Compilers/MapCastByDeBruijnWf.v
+++ b/src/Compilers/MapCastByDeBruijnWf.v
@@ -105,4 +105,4 @@ Section language.
   Proof using base_type_code_lb. exact (@Wf_MapCast (Arrow s d) e input_bounds). Qed.
 End language.
 
-Hint Resolve Wf_MapCast Wf_MapCast_arrow : wf.
+Global Hint Resolve Wf_MapCast Wf_MapCast_arrow : wf.

--- a/src/Compilers/MultiSizeTest.v
+++ b/src/Compilers/MultiSizeTest.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Arith.Arith.
 Require Import Crypto.Compilers.SmartMap.
 

--- a/src/Compilers/Named/CompileInterp.v
+++ b/src/Compilers/Named/CompileInterp.v
@@ -1,4 +1,5 @@
 (** * PHOAS → Named Representation of Gallina *)
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Named.Context.
 Require Import Crypto.Compilers.Named.Syntax.
 Require Import Crypto.Compilers.Named.NameUtil.

--- a/src/Compilers/Named/CompileInterpSideConditions.v
+++ b/src/Compilers/Named/CompileInterpSideConditions.v
@@ -1,3 +1,4 @@
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Named.Context.
 Require Import Crypto.Compilers.Named.Syntax.
 Require Import Crypto.Compilers.Named.NameUtil.

--- a/src/Compilers/Named/CompileProperties.v
+++ b/src/Compilers/Named/CompileProperties.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Named.Syntax.
 Require Import Crypto.Compilers.Named.NameUtil.
 Require Import Crypto.Compilers.Named.NameUtilProperties.

--- a/src/Compilers/Named/CompileWf.v
+++ b/src/Compilers/Named/CompileWf.v
@@ -1,4 +1,5 @@
 (** * PHOAS → Named Representation of Gallina *)
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Named.Context.
 Require Import Crypto.Compilers.Named.Syntax.
 Require Import Crypto.Compilers.Named.Wf.

--- a/src/Compilers/Named/ContextProperties/NameUtil.v
+++ b/src/Compilers/Named/ContextProperties/NameUtil.v
@@ -1,4 +1,5 @@
 Require Import Coq.micromega.Lia.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.FixCoqMistakes.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.Wf.

--- a/src/Compilers/Named/ContextProperties/NameUtil.v
+++ b/src/Compilers/Named/ContextProperties/NameUtil.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.FixCoqMistakes.
 Require Import Crypto.Compilers.Syntax.

--- a/src/Compilers/Named/ContextProperties/Proper.v
+++ b/src/Compilers/Named/ContextProperties/Proper.v
@@ -1,4 +1,4 @@
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.Named.Syntax.
 Require Import Crypto.Compilers.Named.Context.

--- a/src/Compilers/Named/ContextProperties/SmartMap.v
+++ b/src/Compilers/Named/ContextProperties/SmartMap.v
@@ -1,3 +1,4 @@
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.Relations.
 Require Import Crypto.Compilers.SmartMap.
@@ -227,7 +228,7 @@ Section with_context2.
            f_base (fun _ (n : Name) => n)
            N)
       = option_map f_base (find_Name1 (T:=T) n N).
-  Proof.
+  Proof using Type.
     induction T; simpl in *;
       [ | | specialize (IHT1 (fst N));
             specialize (IHT2 (snd N)) ];
@@ -271,7 +272,7 @@ Section with_context2.
                 (fun _ (n : Name) => n) N)
              N'
              default').
-  Proof.
+  Proof using Type.
     revert default default'; induction T; intros;
       [ | | specialize (IHT1 (fst N') (fst N));
             specialize (IHT2 (snd N') (snd N)) ];
@@ -290,7 +291,7 @@ Section with_context2.
         N'
         default'
       = default'.
-  Proof.
+  Proof using Type.
     revert default'; induction T; intros;
       [ | | specialize (IHT1 (fst N') (fst N));
             specialize (IHT2 (snd N') (snd N)) ];

--- a/src/Compilers/Named/FMapContext.v
+++ b/src/Compilers/Named/FMapContext.v
@@ -9,6 +9,7 @@ Require Import Crypto.Util.Equality.
 Module FMapContextFun (E : DecidableType) (W : WSfun E).
   Module Import Properties := WProperties_fun E W.
   Import F.
+  Local Hint Resolve E.eq_refl : core.
   Section ctx.
     Context (E_eq_l : forall x y, E.eq x y -> x = y)
             base_type_code (var : base_type_code -> Type)

--- a/src/Compilers/Named/InterpSideConditionsInterp.v
+++ b/src/Compilers/Named/InterpSideConditionsInterp.v
@@ -1,3 +1,4 @@
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.Named.Syntax.
 Require Import Crypto.Compilers.Named.Context.
@@ -22,7 +23,7 @@ Section language.
   Lemma snd_interpf_side_conditions_gen_eq {t} {ctx : Context} {e}
     : interpf (t:=t) (ctx:=ctx) (interp_op:=interp_op) e
       = option_map (@snd _ _) (interpf_side_conditions_gen interp_op interped_op_side_conditions ctx e).
-  Proof.
+  Proof using Type.
     revert ctx; induction e; intros;
       repeat first [ reflexivity
                    | progress subst
@@ -41,5 +42,5 @@ Section language.
   Lemma snd_interpf_side_conditions_gen_Some {t} {ctx : Context} {e v}
     : interpf (t:=t) (ctx:=ctx) (interp_op:=interp_op) e = Some v
       <-> option_map (@snd _ _) (interpf_side_conditions_gen interp_op interped_op_side_conditions ctx e) = Some v.
-  Proof. rewrite snd_interpf_side_conditions_gen_eq; reflexivity. Qed.
+  Proof using Type. rewrite snd_interpf_side_conditions_gen_eq; reflexivity. Qed.
 End language.

--- a/src/Compilers/Named/InterpretToPHOASInterp.v
+++ b/src/Compilers/Named/InterpretToPHOASInterp.v
@@ -1,3 +1,4 @@
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Named.Context.
 Require Import Crypto.Compilers.Named.Syntax.
 Require Import Crypto.Compilers.Named.Wf.

--- a/src/Compilers/Named/InterpretToPHOASWf.v
+++ b/src/Compilers/Named/InterpretToPHOASWf.v
@@ -1,3 +1,4 @@
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Named.Context.
 Require Import Crypto.Compilers.Named.Syntax.
 Require Import Crypto.Compilers.Named.Wf.
@@ -136,4 +137,4 @@ Section language.
   End all.
 End language.
 
-Hint Resolve Wf_InterpToPHOAS : wf.
+Global Hint Resolve Wf_InterpToPHOAS : wf.

--- a/src/Compilers/Named/MapCastInterp.v
+++ b/src/Compilers/Named/MapCastInterp.v
@@ -1,3 +1,4 @@
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Bool.Sumbool.
 Require Import Coq.Logic.Eqdep_dec.
 Require Import Crypto.Compilers.SmartMap.

--- a/src/Compilers/Named/MapCastWf.v
+++ b/src/Compilers/Named/MapCastWf.v
@@ -1,3 +1,4 @@
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Bool.Sumbool.
 Require Import Coq.Logic.Eqdep_dec.
 Require Import Crypto.Compilers.SmartMap.

--- a/src/Compilers/Named/NameUtilProperties.v
+++ b/src/Compilers/Named/NameUtilProperties.v
@@ -1,6 +1,7 @@
 Require Import Coq.micromega.Lia.
 Require Import Coq.Arith.Arith.
 Require Import Coq.Lists.List.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.CountLets.
 Require Import Crypto.Compilers.Named.NameUtil.

--- a/src/Compilers/Named/NameUtilProperties.v
+++ b/src/Compilers/Named/NameUtilProperties.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Arith.Arith.
 Require Import Coq.Lists.List.
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.

--- a/src/Compilers/Named/PositiveContext/DefaultsProperties.v
+++ b/src/Compilers/Named/PositiveContext/DefaultsProperties.v
@@ -1,3 +1,4 @@
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Lists.List.
 Require Import Coq.Numbers.BinNums.
 Require Import Crypto.Compilers.Syntax.

--- a/src/Compilers/Named/WfFromUnit.v
+++ b/src/Compilers/Named/WfFromUnit.v
@@ -1,3 +1,4 @@
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.Named.Context.
 Require Import Crypto.Compilers.Named.ContextProperties.
@@ -79,4 +80,4 @@ Section language.
   Qed.
 End language.
 
-Hint Resolve wf_from_unit Wf_from_unit wff_from_unit : wf.
+Global Hint Resolve wf_from_unit Wf_from_unit wff_from_unit : wf.

--- a/src/Compilers/Named/WfInterp.v
+++ b/src/Compilers/Named/WfInterp.v
@@ -1,3 +1,4 @@
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.Named.Context.
 Require Import Crypto.Compilers.Named.Syntax.

--- a/src/Compilers/Reify.v
+++ b/src/Compilers/Reify.v
@@ -368,9 +368,9 @@ Ltac do_reifyf_goal _ :=
   debug_leave_reify_rec e;
   eexact e.
 
-Hint Extern 0 (reify (@exprf ?base_type_code ?interp_base_type ?op ?var) ?e)
+Global Hint Extern 0 (reify (@exprf ?base_type_code ?interp_base_type ?op ?var) ?e)
 => do_reifyf_goal () : typeclass_instances.
-Hint Extern 0 (reify_internal (@exprf ?base_type_code ?interp_base_type ?op ?var) ?e)
+Global Hint Extern 0 (reify_internal (@exprf ?base_type_code ?interp_base_type ?op ?var) ?e)
 => do_reifyf_goal () : typeclass_instances.
 
 (** For reification including [Abs] *)
@@ -426,9 +426,9 @@ Ltac do_reify_abs_goal _ :=
   debug_leave_reify_rec e;
   eexact e.
 
-Hint Extern 0 (reify_abs (@exprf ?base_type_code ?interp_base_type ?op ?var) ?e)
+Global Hint Extern 0 (reify_abs (@exprf ?base_type_code ?interp_base_type ?op ?var) ?e)
 => do_reify_abs_goal () : typeclass_instances.
-Hint Extern 0 (reify_abs_internal (@exprf ?base_type_code ?interp_base_type ?op ?var) ?e)
+Global Hint Extern 0 (reify_abs_internal (@exprf ?base_type_code ?interp_base_type ?op ?var) ?e)
 => do_reify_abs_goal () : typeclass_instances.
 
 Ltac Reify' base_type_code interp_base_type op e :=

--- a/src/Compilers/Relations.v
+++ b/src/Compilers/Relations.v
@@ -1,4 +1,4 @@
-Require Import Coq.Lists.List Coq.Classes.RelationClasses Coq.Classes.Morphisms.
+Require Import Coq.Lists.List Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.SmartMap.
 Require Import Crypto.Compilers.Wf.

--- a/src/Compilers/RewriterWf.v
+++ b/src/Compilers/RewriterWf.v
@@ -58,4 +58,4 @@ Section language.
   Qed.
 End language.
 
-Hint Resolve Wf_RewriteOp : wf.
+Global Hint Resolve Wf_RewriteOp : wf.

--- a/src/Compilers/SmartMap.v
+++ b/src/Compilers/SmartMap.v
@@ -1,4 +1,4 @@
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.Tuple.
 Require Import Crypto.Util.Tactics.RewriteHyp.

--- a/src/Compilers/TestCase.v
+++ b/src/Compilers/TestCase.v
@@ -1,4 +1,5 @@
 Require Import Coq.ZArith.ZArith.
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.micromega.Lia Coq.micromega.Psatz.
 Require Import Coq.PArith.BinPos Coq.Lists.List.
 Require Import Crypto.Compilers.Named.Context.

--- a/src/Compilers/TestCase.v
+++ b/src/Compilers/TestCase.v
@@ -1,6 +1,6 @@
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
-Require Import Coq.micromega.Lia Coq.micromega.Psatz.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.PArith.BinPos Coq.Lists.List.
 Require Import Crypto.Compilers.Named.Context.
 Require Import Crypto.Compilers.Named.Syntax.

--- a/src/Compilers/Wf.v
+++ b/src/Compilers/Wf.v
@@ -65,4 +65,4 @@ Global Arguments wff {_ _ _ _} G {t} _ _.
 Global Arguments wf {_ _ _ _ t} _ _.
 Global Arguments Wf {_ _ t} _.
 
-Hint Constructors wf wff : wf.
+Global Hint Constructors wf wff : wf.

--- a/src/Compilers/WfProofs.v
+++ b/src/Compilers/WfProofs.v
@@ -1,3 +1,4 @@
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.Wf.
 Require Import Crypto.Compilers.WfInversion.
@@ -164,7 +165,7 @@ Section language.
       : wff G (t:=t) (var1:=var1) (var2:=var2)
             (SmartPairf (SmartVarfMap f v))
             (SmartPairf (SmartVarfMap (var:=var) g v)).
-    Proof.
+    Proof using Type.
       induction t; try solve [ cbv [SmartPairf]; simpl; auto ].
       rewrite !SmartVarfMap_Pair, !SmartPairf_Pair; auto.
     Qed.
@@ -174,7 +175,7 @@ Section language.
       : wff G (t:=t) (var1:=var1) (var2:=var2)
             (SmartPairf (SmartValf (fun t => exprf (Tbase t)) f _))
             (SmartPairf (SmartValf (fun t => exprf (Tbase t)) g _)).
-    Proof.
+    Proof using Type.
       induction t; try solve [ cbv [SmartPairf]; simpl; auto ].
     Qed.
   End with_var.
@@ -203,7 +204,7 @@ Section language.
         -> List.In
              (existT _ (f_base t) (f_var12 t x, f_var'12 t x'))
              (flatten_binding_list x1 x2).
-    Proof.
+    Proof using Type.
       induction T;
         repeat first [ progress simpl in *
                      | progress intros
@@ -448,7 +449,7 @@ Section language.
                           base_type_code _ _ T
                           (SmartVarfMap2 (fun t (a : var1 t) (b : var3 t) => (a, b)) x z)
                           (SmartVarfMap2 (fun t (a : var1' t) (b : var3' t) => (a, b)) x' z'))).
-  Proof.
+  Proof using op.
     induction T;
       repeat first [ progress intros
                    | progress subst
@@ -470,4 +471,4 @@ Section language.
   Qed.
 End language.
 
-Hint Resolve wff_SmartVarf wff_SmartVarVarf wff_SmartVarVarf_nil : wf.
+Global Hint Resolve wff_SmartVarf wff_SmartVarVarf wff_SmartVarVarf_nil : wf.

--- a/src/Compilers/WfReflectiveGen.v
+++ b/src/Compilers/WfReflectiveGen.v
@@ -48,6 +48,7 @@
       -> option pointed_Prop] *)
 
 Require Import Coq.Arith.Arith Coq.Logic.Eqdep_dec.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Util.Notations Crypto.Util.Option Crypto.Util.Sigma Crypto.Util.Prod Crypto.Util.Decidable Crypto.Util.ListUtil.
 Require Import Crypto.Util.Tactics.RewriteHyp.

--- a/src/Compilers/Z/ArithmeticSimplifierInterp.v
+++ b/src/Compilers/Z/ArithmeticSimplifierInterp.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Psatz.
+Require Import Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.SmartMap.

--- a/src/Compilers/Z/ArithmeticSimplifierWf.v
+++ b/src/Compilers/Z/ArithmeticSimplifierWf.v
@@ -13,6 +13,7 @@ Require Import Crypto.Compilers.Z.Syntax.Util.
 Require Import Crypto.Util.Option.
 Require Import Crypto.Util.Sum.
 Require Import Crypto.Util.Prod.
+Require Import Crypto.Util.Decidable.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.Tactics.DestructHead.
 Require Import Crypto.Util.Tactics.SpecializeBy.
@@ -215,4 +216,4 @@ Proof.
          end.
 Qed.
 
-Hint Resolve Wf_SimplifyArith : wf.
+Global Hint Resolve Wf_SimplifyArith : wf.

--- a/src/Compilers/Z/Bounds/InterpretationLemmas/IsBoundedBy.v
+++ b/src/Compilers/Z/Bounds/InterpretationLemmas/IsBoundedBy.v
@@ -1,4 +1,4 @@
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.micromega.Psatz.
 Require Import Crypto.Compilers.Z.Syntax.
@@ -10,10 +10,13 @@ Require Import Crypto.Compilers.SmartMap.
 Require Import Crypto.Util.ZRange.CornersMonotoneBounds.
 Require Import Crypto.Util.ZUtil.Stabilization.
 Require Import Crypto.Util.ZUtil.MulSplit.
+Require Import Crypto.Util.ZUtil.Div.
+Require Import Crypto.Util.ZUtil.Pow.
 Require Import Crypto.Util.ZUtil.Modulo.
 Require Import Crypto.Util.ZUtil.LandLorShiftBounds.
 Require Import Crypto.Util.ZUtil.Morphisms.
 Require Import Crypto.Util.ZUtil.Definitions.
+Require Import Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
 Require Import Crypto.Util.PointedProp.
 Require Import Crypto.Util.Bool.

--- a/src/Compilers/Z/Bounds/InterpretationLemmas/IsBoundedBy.v
+++ b/src/Compilers/Z/Bounds/InterpretationLemmas/IsBoundedBy.v
@@ -1,6 +1,6 @@
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Psatz.
+Require Import Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Z.Syntax.
 Require Import Crypto.Compilers.Z.Syntax.Util.
 Require Import Crypto.Compilers.Syntax.

--- a/src/Compilers/Z/Bounds/InterpretationLemmas/PullCast.v
+++ b/src/Compilers/Z/Bounds/InterpretationLemmas/PullCast.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Psatz.
+Require Import Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Z.Syntax.
 Require Import Crypto.Compilers.Z.Syntax.Util.
 Require Import Crypto.Compilers.Z.Syntax.Equality.

--- a/src/Compilers/Z/Bounds/InterpretationLemmas/Tactics.v
+++ b/src/Compilers/Z/Bounds/InterpretationLemmas/Tactics.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Psatz.
+Require Import Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Z.Bounds.Interpretation.
 Require Import Crypto.Util.ZUtil.Hints.
 Require Import Crypto.Util.ZUtil.Hints.Core.

--- a/src/Compilers/Z/Bounds/MapCastByDeBruijnWf.v
+++ b/src/Compilers/Z/Bounds/MapCastByDeBruijnWf.v
@@ -34,7 +34,7 @@ Definition Wf_MapCast_arrow
        (fun _ _ opc _ => @genericize_op _ _ _ opc _ _ _)
        s d e input_bounds b e' He' Hwf.
 
-Hint Extern 1 (Wf ?e')
+Global Hint Extern 1 (Wf ?e')
 => match goal with
    | [ He : MapCast _ _ _ = Some (existT _ _ e') |- _ ]
      => first [ refine (@Wf_MapCast _ _ _ _ _ _ He _)

--- a/src/Compilers/Z/Bounds/Pipeline.v
+++ b/src/Compilers/Z/Bounds/Pipeline.v
@@ -17,7 +17,7 @@ while instantiating [?x] and [?bounds] with nicely-reduced constants.
 Module Export Exports.
   Export Glue.Exports.
   Export ReflectiveTactics.Exports.
-  Existing Instance DefaultedTypes.by_default.
+  Global Existing Instance DefaultedTypes.by_default.
 End Exports.
 
 Ltac refine_reflectively_gen allowable_bit_widths opts :=

--- a/src/Compilers/Z/Bounds/Pipeline/Definition.v
+++ b/src/Compilers/Z/Bounds/Pipeline/Definition.v
@@ -168,6 +168,9 @@ Section with_round_up_list.
   Local Notation pick_typeb := (@Bounds.bounds_to_base_type (Bounds.round_up_to_in_list allowable_lgsz)) (only parsing).
   Local Notation pick_type v := (SmartFlatTypeMap pick_typeb v).
   Local Opaque to_prop InterpSideConditions.
+  (* Import Hints *)
+  Import Crypto.Compilers.Z.Syntax.Equality.
+  Import Crypto.Compilers.Z.Bounds.Interpretation.Bounds.
 
   Definition PostWfPreBoundsPipelineCorrect
              opts
@@ -229,7 +232,7 @@ Section with_round_up_list.
              (Hside : to_prop (InterpSideConditions e' v))
     : Bounds.is_bounded_by b (Interp e v)
       /\ cast_back_flat_const (Interp e'' v') = Interp e v.
-  Proof.
+  Proof using Type.
     rewrite <- (proj1 (PostWfPreBoundsPipelineCorrect opts e Hwf)) by assumption.
     eapply PostWfBoundsPipelineCorrect; eauto.
     apply PostWfPreBoundsPipelineCorrect; assumption.

--- a/src/Compilers/Z/Bounds/Relax.v
+++ b/src/Compilers/Z/Bounds/Relax.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.Arith.Arith.
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.

--- a/src/Compilers/Z/Bounds/Relax.v
+++ b/src/Compilers/Z/Bounds/Relax.v
@@ -1,7 +1,7 @@
 Require Import Coq.micromega.Lia.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.Arith.Arith.
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.TypeInversion.
 Require Import Crypto.Compilers.Relations.
@@ -16,6 +16,7 @@ Require Import Crypto.Util.Tactics.SpecializeBy.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.Tactics.SplitInContext.
 Require Import Crypto.Util.Option.
+Require Import Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.ZUtil.Log2.
 Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
 Require Import Crypto.Util.Bool.

--- a/src/Compilers/Z/Bounds/RoundUpLemmas.v
+++ b/src/Compilers/Z/Bounds/RoundUpLemmas.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Z.Bounds.Interpretation.
 Require Import Crypto.Util.ZRange.
 Require Import Crypto.Util.Tactics.BreakMatch.

--- a/src/Compilers/Z/CommonSubexpressionElimination.v
+++ b/src/Compilers/Z/CommonSubexpressionElimination.v
@@ -1,5 +1,5 @@
 (** * Common Subexpression Elimination for PHOAS Syntax *)
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.Sorting.Mergesort.
 Require Import Coq.Structures.Orders.

--- a/src/Compilers/Z/CommonSubexpressionEliminationWf.v
+++ b/src/Compilers/Z/CommonSubexpressionEliminationWf.v
@@ -26,4 +26,4 @@ Proof.
   { destruct n; simpl; try congruence. }
 Qed.
 
-Hint Resolve Wf_CSE : wf.
+Global Hint Resolve Wf_CSE : wf.

--- a/src/Compilers/Z/GeneralizeVarWf.v
+++ b/src/Compilers/Z/GeneralizeVarWf.v
@@ -27,4 +27,4 @@ Definition Wf_GeneralizeVar_arrow
        (fun _ t => Op (OpConst 0%Z) TT)
        s d e e' He'.
 
-Hint Resolve Wf_GeneralizeVar Wf_GeneralizeVar_arrow : wf.
+Global Hint Resolve Wf_GeneralizeVar Wf_GeneralizeVar_arrow : wf.

--- a/src/Compilers/Z/InlineConstAndOpByRewriteWf.v
+++ b/src/Compilers/Z/InlineConstAndOpByRewriteWf.v
@@ -9,5 +9,5 @@ Module Export Rewrite.
   : Wf (InlineConstAndOp e)
     := @Wf_InlineConstAndOp _ _ _ _ _ t e Hwf.
 
-  Hint Resolve Wf_InlineConstAndOp : wf.
+  Global Hint Resolve Wf_InlineConstAndOp : wf.
 End Rewrite.

--- a/src/Compilers/Z/InlineConstAndOpWf.v
+++ b/src/Compilers/Z/InlineConstAndOpWf.v
@@ -8,4 +8,4 @@ Definition Wf_InlineConstAndOp {t} (e : Expr t) (Hwf : Wf e)
   : Wf (InlineConstAndOp e)
   := @Wf_InlineConstAndOp _ _ _ _ _ t e Hwf.
 
-Hint Resolve Wf_InlineConstAndOp : wf.
+Global Hint Resolve Wf_InlineConstAndOp : wf.

--- a/src/Compilers/Z/InlineWf.v
+++ b/src/Compilers/Z/InlineWf.v
@@ -12,4 +12,4 @@ Definition Wf_InlineConst {t} (e : Expr t) (Hwf : Wf e)
   : Wf (InlineConst e)
   := @Wf_InlineConst _ _ _ t e Hwf.
 
-Hint Resolve Wf_InlineConstAndOpp Wf_InlineConst : wf.
+Global Hint Resolve Wf_InlineConstAndOpp Wf_InlineConst : wf.

--- a/src/Compilers/Z/Named/RewriteAddToAdcInterp.v
+++ b/src/Compilers/Z/Named/RewriteAddToAdcInterp.v
@@ -1,4 +1,5 @@
 Require Import Coq.ZArith.ZArith.
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Named.Context.
 Require Import Crypto.Compilers.Named.ContextDefinitions.
 Require Import Crypto.Compilers.Named.ContextProperties.Proper.
@@ -246,17 +247,17 @@ Section named.
         (H : invert_for_do_rewrite_step1 e = Some v)
     : e = let '((a2, c1, bw1, a, b), P) := v in
           (nlet (a2, c1) : tZ * tZ := ADD bw1 a b in P)%nexpr.
-  Proof. t_rewrite_step_correct. Qed.
+  Proof using Type. t_rewrite_step_correct. Qed.
   Lemma invert_for_do_rewrite_step2_correct {t} {e : exprf t} {v}
         (H : invert_for_do_rewrite_step2 e = Some v)
     : e = let '((s, c2, bw2, c0, a2'), P) := v in
           (nlet (s , c2) : tZ * tZ := (ADD bw2 c0 (Var a2')) in P)%nexpr.
-  Proof. t_rewrite_step_correct. Qed.
+  Proof using Type. t_rewrite_step_correct. Qed.
   Lemma invert_for_do_rewrite_step3_correct {t} {e : exprf t} {v}
         (H : invert_for_do_rewrite_step3 e = Some v)
     : e = let '((c, c1', c2'), P) := v in
           (nlet c        : tZ      := (ADX (Var c1') (Var c2')) in P)%nexpr.
-  Proof. t_rewrite_step_correct. Qed.
+  Proof using Type. t_rewrite_step_correct. Qed.
 
   Lemma invert_for_do_rewrite_correct {t} {e : exprf t} {v}
         (H : invert_for_do_rewrite e = Some v)
@@ -283,7 +284,7 @@ Section named.
                   && negb (name_list_has_duplicate (a2::c1::s::c2::nil ++ get_namesf c0 ++ get_namesf a ++ get_namesf b)%list))
                = true)
       end%core%nexpr%bool.
-  Proof.
+  Proof using Type.
     unfold invert_for_do_rewrite in H; break_innermost_match_hyps;
       repeat first [ progress subst
                    | progress inversion_option
@@ -313,7 +314,7 @@ Section named.
   Lemma interpf_do_rewrite
         {t} {e : exprf t}
     : retT e (do_rewrite e).
-  Proof.
+  Proof using InterpContextOk Name_bl Name_lb.
     unfold do_rewrite.
     pose proof (@invert_for_do_rewrite_correct t e) as H'.
     break_innermost_match; inversion_option;
@@ -396,7 +397,7 @@ Section named.
   Lemma interpf_rewrite_exprf
         {t} (e : exprf t)
     : retT e (rewrite_exprf e).
-  Proof.
+  Proof using InterpContextOk Name_bl Name_lb.
     pose t as T.
     pose (rewrite_exprf_prestep (@rewrite_exprf) e) as E.
     induction e; simpl in *;
@@ -433,7 +434,7 @@ Section named.
              v x,
       Named.interp (interp_op:=interp_op) (ctx:=ctx) (rewrite_expr e) x = Some v
       -> Named.interp (interp_op:=interp_op) (ctx:=ctx) e x = Some v.
-  Proof.
+  Proof using InterpContextOk Name_bl Name_lb.
     unfold Named.interp, rewrite_expr; destruct e; simpl.
     intros *; apply interpf_rewrite_exprf.
   Qed.
@@ -443,7 +444,7 @@ Section named.
     : forall v x,
       Named.Interp (Context:=InterpContext) (interp_op:=interp_op) (rewrite_expr e) x = Some v
       -> Named.Interp (Context:=InterpContext) (interp_op:=interp_op) e x = Some v.
-  Proof.
+  Proof using InterpContextOk Name_bl Name_lb.
     intros *; apply interp_rewrite_expr.
   Qed.
 End named.

--- a/src/Compilers/Z/RewriteAddToAdcWf.v
+++ b/src/Compilers/Z/RewriteAddToAdcWf.v
@@ -36,4 +36,4 @@ Section language.
   Qed.
 End language.
 
-Hint Resolve Wf_RewriteAdc : wf.
+Global Hint Resolve Wf_RewriteAdc : wf.

--- a/src/Compilers/Z/Syntax/Util.v
+++ b/src/Compilers/Z/Syntax/Util.v
@@ -1,3 +1,4 @@
+Require Export Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.micromega.Lia.
 Require Import Crypto.Compilers.Syntax.

--- a/src/Compilers/Z/Syntax/Util.v
+++ b/src/Compilers/Z/Syntax/Util.v
@@ -1,6 +1,6 @@
 Require Export Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Compilers.Syntax.
 Require Import Crypto.Compilers.SmartMap.
 Require Import Crypto.Compilers.Wf.

--- a/src/Compilers/ZExtended/InlineConstAndOpByRewriteWf.v
+++ b/src/Compilers/ZExtended/InlineConstAndOpByRewriteWf.v
@@ -9,5 +9,5 @@ Module Export Rewrite.
   : Wf (InlineConstAndOp e)
     := @Wf_InlineConstAndOp _ _ _ _ _ t e Hwf.
 
-  Hint Resolve Wf_InlineConstAndOp : wf.
+  Global Hint Resolve Wf_InlineConstAndOp : wf.
 End Rewrite.

--- a/src/Compilers/ZExtended/InlineConstAndOpWf.v
+++ b/src/Compilers/ZExtended/InlineConstAndOpWf.v
@@ -8,4 +8,4 @@ Definition Wf_InlineConstAndOp {t} (e : Expr t) (Hwf : Wf e)
   : Wf (InlineConstAndOp e)
   := @Wf_InlineConstAndOp _ _ _ _ _ t e Hwf.
 
-Hint Resolve Wf_InlineConstAndOp : wf.
+Global Hint Resolve Wf_InlineConstAndOp : wf.

--- a/src/Curves/Edwards/AffineProofs.v
+++ b/src/Curves/Edwards/AffineProofs.v
@@ -2,7 +2,7 @@ Require Export Crypto.Spec.CompleteEdwardsCurve.
 
 Require Import Crypto.Algebra.Hierarchy Crypto.Algebra.ScalarMult Crypto.Util.Decidable.
 Require Import Coq.Logic.Eqdep_dec.
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Relations.Relation_Definitions.
 Require Import Crypto.Util.Tuple Crypto.Util.Notations.
 Require Import Crypto.Util.Tactics.UniquePose.
@@ -10,6 +10,8 @@ Require Import Crypto.Util.Tactics.DestructHead.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.Tactics.SetoidSubst.
 Require Export Crypto.Util.FixCoqMistakes.
+
+Local Existing Instance Monoid.is_homomorphism_phi_proper.
 
 Module E.
   Import Group Ring Field CompleteEdwardsCurve.E.
@@ -196,7 +198,7 @@ Module E.
 
       Lemma decompress_None b (H:Logic.eq (decompress b) None)
         : forall P, not (Logic.eq (compress P) b).
-      Proof.
+      Proof using Type.
         cbv [compress decompress exist_option coordinates] in *; intros.
         t'.
         { intro.
@@ -314,3 +316,11 @@ Module E.
     Qed.
   End Homomorphism.
 End E.
+
+Global Existing Instances
+       E.associative_add
+       E.edwards_curve_commutative_group
+       E.Proper_coordinates
+       E.Proper_mul
+       E.Kchar_ge_2
+.

--- a/src/Curves/Edwards/Pre.v
+++ b/src/Curves/Edwards/Pre.v
@@ -1,4 +1,4 @@
-Require Import Coq.Classes.Morphisms. Require Coq.Setoids.Setoid Crypto.Util.Relations.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop. Require Coq.Setoids.Setoid Crypto.Util.Relations.
 Require Import Crypto.Algebra.Hierarchy Crypto.Algebra.Ring Crypto.Algebra.Field.
 Require Import Crypto.Util.Notations Crypto.Util.Decidable (*Crypto.Util.Tactics*).
 Require Import Coq.PArith.BinPos.

--- a/src/Curves/Edwards/XYZT/Basic.v
+++ b/src/Curves/Edwards/XYZT/Basic.v
@@ -1,4 +1,4 @@
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 
 Require Import Crypto.Spec.CompleteEdwardsCurve Crypto.Curves.Edwards.AffineProofs.
 
@@ -7,6 +7,7 @@ Require Export Crypto.Util.FixCoqMistakes.
 Require Import Crypto.Util.Decidable.
 Require Import Crypto.Util.Tactics.DestructHead.
 Require Import Crypto.Util.Tactics.UniquePose.
+Import Field.Hints.
 
 Section ExtendedCoordinates.
   Context {F Feq Fzero Fone Fopp Fadd Fsub Fmul Finv Fdiv}

--- a/src/Curves/Edwards/XYZT/Precomputed.v
+++ b/src/Curves/Edwards/XYZT/Precomputed.v
@@ -1,7 +1,7 @@
 Require Import Crypto.Util.Decidable Crypto.Util.Notations Crypto.Algebra.Hierarchy.
 
 Require Import Crypto.Spec.CompleteEdwardsCurve Crypto.Curves.Edwards.XYZT.Basic.
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 
 Require Import Crypto.Util.Tactics.DestructHead.
 Require Import Crypto.Util.Tactics.BreakMatch.
@@ -56,7 +56,7 @@ Section ExtendedCoordinates.
     (X3, Y3, Z3, T3).
 
     Create HintDb points_as_coordinates discriminated.
-    Hint Unfold XYZT.Basic.point XYZT.Basic.coordinates XYZT.Basic.from_twisted XYZT.Basic.m1add
+    Local Hint Unfold XYZT.Basic.point XYZT.Basic.coordinates XYZT.Basic.from_twisted XYZT.Basic.m1add
          E.point E.coordinates m1add_precomputed_coordinates of_twisted precomputed_point : points_as_coordinates.
     Local Notation m1add := (Basic.m1add(nonzero_a:=nonzero_a)(square_a:=square_a)(a_eq_minus1:=a_eq_minus1)(nonsquare_d:=nonsquare_d)(k_eq_2d:=reflexivity _)).
     Local Notation XYZT_of_twisted := (Basic.from_twisted(nonzero_a:=nonzero_a)(d:=d)).
@@ -64,7 +64,7 @@ Section ExtendedCoordinates.
       let '(X1, Y1, Z1, T1) := m1add_precomputed_coordinates (XYZT.Basic.coordinates P) (of_twisted Q) in
       let '(X2, Y2, Z2, T2) := coordinates (m1add P (XYZT_of_twisted Q)) in
             Z2*X1 = Z1*X2 /\ Z2*Y1 = Z1*Y2.
-    Proof.
+    Proof using Type.
       repeat match goal with
              | _ => progress autounfold with points_as_coordinates in *
              | _ => progress destruct_head' @prod

--- a/src/Curves/Montgomery/XZProofs.v
+++ b/src/Curves/Montgomery/XZProofs.v
@@ -18,7 +18,7 @@ Require Import Crypto.Spec.MontgomeryCurve Crypto.Curves.Montgomery.Affine.
 Require Import Crypto.Curves.Montgomery.AffineInstances.
 Require Import Crypto.Curves.Montgomery.XZ BinPos.
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 
 Module M.
   Section MontgomeryCurve.

--- a/src/Curves/Montgomery/XZProofs.v
+++ b/src/Curves/Montgomery/XZProofs.v
@@ -1,8 +1,10 @@
+Require Import Coq.Classes.RelationClasses.
 Require Import Crypto.Algebra.Field.
 Require Import Crypto.Algebra.ScalarMult.
 Require Import Crypto.Util.Sum Crypto.Util.Prod Crypto.Util.LetIn.
 Require Import Crypto.Util.Decidable.
 Require Import Crypto.Util.Tuple.
+Require Import Crypto.Util.NatUtil.
 Require Import Crypto.Util.ZUtil.Notations.
 Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
 Require Import Crypto.Util.ZUtil.Shift.
@@ -15,8 +17,7 @@ Require Import Crypto.Util.Tactics.UniquePose.
 Require Import Crypto.Spec.MontgomeryCurve Crypto.Curves.Montgomery.Affine.
 Require Import Crypto.Curves.Montgomery.AffineInstances.
 Require Import Crypto.Curves.Montgomery.XZ BinPos.
-Require Import Coq.Classes.Morphisms.
-Require Import Coq.micromega.Lia.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.micromega.Lia.
 
 Module M.
@@ -120,23 +121,23 @@ Module M.
     Ltac t := t_fast; maybefast; fsatz.
 
     Create HintDb points_as_coordinates discriminated.
-    Hint Unfold Proper respectful Reflexive Symmetric Transitive : points_as_coordinates.
-    Hint Unfold Let_In : points_as_coordinates.
-    Hint Unfold fst snd proj1_sig : points_as_coordinates.
-    Hint Unfold fieldwise fieldwise' : points_as_coordinates.
-    Hint Unfold M.add M.opp M.point M.coordinates M.xzladderstep M.donnaladderstep M.boringladderstep M.to_xz : points_as_coordinates.
+    Local Hint Unfold Proper respectful Reflexive Symmetric Transitive : points_as_coordinates.
+    Local Hint Unfold Let_In : points_as_coordinates.
+    Local Hint Unfold fst snd proj1_sig : points_as_coordinates.
+    Local Hint Unfold fieldwise fieldwise' : points_as_coordinates.
+    Local Hint Unfold M.add M.opp M.point M.coordinates M.xzladderstep M.donnaladderstep M.boringladderstep M.to_xz : points_as_coordinates.
 
     Lemma donnaladderstep_same x1 Q Q' :
       fieldwise (n:=2) (fieldwise (n:=2) Feq)
                 (xzladderstep x1 Q Q')
                 (M.donnaladderstep(a24:=a24)(Fadd:=Fadd)(Fsub:=Fsub)(Fmul:=Fmul) x1 Q Q').
-    Proof. t. Qed.
+    Proof using Feq_dec a24_correct b_nonzero field. t. Qed.
 
     Lemma boringladderstep_same (ap2d4:F) (ap2d4_correct:(1+1+1+1)*a24 = a+1+1) x1 Q Q' :
       fieldwise (n:=2) (fieldwise (n:=2) Feq)
                 (xzladderstep x1 Q Q')
                 (M.boringladderstep(ap2d4:=ap2d4)(Fadd:=Fadd)(Fsub:=Fsub)(Fmul:=Fmul) x1 Q Q').
-    Proof. t. Qed.
+    Proof using Feq_dec a24_correct b_nonzero field. t. Qed.
 
     Definition projective (P:F*F) :=
       if dec (snd P = 0) then fst P <> 0 else True.
@@ -146,7 +147,7 @@ Module M.
       | ∞ => False                  (* Q <> Q' *)
       | (x,y) => x = x1 /\ x1 <> 0  (* Q-Q' <> (0, 0) *)
       end.
-    Hint Unfold projective eq ladder_invariant : points_as_coordinates.
+    Local Hint Unfold projective eq ladder_invariant : points_as_coordinates.
 
     Lemma to_xz_add_coordinates (x1:F) (xz x'z':F*F)
           (Hxz:projective xz) (Hz'z':projective x'z')
@@ -156,26 +157,26 @@ Module M.
       :  projective (snd (xzladderstep x1 xz x'z'))
       /\ eq (fst (xzladderstep x1 xz x'z')) (to_xz (Madd Q Q ))
       /\ eq (snd (xzladderstep x1 xz x'z')) (to_xz (Madd Q Q')).
-    Proof. Time t_fast. Time par: abstract (maybefast; fsatz). Time Qed.
+    Proof using a24_correct char_ge_12 char_ge_28 char_ge_5. Time t_fast. Time par: abstract (maybefast; fsatz). Time Qed.
     (* 12 ;; 24 ;; 3 *)
 
     Context {a2m4_nonsquare:forall r, r*r <> a*a - (1+1+1+1)}.
 
     Lemma projective_fst_xzladderstep x1 Q (HQ:projective Q) Q'
       :  projective (fst (xzladderstep x1 Q Q')).
-    Proof.
+    Proof using a24_correct a2m4_nonsquare b_nonzero char_ge_28 field.
       specialize (a2m4_nonsquare (fst Q/snd Q  - fst Q/snd Q)).
       destruct (dec (snd Q = 0)); t.
     Qed.
 
     Local Definition a2m4_nz : a*a - (1+1+1+1) <> 0.
-    Proof. specialize (a2m4_nonsquare 0). fsatz. Qed.
+    Proof using Feq_dec a24_correct a2m4_nonsquare b_nonzero field. specialize (a2m4_nonsquare 0). fsatz. Qed.
 
     Lemma difference_preserved Q Q' :
           M.eq
             (Madd (Madd Q Q) (Mopp (Madd Q Q')))
             (Madd Q (Mopp Q')).
-    Proof.
+    Proof using a24_correct a2m4_nonsquare char_ge_12 char_ge_28.
       pose proof (let (_, h, _, _) := AffineInstances.M.MontgomeryWeierstrassIsomorphism b_nonzero (a:=a) a2m4_nz in h) as commutative_group.
       rewrite Group.inv_op.
       rewrite <-Hierarchy.associative.
@@ -189,7 +190,7 @@ Module M.
 
     Lemma ladder_invariant_preserved x1 Q Q' (H:ladder_invariant x1 Q Q')
       : ladder_invariant x1 (Madd Q Q) (Madd Q Q').
-    Proof.
+    Proof using a24_correct a2m4_nonsquare char_ge_12 char_ge_28.
       cbv [ladder_invariant] in *.
       pose proof difference_preserved Q Q' as Hrw.
       (* FIXME: what we actually want to do here is to rewrite with in
@@ -206,7 +207,7 @@ Module M.
 
     Lemma ladder_invariant_swap x1 Q Q' (H:ladder_invariant x1 Q Q')
       : ladder_invariant x1 Q' Q.
-    Proof. t. Qed.
+    Proof using a24_correct char_ge_28. t. Qed.
 
     Lemma to_xz_add x1 xz x'z' Q Q'
           (Hxz : projective xz) (Hx'z' : projective x'z')
@@ -217,45 +218,45 @@ Module M.
         /\ eq (fst (xzladderstep x1 xz x'z')) (to_xz (Madd Q Q ))
         /\ eq (snd (xzladderstep x1 xz x'z')) (to_xz (Madd Q Q'))
         /\ ladder_invariant x1 (Madd Q Q) (Madd Q Q').
-    Proof.
+    Proof using a24_correct a2m4_nonsquare char_ge_12 char_ge_28 char_ge_5.
       destruct (to_xz_add_coordinates x1 xz x'z' Hxz Hx'z' Q Q' HQ HQ' HI) as [? [? ?]].
       eauto 99 using projective_fst_xzladderstep, ladder_invariant_preserved.
     Qed.
 
     Definition to_x (xz:F*F) : F :=
       if dec (snd xz = 0) then 0 else fst xz / snd xz.
-    Hint Unfold to_x : points_as_coordinates.
+    Local Hint Unfold to_x : points_as_coordinates.
 
     Lemma to_x_to_xz Q : to_x (to_xz Q) = match M.coordinates Q with
                                           | ∞ => 0
                                           | (x,y) => x
                                           end.
-    Proof. t. Qed.
+    Proof using a24_correct b_nonzero field. t. Qed.
 
     Lemma proper_to_x_projective xz x'z'
            (Hxz:projective xz) (Hx'z':projective x'z')
            (H:eq xz x'z') : Feq (to_x xz) (to_x x'z').
-    Proof. destruct (dec (snd xz = 0)), (dec(snd x'z' = 0)); t. Qed.
+    Proof using a24_correct b_nonzero field. destruct (dec (snd xz = 0)), (dec(snd x'z' = 0)); t. Qed.
 
     Lemma to_x_zero x : to_x (pair x 0) = 0.
-    Proof. t. Qed.
+    Proof using a24_correct b_nonzero field. t. Qed.
 
-    Hint Unfold M.eq : points_as_coordinates.
+    Local Hint Unfold M.eq : points_as_coordinates.
     Global Instance Proper_to_xz : Proper (M.eq ==> eq) to_xz.
-    Proof. t. Qed.
+    Proof using Feq_dec a24_correct b_nonzero field. t. Qed.
 
     Global Instance  Reflexive_eq : Reflexive eq.
-    Proof. t. Qed.
+    Proof using Feq_dec a24_correct b_nonzero field. t. Qed.
     Global Instance  Symmetric_eq : Symmetric eq.
-    Proof. t. Qed.
+    Proof using Feq_dec a24_correct b_nonzero field. t. Qed.
     Lemma transitive_eq {p} q {r} : projective q -> eq p q -> eq q r -> eq p r.
-    Proof. t. Qed.
+    Proof using a24_correct b_nonzero field. t. Qed.
 
     Lemma projective_to_xz Q : projective (to_xz Q).
-    Proof. t. Qed.
+    Proof using a24_correct b_nonzero field. t. Qed.
 
     Global Instance Proper_ladder_invariant : Proper (Feq ==> M.eq ==> M.eq ==> iff) ladder_invariant.
-    Proof. t. Qed.
+    Proof using a24_correct char_ge_28. t. Qed.
 
     Local Notation montladder := (M.montladder(a24:=a24)(Fadd:=Fadd)(Fsub:=Fsub)(Fmul:=Fmul)(Fzero:=Fzero)(Fone:=Fone)(Finv:=Finv)(cswap:=fun b x y => if b then pair y x else pair x y)).
     Local Notation scalarmult := (@ScalarMult.scalarmult_ref Mpoint Madd M.zero Mopp).
@@ -264,10 +265,10 @@ Module M.
     Import Coq.ZArith.BinInt.
 
     Lemma to_x_inv00 (HFinv:Finv 0 = 0) x z : to_x (pair x z) = x * Finv z.
-    Proof. t_fast; setoid_subst_rel Feq; rewrite ?HFinv in *; fsatz. Qed.
+    Proof using a24_correct b_nonzero field. t_fast; setoid_subst_rel Feq; rewrite ?HFinv in *; fsatz. Qed.
 
     Lemma Z_shiftr_testbit_1 n i: Logic.eq (n>>i)%Z (Z.div2 (n >> i) + Z.div2 (n >> i) + Z.b2z (Z.testbit n i))%Z.
-    Proof. rewrite ?Z.testbit_odd, ?Z.add_diag, <-?Z.div2_odd; reflexivity. Qed.
+    Proof using Type. rewrite ?Z.testbit_odd, ?Z.add_diag, <-?Z.div2_odd; reflexivity. Qed.
 
     (* We prove montladder correct by considering the zero and non-zero case
        separately. *)
@@ -280,7 +281,7 @@ Module M.
           (Hn : (0 <= n < 2^scalarbits)%Z)
           (Hscalarbits : (0 <= scalarbits)%Z)
       : montladder scalarbits (Z.testbit n) point = 0.
-    Proof.
+    Proof using Feq_dec a24_correct b_nonzero field.
       cbv beta delta [M.montladder].
       (* [while.by_invariant] expects a goal like [?P (while _ _ _ _)], make it so: *)
       lazymatch goal with |- context [while ?t ?b ?l ?ii] => pattern (while t b l ii) end.
@@ -322,7 +323,7 @@ Module M.
           (Hscalarbits : (0 <= scalarbits)%Z)
           (Hpoint : point = to_x (to_xz P))
       : montladder scalarbits (Z.testbit n) point = to_x (to_xz (scalarmult n P)).
-    Proof.
+    Proof using a24_correct a2m4_nonsquare char_ge_12 char_ge_28 char_ge_5.
       pose proof (let (_, h, _, _) := AffineInstances.M.MontgomeryWeierstrassIsomorphism b_nonzero (a:=a) a2m4_nz in h) as commutative_group.
       cbv beta delta [M.montladder].
       (* [while.by_invariant] expects a goal like [?P (while _ _ _ _)], make it so: *)
@@ -396,20 +397,20 @@ Module M.
           (P : M.point)
           (H : 0 = to_x (to_xz P))
       : 0 = to_x (to_xz (Mopp P)).
-    Proof. t. Qed.
+    Proof using Type. t. Qed.
 
     Lemma add_to_x_to_xz_0
           (P Q : M.point)
           (HP : 0 = to_x (to_xz P))
           (HQ : 0 = to_x (to_xz Q))
       : 0 = to_x (to_xz (Madd P Q)).
-    Proof. t. Qed.
+    Proof using a24_correct char_ge_28. t. Qed.
 
     Lemma scalarmult_to_x_to_xz_0
           (n : Z) (P : M.point)
           (H : 0 = to_x (to_xz P))
       : 0 = to_x (to_xz (scalarmult n P)).
-    Proof.
+    Proof using a24_correct char_ge_28.
       induction n using Z.peano_rect_strong.
       { cbn. t. }
       { (* Induction case from n to Z.succ n. *)
@@ -436,7 +437,7 @@ Module M.
           (Hscalarbits : (0 <= scalarbits)%Z)
           (Hpoint : point = to_x (to_xz P))
       : montladder scalarbits (Z.testbit n) point = to_x (to_xz (scalarmult n P)).
-    Proof.
+    Proof using a24_correct a2m4_nonsquare char_ge_12 char_ge_28 char_ge_5.
       destruct (dec (point = 0)) as [Hz|Hnz].
       { rewrite (montladder_correct_0 HFinv _ _ _ Hz Hn Hscalarbits).
         setoid_subst_rel Feq.

--- a/src/Curves/Weierstrass/AffineProofs.v
+++ b/src/Curves/Weierstrass/AffineProofs.v
@@ -1,5 +1,5 @@
 Require Import Coq.Numbers.BinNums.
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Spec.WeierstrassCurve Crypto.Curves.Weierstrass.Affine.
 Require Import Crypto.Algebra.Field Crypto.Algebra.Hierarchy.
 Require Import Crypto.Util.Decidable Crypto.Util.Tactics.DestructHead Crypto.Util.Tactics.BreakMatch.

--- a/src/Curves/Weierstrass/Jacobian.v
+++ b/src/Curves/Weierstrass/Jacobian.v
@@ -1,4 +1,4 @@
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 
 Require Import Crypto.Spec.WeierstrassCurve.
 Require Import Crypto.Util.Decidable Crypto.Algebra.Field.
@@ -66,11 +66,11 @@ Module Jacobian.
     Ltac t := prept; trivial; try contradiction; fsatz.
 
     Create HintDb points_as_coordinates discriminated.
-    Hint Unfold Proper respectful Reflexive Symmetric Transitive : points_as_coordinates.
-    Hint Unfold point eq W.eq W.point W.coordinates proj1_sig fst snd : points_as_coordinates.
+    Local Hint Unfold Proper respectful Reflexive Symmetric Transitive : points_as_coordinates.
+    Local Hint Unfold point eq W.eq W.point W.coordinates proj1_sig fst snd : points_as_coordinates.
 
     Global Instance Equivalence_eq : Equivalence eq.
-    Proof. t. Qed.
+    Proof using field. t. Qed.
 
     Program Definition of_affine (P:Wpoint) : point :=
       match W.coordinates P return F*F*F with
@@ -87,11 +87,11 @@ Module Jacobian.
       end.
     Next Obligation. Proof. t. Qed.
 
-    Hint Unfold to_affine of_affine : points_as_coordinates.
-    Global Instance Proper_of_affine : Proper (W.eq ==> eq) of_affine. Proof. t. Qed.
-    Global Instance Proper_to_affine : Proper (eq ==> W.eq) to_affine. Proof. t. Qed.
-    Lemma to_affine_of_affine P : W.eq (to_affine (of_affine P)) P. Proof. t. Qed.
-    Lemma of_affine_to_affine P : eq (of_affine (to_affine P)) P. Proof. t. Qed.
+    Local Hint Unfold to_affine of_affine : points_as_coordinates.
+    Global Instance Proper_of_affine : Proper (W.eq ==> eq) of_affine. Proof using Type. t. Qed.
+    Global Instance Proper_to_affine : Proper (eq ==> W.eq) to_affine. Proof using Type. t. Qed.
+    Lemma to_affine_of_affine P : W.eq (to_affine (of_affine P)) P. Proof using Type. t. Qed.
+    Lemma of_affine_to_affine P : eq (of_affine (to_affine P)) P. Proof using Type. t. Qed.
 
     Program Definition opp (P:point) : point :=
       match proj1_sig P return F*F*F with
@@ -463,7 +463,7 @@ Module Jacobian.
                   end;
                   fsatz ].
 
-    Hint Unfold double negb andb add_precondition z_is_zero_or_one : points_as_coordinates.
+    Local Hint Unfold double negb andb add_precondition z_is_zero_or_one : points_as_coordinates.
     Program Definition add_impl (mixed : bool) (P Q : point)
             (H : add_precondition Q mixed) : point :=
       match proj1_sig P, proj1_sig Q return F*F*F with
@@ -528,22 +528,22 @@ Module Jacobian.
     Definition add_mixed (P : point) (Q : point) (H : z_is_zero_or_one Q) :=
       add_impl true P Q H.
 
-    Hint Unfold W.eq W.add to_affine add add_mixed add_impl : points_as_coordinates.
+    Local Hint Unfold W.eq W.add to_affine add add_mixed add_impl : points_as_coordinates.
 
-    Lemma Proper_double : Proper (eq ==> eq) double. Proof. faster_t_noclear. Qed.
+    Lemma Proper_double : Proper (eq ==> eq) double. Proof using char_ge_3. faster_t_noclear. Qed.
     Lemma to_affine_double P :
       W.eq (to_affine (double P)) (W.add (to_affine P) (to_affine P)).
-    Proof. faster_t_noclear. Qed.
+    Proof using Type. faster_t_noclear. Qed.
 
     Lemma add_mixed_eq_add (P : point) (Q : point) (H : z_is_zero_or_one Q) :
       eq (add P Q) (add_mixed P Q H).
-    Proof. faster_t. Qed.
+    Proof using Type. faster_t. Qed.
 
-    Lemma Proper_add : Proper (eq ==> eq ==> eq) add. Proof. faster_t_noclear. Qed.
+    Lemma Proper_add : Proper (eq ==> eq ==> eq) add. Proof using Type. faster_t_noclear. Qed.
     Import BinPos.
     Lemma to_affine_add P Q
       : W.eq (to_affine (add P Q)) (W.add (to_affine P) (to_affine Q)).
-    Proof.
+    Proof using Type.
       Time prept; try contradiction; speed_up_fsatz; clean_up_speed_up_fsatz. (* 15.009 secs (14.871u,0.048s) *)
       Time all: fsatz. (* 6.335 secs (6.172u,0.163s) *)
       Time Qed. (* 1.924 secs (1.928u,0.s) *)
@@ -582,11 +582,11 @@ Module Jacobian.
         end.
       Next Obligation. Proof. t. Qed.
 
-      Hint Unfold double_minus_3 : points_as_coordinates.
+      Local Hint Unfold double_minus_3 : points_as_coordinates.
 
       Lemma double_minus_3_eq_double (P : point) :
         eq (double P) (double_minus_3 P).
-      Proof. faster_t. Qed.
+      Proof using char_ge_3. faster_t. Qed.
     End AEqMinus3.
   End Jacobian.
 End Jacobian.

--- a/src/Demo.v
+++ b/src/Demo.v
@@ -1,5 +1,5 @@
 (* Following http://adam.chlipala.net/theses/andreser.pdf chapter 3 *)
-Require Import Coq.ZArith.ZArith Coq.micromega.Lia Crypto.Algebra.Nsatz.
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Crypto.Algebra.Nsatz.
 Require Import Crypto.Util.Tactics.UniquePose Crypto.Util.Decidable.
 Require Import Crypto.Util.Tuple Crypto.Util.Prod Crypto.Util.LetIn.
 Require Import Crypto.Util.ListUtil Coq.Lists.List Crypto.Util.NatUtil.

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -1,5 +1,5 @@
 (* Following http://adam.chlipala.net/theses/andreser.pdf chapter 3 *)
-Require Import Coq.ZArith.ZArith Coq.micromega.Lia Crypto.Algebra.Nsatz.
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Crypto.Algebra.Nsatz.
 Require Import Coq.Strings.String.
 Require Import Coq.MSets.MSetPositive.
 Require Import Coq.FSets.FMapPositive.
@@ -67,11 +67,11 @@ Module Associational.
     fold_right (fun x y => x + y) 0%Z (map (fun t => fst t * snd t) p).
 
   Lemma eval_nil : eval nil = 0.
-  Proof. trivial.                                             Qed.
+  Proof using Type. trivial.                                             Qed.
   Lemma eval_cons p q : eval (p::q) = fst p * snd p + eval q.
-  Proof. trivial.                                             Qed.
+  Proof using Type. trivial.                                             Qed.
   Lemma eval_app p q: eval (p++q) = eval p + eval q.
-  Proof. induction p; rewrite <-?List.app_comm_cons;
+  Proof using Type. induction p; rewrite <-?List.app_comm_cons;
            rewrite ?eval_nil, ?eval_cons; nsatz.              Qed.
 
   Hint Rewrite eval_nil eval_cons eval_app : push_eval.
@@ -81,7 +81,7 @@ Module Associational.
 
   Lemma eval_map_mul (a x:Z) (p:list (Z*Z))
   : eval (List.map (fun t => (a*fst t, x*snd t)) p) = a*x*eval p.
-  Proof. induction p; push; nsatz.                            Qed.
+  Proof using Type. induction p; push; nsatz.                            Qed.
   Hint Rewrite eval_map_mul : push_eval.
 
   Definition mul (p q:list (Z*Z)) : list (Z*Z) :=
@@ -90,13 +90,13 @@ Module Associational.
         (fst t * fst t', snd t * snd t'))
     q) p.
   Lemma eval_mul p q : eval (mul p q) = eval p * eval q.
-  Proof. induction p; cbv [mul]; push; nsatz.                 Qed.
+  Proof using Type. induction p; cbv [mul]; push; nsatz.                 Qed.
   Hint Rewrite eval_mul : push_eval.
 
   Definition negate_snd (p:list (Z*Z)) : list (Z*Z) :=
     map (fun cx => (fst cx, -snd cx)) p.
   Lemma eval_negate_snd p : eval (negate_snd p) = - eval p.
-  Proof. induction p; cbv [negate_snd]; push; nsatz.          Qed.
+  Proof using Type. induction p; cbv [negate_snd]; push; nsatz.          Qed.
   Hint Rewrite eval_negate_snd : push_eval.
 
   Example base10_2digit_mul (a0:Z) (a1:Z) (b0:Z) (b1:Z) :
@@ -114,7 +114,7 @@ Module Associational.
        (snd hi_lo, map (fun t => (fst t / s, snd t)) (fst hi_lo)).
   Lemma eval_split s p (s_nz:s<>0) :
     eval (fst (split s p)) + s * eval (snd (split s p)) = eval p.
-  Proof. cbv [Let_In split]; induction p;
+  Proof using Type. cbv [Let_In split]; induction p;
     repeat match goal with
     | |- context[?a/?b] =>
       unique pose proof (Z_div_exact_full_2 a b ltac:(trivial) ltac:(trivial))
@@ -124,7 +124,7 @@ Module Associational.
 
   Lemma reduction_rule a b s c (modulus_nz:s-c<>0) :
     (a + s * b) mod (s - c) = (a + c * b) mod (s - c).
-  Proof. replace (a + s * b) with ((a + c*b) + b*(s-c)) by nsatz.
+  Proof using Type. replace (a + s * b) with ((a + c*b) + b*(s-c)) by nsatz.
     rewrite Z.add_mod,Z_mod_mult,Z.add_0_r,Z.mod_mod;trivial. Qed.
 
   Definition reduce (s:Z) (c:list _) (p:list _) : list (Z*Z) :=
@@ -132,7 +132,7 @@ Module Associational.
 
   Lemma eval_reduce s c p (s_nz:s<>0) (modulus_nz:s-eval c<>0) :
     eval (reduce s c p) mod (s - eval c) = eval p mod (s - eval c).
-  Proof. cbv [reduce]; push.
+  Proof using Type. cbv [reduce]; push.
          rewrite <-reduction_rule, eval_split; trivial.      Qed.
   Hint Rewrite eval_reduce : push_eval.
 
@@ -140,13 +140,13 @@ Module Associational.
     map (fun t => dlet_nd t2 := snd t in (fst t, t2)) p.
 
   Lemma bind_snd_correct p : bind_snd p = p.
-  Proof.
+  Proof using Type.
     cbv [bind_snd]; induction p as [| [? ?] ];
       push; [|rewrite IHp]; reflexivity.
   Qed.
 
   Lemma eval_rev p : eval (rev p) = eval p.
-  Proof. induction p; cbn [rev]; push; lia. Qed.
+  Proof using Type. induction p; cbn [rev]; push; lia. Qed.
 
   Section Carries.
     Definition carryterm (w fw:Z) (t:Z * Z) :=
@@ -684,7 +684,7 @@ Module Saturated.
 
       Lemma eval_map_sat_multerm s a q (s_nonzero:s<>0):
         Associational.eval (flat_map (sat_multerm s a) q) = fst a * snd a * Associational.eval q.
-      Proof.
+      Proof using Type.
         cbv [sat_multerm Let_In]; induction q;
           repeat match goal with
                  | _ => progress autorewrite with cancel_pair push_eval to_div_mod in *
@@ -698,7 +698,7 @@ Module Saturated.
 
       Lemma eval_sat_mul s p q (s_nonzero:s<>0):
         Associational.eval (sat_mul s p q) = Associational.eval p * Associational.eval q.
-      Proof.
+      Proof using Type.
         cbv [sat_mul]; induction p; [reflexivity|].
         repeat match goal with
                | _ => progress (autorewrite with push_flat_map push_eval in * )
@@ -723,7 +723,7 @@ Module Saturated.
 
       Lemma eval_map_sat_multerm_const s a q (s_nonzero:s<>0):
         Associational.eval (flat_map (sat_multerm_const s a) q) = fst a * snd a * Associational.eval q.
-      Proof.
+      Proof using Type.
         cbv [sat_multerm_const Let_In]; induction q;
           repeat match goal with
                  | _ => progress autorewrite with cancel_pair push_eval to_div_mod in *
@@ -741,7 +741,7 @@ Module Saturated.
 
       Lemma eval_sat_mul_const s p q (s_nonzero:s<>0):
         Associational.eval (sat_mul_const s p q) = Associational.eval p * Associational.eval q.
-      Proof.
+      Proof using Type.
         cbv [sat_mul_const]; induction p; [reflexivity|].
         repeat match goal with
                | _ => progress (autorewrite with push_flat_map push_eval in * )
@@ -756,21 +756,21 @@ Module Saturated.
   Section DivMod.
     Lemma mod_step a b c d: 0 < a -> 0 < b ->
                             c mod a + a * ((c / a + d) mod b) = (a * d + c) mod (a * b).
-    Proof.
+    Proof using Type.
       intros; rewrite Z.rem_mul_r by lia. push_Zmod.
       autorewrite with zsimplify pull_Zmod. repeat (f_equal; try ring).
     Qed.
 
     Lemma div_step a b c d : 0 < a -> 0 < b ->
                              (c / a + d) / b = (a * d + c) / (a * b).
-    Proof. intros; Z.div_mod_to_quot_rem_in_goal; nia. Qed.
+    Proof using Type. intros; Z.div_mod_to_quot_rem_in_goal; nia. Qed.
 
     Lemma add_mod_div_multiple a b n m:
       n > 0 ->
       0 <= m / n ->
       m mod n = 0 ->
       (a / n + b) mod (m / n) = (a + n * b) mod m / n.
-    Proof.
+    Proof using Type.
       intros. rewrite <-!Z.div_add' by auto using Z.positive_is_nonzero.
       rewrite Z.mod_pull_div, Z.mul_div_eq' by auto using Z.gt_lt.
       repeat (f_equal; try lia).
@@ -779,7 +779,7 @@ Module Saturated.
     Lemma add_mod_l_multiple a b n m:
       0 < n / m -> m <> 0 -> n mod m = 0 ->
       (a mod n + b) mod m = (a + b) mod m.
-    Proof.
+    Proof using Type.
       intros.
       rewrite (proj2 (Z.div_exact n m ltac:(auto))) by auto.
       rewrite Z.rem_mul_r by auto.
@@ -799,7 +799,7 @@ Module Saturated.
       y2 = y1 + n1 * x ->
       @is_div_mod T evalf1 dm1 y1 n1 ->
       @is_div_mod T evalf2 dm2 y2 n2.
-    Proof.
+    Proof using Type.
       intros; subst y2; cbv [is_div_mod] in *.
       repeat match goal with
              | H: _ /\ _ |- _ => destruct H
@@ -816,7 +816,7 @@ Module Saturated.
       y1 = y2 ->
       @is_div_mod T evalf dm y1 n ->
       @is_div_mod T evalf dm y2 n.
-    Proof. congruence. Qed.
+    Proof using Type. congruence. Qed.
   End DivMod.
 End Saturated.
 
@@ -1999,12 +1999,12 @@ Module Import MOVEME.
   Lemma fold_andb_map_map {A B C} f g ls1 ls2
     : @fold_andb_map A B f ls1 (@List.map C _ g ls2)
       = fold_andb_map (fun a b => f a (g b)) ls1 ls2.
-  Proof. revert ls1 ls2; induction ls1, ls2; cbn; congruence. Qed.
+  Proof using Type. revert ls1 ls2; induction ls1, ls2; cbn; congruence. Qed.
 
   Lemma fold_andb_map_length A B f ls1 ls2
         (H : @fold_andb_map A B f ls1 ls2 = true)
     : length ls1 = length ls2.
-  Proof.
+  Proof using Type.
     revert ls1 ls2 H; induction ls1, ls2; cbn; intros; Bool.split_andb; f_equal;
       try congruence; auto.
   Qed.
@@ -2014,7 +2014,7 @@ Definition expanding_id (n : nat) (ls : list Z) := expand_list (-1)%Z ls n.
 
 Lemma expanding_id_id n ls (H : List.length ls = n)
   : expanding_id n ls = ls.
-Proof.
+Proof using Type.
   unfold expanding_id. rewrite expand_list_correct by assumption; reflexivity.
 Qed.
 
@@ -2030,7 +2030,7 @@ Module Ring.
 
   Lemma length_is_bounded_by bounds ls
     : is_bounded_by bounds ls = true -> length ls = length bounds.
-  Proof.
+  Proof using Type.
     intro H.
     apply fold_andb_map_length in H; congruence.
   Qed.
@@ -3148,7 +3148,7 @@ Module Compilers.
           End gen.
 
           Definition cast_outside_of_range (r : zrange) (v : BinInt.Z) : BinInt.Z.
-          Proof. exact v. Qed.
+          Proof using Type. exact v. Qed.
 
           (** Interpret identifiers where [Z_cast] is an opaque
               identity function when the value is not inside the range
@@ -3799,7 +3799,7 @@ Module Compilers.
 
   Lemma interp_reify_list {t} ls
     : interp (@reify_list _ t ls) = List.map interp ls.
-  Proof.
+  Proof using Type.
     unfold reify_list.
     induction ls as [|x xs IHxs]; cbn in *; [ reflexivity | ].
     rewrite IHxs; reflexivity.
@@ -4828,7 +4828,7 @@ Module Compilers.
 
         Lemma is_bounded_by_Some {t} r val
           : is_bounded_by (@Some t r) val = type.is_bounded_by r val.
-        Proof.
+        Proof using Type.
           induction t;
             repeat first [ reflexivity
                          | progress cbn in *
@@ -4848,7 +4848,7 @@ Module Compilers.
               (Htight : @is_tighter_than t r1 r2 = true)
               (Hbounds : is_bounded_by r1 val = true)
           : is_bounded_by r2 val = true.
-        Proof.
+        Proof using Type.
           induction t;
             repeat first [ progress destruct_head'_prod
                          | progress destruct_head'_and
@@ -4874,7 +4874,7 @@ Module Compilers.
               (Htight : @is_tighter_than t r1 (Some r2) = true)
               (Hbounds : is_bounded_by r1 val = true)
           : type.is_bounded_by r2 val = true.
-        Proof.
+        Proof using Type.
           rewrite <- is_bounded_by_Some.
           eapply is_tighter_than_is_bounded_by; eassumption.
         Qed.
@@ -6206,7 +6206,7 @@ Module Compilers.
              (Harg : ZRange.type.option.is_bounded_by b_in arg = true),
       Interp rv arg = Interp e arg
       /\ ZRange.type.option.is_bounded_by b_out (Interp rv arg) = true.
-  Proof.
+  Proof using Type.
     cbv [CheckedPartialEvaluateWithBounds1 CheckPartialEvaluateWithBounds1 Let_In] in *;
       break_innermost_match_hyps; inversion_sum; subst.
     intros arg Harg.
@@ -6228,7 +6228,7 @@ Module Compilers.
           rv (Hrv : CheckedPartialEvaluateWithBounds0 relax_zrange e b_out = inl rv)
     : Interp rv = Interp e
       /\ ZRange.type.option.is_bounded_by b_out (Interp rv) = true.
-  Proof.
+  Proof using Type.
     cbv [CheckedPartialEvaluateWithBounds0 CheckPartialEvaluateWithBounds0 Let_In] in *;
       break_innermost_match_hyps; inversion_sum; subst.
     split.
@@ -6526,7 +6526,7 @@ Notation "x * y"
 Notation "x" := (Var x) (only printing, at level 9) : expr_scope.
 
 Example test1 : True.
-Proof.
+Proof using Type.
   let v := Reify ((fun x => 2^x) 255)%Z in
   pose v as E.
   vm_compute in E.
@@ -6539,7 +6539,7 @@ Proof.
 Qed.
 Module test2.
   Example test2 : True.
-  Proof.
+  Proof using Type.
     let v := Reify (fun y : Z
                     => (fun k : Z * Z -> Z * Z
                         => dlet_nd x := (y * y) in
@@ -6572,7 +6572,7 @@ Module test2.
 End test2.
 Module test3.
   Example test3 : True.
-  Proof.
+  Proof using Type.
     let v := Reify (fun y : Z
                     => dlet_nd x := dlet_nd x := (y * y) in
                         (x * x) in
@@ -6611,7 +6611,7 @@ Module test3.
 End test3.
 Module test4.
   Example test4 : True.
-  Proof.
+  Proof using Type.
     let v := Reify (fun y : (list Z * list Z)
                     => dlet_nd x := List.nth_default (-1) (fst y) 0 in
                         dlet_nd z := List.nth_default (-1) (snd y) 0 in
@@ -6640,7 +6640,7 @@ Module test4.
 End test4.
 Module test5.
   Example test5 : True.
-  Proof.
+  Proof using Type.
     let v := Reify (fun y : (Z * Z)
                     => dlet_nd x := (13 * (fst y * snd y)) in
                         x) in
@@ -6662,7 +6662,7 @@ End test5.
 Module test6.
   (* check for no dead code with if *)
   Example test6 : True.
-  Proof.
+  Proof using Type.
     let v := Reify (fun y : Z
                     => if 0 =? 1
                        then dlet_nd x := (y * y) in
@@ -6684,7 +6684,7 @@ Module test6.
 End test6.
 Module test7.
   Example test7 : True.
-  Proof.
+  Proof using Type.
     let v := Reify (fun y : Z
                     => dlet_nd x := y + y in
                         dlet_nd z := x in
@@ -6707,7 +6707,7 @@ Module test7.
 End test7.
 Module test8.
   Example test8 : True.
-  Proof.
+  Proof using Type.
     let v := Reify (fun y : Z
                     => dlet_nd x := y + y in
                         dlet_nd z := x in
@@ -6727,7 +6727,7 @@ Module test8.
 End test8.
 Module test9.
   Example test9 : True.
-  Proof.
+  Proof using Type.
     let v := Reify (fun y : list Z => (hd 0%Z y, tl y)) in
     pose v as E.
     vm_compute in E.
@@ -6754,7 +6754,7 @@ Module test9.
 End test9.
 Module test10.
   Example test10 : True.
-  Proof.
+  Proof using Type.
     let v := Reify (fun (f : Z -> Z -> Z) x y => f (x + y) (x * y))%Z in
     pose v as E.
     vm_compute in E.
@@ -6774,7 +6774,7 @@ Module test10.
 End test10.
 Module test11.
   Example test11 : True.
-  Proof.
+  Proof using Type.
     let v := Reify (fun x y => (fun f a b => f a b) (fun a b => a + b) (x + y) (x * y))%Z in
     pose v as E.
     vm_compute in E.
@@ -7033,7 +7033,7 @@ Module Pipeline.
              (Harg : ZRange.type.option.is_bounded_by arg_bounds arg = true),
       ZRange.type.option.is_bounded_by out_bounds (Interp rv arg) = true
       /\ Interp rv arg = app_curried (Interp e) arg.
-  Proof.
+  Proof using Type.
     cbv [BoundsPipeline Let_In] in *;
       repeat match goal with
              | [ H : match ?x with _ => _ end = Success _ |- _ ]
@@ -7086,7 +7086,7 @@ Module Pipeline.
         rv
         (Hrv : BoundsPipeline (*with_dead_code_elimination*) with_subst01 relax_zrange e arg_bounds out_bounds = Success rv)
     : BoundsPipeline_correct_transT arg_bounds out_bounds InterpE rv.
-  Proof.
+  Proof using Type.
     intros arg Harg; rewrite <- InterpE_correct by assumption.
     eapply @BoundsPipeline_correct; eassumption.
   Qed.
@@ -7123,7 +7123,7 @@ Module Pipeline.
              (Harg : ZRange.type.option.is_bounded_by arg_bounds arg = true),
       ZRange.type.option.is_bounded_by out_bounds (Interp rv arg) = true
       /\ Interp rv arg = app_curried (for_reification.Interp E) arg.
-  Proof.
+  Proof using Type.
     cbv [BoundsPipeline_full] in *.
     eapply BoundsPipeline_correct_trans; [ eassumption | | eassumption.. ].
     intros; erewrite PrePipeline_correct; reflexivity.
@@ -7142,7 +7142,7 @@ Definition round_up_bitwidth_gen (possible_values : list Z) (bitwidth : Z) : opt
 Lemma round_up_bitwidth_gen_le possible_values bitwidth v
   : round_up_bitwidth_gen possible_values bitwidth = Some v
     -> bitwidth <= v.
-Proof.
+Proof using Type.
   cbv [round_up_bitwidth_gen].
   induction possible_values as [|x xs IHxs]; cbn; intros; inversion_option.
   break_innermost_match_hyps; Z.ltb_to_lt; inversion_option; subst; trivial.
@@ -7160,7 +7160,7 @@ Lemma relax_zrange_gen_good
       (possible_values : list Z)
   : forall r r' z : zrange,
     (z <=? r)%zrange = true -> relax_zrange_gen possible_values r = Some r' -> (z <=? r')%zrange = true.
-Proof.
+Proof using Type.
   cbv [is_tighter_than_bool relax_zrange_gen]; intros *.
   pose proof (Z.log2_up_nonneg (upper r + 1)).
   rewrite !Bool.andb_true_iff; destruct_head' zrange; cbn [ZRange.lower ZRange.upper] in *.
@@ -7755,7 +7755,7 @@ Module X25519_64.
   Proof. Time solve_rone machine_wordsize. Time Qed.
   Lemma base_51_curve_good
     : check_args n s c machine_wordsize (Pipeline.Success tt) = Pipeline.Success tt.
-  Proof. vm_compute; reflexivity. Qed.
+  Proof using Type. vm_compute; reflexivity. Qed.
 
   Definition base_51_good : GoodT n s c
     := Good n s c machine_wordsize
@@ -8330,11 +8330,11 @@ Module Straightline.
 
       Lemma interp_cast_correct r (x : uexpr type.Z) :
         ident.cast ident.cast_outside_of_range r (uinterp x) = uinterp (AppIdent (ident.Z.cast r) x).
-      Proof. reflexivity. Qed.
+      Proof using Type. reflexivity. Qed.
 
       Lemma interp_cast2_correct r (x : uexpr (type.prod type.Z type.Z)) :
         @interp_cast2 (ident.cast ident.cast_outside_of_range) r (uinterp x) = uinterp (AppIdent (ident.Z.cast2 r) x).
-      Proof. cbn; break_match; reflexivity. Qed.
+      Proof using Type. cbn; break_match; reflexivity. Qed.
 
       Ltac invert H :=
         inversion H; subst;
@@ -8354,14 +8354,14 @@ Module Straightline.
       Lemma invert_AppIdent_correct {d} (e : uexpr d) x p :
         invert_AppIdent e = Some (existT (fun s : type => (ident s d * default.expr s)%type) x p) ->
         e = AppIdent (fst p) (snd p).
-      Proof.
+      Proof using Type.
         cbv [invert_AppIdent].
         break_match; try discriminate.
         intro H; invert H. reflexivity.
       Qed.
 
       Lemma depth_positive {var t} dummy_var (e : Uncurried.expr.expr t) : 0 < depth var dummy_var e.
-      Proof. destruct e; cbn [depth]; rewrite Nat2Z.inj_succ; lia. Qed.
+      Proof using Type. destruct e; cbn [depth]; rewrite Nat2Z.inj_succ; lia. Qed.
 
       Lemma of_uncurried_scalar_ident_correct {s d} (idc : ident s d) args args':
         ok_scalar_ident idc ->
@@ -8370,7 +8370,7 @@ Module Straightline.
         exists s,
           of_uncurried_scalar_ident idc args' = Some s
           /\ interp_scalar s = uinterp (AppIdent idc args).
-      Proof.
+      Proof using Type.
         destruct 1; intros;
           repeat match goal with
                  | _ => eexists; split; [ reflexivity | cbn [interp_scalar] ]
@@ -8387,7 +8387,7 @@ Module Straightline.
         exists s,
           of_uncurried_scalar e = Some s
           /\ interp_scalar s = uinterp  e.
-      Proof.
+      Proof using Type.
         induction 1; cbn [of_uncurried_scalar]; intros;
           repeat match goal with
                  | _ => progress cbn [interp_scalar]
@@ -9838,7 +9838,7 @@ Module PreFancy.
   Lemma interp_cast_mod_correct w r x :
     lower r <= x <= upper r ->
     interp_cast_mod w r x = x.
-  Proof.
+  Proof using Type.
     cbv [interp_cast_mod].
     intros; break_match; rewrite ?andb_true_iff in *; intuition; Z.ltb_to_lt;
       apply Z.mod_small; lia.
@@ -9856,7 +9856,7 @@ Module PreFancy.
             (of_uncurried (dummy_arrow:=dummy_arrow) (depth (fun _ : type => unit) (fun _ : type => tt) (e _)) (e' x)) ->
     (depth type.interp (@DefaultValue.type.default) (e' x) <= depth (fun _ : type => unit) (fun _ : type => tt) (e _))%nat ->
     @interp log2wordmax (interp_cast_mod log2wordmax) _ (of_Expr log2wordmax consts e type.interp x dummy_arrow) = @Uncurried.expr.interp _ (@ident.interp) _ (e type.interp) x.
-  Proof.
+  Proof using Type.
     intro He'; intros; cbv [of_Expr Straightline.of_Expr].
     rewrite He'; cbn [invert_Abs expr.interp].
     assert (forall r z, lower r <= z <= upper r -> ident.cast ident.cast_outside_of_range r z = z) as interp_cast_correct.
@@ -10218,9 +10218,9 @@ Module Fancy.
     Definition reg_eqb x y := if reg_dec x y then true else false.
 
     Lemma reg_eqb_neq x y : x <> y -> reg_eqb x y = false.
-    Proof. cbv [reg_eqb]; break_match; congruence. Qed.
+    Proof using Type. cbv [reg_eqb]; break_match; congruence. Qed.
     Lemma reg_eqb_refl x : reg_eqb x x = true.
-    Proof. cbv [reg_eqb]; break_match; congruence. Qed.
+    Proof using Type. cbv [reg_eqb]; break_match; congruence. Qed.
   End Registers.
 
   Section of_prefancy.
@@ -10339,7 +10339,7 @@ Module Fancy.
                           then x2
                           else 0).
   Lemma test_prog_ok : expected = actual.
-  Proof. reflexivity. Qed.
+  Proof using Type. reflexivity. Qed.
 
   Definition of_Expr {s d} next_name (consts : Z -> option positive) (consts_list : list Z) (e : Expr (s -> d)) (x : var positive s) dummy_arrow : positive -> @expr positive :=
     fun error =>
@@ -10414,13 +10414,13 @@ Module ProdEquiv.
       let result := spec i (Tuple.map ctx args) cc in
       let new_cc := CC.update (writes_conditions i) result cc_spec cc in
       let new_ctx := fun n => if reg_eqb n rd then result mod wordmax else ctx n in interp256 cont new_cc new_ctx.
-  Proof. reflexivity. Qed.
+  Proof using Type. reflexivity. Qed.
 
   Lemma interp_state_equiv e :
     forall cc ctx cc' ctx',
     cc = cc' -> (forall r, ctx r = ctx' r) ->
     interp256 e cc ctx = interp256 e cc' ctx'.
-  Proof.
+  Proof using Type.
     induction e; intros; subst; cbn; [solve[auto]|].
     apply IHe; rewrite Tuple.map_ext with (g:=ctx') by auto;
       [reflexivity|].
@@ -10428,7 +10428,7 @@ Module ProdEquiv.
   Qed.
   Lemma cc_overwrite_full x1 x2 l1 cc :
     CC.update [CC.C; CC.M; CC.L; CC.Z] x2 cc_spec (CC.update l1 x1 cc_spec cc) = CC.update [CC.C; CC.M; CC.L; CC.Z] x2 cc_spec cc.
-  Proof.
+  Proof using Type.
     cbv [CC.update]. cbn [CC.cc_c CC.cc_m CC.cc_l CC.cc_z].
     break_match; try match goal with H : ~ In _ _ |- _ => cbv [In] in H; tauto end.
     reflexivity.
@@ -10441,7 +10441,7 @@ Module ProdEquiv.
     r <> rd ->
     (~ In r (Tuple.to_list _ args)) ->
     value_unused r (Instr i rd args cont).
-  Proof.
+  Proof using Type.
     cbv [value_unused] in *; intros.
     rewrite !interp_step; cbv zeta.
     rewrite Hcont with (x:=x).
@@ -10457,7 +10457,7 @@ Module ProdEquiv.
   Lemma value_unused_overwrite r i args cont :
     (~ In r (Tuple.to_list _ args)) ->
     value_unused r (Instr i r args cont).
-  Proof.
+  Proof using Type.
     cbv [value_unused]; intros; rewrite !interp_step; cbv zeta.
     match goal with |- ?lhs = ?rhs =>
                     match lhs with context [Tuple.map ?f ?t] =>
@@ -10471,7 +10471,7 @@ Module ProdEquiv.
   Lemma value_unused_ret r r' :
     r <> r' ->
     value_unused r (Ret r').
-  Proof.
+  Proof using Type.
     cbv - [reg_dec]; intros.
     break_match; congruence.
   Qed.
@@ -10510,7 +10510,7 @@ Module ProdEquiv.
                      (Instr MUL128LL out (src1, src2)
                                  (Instr (ADD 128) out (out, tmp2)
                                         (Instr (ADD 128) out (out, tmp) cont))))) cc ctx.
-  Proof.
+  Proof using Type.
     intros; cbv [Prod.Mul256].
     repeat (do_interp_step; cbn [spec MUL128LL MUL128UL MUL128LU ADD] in * ).
 
@@ -10551,7 +10551,7 @@ Module ProdEquiv.
                                           (Instr (ADDC (-128)) outHigh (outHigh, tmp2)
                                                  (Instr (ADD 128) out (out, tmp)
                                                         (Instr (ADDC (-128)) outHigh (outHigh, tmp) cont)))))))) cc ctx.
-  Proof.
+  Proof using Type.
     intros; cbv [Prod.Mul256x256].
     repeat (do_interp_step; cbn [spec MUL128LL MUL128UL MUL128LU MUL128UU ADD ADDC] in * ).
 
@@ -10570,21 +10570,21 @@ Module ProdEquiv.
 
   Lemma mulll_comm rd x y cont cc ctx :
     ProdEquiv.interp256 (Fancy.Instr Fancy.MUL128LL rd (x, y) cont) cc ctx = ProdEquiv.interp256 (Fancy.Instr Fancy.MUL128LL rd (y, x) cont) cc ctx.
-  Proof. rewrite !ProdEquiv.interp_step. cbn - [Fancy.interp]. rewrite Z.mul_comm. reflexivity. Qed.
+  Proof using Type. rewrite !ProdEquiv.interp_step. cbn - [Fancy.interp]. rewrite Z.mul_comm. reflexivity. Qed.
 
   Lemma mulhh_comm rd x y cont cc ctx :
     ProdEquiv.interp256 (Fancy.Instr Fancy.MUL128UU rd (x, y) cont) cc ctx = ProdEquiv.interp256 (Fancy.Instr Fancy.MUL128UU rd (y, x) cont) cc ctx.
-  Proof. rewrite !ProdEquiv.interp_step. cbn - [Fancy.interp]. rewrite Z.mul_comm. reflexivity. Qed.
+  Proof using Type. rewrite !ProdEquiv.interp_step. cbn - [Fancy.interp]. rewrite Z.mul_comm. reflexivity. Qed.
 
   Lemma mullh_mulhl rd x y cont cc ctx :
     ProdEquiv.interp256 (Fancy.Instr Fancy.MUL128LU rd (x, y) cont) cc ctx = ProdEquiv.interp256 (Fancy.Instr Fancy.MUL128UL rd (y, x) cont) cc ctx.
-  Proof. rewrite !ProdEquiv.interp_step. cbn - [Fancy.interp]. rewrite Z.mul_comm. reflexivity. Qed.
+  Proof using Type. rewrite !ProdEquiv.interp_step. cbn - [Fancy.interp]. rewrite Z.mul_comm. reflexivity. Qed.
 
   Lemma add_comm rd x y cont cc ctx :
     0 <= ctx x < 2^256 ->
     0 <= ctx y < 2^256 ->
     ProdEquiv.interp256 (Fancy.Instr (Fancy.ADD 0) rd (x, y) cont) cc ctx = ProdEquiv.interp256 (Fancy.Instr (Fancy.ADD 0) rd (y, x) cont) cc ctx.
-  Proof.
+  Proof using Type.
     intros; rewrite !ProdEquiv.interp_step. cbn - [Fancy.interp]. rewrite Z.add_comm.
     rewrite !(Z.mod_small (ctx _)) by (cbn in *; lia). reflexivity.
   Qed.
@@ -10593,7 +10593,7 @@ Module ProdEquiv.
     0 <= ctx x < 2^256 ->
     0 <= ctx y < 2^256 ->
     ProdEquiv.interp256 (Fancy.Instr (Fancy.ADDC 0) rd (x, y) cont) cc ctx = ProdEquiv.interp256 (Fancy.Instr (Fancy.ADDC 0) rd (y, x) cont) cc ctx.
-  Proof.
+  Proof using Type.
     intros; rewrite !ProdEquiv.interp_step. cbn - [Fancy.interp]. rewrite (Z.add_comm (ctx x)).
     rewrite !(Z.mod_small (ctx _)) by (cbn in *; lia). reflexivity.
   Qed.
@@ -10645,13 +10645,13 @@ Module Fancy_PreFancy_Equiv.
   Import Fancy.Registers.
 
   Lemma interp_cast_mod_eq w u x: u = 2^w - 1 -> PreFancy.interp_cast_mod w r[0 ~> u] x = x mod 2^w.
-  Proof.
+  Proof using Type.
     cbv [PreFancy.interp_cast_mod upper lower]; intros; subst.
     rewrite !Z.eqb_refl.
     reflexivity.
   Qed.
   Lemma interp_cast_mod_flag w x: PreFancy.interp_cast_mod w r[0 ~> 1] x = x mod 2.
-  Proof.
+  Proof using Type.
     cbv [PreFancy.interp_cast_mod upper lower].
     break_match; Z.ltb_to_lt; subst; try lia.
     f_equal; lia.
@@ -10668,7 +10668,7 @@ Module Fancy_PreFancy_Equiv.
     Fancy.interp reg_eqb (2^w) Fancy.cc_spec (Fancy.Instr i rd regs e) cc ctx
     = PreFancy.interp (t:=type.Z) (interp_cast:=PreFancy.interp_cast_mod w) w
                       (@Straightline.expr.LetInAppIdentZ _ _ s _ (r[0~>2^w-1])%zrange idc args f).
-  Proof.
+  Proof using Type.
     cbv zeta; intros spec_eq next_eq.
     cbn [Fancy.interp PreFancy.interp].
     rewrite next_eq.
@@ -10691,7 +10691,7 @@ Module Fancy_PreFancy_Equiv.
     Fancy.interp reg_eqb (2^w) Fancy.cc_spec (Fancy.Instr i rd regs e) cc ctx
     = PreFancy.interp (t:=type.Z) (interp_cast:=PreFancy.interp_cast_mod w) w
                       (@Straightline.expr.LetInAppIdentZZ _ _ s _ (r[0~>u], r[0~>1])%zrange idc args f).
-  Proof.
+  Proof using Type.
     cbv zeta; intros spec_eq1 spec_eq2 next_eq.
     cbn [Fancy.interp PreFancy.interp].
     cbv [Straightline.expr.interp_cast2]. cbn [fst snd].
@@ -10766,13 +10766,14 @@ Module BarrettReduction.
       cond_sub2 q3 M.
 
     Lemma looser_bound : M * 2 ^ k < 2 ^ (2*k).
-    Proof using M_nz M_range k_pos. clear -M_range M_nz x_range k_pos; rewrite <-Z.add_diag, Z.pow_add_r; nia. Qed.
+    Proof using M_nz M_range k_pos. clear -M_range M_nz k_pos; assert (0 < 2^k) by auto with zarith; rewrite <-Z.add_diag, Z.pow_add_r; nia. Qed.
 
     Lemma pow_2k_eq : 2 ^ (2*k) = 2 ^ (k - 1) * 2 ^ (k + 1).
     Proof using k_pos. clear -k_pos; rewrite <-Z.pow_add_r by lia. f_equal; ring. Qed.
 
     Lemma mu_bounds : 2 ^ k <= mu < 2^(k+1).
     Proof using M_nz M_range k_pos.
+      clear -M_nz M_range k_pos mu.
       pose proof looser_bound.
       subst mu. split.
       { apply Z.div_le_lower_bound; lia. }
@@ -10802,7 +10803,7 @@ Module BarrettReduction.
     Local Hint Resolve q_correct.
 
     Lemma x_mod_small : x mod 2 ^ (k - 1) <= M.
-    Proof using M_range k_pos. transitivity (2 ^ (k - 1)); auto with zarith. Qed.
+    Proof using M_range k_pos. clear -M_range k_pos. transitivity (2 ^ (k - 1)); auto with zarith. Qed.
     Local Hint Resolve x_mod_small.
 
     Lemma q_bounds : 0 <= q < 2 ^ k.
@@ -10887,11 +10888,12 @@ Module BarrettReduction.
 
     Lemma represents_low_range t x :
       represents t x -> 0 <= x mod 2^k < 2^k.
-    Proof using Hn_nz Hnout k_bound. auto with zarith. Qed.
+    Proof using Hn_nz Hnout k_bound. clear -Hn_nz Hnout k_bound. auto with zarith. Qed.
 
     Lemma represents_high_range t x :
       represents t x -> 0 <= x / 2^k < 2^k.
     Proof using Hn_nz Hnout k_bound.
+      clear -Hn_nz Hnout k_bound.
       destruct 1 as [? [? ?] ]; intros.
       auto using Z.div_lt_upper_bound with zarith.
     Qed.
@@ -10925,6 +10927,7 @@ Module BarrettReduction.
       0 <= i <= k ->
       represents (shiftr a i) (x / 2 ^ i).
     Proof using Hn_nz Hnout M_bound1 k_bound muLow_bounds.
+      clear -Hn_nz Hnout M_bound1 k_bound muLow_bounds w.
       cbv [shiftr]; intros; push_rep.
       match goal with H : _ |- _ => pose proof (represents_range _ _ H) end.
       assert (0 < 2 ^ i) by auto with zarith.
@@ -10971,6 +10974,7 @@ Module BarrettReduction.
     Lemma eval_represents t x :
       represents t x -> eval w 2 t = x.
     Proof using Hn_nz Hnout Hw M_bound1 k_bound muLow_bounds.
+      clear -Hn_nz Hnout Hw M_bound1 k_bound muLow_bounds.
       intros; rewrite (represents_eq t x) by assumption.
       cbn. change_weight; push_rep.
       autorewrite with zsimplify. reflexivity.
@@ -10997,6 +11001,7 @@ Module BarrettReduction.
       0 <= x - y < 2^k*2^k ->
       represents (widesub t1 t2) (x - y).
     Proof using Hn_nz Hnout M_bound1 k_bound muLow_bounds.
+      clear -Hn_nz Hnout M_bound1 k_bound muLow_bounds w.
       intros; cbv [widesub Let_In].
       rewrite (represents_eq t1 x) by assumption.
       rewrite (represents_eq t2 y) by assumption.
@@ -11064,6 +11069,7 @@ Module BarrettReduction.
       0 <= y < 2 ^ k ->
       represents [x;y] (x + 2^k*y).
     Proof using Hn_nz Hnout M_bound1 k_bound n_le_k.
+      clear -Hn_nz Hnout M_bound1 k_bound n_le_k.
       intros; cbv [represents]; autorewrite with zsimplify.
       repeat split; (reflexivity || nia).
     Qed.
@@ -11072,6 +11078,7 @@ Module BarrettReduction.
       0 <= x < 2^k ->
       represents [x; 0] x.
     Proof using Hn_nz Hnout M_bound1 k_bound n_le_k.
+      clear -Hn_nz Hnout M_bound1 k_bound n_le_k w props.
       intros.
       eapply represents_trans.
       { eauto using represents_add with zarith. }
@@ -11086,6 +11093,7 @@ Module BarrettReduction.
       a0b1 = x mod 2^k * (y / 2^k) ->
       represents (mul_high a b a0b1) ((x * y) / 2^k).
     Proof using Hw M_bound1 muLow_bounds n_le_k props.
+      clear -Hw M_bound1 muLow_bounds n_le_k props.
       cbv [mul_high Let_In]; rewrite Z.pow_add_r, Z.pow_1_r by lia; intros.
       assert (4 <= 2 ^ k) by (transitivity (Z.pow 2 2); auto with zarith).
       assert (0 <= x * y / 2^k < 2^k*2^k) by (Z.div_mod_to_quot_rem_in_goal; nia).
@@ -11118,6 +11126,7 @@ Module BarrettReduction.
 
     Lemma cc_l_only_bit : forall x s, 0 <= x < 2 * s -> Z.cc_l (x / s) = 0 <-> x < s.
     Proof using Hn_nz Hnout k_bound.
+      clear -Hn_nz Hnout k_bound.
       cbv [Z.cc_l]; intros.
       rewrite Z.div_between_0_if by lia.
       break_match; Z.ltb_to_lt; Z.rewrite_mod_small; lia.
@@ -11129,6 +11138,7 @@ Module BarrettReduction.
       0 <= y < 2 ^ k ->
       cond_sub1 a y = if (x <? 2 ^ k) then x else x - y.
     Proof using Hn_nz Hnout M_bound1 M_pos k_bound muLow_bounds.
+      clear -Hn_nz Hnout M_bound1 M_pos k_bound muLow_bounds w props.
       intros; cbv [cond_sub1 Let_In]. rewrite Z.zselect_correct. push_rep.
       break_match; Z.ltb_to_lt; rewrite cc_l_only_bit in *; try lia;
         autorewrite with zsimplify_fast to_div_mod pull_Zmod; auto with zarith.
@@ -11138,6 +11148,7 @@ Module BarrettReduction.
     Lemma cond_sub2_correct x y :
       cond_sub2 x y = if (x <? y) then x else x - y.
     Proof using Hn_nz Hnout k.
+      clear -Hn_nz Hnout k.
       cbv [cond_sub2]. rewrite Z.add_modulo_correct.
       autorewrite with zsimplify_fast. break_match; Z.ltb_to_lt; lia.
     Qed.
@@ -11148,10 +11159,10 @@ Module BarrettReduction.
       Let x := xLow + 2^k * xHigh.
 
       Lemma x_rep : represents xt x.
-      Proof using Hn_nz Hnout M_bound1 M_pos k_bound n_le_k xHigh_bounds xLow_bounds. cbv [represents]; subst xt x; autorewrite with cancel_pair zsimplify; repeat split; nia. Qed.
+      Proof using Hn_nz Hnout M_bound1 M_pos k_bound n_le_k xHigh_bounds xLow_bounds. clear -Hn_nz Hnout M_bound1 M_pos k_bound n_le_k xHigh_bounds xLow_bounds. cbv [represents]; subst xt x; autorewrite with cancel_pair zsimplify; repeat split; nia. Qed.
 
       Lemma x_bounds : 0 <= x < M * 2 ^ k.
-      Proof using Hn_nz Hnout M_bound1 k_bound muLow_bounds n_le_k xHigh_bounds xLow_bounds. subst x; nia. Qed.
+      Proof using Hn_nz Hnout M_bound1 k_bound muLow_bounds n_le_k xHigh_bounds xLow_bounds. clear -Hn_nz Hnout M_bound1 k_bound muLow_bounds n_le_k xHigh_bounds xLow_bounds. subst x; nia. Qed.
 
       Definition muSelect := Z.zselect (Z.cc_m (2 ^ k) xHigh) 0 muLow.
 
@@ -11181,7 +11192,7 @@ Module BarrettReduction.
       Qed.
 
       Lemma mu_rep : represents [muLow; 1] (2 ^ (2 * k) / M).
-      Proof using Hn_nz Hnout M_bound1 k_bound muLow_bounds muLow_eq n_le_k x. rewrite <-muLow_eq. eapply represents_trans; auto with zarith. Qed.
+      Proof using Hn_nz Hnout M_bound1 k_bound muLow_bounds muLow_eq n_le_k x. clear -Hn_nz Hnout M_bound1 k_bound muLow_bounds muLow_eq n_le_k x w props. rewrite <-muLow_eq. eapply represents_trans; auto with zarith. Qed.
 
       Derive barrett_reduce
              SuchThat (barrett_reduce = x mod M)
@@ -11312,7 +11323,7 @@ Module Barrett256.
       0 <= xLow < 2 ^ machine_wordsize ->
       0 <= xHigh < M ->
       BarrettReduction.barrett_reduce machine_wordsize M muLow 2 2 xLow xHigh = (xLow + 2 ^ machine_wordsize * xHigh) mod M.
-  Proof.
+  Proof using Type.
     intros.
     apply BarrettReduction.barrett_reduce_correct; cbv [machine_wordsize M muLow] in *;
       try lia;
@@ -11329,7 +11340,7 @@ Module Barrett256.
         (Some r[0 ~> 2 ^ machine_wordsize - 1]%zrange, Some r[0 ~> 2 ^ machine_wordsize - 1]%zrange)
         xy = true ->
        expr.Interp (@ident.interp) barrett_red256 xy = app_curried (t:=type.arrow (type.prod type.Z type.Z) type.Z) (fun xy => BarrettReduction.barrett_reduce machine_wordsize M muLow 2 2 (fst xy) (snd xy)) xy.
-  Proof. intros; destruct (barrett_red256_correct xy); assumption. Qed.
+  Proof using Type. intros; destruct (barrett_red256_correct xy); assumption. Qed.
   Lemma barrett_red256_correct_proj2' :
     forall x y : Z,
       ZRange.type.option.is_bounded_by
@@ -11337,14 +11348,14 @@ Module Barrett256.
         (Some r[0 ~> 2 ^ machine_wordsize - 1]%zrange, Some r[0 ~> 2 ^ machine_wordsize - 1]%zrange)
         (x, y) = true ->
        expr.Interp (@ident.interp) barrett_red256 (x, y) = BarrettReduction.barrett_reduce machine_wordsize M muLow 2 2 x y.
-  Proof. intros; rewrite barrett_red256_correct_proj2 by assumption; unfold app_curried; exact eq_refl. Qed.
+  Proof using Type. intros; rewrite barrett_red256_correct_proj2 by assumption; unfold app_curried; exact eq_refl. Qed.
 
   Lemma barrett_red256_correct_full  :
     forall (xLow xHigh : Z),
       0 <= xLow < 2 ^ machine_wordsize ->
       0 <= xHigh < M ->
       expr.interp (@ident.interp) (barrett_red256 type.interp) (xLow, xHigh) = (xLow + 2 ^ machine_wordsize * xHigh) mod M.
-  Proof.
+  Proof using Type.
     intros.
     rewrite <-barrett_reduce_correct_specialized by assumption.
     rewrite <-barrett_red256_correct_proj2'.
@@ -11360,7 +11371,7 @@ Module Barrett256.
       0 <= xLow < 2 ^ machine_wordsize ->
       0 <= xHigh < M ->
       @PreFancy.interp machine_wordsize (PreFancy.interp_cast_mod machine_wordsize) type.Z (barrett_red256_prefancy (xLow, xHigh) dummy_arrow) = (xLow + 2 ^ machine_wordsize * xHigh) mod M.
-  Proof.
+  Proof using Type.
     intros. rewrite barrett_red256_prefancy_eq; cbv [barrett_red256_prefancy'].
     erewrite PreFancy.of_Expr_correct.
     { apply barrett_red256_correct_full; try assumption; reflexivity. }
@@ -11532,7 +11543,7 @@ Module Barrett256.
              cc_start_state.(Fancy.CC.cc_m) = (Z.cc_m (2^256) (start_context xHigh) =? 1) ->
              let X := start_context x + 2^machine_wordsize * start_context xHigh in
              ProdEquiv.interp256 (Prod.MulMod x xHigh RegMuLow scratchp1 scratchp2 scratchp3 scratchp4 scratchp5) cc_start_state start_context = X mod M.
-  Proof.
+  Proof using Type.
     intros. subst X.
     assert (0 <= start_context xHigh < 2^machine_wordsize) by (cbv [M] in *; cbn; lia).
     let r := (eval compute in (2 ^ machine_wordsize)) in
@@ -11731,7 +11742,7 @@ Module SaturatedSolinas.
 
     Let weight := weight log2base 1.
     Let props : @weight_properties weight := wprops log2base 1 ltac:(lia).
-    Local Lemma base_nz : 2 ^ log2base <> 0. Proof using log2base_pos n_nz s_nz. auto with zarith. Qed.
+    Local Lemma base_nz : 2 ^ log2base <> 0. Proof using log2base_pos n_nz s_nz. clear -log2base_pos n_nz s_nz weight props. auto with zarith. Qed.
 
     Derive mulmod
            SuchThat (forall (f g : list Z)
@@ -12298,7 +12309,7 @@ Module Montgomery256.
     forall (lo hi : Z),
       0 <= lo < R -> 0 <= hi < R -> 0 <= lo + R * hi < R * N ->
       MontgomeryReduction.montred' N R N' (Z.log2 R) 2 2 (lo, hi) = ((lo + R * hi) * R') mod N.
-  Proof.
+  Proof using Type.
     intros.
     apply MontgomeryReduction.montred'_correct with (T:=lo + R * hi) (R':=R');
       try match goal with
@@ -12316,7 +12327,7 @@ Module Montgomery256.
         (Some r[0 ~> 2 ^ machine_wordsize - 1]%zrange, Some r[0 ~> 2 ^ machine_wordsize - 1]%zrange)
         xy = true ->
        expr.Interp (@ident.interp) montred256 xy = app_curried (t:=type.arrow (type.prod type.Z type.Z) type.Z) (MontgomeryReduction.montred' N R N' (Z.log2 R) 2 2) xy.
-  Proof. intros; destruct (montred256_correct xy); assumption. Qed.
+  Proof using Type. intros; destruct (montred256_correct xy); assumption. Qed.
   Lemma montred256_correct_proj2' :
     forall xy : type.interp (type.prod type.Z type.Z),
       ZRange.type.option.is_bounded_by
@@ -12324,13 +12335,13 @@ Module Montgomery256.
         (Some r[0 ~> 2 ^ machine_wordsize - 1]%zrange, Some r[0 ~> 2 ^ machine_wordsize - 1]%zrange)
         xy = true ->
        expr.Interp (@ident.interp) montred256 xy = MontgomeryReduction.montred' N R N' (Z.log2 R) 2 2 xy.
-  Proof. intros; rewrite montred256_correct_proj2 by assumption; unfold app_curried; exact eq_refl. Qed.
+  Proof using Type. intros; rewrite montred256_correct_proj2 by assumption; unfold app_curried; exact eq_refl. Qed.
 
   Lemma montred256_correct_full  R' (R'_correct : Z.equiv_modulo N (R * R') 1) :
     forall (lo hi : Z),
       0 <= lo < R -> 0 <= hi < R -> 0 <= lo + R * hi < R * N ->
       expr.interp (@ident.interp) (montred256 type.interp) (lo, hi) = ((lo + R * hi) * R') mod N.
-  Proof.
+  Proof using Type.
     intros.
     rewrite <-montred'_correct_specialized by assumption.
     rewrite <-montred256_correct_proj2'.
@@ -12380,7 +12391,7 @@ Module Montgomery256.
     forall (lo hi : Z) dummy_arrow,
       0 <= lo < R -> 0 <= hi < R -> 0 <= lo + R * hi < R * N ->
       @PreFancy.interp machine_wordsize (PreFancy.interp_cast_mod machine_wordsize) type.Z (montred256_prefancy (lo,hi) dummy_arrow) = ((lo + R * hi) * R') mod N.
-  Proof.
+  Proof using Type.
     intros. rewrite montred256_prefancy_eq; cbv [montred256_prefancy'].
     erewrite PreFancy.of_Expr_correct.
     { apply montred256_correct_full; try assumption; reflexivity. }
@@ -12466,7 +12477,7 @@ Module Montgomery256.
                                               then start_context RegPInv
                                               else start_context r)
     = ProdEquiv.interp256 (Prod.MontRed256 lo hi y t1 t2 scratch RegPInv) cc_start_state start_context.
-  Proof.
+  Proof using Type.
     intros. cbv [R] in *.
     cbv [Prod.MontRed256 montred256_alloc].
 
@@ -12567,7 +12578,7 @@ Module Montgomery256.
       let x := (start_context lo) + R * (start_context hi) in (* x is the input (split into two registers) *)
       (0 <= x < R * N) -> (* input precondition *)
       (ProdEquiv.interp256 (Prod.MontRed256 lo hi y t1 t2 scratch RegPInv) cc_start_state start_context = (x * R') mod N).
-  Proof.
+  Proof using Type.
     intros. subst x. cbv [N R N'] in *.
     rewrite <-montred256_prefancy_correct with (dummy_arrow := fun s d _ => DefaultValue.type.default) by auto.
     rewrite <-montred256_alloc_equivalent with (errorR := RegZero) (errorP := 1%positive) (extra_reg:=extra_reg)

--- a/src/LegacyArithmetic/ArchitectureToZLikeProofs.v
+++ b/src/LegacyArithmetic/ArchitectureToZLikeProofs.v
@@ -1,5 +1,5 @@
 (*** Proving ℤ-Like via Architecture *)
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Crypto.LegacyArithmetic.Interface.
 Require Import Crypto.LegacyArithmetic.InterfaceProofs.

--- a/src/LegacyArithmetic/ArchitectureToZLikeProofs.v
+++ b/src/LegacyArithmetic/ArchitectureToZLikeProofs.v
@@ -4,11 +4,14 @@ Require Import Coq.ZArith.ZArith.
 Require Import Crypto.LegacyArithmetic.Interface.
 Require Import Crypto.LegacyArithmetic.InterfaceProofs.
 Require Import Crypto.LegacyArithmetic.Double.Core.
+Require Import Crypto.LegacyArithmetic.Double.Proofs.Decode.
 Require Import Crypto.LegacyArithmetic.Double.Proofs.RippleCarryAddSub.
 Require Import Crypto.LegacyArithmetic.Double.Proofs.Multiply.
 Require Import Crypto.LegacyArithmetic.ArchitectureToZLike.
 Require Import Crypto.LegacyArithmetic.ZBounded.
 Require Import Crypto.Util.Tuple.
+Require Import Crypto.Util.ZUtil.Div.
+Require Import Crypto.Util.ZUtil.Pow.
 Require Import Crypto.Util.ZUtil.Notations.
 Require Import Crypto.Util.ZUtil.Tactics.RewriteModSmall.
 Require Import Crypto.Util.Tactics.UniquePose.
@@ -127,3 +130,7 @@ Section fancy_machine_p256_montgomery_foundation.
     : ZLikeProperties (ZLikeOps_of_ArchitectureBoundedOps ops modulus smaller_bound_exp)
     := ZLikeProperties_of_ArchitectureBoundedOps_Factored _ _ eq_refl eq_refl modulus_in_range _ smaller_bound_smaller n_pos.
 End fancy_machine_p256_montgomery_foundation.
+
+Module Export Hints.
+  Export Double.Core.Hints.
+End Hints.

--- a/src/LegacyArithmetic/BarretReduction.v
+++ b/src/LegacyArithmetic/BarretReduction.v
@@ -1,7 +1,7 @@
 (*** Barrett Reduction *)
 (** This file implements Barrett Reduction on [ZLikeOps].  We follow
     [BarretReduction/ZHandbook.v]. *)
-Require Import Coq.ZArith.ZArith Coq.Lists.List Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.micromega.Psatz.
+Require Import Coq.ZArith.ZArith Coq.Lists.List Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Arithmetic.BarrettReduction.HAC.
 Require Import Crypto.LegacyArithmetic.ZBounded.
 Require Import Crypto.Util.Notations.

--- a/src/LegacyArithmetic/BarretReduction.v
+++ b/src/LegacyArithmetic/BarretReduction.v
@@ -1,10 +1,11 @@
 (*** Barrett Reduction *)
 (** This file implements Barrett Reduction on [ZLikeOps].  We follow
     [BarretReduction/ZHandbook.v]. *)
-Require Import Coq.ZArith.ZArith Coq.Lists.List Coq.Classes.Morphisms Coq.micromega.Psatz.
+Require Import Coq.ZArith.ZArith Coq.Lists.List Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.micromega.Psatz.
 Require Import Crypto.Arithmetic.BarrettReduction.HAC.
 Require Import Crypto.LegacyArithmetic.ZBounded.
 Require Import Crypto.Util.Notations.
+Require Import Crypto.Util.ZUtil.Hints.ZArith.
 
 Local Open Scope small_zlike_scope.
 Local Open Scope large_zlike_scope.

--- a/src/LegacyArithmetic/BaseSystem.v
+++ b/src/LegacyArithmetic/BaseSystem.v
@@ -1,6 +1,6 @@
 Require Import Coq.Lists.List.
 Require Import Coq.ZArith.ZArith Coq.ZArith.Zdiv.
-Require Import Coq.micromega.Lia Coq.Numbers.Natural.Peano.NPeano Coq.Arith.Arith.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.Numbers.Natural.Peano.NPeano Coq.Arith.Arith.
 Require Import Crypto.Util.ListUtil.
 Require Import Crypto.Util.Notations.
 Require Export Crypto.Util.FixCoqMistakes.

--- a/src/LegacyArithmetic/BaseSystemProofs.v
+++ b/src/LegacyArithmetic/BaseSystemProofs.v
@@ -1,7 +1,7 @@
-Require Import Coq.Lists.List Coq.micromega.Psatz.
+Require Import Coq.Lists.List Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ListUtil.
 Require Import Coq.ZArith.ZArith Coq.ZArith.Zdiv.
-Require Import Coq.micromega.Lia Coq.Numbers.Natural.Peano.NPeano Coq.Arith.Arith.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.Numbers.Natural.Peano.NPeano Coq.Arith.Arith.
 Require Import Crypto.LegacyArithmetic.BaseSystem.
 Require Import Crypto.Util.Tactics.UniquePose.
 Require Import Crypto.Util.Notations.

--- a/src/LegacyArithmetic/Double/Core.v
+++ b/src/LegacyArithmetic/Double/Core.v
@@ -1,7 +1,7 @@
 (*** Implementing Large Bounded Arithmetic via pairs *)
 Require Import Coq.ZArith.ZArith.
 Require Import Crypto.LegacyArithmetic.Interface.
-Require Import Crypto.LegacyArithmetic.InterfaceProofs.
+Require Import Crypto.LegacyArithmetic.InterfaceProofs. Export InterfaceProofs.Hints.
 Require Import Crypto.Util.Tuple.
 Require Import Crypto.Util.ListUtil.
 Require Import Crypto.Util.Notations.
@@ -23,7 +23,9 @@ Definition tuple_decoder {n W} {decode : decoder n W} {k : nat} : decoder (k * n
   := {| decode w := BaseSystem.decode (Pow2Base.base_from_limb_widths (List.repeat n k))
                                       (List.map decode (List.rev (Tuple.to_list _ w))) |}.
 Global Arguments tuple_decoder : simpl never.
-Hint Extern 3 (decoder _ (tuple ?W ?k)) => let kv := (eval simpl in (Z.of_nat k)) in apply (fun n decode => (@tuple_decoder n W decode k : decoder (kv * n) (tuple W k))) : typeclass_instances.
+Module Export Hints.
+  Global Hint Extern 3 (decoder _ (tuple ?W ?k)) => let kv := (eval simpl in (Z.of_nat k)) in apply (fun n decode => (@tuple_decoder n W decode k : decoder (kv * n) (tuple W k))) : typeclass_instances.
+End Hints.
 
 Section ripple_carry_definitions.
   (** tuple is high to low ([to_list] reverses) *)

--- a/src/LegacyArithmetic/Double/Proofs/Decode.v
+++ b/src/LegacyArithmetic/Double/Proofs/Decode.v
@@ -128,11 +128,11 @@ Proof.
   rewrite <- !ext; split; assumption.
 Qed.
 
-Hint Extern 1 (@is_add_with_carry _ _ (@tuple_decoder ?n ?W ?decode 1) ?adc)
+Global Hint Extern 1 (@is_add_with_carry _ _ (@tuple_decoder ?n ?W ?decode 1) ?adc)
 => apply (@is_add_with_carry_1tuple n W decode adc) : typeclass_instances.
 
-Hint Resolve (fun n W decode pf => (@tuple_is_decode n W decode 2 pf : @is_decode (2 * n) (tuple W 2) (@tuple_decoder n W decode 2))) : typeclass_instances.
-Hint Extern 3 (@is_decode _ (tuple ?W ?k) _) => let kv := (eval simpl in (Z.of_nat k)) in apply (fun n decode pf => (@tuple_is_decode n W decode k pf : @is_decode (kv * n) (tuple W k) (@tuple_decoder n W decode k : decoder (kv * n)%Z (tuple W k)))) : typeclass_instances.
+Global Hint Resolve (fun n W decode pf => (@tuple_is_decode n W decode 2 pf : @is_decode (2 * n) (tuple W 2) (@tuple_decoder n W decode 2))) : typeclass_instances.
+Global Hint Extern 3 (@is_decode _ (tuple ?W ?k) _) => let kv := (eval simpl in (Z.of_nat k)) in apply (fun n decode pf => (@tuple_is_decode n W decode k pf : @is_decode (kv * n) (tuple W k) (@tuple_decoder n W decode k : decoder (kv * n)%Z (tuple W k)))) : typeclass_instances.
 
 Hint Rewrite @tuple_decoder_S @tuple_decoder_O @tuple_decoder_m1 @tuple_decoder_n_O using solve [ auto with zarith ] : simpl_tuple_decoder.
 Hint Rewrite Z.mul_1_l : simpl_tuple_decoder.

--- a/src/LegacyArithmetic/Double/Proofs/Decode.v
+++ b/src/LegacyArithmetic/Double/Proofs/Decode.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith Coq.Lists.List Coq.micromega.Psatz.
+Require Import Coq.ZArith.ZArith Coq.Lists.List Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.LegacyArithmetic.Interface.
 Require Import Crypto.LegacyArithmetic.InterfaceProofs.
 Require Import Crypto.LegacyArithmetic.Double.Core.

--- a/src/LegacyArithmetic/Double/Proofs/LoadImmediate.v
+++ b/src/LegacyArithmetic/Double/Proofs/LoadImmediate.v
@@ -1,8 +1,10 @@
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Crypto.LegacyArithmetic.Interface.
 Require Import Crypto.LegacyArithmetic.InterfaceProofs.
 Require Import Crypto.LegacyArithmetic.Double.Core.
 Require Import Crypto.LegacyArithmetic.Double.Proofs.Decode.
+Require Import Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.ZUtil.Tactics.ZeroBounds.
 
 Local Open Scope Z_scope.

--- a/src/LegacyArithmetic/Double/Proofs/Multiply.v
+++ b/src/LegacyArithmetic/Double/Proofs/Multiply.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith Coq.micromega.Psatz.
+Require Import Coq.ZArith.ZArith Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.LegacyArithmetic.Interface.
 Require Import Crypto.LegacyArithmetic.InterfaceProofs.
 Require Import Crypto.LegacyArithmetic.Double.Core.

--- a/src/LegacyArithmetic/Double/Proofs/RippleCarryAddSub.v
+++ b/src/LegacyArithmetic/Double/Proofs/RippleCarryAddSub.v
@@ -1,5 +1,5 @@
 Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
-Require Import Coq.ZArith.ZArith Coq.micromega.Psatz.
+Require Import Coq.ZArith.ZArith Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.LegacyArithmetic.Interface.
 Require Import Crypto.LegacyArithmetic.InterfaceProofs.
 Require Import Crypto.LegacyArithmetic.Double.Core.

--- a/src/LegacyArithmetic/Double/Proofs/RippleCarryAddSub.v
+++ b/src/LegacyArithmetic/Double/Proofs/RippleCarryAddSub.v
@@ -1,3 +1,4 @@
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith Coq.micromega.Psatz.
 Require Import Crypto.LegacyArithmetic.Interface.
 Require Import Crypto.LegacyArithmetic.InterfaceProofs.
@@ -150,9 +151,9 @@ Section ripple_carry_adc.
 
 End ripple_carry_adc.
 
-Hint Extern 2 (@is_add_with_carry _ (tuple ?W ?k) (@tuple_decoder ?n _ ?decode _) (@ripple_carry_adc _ ?adc _))
+Global Hint Extern 2 (@is_add_with_carry _ (tuple ?W ?k) (@tuple_decoder ?n _ ?decode _) (@ripple_carry_adc _ ?adc _))
 => apply (@ripple_carry_is_add_with_carry n W decode adc k) : typeclass_instances.
-Hint Resolve (fun n W decode adc isdecode isadc
+Global Hint Resolve (fun n W decode adc isdecode isadc
               => @ripple_carry_is_add_with_carry n W decode adc 2 isdecode isadc
                  : @is_add_with_carry (Z.of_nat 2 * n) (W * W) (@tuple_decoder n W decode 2) (@ripple_carry_adc W adc 2))
   : typeclass_instances.
@@ -195,9 +196,9 @@ Section ripple_carry_subc.
 
 End ripple_carry_subc.
 
-Hint Extern 2 (@is_sub_with_carry _ (tuple ?W ?k) (@tuple_decoder ?n _ ?decode _) (@ripple_carry_subc _ ?subc _))
+Global Hint Extern 2 (@is_sub_with_carry _ (tuple ?W ?k) (@tuple_decoder ?n _ ?decode _) (@ripple_carry_subc _ ?subc _))
 => apply (@ripple_carry_is_sub_with_carry n W decode subc k) : typeclass_instances.
-Hint Resolve (fun n W decode subc isdecode issubc
+Global Hint Resolve (fun n W decode subc isdecode issubc
               => @ripple_carry_is_sub_with_carry n W decode subc 2 isdecode issubc
                  : @is_sub_with_carry (Z.of_nat 2 * n) (W * W) (@tuple_decoder n W decode 2) (@ripple_carry_subc W subc 2))
   : typeclass_instances.

--- a/src/LegacyArithmetic/Double/Proofs/ShiftLeft.v
+++ b/src/LegacyArithmetic/Double/Proofs/ShiftLeft.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith Coq.micromega.Psatz.
+Require Import Coq.ZArith.ZArith Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.LegacyArithmetic.Interface.
 Require Import Crypto.LegacyArithmetic.Double.Core.
 Require Import Crypto.LegacyArithmetic.Double.Proofs.Decode.

--- a/src/LegacyArithmetic/Double/Proofs/ShiftLeft.v
+++ b/src/LegacyArithmetic/Double/Proofs/ShiftLeft.v
@@ -3,6 +3,9 @@ Require Import Crypto.LegacyArithmetic.Interface.
 Require Import Crypto.LegacyArithmetic.Double.Core.
 Require Import Crypto.LegacyArithmetic.Double.Proofs.Decode.
 Require Import Crypto.LegacyArithmetic.Double.Proofs.ShiftLeftRightTactic.
+Require Import Crypto.Util.ZUtil.Pow2Mod.
+Require Import Crypto.Util.ZUtil.Pow.
+Require Import Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.ZUtil.Notations.
 Require Import Crypto.Util.ZUtil.Definitions.
 

--- a/src/LegacyArithmetic/Double/Proofs/ShiftLeftRightTactic.v
+++ b/src/LegacyArithmetic/Double/Proofs/ShiftLeftRightTactic.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Crypto.LegacyArithmetic.Interface.
 Require Import Crypto.Util.ZUtil.Notations.

--- a/src/LegacyArithmetic/Double/Proofs/ShiftRight.v
+++ b/src/LegacyArithmetic/Double/Proofs/ShiftRight.v
@@ -1,8 +1,14 @@
 Require Import Coq.ZArith.ZArith.
 Require Import Crypto.LegacyArithmetic.Interface.
+Require Import Crypto.LegacyArithmetic.InterfaceProofs.
 Require Import Crypto.LegacyArithmetic.Double.Core.
 Require Import Crypto.LegacyArithmetic.Double.Proofs.Decode.
 Require Import Crypto.LegacyArithmetic.Double.Proofs.ShiftLeftRightTactic.
+Require Import Crypto.Util.ZUtil.Pow.
+Require Import Crypto.Util.ZUtil.Div.
+Require Import Crypto.Util.ZUtil.Pow2Mod.
+Require Import Crypto.Util.ZUtil.Hints.ZArith.
+Require Export Crypto.Util.FixCoqMistakes.
 
 Local Open Scope Z_scope.
 

--- a/src/LegacyArithmetic/Double/Proofs/ShiftRightDoubleWordImmediate.v
+++ b/src/LegacyArithmetic/Double/Proofs/ShiftRightDoubleWordImmediate.v
@@ -4,6 +4,7 @@ Require Import Crypto.LegacyArithmetic.Double.Core.
 Require Import Crypto.LegacyArithmetic.Double.Proofs.Decode.
 Require Import Crypto.LegacyArithmetic.Double.Proofs.ShiftLeftRightTactic.
 Require Import Crypto.Util.ZUtil.Hints.Core.
+Require Import Crypto.Util.ZUtil.Pow2Mod.
 Require Import Crypto.Util.ZUtil.Definitions.
 
 Local Open Scope Z_scope.

--- a/src/LegacyArithmetic/Double/Proofs/SpreadLeftImmediate.v
+++ b/src/LegacyArithmetic/Double/Proofs/SpreadLeftImmediate.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith Coq.micromega.Psatz.
+Require Import Coq.ZArith.ZArith Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.LegacyArithmetic.Interface.
 Require Import Crypto.LegacyArithmetic.InterfaceProofs.
 Require Import Crypto.LegacyArithmetic.Double.Core.

--- a/src/LegacyArithmetic/Interface.v
+++ b/src/LegacyArithmetic/Interface.v
@@ -4,7 +4,7 @@ Require Import Coq.ZArith.ZArith.
 Require Import Crypto.Util.ZUtil.Notations.
 
 Require Import Crypto.Util.Tuple.
-Require Import Crypto.Util.AutoRewrite.
+Require Export Crypto.Util.AutoRewrite.
 Require Import Crypto.Util.Notations.
 
 Local Open Scope type_scope.
@@ -21,14 +21,14 @@ Class is_decode {n W} (decode : decoder n W) :=
 Class bounded_in_range_cls (x y z : Z) := is_bounded_in_range : x <= y < z.
 Ltac bounded_solver_tac :=
   solve [ eassumption | typeclasses eauto | lia ].
-Hint Extern 0 (bounded_in_range_cls _ _ _) => unfold bounded_in_range_cls; bounded_solver_tac : typeclass_instances.
+Global Hint Extern 0 (bounded_in_range_cls _ _ _) => unfold bounded_in_range_cls; bounded_solver_tac : typeclass_instances.
 Global Arguments bounded_in_range_cls / _ _ _.
 Global Instance decode_range_bound {n W} {decode : decoder n W} {H : is_decode decode}
   : forall x, bounded_in_range_cls 0 (decode x) (2^n)
   := H.
 
 Class bounded_le_cls (x y : Z) := is_bounded_le : x <= y.
-Hint Extern 0 (bounded_le_cls _ _) => unfold bounded_le_cls; bounded_solver_tac : typeclass_instances.
+Global Hint Extern 0 (bounded_le_cls _ _) => unfold bounded_le_cls; bounded_solver_tac : typeclass_instances.
 Global Arguments bounded_le_cls / _ _.
 
 Inductive bounded_decode_pusher_tag := decode_tag.
@@ -418,6 +418,33 @@ Module fancy_machine.
     }.
 End fancy_machine.
 
+Global Existing Instances
+       fancy_machine.decode
+       fancy_machine.ldi
+       fancy_machine.shrd
+       fancy_machine.shl
+       fancy_machine.shr
+       fancy_machine.adc
+       fancy_machine.subc
+       fancy_machine.mulhwll
+       fancy_machine.mulhwhl
+       fancy_machine.mulhwhh
+       fancy_machine.selc
+       fancy_machine.addm
+       fancy_machine.decode_range
+       fancy_machine.load_immediate
+       fancy_machine.shift_right_doubleword_immediate
+       fancy_machine.shift_left_immediate
+       fancy_machine.shift_right_immediate
+       fancy_machine.add_with_carry
+       fancy_machine.sub_with_carry
+       fancy_machine.multiply_low_low
+       fancy_machine.multiply_high_low
+       fancy_machine.multiply_high_high
+       fancy_machine.select_conditional
+       fancy_machine.add_modulo
+.
+
 Module x86.
   Local Notation imm := Z (only parsing).
 
@@ -450,3 +477,26 @@ Module x86.
       bitwise_or_with_CF :> is_bitwise_or_with_CF orf
     }.
 End x86.
+
+Global Existing Instances
+       x86.decode
+       x86.ldi
+       x86.shrdf
+       x86.shlf
+       x86.shrf
+       x86.adc
+       x86.subc
+       x86.muldwf
+       x86.selc
+       x86.orf
+       x86.decode_range
+       x86.load_immediate
+       x86.shift_right_doubleword_immediate_with_CF
+       x86.shift_left_immediate_with_CF
+       x86.shift_right_immediate_with_CF
+       x86.add_with_carry
+       x86.sub_with_carry
+       x86.multiply_double_with_CF
+       x86.select_conditional
+       x86.bitwise_or_with_CF
+.

--- a/src/LegacyArithmetic/Interface.v
+++ b/src/LegacyArithmetic/Interface.v
@@ -1,5 +1,5 @@
 (*** Interface for bounded arithmetic *)
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Crypto.Util.ZUtil.Notations.
 

--- a/src/LegacyArithmetic/InterfaceProofs.v
+++ b/src/LegacyArithmetic/InterfaceProofs.v
@@ -1,5 +1,5 @@
 (** * Alternate forms for Interface for bounded arithmetic *)
-Require Import Coq.ZArith.ZArith Coq.micromega.Psatz.
+Require Import Coq.ZArith.ZArith Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.LegacyArithmetic.Interface.
 Require Import Crypto.Util.ZUtil.Notations.
 Require Import Crypto.Util.ZUtil.Hints.

--- a/src/LegacyArithmetic/InterfaceProofs.v
+++ b/src/LegacyArithmetic/InterfaceProofs.v
@@ -196,13 +196,15 @@ Section adc_subc.
   Qed.
 End adc_subc.
 
-Hint Extern 2 (rewrite_right_to_left_eq decode_tag _ (_ <=? (@decode ?n ?W ?decoder ?x + @decode _ _ _ ?y)))
-=> apply @fst_add_with_carry_false_leb : typeclass_instances.
-Hint Extern 2 (rewrite_right_to_left_eq decode_tag _ (_ <=? (@decode ?n ?W ?decoder ?x + @decode _ _ _ ?y + 1)))
-=> apply @fst_add_with_carry_true_leb : typeclass_instances.
-Hint Extern 2 (rewrite_right_to_left_eq decode_tag _ (_ <=? (@decode ?n ?W ?decoder ?x + @decode _ _ _ ?y + if ?c then _ else _)))
-=> apply @fst_add_with_carry_leb : typeclass_instances.
-
+Module Export Hints.
+  Export ZUtil.Hints.ZArith.
+  Global Hint Extern 2 (rewrite_right_to_left_eq decode_tag _ (_ <=? (@decode ?n ?W ?decoder ?x + @decode _ _ _ ?y)))
+         => apply @fst_add_with_carry_false_leb : typeclass_instances.
+  Global Hint Extern 2 (rewrite_right_to_left_eq decode_tag _ (_ <=? (@decode ?n ?W ?decoder ?x + @decode _ _ _ ?y + 1)))
+         => apply @fst_add_with_carry_true_leb : typeclass_instances.
+  Global Hint Extern 2 (rewrite_right_to_left_eq decode_tag _ (_ <=? (@decode ?n ?W ?decoder ?x + @decode _ _ _ ?y + if ?c then _ else _)))
+         => apply @fst_add_with_carry_leb : typeclass_instances.
+End Hints.
 
 (* We take special care to handle the case where the decoder is
    syntactically different but the decoded expression is judgmentally

--- a/src/LegacyArithmetic/MontgomeryReduction.v
+++ b/src/LegacyArithmetic/MontgomeryReduction.v
@@ -1,7 +1,7 @@
 (*** Montgomery Multiplication *)
 (** This file implements Montgomery Form, Montgomery Reduction, and
     Montgomery Multiplication on [ZLikeOps].  We follow [Montgomery/Z.v]. *)
-Require Import Coq.ZArith.ZArith Coq.Lists.List Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.micromega.Psatz.
+Require Import Coq.ZArith.ZArith Coq.Lists.List Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Arithmetic.MontgomeryReduction.Definition.
 Require Import Crypto.Arithmetic.MontgomeryReduction.Proofs.
 Require Import Crypto.LegacyArithmetic.ZBounded.

--- a/src/LegacyArithmetic/MontgomeryReduction.v
+++ b/src/LegacyArithmetic/MontgomeryReduction.v
@@ -1,7 +1,7 @@
 (*** Montgomery Multiplication *)
 (** This file implements Montgomery Form, Montgomery Reduction, and
     Montgomery Multiplication on [ZLikeOps].  We follow [Montgomery/Z.v]. *)
-Require Import Coq.ZArith.ZArith Coq.Lists.List Coq.Classes.Morphisms Coq.micromega.Psatz.
+Require Import Coq.ZArith.ZArith Coq.Lists.List Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.micromega.Psatz.
 Require Import Crypto.Arithmetic.MontgomeryReduction.Definition.
 Require Import Crypto.Arithmetic.MontgomeryReduction.Proofs.
 Require Import Crypto.LegacyArithmetic.ZBounded.

--- a/src/LegacyArithmetic/Pow2BaseProofs.v
+++ b/src/LegacyArithmetic/Pow2BaseProofs.v
@@ -1,10 +1,10 @@
 Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
-Require Import Coq.ZArith.Zpower Coq.ZArith.ZArith Coq.micromega.Psatz.
+Require Import Coq.ZArith.Zpower Coq.ZArith.ZArith Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Numbers.Natural.Peano.NPeano.
 Require Import Coq.Lists.List.
 Require Import Coq.funind.Recdef.
 Require Import Crypto.Util.ListUtil Crypto.Util.NatUtil.
-Require Export Crypto.Util.ZUtil.Hints.Core.
+Require Export Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.ZUtil.Definitions.
 Require Import Crypto.Util.ZUtil.Testbit.
 Require Import Crypto.Util.ZUtil.Pow2Mod.

--- a/src/LegacyArithmetic/Pow2BaseProofs.v
+++ b/src/LegacyArithmetic/Pow2BaseProofs.v
@@ -1,8 +1,10 @@
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.Zpower Coq.ZArith.ZArith Coq.micromega.Psatz.
 Require Import Coq.Numbers.Natural.Peano.NPeano.
 Require Import Coq.Lists.List.
 Require Import Coq.funind.Recdef.
 Require Import Crypto.Util.ListUtil Crypto.Util.NatUtil.
+Require Export Crypto.Util.ZUtil.Hints.Core.
 Require Import Crypto.Util.ZUtil.Definitions.
 Require Import Crypto.Util.ZUtil.Testbit.
 Require Import Crypto.Util.ZUtil.Pow2Mod.
@@ -28,10 +30,10 @@ Create HintDb pull_upper_bound discriminated.
 Create HintDb push_base_from_limb_widths discriminated.
 Create HintDb pull_base_from_limb_widths discriminated.
 
-Hint Extern 1 => progress autorewrite with push_upper_bound in * : push_upper_bound.
-Hint Extern 1 => progress autorewrite with pull_upper_bound in * : pull_upper_bound.
-Hint Extern 1 => progress autorewrite with push_base_from_limb_widths in * : push_base_from_limb_widths.
-Hint Extern 1 => progress autorewrite with pull_base_from_limb_widths in * : pull_base_from_limb_widths.
+Global Hint Extern 1 => progress autorewrite with push_upper_bound in * : push_upper_bound.
+Global Hint Extern 1 => progress autorewrite with pull_upper_bound in * : pull_upper_bound.
+Global Hint Extern 1 => progress autorewrite with push_base_from_limb_widths in * : push_base_from_limb_widths.
+Global Hint Extern 1 => progress autorewrite with pull_base_from_limb_widths in * : pull_base_from_limb_widths.
 
 Section Pow2BaseProofs.
   Context {limb_widths} (limb_widths_nonneg : forall w, In w limb_widths -> 0 <= w).

--- a/src/LegacyArithmetic/VerdiTactics.v
+++ b/src/LegacyArithmetic/VerdiTactics.v
@@ -26,6 +26,8 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *)
 
+Require Export Crypto.Util.GlobalSettings.
+
 Ltac subst_max := idtac "VerdiTactics is deprecated in fiat-crypto";
   repeat match goal with
            | [ H : ?X = _ |- _ ]  => subst X

--- a/src/LegacyArithmetic/ZBounded.v
+++ b/src/LegacyArithmetic/ZBounded.v
@@ -1,7 +1,7 @@
 (*** Bounded ℤ-Like Types *)
 (** This file specifies a ℤ-like type of bounded integers, with
     operations for Montgomery Reduction and Barrett Reduction. *)
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
 Require Import Crypto.Util.Tactics.BreakMatch.

--- a/src/LegacyArithmetic/ZBounded.v
+++ b/src/LegacyArithmetic/ZBounded.v
@@ -95,7 +95,7 @@ Arguments ZLikeProperties [small_bound smaller_bound modulus] Zops, small_bound 
 Existing Class large_valid.
 Existing Class medium_valid.
 Existing Class small_valid.
-Existing Instances Mod_SmallBound_valid DivBy_SmallerBound_valid DivBy_SmallBound_valid Mul_valid CarryAdd_valid CarrySubSmall_valid ConditionalSubtract_valid ConditionalSubtractModulus_valid modulus_digits_valid medium_to_large_valid.
+Global Existing Instances Mod_SmallBound_valid DivBy_SmallerBound_valid DivBy_SmallBound_valid Mul_valid CarryAdd_valid CarrySubSmall_valid ConditionalSubtract_valid ConditionalSubtractModulus_valid modulus_digits_valid medium_to_large_valid.
 
 Lemma ConditionalSubtractModulus_correct'
       {small_bound smaller_bound modulus : Z} {Zops : ZLikeOps small_bound smaller_bound modulus}

--- a/src/LegacyArithmetic/ZBoundedZ.v
+++ b/src/LegacyArithmetic/ZBoundedZ.v
@@ -4,6 +4,7 @@ Require Import Crypto.LegacyArithmetic.ZBounded.
 Require Import Crypto.Util.ZUtil.Definitions.
 Require Import Crypto.Util.ZUtil.Pow2Mod.
 Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
+Require Import Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.LetIn.
 Require Import Crypto.Util.Notations.
@@ -29,7 +30,7 @@ Global Instance ZZLikeOps small_bound_exp smaller_bound_exp modulus : ZLikeOps (
 Local Arguments Z.mul !_ !_.
 
 Class cls_is_true (x : bool) := build_is_true : x = true.
-Hint Extern 1 (cls_is_true ?b) => vm_compute; reflexivity : typeclass_instances.
+Global Hint Extern 1 (cls_is_true ?b) => vm_compute; reflexivity : typeclass_instances.
 
 Local Ltac pre_t :=
   unfold cls_is_true, Let_In in *; Z.ltb_to_lt;

--- a/src/LegacyArithmetic/ZBoundedZ.v
+++ b/src/LegacyArithmetic/ZBoundedZ.v
@@ -1,10 +1,11 @@
 (*** ℤ can be a bounded ℤ-Like type *)
-Require Import Coq.ZArith.ZArith Coq.micromega.Psatz.
+Require Import Coq.ZArith.ZArith Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.LegacyArithmetic.ZBounded.
 Require Import Crypto.Util.ZUtil.Definitions.
 Require Import Crypto.Util.ZUtil.Pow2Mod.
 Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
 Require Import Crypto.Util.ZUtil.Hints.ZArith.
+Require Import Crypto.Util.ZUtil.Div.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.LetIn.
 Require Import Crypto.Util.Notations.

--- a/src/Primitives/EdDSARepChange.v
+++ b/src/Primitives/EdDSARepChange.v
@@ -8,7 +8,7 @@ Require Import Crypto.Util.Tactics.SetEvars.
 Require Import Crypto.Util.Tactics.SubstEvars.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.Tactics.SpecializeBy.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.Notations.
 Require Import Crypto.Util.Option Crypto.Util.Logic Crypto.Util.Relations Crypto.Util.WordUtil Util.LetIn Util.NatUtil.
 Require Import Crypto.Spec.ModularArithmetic Crypto.Arithmetic.PrimeFieldTheorems.

--- a/src/Primitives/EdDSARepChange.v
+++ b/src/Primitives/EdDSARepChange.v
@@ -1,7 +1,7 @@
 Require Import Coq.ZArith.ZArith.
 Require Import Crypto.Util.FixCoqMistakes.
 Require Import Crypto.Spec.EdDSA bbv.WordScope.
-Require Import Coq.Classes.Morphisms Coq.Relations.Relation_Definitions.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.Relations.Relation_Definitions.
 Require Import Crypto.Algebra.Monoid Crypto.Algebra.Group Crypto.Algebra.ScalarMult.
 Require Import Crypto.Util.Decidable Crypto.Util.Option.
 Require Import Crypto.Util.Tactics.SetEvars.

--- a/src/Primitives/MxDHRepChange.v
+++ b/src/Primitives/MxDHRepChange.v
@@ -1,3 +1,4 @@
+Require Import Coq.Lists.SetoidList.
 Require Import Crypto.Spec.MxDH.
 Require Import Crypto.Algebra.Monoid Crypto.Algebra.Group Crypto.Algebra.Ring Crypto.Algebra.Field.
 Require Import Crypto.Util.Tuple Crypto.Util.Prod.
@@ -40,7 +41,7 @@ Section MxDHRepChange.
 
   (*Import Crypto.Util.Tactics.*)
   Import List.
-  Import Coq.Classes.Morphisms.
+  Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 
   Global Instance Proper_ladderstep :
     Proper (Keq ==> (fieldwise (n:=2) Keq) ==> fieldwise (n:=2) Keq ==> fieldwise (n:=2) (fieldwise (n:=2) Keq)) (@MxDH.ladderstep K Kadd Ksub Kmul Ka24).

--- a/src/Spec/Ed25519.v
+++ b/src/Spec/Ed25519.v
@@ -6,6 +6,9 @@ Require Import Crypto.Spec.EdDSA.
 
 Require Crypto.Arithmetic.PrimeFieldTheorems. (* to know that Z mod p is a field *)
 Require Crypto.Curves.Edwards.AffineProofs.
+Import ModularArithmeticTheorems.F.Instances.
+Import Crypto.Util.Decidable.
+Import PrimeFieldTheorems.F.Instances.
 
 (* these 2 proofs can be generated using https://github.com/andres-erbsen/safecurves-primes *)
 Axiom prime_q : Znumtheory.prime (2^255-19). Global Existing Instance prime_q.
@@ -34,12 +37,12 @@ Section Ed25519.
 
   Context {SHA512: forall n : nat, Word.word n -> Word.word 512}.
 
-  Local Instance char_gt_e : 
+  Local Instance char_gt_e :
     @Ring.char_ge (@F q) eq F.zero F.one F.opp F.add F.sub F.mul
                   (BinNat.N.succ_pos BinNat.N.two).
-  Proof. eapply Hierarchy.char_ge_weaken;
+  Proof using Type. eapply Hierarchy.char_ge_weaken;
            [apply (_:Ring.char_ge q)|Decidable.vm_decide]. Qed.
-    
+
 
   Definition E : Type := E.point
                            (F:=Fq) (Feq:=Logic.eq) (Fone:=F.one) (Fadd:=F.add) (Fmul:=F.mul)
@@ -49,7 +52,7 @@ Section Ed25519.
 
   Program Definition B : E :=
     (F.of_Z q 15112221349535400772501151409588531511454012693041857206046113283949847762202,
-     F.of_Z q 4 / F.of_Z q 5).
+      F.of_Z q 4 / F.of_Z q 5).
 
   Local Infix "++" := Word.combine.
   Local Notation bit b := (Word.WS b Word.WO : Word.word 1).
@@ -80,6 +83,7 @@ Section Ed25519.
           (l:=l) (b:=b) (n:=n) (c:=c)
           (Eenc:=Eenc) (Senc:=Senc) (H:=SHA512).
   Proof using Type.
+    Import AffineProofs ScalarMult. (* hints *)
     split; try exact _.
     Crypto.Util.Decidable.vm_decide.
     Crypto.Util.Decidable.vm_decide.

--- a/src/Spec/EdDSA.v
+++ b/src/Spec/EdDSA.v
@@ -6,6 +6,8 @@ Require Coq.Numbers.Natural.Peano.NPeano.
 
 Require Import Crypto.Spec.ModularArithmetic.
 
+Import Algebra.ScalarMult.Hints.
+
 Local Infix "-" := BinInt.Z.sub.
 Local Infix "^" := BinInt.Z.pow.
 Local Infix "mod" := BinInt.Z.modulo.

--- a/src/Spec/MontgomeryCurve.v
+++ b/src/Spec/MontgomeryCurve.v
@@ -1,6 +1,7 @@
 Require Crypto.Algebra.Field.
 Require Crypto.Util.GlobalSettings.
 Require Crypto.Util.Tactics.DestructHead Crypto.Util.Sum Crypto.Util.Prod.
+Import Crypto.Algebra.Field.Hints.
 
 Module M.
   Section MontgomeryCurve.

--- a/src/Spec/WeierstrassCurve.v
+++ b/src/Spec/WeierstrassCurve.v
@@ -1,4 +1,5 @@
 Require Crypto.Algebra.Field.
+Import Crypto.Algebra.Field.Hints.
 
 Module W.
   Section WeierstrassCurves.

--- a/src/Specific/Framework/ArithmeticSynthesis/Base.v
+++ b/src/Specific/Framework/ArithmeticSynthesis/Base.v
@@ -1,6 +1,6 @@
 Require Import Coq.ZArith.ZArith Coq.ZArith.BinIntDef.
 Require Import Coq.Lists.List. Import ListNotations.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.QArith.QArith_base.
 Require Import Crypto.Arithmetic.Core. Import B.
 Require Import Crypto.Specific.Framework.CurveParameters.

--- a/src/Specific/Framework/ArithmeticSynthesis/Base.v
+++ b/src/Specific/Framework/ArithmeticSynthesis/Base.v
@@ -6,7 +6,8 @@ Require Import Crypto.Arithmetic.Core. Import B.
 Require Import Crypto.Specific.Framework.CurveParameters.
 Require Import Crypto.Specific.Framework.ArithmeticSynthesis.HelperTactics.
 Require Import Crypto.Util.QUtil.
-Require Import Crypto.Util.Decidable.
+Require Export Crypto.Util.Decidable.
+Require Import Crypto.Util.Relations.
 Require Import Crypto.Util.ZUtil.Tactics.PullPush.Modulo.
 Require Crypto.Util.Tuple.
 Require Import Crypto.Util.Tactics.CacheTerm.
@@ -280,3 +281,7 @@ Ltac pose_m_enc_bounded sz bitwidth m_enc m_enc_bounded :=
     (Tuple.map (n:=sz) (BinInt.Z.land (Z.ones bitwidth)) m_enc = m_enc)
     ltac:(vm_compute; reflexivity)
            m_enc_bounded.
+
+Module Export Exports.
+  Export Crypto.Util.Decidable.
+End Exports.

--- a/src/Specific/Framework/ArithmeticSynthesis/Defaults.v
+++ b/src/Specific/Framework/ArithmeticSynthesis/Defaults.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith Coq.ZArith.BinIntDef.
 Require Import Coq.QArith.QArith_base.
 Require Import Coq.Lists.List. Import ListNotations.

--- a/src/Specific/Framework/ArithmeticSynthesis/Freeze.v
+++ b/src/Specific/Framework/ArithmeticSynthesis/Freeze.v
@@ -15,7 +15,7 @@ Require Crypto.Util.Tuple.
 Require Import Crypto.Util.Tactics.CacheTerm.
 
 Module Export Exports.
-  Hint Opaque freeze : uncps.
+  Global Hint Opaque freeze : uncps.
   Hint Rewrite freeze_id : uncps.
 End Exports.
 

--- a/src/Specific/Framework/ArithmeticSynthesis/Montgomery.v
+++ b/src/Specific/Framework/ArithmeticSynthesis/Montgomery.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Arithmetic.MontgomeryReduction.WordByWord.Definition.
 Require Import Crypto.Arithmetic.MontgomeryReduction.WordByWord.Proofs.
 Require Import Crypto.Arithmetic.Core. Import B.

--- a/src/Specific/Framework/IntegrationTestTemporaryMiscCommon.v
+++ b/src/Specific/Framework/IntegrationTestTemporaryMiscCommon.v
@@ -1,6 +1,6 @@
 (*** XXX TODO MOVE ALL THINGS IN THIS FILE TO BETTER PLACES *)
 Require Import Coq.ZArith.BinInt.
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.Tuple.
 Require Import Crypto.Util.BoundedWord.
 Require Import Crypto.Util.Sigma.Lift.

--- a/src/Specific/Framework/MontgomeryReificationTypes.v
+++ b/src/Specific/Framework/MontgomeryReificationTypes.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Lists.List.
 Local Open Scope Z_scope.
 

--- a/src/Specific/Framework/ReificationTypes.v
+++ b/src/Specific/Framework/ReificationTypes.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Lists.List.
 Local Open Scope Z_scope.
 

--- a/src/Specific/Framework/SynthesisFramework.v
+++ b/src/Specific/Framework/SynthesisFramework.v
@@ -17,6 +17,39 @@ Require Import Crypto.Specific.Framework.IntegrationTestTemporaryMiscCommon.
 Require Import Crypto.Compilers.Z.Bounds.Pipeline.
 
 Module Export Exports.
+  Export Coq.Classes.Equivalence Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop. (* hints *)
+  Export Crypto.Util.Decidable. (* hints *)
+  Module Export TupleInstances.
+    Import Crypto.Util.Tuple.
+    Global Existing Instance Reflexive_fieldwise' | 5.
+    Global Existing Instance Symmetric_fieldwise' | 5.
+    Global Existing Instance Transitive_fieldwise' | 5.
+    Global Existing Instance Equivalence_fieldwise'.
+    Global Existing Instance Reflexive_fieldwise | 5.
+    Global Existing Instance Symmetric_fieldwise | 5.
+    Global Existing Instance Transitive_fieldwise | 5.
+    Global Existing Instance Equivalence_fieldwise.
+    Global Existing Instance dec_fieldwise' | 10.
+    Global Existing Instance dec_fieldwise | 10.
+    Global Existing Instance dec_eq' | 10.
+    Global Existing Instance dec_eq | 10.
+    Global Existing Instance map'_Proper | 10.
+    Global Existing Instance map_Proper | 10.
+    Global Existing Instances
+           fieldwise'_Proper_gen
+           fieldwise_Proper_gen
+           fieldwise'_Proper_gen_eq
+           fieldwise_Proper_gen_eq
+           fieldwise'_Proper
+           fieldwise_Proper
+           fieldwise'_Proper_iff
+           fieldwise_Proper_iff
+           fieldwise'_Proper_flip_impl
+           fieldwise_Proper_flip_impl
+    | 10.
+  End TupleInstances.
+  Export ModularArithmeticTheorems.F.Instances.
+  Export Field.Hints.
   Export Pipeline.Exports.
   Export ArithmeticSynthesis.Defaults.Exports.
   Export ArithmeticSynthesis.Freeze.Exports.

--- a/src/Specific/NISTP256/FancyMachine256/Barrett.v
+++ b/src/Specific/NISTP256/FancyMachine256/Barrett.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Specific.NISTP256.FancyMachine256.Core.
 Require Import LegacyArithmetic.BarretReduction.
 Require Import Crypto.Arithmetic.BarrettReduction.HAC.

--- a/src/Specific/NISTP256/FancyMachine256/Core.v
+++ b/src/Specific/NISTP256/FancyMachine256/Core.v
@@ -1,6 +1,6 @@
 (** * A Fancy Machine with 256-bit registers *)
 Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
-Require Import Coq.PArith.BinPos Coq.micromega.Psatz.
+Require Import Coq.PArith.BinPos Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Export Coq.ZArith.ZArith Coq.Lists.List.
 Require Import Crypto.Util.Decidable.
 Require Export Crypto.LegacyArithmetic.Interface.

--- a/src/Specific/NISTP256/FancyMachine256/Core.v
+++ b/src/Specific/NISTP256/FancyMachine256/Core.v
@@ -1,5 +1,5 @@
 (** * A Fancy Machine with 256-bit registers *)
-Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms.
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.PArith.BinPos Coq.micromega.Psatz.
 Require Export Coq.ZArith.ZArith Coq.Lists.List.
 Require Import Crypto.Util.Decidable.
@@ -25,6 +25,7 @@ Require Export Crypto.Util.Notations.
 Require Import Crypto.Util.ListUtil.
 Require Export Crypto.Util.LetIn.
 Require Import Crypto.Util.Tactics.BreakMatch.
+Export Double.Core.Hints.
 Export ListNotations.
 
 Open Scope Z_scope.

--- a/src/Specific/NISTP256/FancyMachine256/Montgomery.v
+++ b/src/Specific/NISTP256/FancyMachine256/Montgomery.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Specific.NISTP256.FancyMachine256.Core.
 Require Import Crypto.LegacyArithmetic.MontgomeryReduction.
 Require Import Crypto.Arithmetic.MontgomeryReduction.Proofs.

--- a/src/Util/Bool.v
+++ b/src/Util/Bool.v
@@ -1,5 +1,6 @@
 (*** Boolean Utility Lemmas and Databases *)
 Require Import Coq.Bool.Bool.
+Require Export Crypto.Util.GlobalSettings.
 
 (** For equalities of booleans *)
 Create HintDb bool_congr discriminated.
@@ -8,10 +9,10 @@ Create HintDb bool_congr_setoid discriminated.
 (** For generic simplifications of things involving booleans, e.g., if-statements *)
 Create HintDb boolsimplify discriminated.
 
-Hint Extern 1 => progress autorewrite with boolsimplify in * : boolsimplify.
-Hint Extern 1 => progress autorewrite with bool_congr in * : bool_congr.
-Hint Extern 1 => progress autorewrite with bool_congr_setoid in * : bool_congr_setoid.
-Hint Extern 2 => progress rewrite_strat topdown hints bool_congr_setoid : bool_congr_setoid.
+Global Hint Extern 1 => progress autorewrite with boolsimplify in * : boolsimplify.
+Global Hint Extern 1 => progress autorewrite with bool_congr in * : bool_congr.
+Global Hint Extern 1 => progress autorewrite with bool_congr_setoid in * : bool_congr_setoid.
+Global Hint Extern 2 => progress rewrite_strat topdown hints bool_congr_setoid : bool_congr_setoid.
 
 Hint Rewrite Bool.andb_diag Bool.orb_diag Bool.eqb_reflx Bool.negb_involutive Bool.eqb_negb1 Bool.eqb_negb2 Bool.orb_true_r Bool.orb_true_l Bool.orb_false_r Bool.orb_false_l Bool.orb_negb_r Bool.andb_false_r Bool.andb_false_l Bool.andb_true_r Bool.andb_false_r Bool.andb_negb_r Bool.xorb_false_r Bool.xorb_false_l Bool.xorb_true_r Bool.xorb_true_l Bool.xorb_nilpotent : bool_congr.
 Hint Rewrite Bool.negb_if : boolsimplify.
@@ -24,12 +25,12 @@ Create HintDb push_andb discriminated.
 Create HintDb pull_andb discriminated.
 Create HintDb push_negb discriminated.
 Create HintDb pull_negb discriminated.
-Hint Extern 1 => progress autorewrite with push_orb in * : push_orb.
-Hint Extern 1 => progress autorewrite with pull_orb in * : pull_orb.
-Hint Extern 1 => progress autorewrite with push_andb in * : push_andb.
-Hint Extern 1 => progress autorewrite with pull_andb in * : pull_andb.
-Hint Extern 1 => progress autorewrite with push_negb in * : push_negb.
-Hint Extern 1 => progress autorewrite with pull_negb in * : pull_negb.
+Global Hint Extern 1 => progress autorewrite with push_orb in * : push_orb.
+Global Hint Extern 1 => progress autorewrite with pull_orb in * : pull_orb.
+Global Hint Extern 1 => progress autorewrite with push_andb in * : push_andb.
+Global Hint Extern 1 => progress autorewrite with pull_andb in * : pull_andb.
+Global Hint Extern 1 => progress autorewrite with push_negb in * : push_negb.
+Global Hint Extern 1 => progress autorewrite with pull_negb in * : pull_negb.
 Hint Rewrite Bool.negb_orb Bool.negb_andb : push_negb.
 Hint Rewrite Bool.xorb_negb_negb : pull_negb.
 Hint Rewrite <- Bool.negb_orb Bool.negb_andb Bool.negb_xorb_l Bool.negb_xorb_r : pull_negb.

--- a/src/Util/Bool/Equality.v
+++ b/src/Util/Bool/Equality.v
@@ -1,3 +1,4 @@
 Require Import Coq.Bool.Bool.
+Require Export Crypto.Util.GlobalSettings.
 
 Scheme Equality for bool.

--- a/src/Util/Bool/IsTrue.v
+++ b/src/Util/Bool/IsTrue.v
@@ -1,4 +1,5 @@
 Require Import Coq.Bool.Bool.
+Require Export Crypto.Util.GlobalSettings.
 
 Definition adjust_is_true {P} (v : is_true P) : is_true P
   := match P as P return is_true P -> is_true P with

--- a/src/Util/Bool/Reflect.v
+++ b/src/Util/Bool/Reflect.v
@@ -1,5 +1,6 @@
 (** * Some lemmas about [Bool.reflect] *)
 Require Import Coq.Bool.Bool.
+Require Export Crypto.Util.GlobalSettings.
 
 Lemma reflect_to_dec_iff {P b1 b2} : reflect P b1 -> (b1 = b2) <-> (if b2 then P else ~P).
 Proof.

--- a/src/Util/CPSUtil.v
+++ b/src/Util/CPSUtil.v
@@ -1,6 +1,6 @@
 Require Import Coq.Lists.List. Import ListNotations.
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
-Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.Tactics.DestructHead.
 Require Import Crypto.Util.ListUtil.

--- a/src/Util/CPSUtil.v
+++ b/src/Util/CPSUtil.v
@@ -1,4 +1,5 @@
 Require Import Coq.Lists.List. Import ListNotations.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.Tactics.DestructHead.

--- a/src/Util/ChangeInAll.v
+++ b/src/Util/ChangeInAll.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 (** Work around "Cannot create self-referring hypothesis" coming from
     [change x with y in *] *)
 Ltac change_in_all from to :=

--- a/src/Util/Decidable.v
+++ b/src/Util/Decidable.v
@@ -1,5 +1,6 @@
 (** Typeclass for decidable propositions *)
 
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Logic.Eqdep_dec.
 Require Import Coq.Lists.List.
 Require Import Crypto.Util.FixCoqMistakes.
@@ -84,7 +85,7 @@ Global Instance dec_iff {A B} `{Decidable A, Decidable B} : Decidable (A <-> B) 
 Lemma dec_not {A} `{Decidable A} : Decidable (~A).
 Proof. solve_decidable_transparent. Defined.
 (** Disallow infinite loops of dec_not *)
-Hint Extern 0 (Decidable (~?A)) => apply (@dec_not A) : typeclass_instances.
+Global Hint Extern 0 (Decidable (~?A)) => apply (@dec_not A) : typeclass_instances.
 Global Instance dec_eq_unit : DecidableRel (@eq unit) | 10. exact _. Defined.
 Global Instance dec_eq_bool : DecidableRel (@eq bool) | 10. exact _. Defined.
 Global Instance dec_eq_Empty_set : DecidableRel (@eq Empty_set) | 10. exact _. Defined.
@@ -201,7 +202,7 @@ Ltac vm_decide := abstract vm_decide_no_check.
 Ltac lazy_decide := abstract lazy_decide_no_check.
 
 (** For dubious compatibility with [eauto using]. *)
-Hint Extern 2 (Decidable _) => progress unfold Decidable : typeclass_instances core.
+Global Hint Extern 2 (Decidable _) => progress unfold Decidable : typeclass_instances core.
 
 Definition cast_if_eq {T} `{DecidableRel (@eq T)} {P} (t t' : T) (v : P t) : option (P t')
   := match dec (t = t'), dec (t' = t') with

--- a/src/Util/Decidable/Bool2Prop.v
+++ b/src/Util/Decidable/Bool2Prop.v
@@ -1,61 +1,62 @@
 Require Coq.ZArith.ZArith.
+Require Export Crypto.Util.GlobalSettings.
 
 Lemma unit_eq (x y:unit) : x = y. destruct x, y; reflexivity. Qed.
-Hint Resolve unit_eq.
+Global Hint Resolve unit_eq.
 
-Hint Extern 0 (_ = _ :> bool) => (
+Global Hint Extern 0 (_ = _ :> bool) => (
   match goal with
   | [H:Bool.eqb ?a ?b = true |- ?a = ?b ] => apply (proj1 (Bool.eqb_true_iff _ _) H)
   | [H:Bool.eqb ?b ?a = true |- ?a = ?b ] => symmetry; apply (proj1 (Bool.eqb_true_iff _ _) H)
   end).
 
-Hint Extern 0 (_ = _ :> nat) => (
+Global Hint Extern 0 (_ = _ :> nat) => (
   match goal with
   | [H:Nat.eqb ?a ?b = true |- ?a = ?b ] => apply (proj1 (PeanoNat.Nat.eqb_eq _ _) H)
   | [H:Nat.eqb ?b ?a = true |- ?a = ?b ] => symmetry; apply (proj1 (PeanoNat.Nat.eqb_eq _ _) H)
   end).
 
-Hint Extern 0 (_ <= _) => (
+Global Hint Extern 0 (_ <= _) => (
   match goal with
   | [H:Nat.ltb ?a ?b = true |- ?a < ?b ] => apply (proj1 (PeanoNat.Nat.ltb_lt _ _) H)
   end).
 
-Hint Extern 0 (_ <= _) => (
+Global Hint Extern 0 (_ <= _) => (
   match goal with
   | [H:Nat.leb ?a ?b = true |- ?a <= ?b ] => apply (proj1 (PeanoNat.Nat.leb_le _ _) H)
   end).
 
-Hint Extern 0 (_ = _ :> BinNums.N) => (
+Global Hint Extern 0 (_ = _ :> BinNums.N) => (
   match goal with
   | [H:BinNat.N.eqb ?a ?b = true |- ?a = ?b ] => apply (proj1 (BinNat.N.eqb_eq _ _) H)
   | [H:BinNat.N.eqb ?b ?a = true |- ?a = ?b ] => symmetry; apply (proj1 (BinNat.N.eqb_eq _ _) H)
   end).
-Hint Extern 0 (_ = _ :> BinInt.Z) => (
+Global Hint Extern 0 (_ = _ :> BinInt.Z) => (
   match goal with
   | [H:BinInt.Z.eqb ?a ?b = true |- ?a = ?b ] => apply (proj1 (BinInt.Z.eqb_eq _ _) H)
   | [H:BinInt.Z.eqb ?a ?b = true |- ?b = ?a ] => symmetry; apply (proj1 (BinInt.Z.eqb_eq _ _) H)
   end).
-Hint Extern 0 (BinInt.Z.lt _ _) => (
+Global Hint Extern 0 (BinInt.Z.lt _ _) => (
   match goal with
   | [H:BinInt.Z.ltb ?a ?b = true |- BinInt.Z.lt ?a ?b ] => apply (proj1 (BinInt.Z.ltb_lt _ _) H)
   | [H:BinInt.Z.gtb ?b ?a = true |- BinInt.Z.lt ?a ?b ] => apply (proj1 (BinInt.Z.gtb_lt _ _) H)
   end).
-Hint Extern 0 (BinInt.Z.le _ _) => (
+Global Hint Extern 0 (BinInt.Z.le _ _) => (
   match goal with
   | [H:BinInt.Z.leb ?a ?b = true |- BinInt.Z.le ?a ?b ] => apply (proj1 (BinInt.Z.leb_le _ _) H)
   | [H:BinInt.Z.geb ?b ?a = true |- BinInt.Z.le ?a ?b ] => apply (proj1 (BinInt.Z.geb_le _ _) H)
   end).
 
-Hint Extern 0 (_ = _ :> BinPos.positive) => (
+Global Hint Extern 0 (_ = _ :> BinPos.positive) => (
   match goal with
   | [H:BinPos.Pos.eqb ?a ?b = true |- ?a = ?b ] => apply (proj1 (BinPos.Pos.eqb_eq _ _) H)
   | [H:BinPos.Pos.eqb ?a ?b = true |- ?b = ?a ] => symmetry; apply (proj1 (BinPos.Pos.eqb_eq _ _) H)
   end).
-Hint Extern 0 (BinPos.Pos.lt _ _) => (
+Global Hint Extern 0 (BinPos.Pos.lt _ _) => (
   match goal with
   | [H:BinPos.Pos.ltb ?a ?b = true |- BinPos.Pos.lt ?a ?b ] => apply (proj1 (BinPos.Pos.ltb_lt _ _) H)
   end).
-Hint Extern 0 (BinPos.Pos.le _ _) => (
+Global Hint Extern 0 (BinPos.Pos.le _ _) => (
   match goal with
   | [H:BinPos.Pos.leb ?a ?b = true |- BinPos.Pos.le ?a ?b ] => apply (proj1 (BinPos.Pos.leb_le _ _) H)
   end).

--- a/src/Util/Decidable/Decidable2Bool.v
+++ b/src/Util/Decidable/Decidable2Bool.v
@@ -1,6 +1,6 @@
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.QArith.QArith_base.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Lists.List.
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.SideConditions.ReductionPackages.

--- a/src/Util/Decidable/Decidable2Bool.v
+++ b/src/Util/Decidable/Decidable2Bool.v
@@ -2,6 +2,7 @@ Require Import Coq.ZArith.ZArith.
 Require Import Coq.QArith.QArith_base.
 Require Import Coq.micromega.Lia.
 Require Import Coq.Lists.List.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.SideConditions.ReductionPackages.
 Require Import Crypto.Util.Tuple.
 Require Import Crypto.Util.Decidable.

--- a/src/Util/DefaultedTypes.v
+++ b/src/Util/DefaultedTypes.v
@@ -1,2 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
+
 Class with_default (T : Type) (default : T) := defaulted : T.
 Global Instance by_default {T} {d} : with_default T d := d.

--- a/src/Util/Equality.v
+++ b/src/Util/Equality.v
@@ -4,7 +4,7 @@
     [eq].  We build up enough lemmas about this structure to deal
     nicely with proofs of equality that come up in practice in this
     project. *)
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.Isomorphism.
 Require Import Crypto.Util.HProp.
 

--- a/src/Util/Factorize.v
+++ b/src/Util/Factorize.v
@@ -1,5 +1,5 @@
 Require Import Coq.Bool.Sumbool.
-Require Import Coq.micromega.Psatz.
+Require Import Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.NArith.NArith.
 Require Import Coq.PArith.PArith.
 Require Import Coq.Lists.List.

--- a/src/Util/Factorize.v
+++ b/src/Util/Factorize.v
@@ -4,6 +4,7 @@ Require Import Coq.NArith.NArith.
 Require Import Coq.PArith.PArith.
 Require Import Coq.Lists.List.
 Require Import Coq.Init.Wf.
+Require Export Crypto.Util.GlobalSettings.
 
 Local Open Scope positive_scope.
 

--- a/src/Util/FixCoqMistakes.v
+++ b/src/Util/FixCoqMistakes.v
@@ -1,5 +1,5 @@
 (** * Fixes *)
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Export Crypto.Util.GlobalSettings.
 
 (** Coq is poorly designed in some ways.  We fix some of these issues
@@ -85,4 +85,4 @@ Ltac solve_Proper_eq :=
       unify R R';
       apply (@reflexive_proper A R')
   end.
-Hint Extern 0 (Proper _ _) => solve_Proper_eq : typeclass_instances.
+Global Hint Extern 0 (Proper _ _) => solve_Proper_eq : typeclass_instances.

--- a/src/Util/FixedWordSizes.v
+++ b/src/Util/FixedWordSizes.v
@@ -2,6 +2,7 @@ Require Import Coq.ZArith.ZArith.
 Require Import Coq.NArith.BinNat.
 Require Import Coq.Arith.Arith.
 Require Import bbv.WordScope.
+Require Export Crypto.Util.GlobalSettings.
 
 Definition word32 := word 32. (* 2^5 *)
 Definition word64 := word 64. (* 2^6 *)
@@ -112,7 +113,7 @@ Definition wlor {logsz}
                    logsz wlor32 wlor64 wlor128 (fun _ => @wor _).
 
 Create HintDb fixed_size_constants discriminated.
-Hint Unfold word32 word64 word128
+Global Hint Unfold word32 word64 word128
      wadd wadd32 wadd64 wadd128
      wsub wsub32 wsub64 wsub128
      wmul wmul32 wmul64 wmul128

--- a/src/Util/FixedWordSizesEquality.v
+++ b/src/Util/FixedWordSizesEquality.v
@@ -1,11 +1,13 @@
 Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.NArith.BinNat.
 Require Import Coq.Arith.Arith.
 Require Import bbv.WordScope.
 Require Import Crypto.Util.FixedWordSizes.
 Require Import Crypto.Util.WordUtil.
+Require Import Crypto.Util.ZUtil.Hints.ZArith.
+Require Import Crypto.Util.ZUtil.Le.
 Require Import Crypto.Util.ZUtil.Log2.
 Require Import Crypto.Util.ZUtil.Z2Nat.
 Require Import Crypto.Util.Tactics.BreakMatch.

--- a/src/Util/FixedWordSizesEquality.v
+++ b/src/Util/FixedWordSizesEquality.v
@@ -1,3 +1,4 @@
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.micromega.Lia.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.NArith.BinNat.
@@ -8,6 +9,8 @@ Require Import Crypto.Util.WordUtil.
 Require Import Crypto.Util.ZUtil.Log2.
 Require Import Crypto.Util.ZUtil.Z2Nat.
 Require Import Crypto.Util.Tactics.BreakMatch.
+
+Local Existing Instance Z.le_preorder.
 
 Definition wordT_beq_hetero {logsz1 logsz2} : wordT logsz1 -> wordT logsz2 -> bool
   := match logsz1 return wordT logsz1 -> wordT logsz2 -> bool with

--- a/src/Util/FsatzAutoLemmas.v
+++ b/src/Util/FsatzAutoLemmas.v
@@ -1,5 +1,5 @@
 Require Import Coq.Program.Program.
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 
 Require Import Crypto.Util.Decidable.
 Require Import Crypto.Algebra.Field.

--- a/src/Util/GlobalSettings.v
+++ b/src/Util/GlobalSettings.v
@@ -13,7 +13,7 @@ Global Set Uniform Inductive Parameters.
 (** Set Primitive Projections. *)
 
 (** Don't use non-imported hints *)
-(** Set Loose Hint Behavior "Strict". *)
+Global Set Loose Hint Behavior "Strict".
 
 (** Universes *)
 (** Set Universe Polymorphism. *)

--- a/src/Util/HList.v
+++ b/src/Util/HList.v
@@ -1,4 +1,4 @@
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Relations.Relation_Definitions.
 Require Import Coq.Lists.List.
 Require Import Crypto.Util.Decidable.

--- a/src/Util/HProp.v
+++ b/src/Util/HProp.v
@@ -1,4 +1,5 @@
 (** * Homotopy Propositions *)
+Require Export Crypto.Util.GlobalSettings.
 (** A homotopy proposition, or hProp, is a subsingleton type, i.e., a
     type with at most one inhabitant.  The property of being an hProp,
     i.e., being irrelevant when considering propositional equality

--- a/src/Util/IffT.v
+++ b/src/Util/IffT.v
@@ -1,4 +1,5 @@
 Require Import Coq.Classes.RelationClasses.
+Require Export Crypto.Util.GlobalSettings.
 Notation iffT A B := (((A -> B) * (B -> A)))%type.
 Notation iffTp := (fun A B => inhabited (iffT A B)).
 

--- a/src/Util/Isomorphism.v
+++ b/src/Util/Isomorphism.v
@@ -1,4 +1,5 @@
 (** * Isomorphisms *)
+Require Export Crypto.Util.GlobalSettings.
 (** Following the category-theoretic definition, [f : A → B] is an
     isomorphism when it has an inverse [f⁻¹ : B → A] which is both a
     left and a right inverse.  In the language of homotopy type

--- a/src/Util/LetIn.v
+++ b/src/Util/LetIn.v
@@ -1,5 +1,5 @@
 Require Import Crypto.Util.FixCoqMistakes.
-Require Import Coq.Classes.Morphisms Coq.Relations.Relation_Definitions.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.Relations.Relation_Definitions.
 Require Import Crypto.Util.Tactics.GetGoal.
 Require Import Crypto.Util.Notations.
 
@@ -51,7 +51,7 @@ Ltac let_in_to_Let_In e :=
     with fun x => @?C x => C end (* match drops the type cast *)
   | ?x => x
   end.
-Hint Extern 0 (_call_let_in_to_Let_In ?e) => (
+Global Hint Extern 0 (_call_let_in_to_Let_In ?e) => (
   let e := let_in_to_Let_In e in eexact e
 ) : typeclass_instances.
 Ltac change_let_in_with_Let_In :=

--- a/src/Util/LetInMonad.v
+++ b/src/Util/LetInMonad.v
@@ -35,7 +35,7 @@ Definition lift2 {A B C} (f : A -> B -> C) : LetInM A -> LetInM B -> LetInM C
   := fun x y => under_lets x (fun x' => under_lets y (fun y' => ret (f x' y'))).
 
 Create HintDb push_denote discriminated.
-Hint Extern 1 => progress autorewrite with push_denote in * : push_denote.
+Global Hint Extern 1 => progress autorewrite with push_denote in * : push_denote.
 
 Ltac push_denote_step :=
   first [ progress simpl @denote in *
@@ -72,7 +72,7 @@ Module Import List.
   Definition app {A} := lift2 (@List.app A).
   Definition nil {A} := ret (@nil A).
   Definition cons {A} x := lift (@cons A x).
-  Hint Unfold app nil cons : push_denote.
+  Global Hint Unfold app nil cons : push_denote.
 
   Definition flat_map {A B} (f : A -> LetInM (list B)) (ls : LetInM (list A))
     := under_lets

--- a/src/Util/ListUtil.v
+++ b/src/Util/ListUtil.v
@@ -1,7 +1,7 @@
 Require Import Coq.Lists.List.
 Require Import Coq.Arith.Arith.
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Arith.Peano_dec.
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Numbers.Natural.Peano.NPeano.

--- a/src/Util/ListUtil.v
+++ b/src/Util/ListUtil.v
@@ -3,7 +3,7 @@ Require Import Coq.Arith.Arith.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.micromega.Lia.
 Require Import Coq.Arith.Peano_dec.
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Numbers.Natural.Peano.NPeano.
 Require Import Crypto.Util.NatUtil.
 Require Import Crypto.Util.Pointed.
@@ -80,7 +80,7 @@ Hint Rewrite
   @prod_length
   : distr_length.
 
-Hint Extern 1 => progress autorewrite with distr_length in * : distr_length.
+Global Hint Extern 1 => progress autorewrite with distr_length in * : distr_length.
 Ltac distr_length := autorewrite with distr_length in *;
   try solve [simpl in *; (idtac + exfalso); lia].
 
@@ -311,7 +311,7 @@ Definition set_nth {T} n x (xs:list T)
   := update_nth n (fun _ => x) xs.
 
 Definition splice_nth {T} n (x:T) xs := firstn n xs ++ x :: skipn (S n) xs.
-Hint Unfold splice_nth.
+Global Hint Unfold splice_nth.
 
 Fixpoint take_while {T} (f : T -> bool) (ls : list T) : list T
   := match ls with
@@ -416,7 +416,7 @@ Lemma nth_error_length_error : forall A i (xs:list A),
 Proof.
   induction i as [|? IHi]; destruct xs; nth_tac'; rewrite IHi by lia; auto.
 Qed.
-Hint Resolve nth_error_length_error.
+Global Hint Resolve nth_error_length_error.
 Hint Rewrite @nth_error_length_error using lia : simpl_nth_error.
 
 Lemma map_nth_default : forall (A B : Type) (f : A -> B) n x y l,
@@ -1180,7 +1180,7 @@ Proof.
   assumption.
 Qed.
 
-Hint Resolve @nth_default_in_bounds : simpl_nth_default.
+Global Hint Resolve @nth_default_in_bounds : simpl_nth_default.
 
 Lemma cons_eq_head : forall {T} (x y:T) xs ys, x::xs = y::ys -> x=y.
 Proof.
@@ -1488,7 +1488,7 @@ Proof.
       intuition auto with zarith. }
 Qed.
 
-Hint Resolve sum_firstn_nonnegative : znonzero.
+Global Hint Resolve sum_firstn_nonnegative : znonzero.
 
 Lemma sum_firstn_app : forall xs ys n,
   sum_firstn (xs ++ ys) n = (sum_firstn xs n + sum_firstn ys (n - length xs))%Z.

--- a/src/Util/ListUtil/FoldBool.v
+++ b/src/Util/ListUtil/FoldBool.v
@@ -1,5 +1,6 @@
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Lists.List.
+Require Export Crypto.Util.GlobalSettings.
 Import ListNotations. Open Scope bool_scope.
 
 Lemma fold_left_orb_true ls

--- a/src/Util/ListUtil/Forall.v
+++ b/src/Util/ListUtil/Forall.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Lists.List.
 Require Import Crypto.Util.Tactics.SpecializeBy.

--- a/src/Util/ListUtil/Forall.v
+++ b/src/Util/ListUtil/Forall.v
@@ -1,5 +1,5 @@
 Require Import Coq.micromega.Lia.
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Lists.List.
 Require Import Crypto.Util.Tactics.SpecializeBy.
 Require Import Crypto.Util.Tactics.SplitInContext.

--- a/src/Util/Logic/ImplAnd.v
+++ b/src/Util/Logic/ImplAnd.v
@@ -1,2 +1,3 @@
+Require Export Crypto.Util.GlobalSettings.
 Lemma impl_and_iff {A B C} : (A -> (B /\ C)) <-> ((A -> B) /\ (A -> C)).
 Proof. tauto. Qed.

--- a/src/Util/Loops.v
+++ b/src/Util/Loops.v
@@ -1,4 +1,5 @@
 Require Import Coq.micromega.Lia.
+Require Export Crypto.Util.GlobalSettings.
 
 Module Import core.
   Section Loops.
@@ -17,7 +18,7 @@ Module Import core.
         match fuel with
         | O => inl a
         | S fuel' => loop fuel' a
-        end 
+        end
       | inr b => inr b
       end.
 
@@ -27,7 +28,7 @@ Module Import core.
     Fixpoint loop_cps (fuel : nat) (s : A) {struct fuel} : forall T, (A + B -> T) -> T :=
       body_cps s _ (fun s =>
         match s with
-        | inl a => 
+        | inl a =>
           match fuel with
           | O => fun _ k => k (inl a)
           | S fuel' => loop_cps fuel' a
@@ -423,7 +424,7 @@ Module while.
                                      else P s)
       : P (while (measure s0) s0).
     Proof. eapply by_invariant_fuel; eauto. Qed.
-    
+
     Context (body_cps : state -> forall T, (state -> T) -> T).
 
     Fixpoint while_cps f s : forall T, (state -> T) -> T :=
@@ -439,7 +440,7 @@ Module while.
     Context (body_cps_ok : forall s {R} f, body_cps s R f = f (body s)).
     Lemma loop_cps_ok n s {R} f : while_cps n s R f = f (while n s).
     Proof.
-      revert s; induction n; intros s; 
+      revert s; induction n; intros s;
         repeat match goal with
                | _ => progress intros
                | _ => progress cbv [cpsreturn cpscall] in *
@@ -457,7 +458,7 @@ End while.
 Notation while := while.while.
 
 Definition for2 {state} (test : state -> bool) (increment body : state -> state)
-  := while test (fun s => let s := body s in increment s). 
+  := while test (fun s => let s := body s in increment s).
 
 Definition for3 {state} init test increment body fuel :=
   @for2 state test increment body fuel init.

--- a/src/Util/Loops.v
+++ b/src/Util/Loops.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Export Crypto.Util.GlobalSettings.
 
 Module Import core.

--- a/src/Util/MSetPositive/Facts.v
+++ b/src/Util/MSetPositive/Facts.v
@@ -1,5 +1,5 @@
 Require Import Coq.Setoids.Setoid.
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Lists.List.
 Require Import Coq.Lists.SetoidList.
 Require Import Coq.MSets.MSetPositive.
@@ -20,6 +20,7 @@ Module PositiveSetFacts.
   Module F := Facts PositiveSet.
   Include F.
   Import PositiveSet.
+  Local Existing Instances E.lt_strorder E.lt_compat POrderedType.PositiveOrder.TO.eq_equiv.
 
   Global Instance elements_Proper_Equal
     : Proper (Equal ==> Logic.eq) elements | 10.

--- a/src/Util/NUtil.v
+++ b/src/Util/NUtil.v
@@ -1,3 +1,4 @@
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.NArith.NArith.
 Require Import Coq.Numbers.Natural.Peano.NPeano.
 Require Import Crypto.Util.NatUtil Crypto.Util.Decidable.
@@ -119,3 +120,10 @@ Module N.
   End ZN.
 
 End N.
+Hint Rewrite
+     N.succ_double_spec
+     N.add_1_r
+     Nat2N.inj_succ
+     Nat2N.inj_mul
+     N2Nat.id: N_nat_conv
+.

--- a/src/Util/NUtil/WithoutReferenceToZ.v
+++ b/src/Util/NUtil/WithoutReferenceToZ.v
@@ -1,5 +1,6 @@
 (** NUtil that doesn't depend on ZUtil stuff *)
 (** Should probably come up with a better organization of this stuff *)
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.Classes.RelationClasses.
 Require Import Coq.NArith.NArith.
 Require Import Coq.Numbers.Natural.Peano.NPeano.
 Require Import Crypto.Util.NatUtil Crypto.Util.Decidable.

--- a/src/Util/NatUtil.v
+++ b/src/Util/NatUtil.v
@@ -1,18 +1,24 @@
 Require Coq.Logic.Eqdep_dec.
 Require Import Coq.Numbers.Natural.Peano.NPeano Coq.micromega.Lia.
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Relations.Relation_Definitions.
 Require Import Coq.micromega.Lia.
 Require Import Coq.Arith.Arith.
 Require Import Coq.NArith.NArith.
+Require Export Crypto.Util.GlobalSettings.
 Import Nat.
+
+Global Existing Instance Nat.le_preorder.
+Global Hint Resolve Nat.max_l Nat.max_r Nat.le_max_l Nat.le_max_r: arith.
+Global Hint Resolve Nat.min_l Nat.min_r Nat.le_min_l Nat.le_min_r: arith.
+
 
 Scheme Equality for nat.
 
 Create HintDb natsimplify discriminated.
 
-Hint Resolve mod_bound_pos plus_le_compat : arith.
-Hint Resolve (fun x y p q => proj1 (@Nat.mod_bound_pos x y p q)) (fun x y p q => proj2 (@Nat.mod_bound_pos x y p q)) : arith.
+Global Hint Resolve mod_bound_pos plus_le_compat : arith.
+Global Hint Resolve (fun x y p q => proj1 (@Nat.mod_bound_pos x y p q)) (fun x y p q => proj2 (@Nat.mod_bound_pos x y p q)) : arith.
 
 Hint Rewrite @mod_small @mod_mod @mod_1_l @mod_1_r succ_pred using lia : natsimplify.
 
@@ -228,7 +234,7 @@ Proof.
   intro; induction k; simpl; nia.
 Qed.
 
-Hint Resolve pow_nonzero : arith.
+Global Hint Resolve pow_nonzero : arith.
 
 Lemma S_pred_nonzero : forall a, (a > 0 -> S (pred a) = a)%nat.
 Proof.
@@ -241,7 +247,7 @@ Lemma mod_same_eq a b : a <> 0 -> a = b -> b mod a = 0.
 Proof. intros; subst; apply mod_same; assumption. Qed.
 
 Hint Rewrite @mod_same_eq using lia : natsimplify.
-Hint Resolve mod_same_eq : arith.
+Global Hint Resolve mod_same_eq : arith.
 
 Lemma mod_mod_eq a b c : a <> 0 -> b = c mod a -> b mod a = b.
 Proof. intros; subst; autorewrite with natsimplify; reflexivity. Qed.

--- a/src/Util/NatUtil.v
+++ b/src/Util/NatUtil.v
@@ -1,8 +1,8 @@
 Require Coq.Logic.Eqdep_dec.
-Require Import Coq.Numbers.Natural.Peano.NPeano Coq.micromega.Lia.
+Require Import Coq.Numbers.Natural.Peano.NPeano Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Relations.Relation_Definitions.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Arith.Arith.
 Require Import Coq.NArith.NArith.
 Require Export Crypto.Util.GlobalSettings.

--- a/src/Util/NumTheoryUtil.v
+++ b/src/Util/NumTheoryUtil.v
@@ -1,5 +1,6 @@
 Require Import Coq.ZArith.Zpower Coq.ZArith.Znumtheory Coq.ZArith.ZArith Coq.ZArith.Zdiv.
-Require Import Coq.micromega.Lia Coq.Numbers.Natural.Peano.NPeano Coq.Arith.Arith.
+Require Import Coq.Bool.Bool Coq.micromega.Lia Coq.Numbers.Natural.Peano.NPeano Coq.Arith.Arith.
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Divide.
 Require Import Crypto.Util.ZUtil.Modulo.
 Require Import Crypto.Util.ZUtil.Odd.

--- a/src/Util/NumTheoryUtil.v
+++ b/src/Util/NumTheoryUtil.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.Zpower Coq.ZArith.Znumtheory Coq.ZArith.ZArith Coq.ZArith.Zdiv.
-Require Import Coq.Bool.Bool Coq.micromega.Lia Coq.Numbers.Natural.Peano.NPeano Coq.Arith.Arith.
+Require Import Coq.Bool.Bool Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.Numbers.Natural.Peano.NPeano Coq.Arith.Arith.
 Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Divide.
 Require Import Crypto.Util.ZUtil.Modulo.

--- a/src/Util/Option.v
+++ b/src/Util/Option.v
@@ -1,4 +1,4 @@
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Relations.Relation_Definitions.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.Tactics.DestructHead.
@@ -108,7 +108,7 @@ Global Instance Proper_option_rect_nd_changebody
 Proof. cbv; repeat (intro || break_match); intuition. Qed.
 
 (* FIXME: there used to be a typeclass resolution hint here, something like
-  Hint Extern 1 (Proper _ (@option_rect ?A (fun _ => ?B))) => exact (@Proper_option_rect_nd_changebody A B _ _) : typeclass_instances.
+  Global Hint Extern 1 (Proper _ (@option_rect ?A (fun _ => ?B))) => exact (@Proper_option_rect_nd_changebody A B _ _) : typeclass_instances.
  but I could not get it working after generalizing [RB] from [Logic.eq] ~ andreser *)
 
 Global Instance Proper_option_rect_nd_changevalue

--- a/src/Util/PER.v
+++ b/src/Util/PER.v
@@ -1,8 +1,9 @@
-Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Relations.Relation_Definitions.
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.Relations.Relation_Definitions.
+Require Export Crypto.Util.GlobalSettings.
 
 Lemma PER_valid_l {A} {R : relation A} {HS : Symmetric R} {HT : Transitive R} x y (H : R x y) : Proper R x.
 Proof. hnf; etransitivity; eassumption || symmetry; eassumption. Qed.
 Lemma PER_valid_r {A} {R : relation A} {HS : Symmetric R} {HT : Transitive R} x y (H : R x y) : Proper R y.
 Proof. hnf; etransitivity; eassumption || symmetry; eassumption. Qed.
-Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_l _ R); [ | | solve [ auto with nocore ] ] : typeclass_instances.
-Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [ auto with nocore ] ] : typeclass_instances.
+Global Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_l _ R); [ | | solve [ auto with nocore ] ] : typeclass_instances.
+Global Hint Extern 10 (Proper ?R ?x) => simple eapply (@PER_valid_r _ R); [ | | solve [ auto with nocore ] ] : typeclass_instances.

--- a/src/Util/Pointed.v
+++ b/src/Util/Pointed.v
@@ -1,4 +1,5 @@
 Require Import Coq.Numbers.BinNums.
+Require Export Crypto.Util.GlobalSettings.
 
 Local Generalizable All Variables.
 

--- a/src/Util/PointedProp.v
+++ b/src/Util/PointedProp.v
@@ -3,6 +3,7 @@
     computationally reduce things like [True /\ True], but can still
     express equality of types. *)
 Require Import Coq.Setoids.Setoid.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.Notations.
 
 Delimit Scope pointed_prop_scope with pointed_prop.
@@ -98,10 +99,10 @@ Create HintDb push_prop_of_option discriminated.
 Create HintDb push_to_prop discriminated.
 Create HintDb push_eq_trivial discriminated.
 Create HintDb push_eq_Some_trivial discriminated.
-Hint Extern 1 => progress autorewrite with push_prop_of_option in * : push_prop_of_option.
-Hint Extern 1 => progress autorewrite with push_to_prop in * : push_to_prop.
-Hint Extern 1 => progress autorewrite with push_eq_trivial in * : push_eq_trivial.
-Hint Extern 1 => progress autorewrite with push_eq_Some_trivial in * : push_eq_Some_trivial.
+Global Hint Extern 1 => progress autorewrite with push_prop_of_option in * : push_prop_of_option.
+Global Hint Extern 1 => progress autorewrite with push_to_prop in * : push_to_prop.
+Global Hint Extern 1 => progress autorewrite with push_eq_trivial in * : push_eq_trivial.
+Global Hint Extern 1 => progress autorewrite with push_eq_Some_trivial in * : push_eq_Some_trivial.
 
 Lemma to_prop_and P Q : to_prop (P /\ Q)%pointed_prop
                         <-> (to_prop P /\ to_prop Q).

--- a/src/Util/Pos.v
+++ b/src/Util/Pos.v
@@ -1,4 +1,5 @@
 Require Import Coq.PArith.BinPosDef.
+Require Export Crypto.Util.GlobalSettings.
 
 Local Open Scope positive_scope.
 (** Append two sequences *)

--- a/src/Util/PrimitiveProd.v
+++ b/src/Util/PrimitiveProd.v
@@ -5,7 +5,7 @@
     between two such pairs, or when we want such an equality, we have
     a systematic way of reducing such equalities to equalities at
     simpler types. *)
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.IffT.
 Require Import Crypto.Util.Equality.
 Require Import Crypto.Util.GlobalSettings.
@@ -151,9 +151,9 @@ Global Instance iffTp_iffTp_prod_Proper
 Proof.
   intros ?? [?] ?? [?]; constructor; tauto.
 Defined.
-Hint Extern 2 (Proper _ prod) => apply iffTp_iffTp_prod_Proper : typeclass_instances.
-Hint Extern 2 (Proper _ (fun A => prod A)) => refine iff_iffTp_prod_Proper : typeclass_instances.
-Hint Extern 2 (Proper _ (fun A B => prod A B)) => refine iff_prod_Proper : typeclass_instances.
+Global Hint Extern 2 (Proper _ prod) => apply iffTp_iffTp_prod_Proper : typeclass_instances.
+Global Hint Extern 2 (Proper _ (fun A => prod A)) => refine iff_iffTp_prod_Proper : typeclass_instances.
+Global Hint Extern 2 (Proper _ (fun A B => prod A B)) => refine iff_prod_Proper : typeclass_instances.
 
 (** ** Useful Tactics *)
 (** *** [inversion_prod] *)

--- a/src/Util/PrimitiveSigma.v
+++ b/src/Util/PrimitiveSigma.v
@@ -5,7 +5,7 @@
     two such pairs, or when we want such an equality, we have a
     systematic way of reducing such equalities to equalities at
     simpler types. *)
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.IffT.
 Require Import Crypto.Util.Equality.
 Require Import Crypto.Util.GlobalSettings.

--- a/src/Util/Prod.v
+++ b/src/Util/Prod.v
@@ -5,7 +5,7 @@
     between two such pairs, or when we want such an equality, we have
     a systematic way of reducing such equalities to equalities at
     simpler types. *)
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.IffT.
 Require Import Crypto.Util.Equality.
 Require Import Crypto.Util.GlobalSettings.
@@ -95,9 +95,9 @@ Global Instance iffTp_iffTp_prod_Proper
 Proof.
   intros ?? [?] ?? [?]; constructor; tauto.
 Defined.
-Hint Extern 2 (Proper _ prod) => apply iffTp_iffTp_prod_Proper : typeclass_instances.
-Hint Extern 2 (Proper _ (fun A => prod A)) => refine iff_iffTp_prod_Proper : typeclass_instances.
-Hint Extern 2 (Proper _ (fun A B => prod A B)) => refine iff_prod_Proper : typeclass_instances.
+Global Hint Extern 2 (Proper _ prod) => apply iffTp_iffTp_prod_Proper : typeclass_instances.
+Global Hint Extern 2 (Proper _ (fun A => prod A)) => refine iff_iffTp_prod_Proper : typeclass_instances.
+Global Hint Extern 2 (Proper _ (fun A B => prod A B)) => refine iff_prod_Proper : typeclass_instances.
 
 (** ** Useful Tactics *)
 (** *** [inversion_prod] *)

--- a/src/Util/QUtil.v
+++ b/src/Util/QUtil.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith Coq.QArith.QArith QArith.Qround.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.Decidable.
 Require Import Crypto.Util.ZUtil.Tactics.DivModToQuotRem.
 Require Import Crypto.Util.ZUtil.Morphisms.

--- a/src/Util/Relations.v
+++ b/src/Util/Relations.v
@@ -1,6 +1,6 @@
 Require Import Crypto.Util.FixCoqMistakes.
 Require Import Crypto.Util.Logic.
-Require Import Coq.Classes.Morphisms Coq.Setoids.Setoid.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.Setoids.Setoid.
 
 Lemma symmetry_iff {T} {R} {Rsym:@Symmetric T R} x y: R x y <-> R y x.
   intuition eauto using symmetry.

--- a/src/Util/SideConditions/CorePackages.v
+++ b/src/Util/SideConditions/CorePackages.v
@@ -1,4 +1,5 @@
 Import EqNotations.
+Require Export Crypto.Util.GlobalSettings.
 
 Local Set Primitive Projections.
 

--- a/src/Util/Sigma/Associativity.v
+++ b/src/Util/Sigma/Associativity.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 (** * Reassociation of [sig] *)
 Definition sig_sig_assoc {A} {P : A -> Prop} {Q}
   : { a : A | P a /\ Q a } -> { ap : { a : A | P a } | Q (proj1_sig ap) }

--- a/src/Util/Sigma/Lift.v
+++ b/src/Util/Sigma/Lift.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 (** * Lift foralls out of sig proofs *)
 
 Definition lift1_sig {A C} (P:A->C->Prop)

--- a/src/Util/Sigma/Related.v
+++ b/src/Util/Sigma/Related.v
@@ -1,6 +1,7 @@
 Require Import Coq.Classes.RelationClasses.
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Relations.Relation_Definitions.
+Require Export Crypto.Util.GlobalSettings.
 Import EqNotations.
 
 Definition related_sigT_by_eq {A P1 P2} (R : forall x : A, P1 x -> P2 x -> Prop)

--- a/src/Util/Strings/BinaryString.v
+++ b/src/Util/Strings/BinaryString.v
@@ -1,5 +1,6 @@
 Require Import Coq.Strings.Ascii Coq.Strings.String.
 Require Import Coq.Numbers.BinNums.
+Require Export Crypto.Util.GlobalSettings.
 Import BinNatDef.
 Import BinIntDef.
 Import BinPosDef.

--- a/src/Util/Strings/HexString.v
+++ b/src/Util/Strings/HexString.v
@@ -1,5 +1,6 @@
 Require Import Coq.Strings.Ascii Coq.Strings.String.
 Require Import Coq.Numbers.BinNums.
+Require Export Crypto.Util.GlobalSettings.
 Import BinNatDef.
 Import BinIntDef.
 Import BinPosDef.

--- a/src/Util/Strings/OctalString.v
+++ b/src/Util/Strings/OctalString.v
@@ -1,5 +1,6 @@
 Require Import Coq.Strings.Ascii Coq.Strings.String.
 Require Import Coq.Numbers.BinNums.
+Require Export Crypto.Util.GlobalSettings.
 Import BinNatDef.
 Import BinIntDef.
 Import BinPosDef.

--- a/src/Util/Strings/String.v
+++ b/src/Util/Strings/String.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Strings.String.
 Require Import Coq.Strings.Ascii.
 Require Import Crypto.Util.Strings.Equality.

--- a/src/Util/Sum.v
+++ b/src/Util/Sum.v
@@ -1,4 +1,4 @@
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Relations.Relation_Definitions.
 Require Import Crypto.Util.Decidable.
 Require Import Crypto.Util.GlobalSettings.

--- a/src/Util/Tactics/CPSId.v
+++ b/src/Util/Tactics/CPSId.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 (** * [cps_id] is a scaffold for writing tactics that convert to cps normal form (where the continuation is the identity *)
 
 Ltac ensure_complex_continuation allow_option k :=

--- a/src/Util/Tactics/ChangeInAll.v
+++ b/src/Util/Tactics/ChangeInAll.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 (** Work around "Cannot create self-referring hypothesis" coming from
     [change x with y in *] *)
 Ltac change_in_all from to :=

--- a/src/Util/Tactics/ClearAll.v
+++ b/src/Util/Tactics/ClearAll.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 Ltac clear_all :=
   clear;
   repeat match goal with

--- a/src/Util/Tactics/ClearDuplicates.v
+++ b/src/Util/Tactics/ClearDuplicates.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 Ltac clear_duplicates_step :=
   match goal with
   | [ H : ?T, H' : ?T |- _ ] => clear H'

--- a/src/Util/Tactics/ClearbodyAll.v
+++ b/src/Util/Tactics/ClearbodyAll.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 Ltac clearbody_all :=
   repeat match goal with
          | [ H := _ |- _ ] => clearbody H

--- a/src/Util/Tactics/Contains.v
+++ b/src/Util/Tactics/Contains.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 (** [contains x expr] succeeds iff [x] appears in [expr] *)
 Ltac contains search_for in_term :=
   idtac;

--- a/src/Util/Tactics/DebugPrint.v
+++ b/src/Util/Tactics/DebugPrint.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 Ltac debuglevel := constr:(0%nat).
 
 Ltac solve_debugfail tac :=
@@ -11,21 +12,21 @@ Ltac solve_debugfail tac :=
 
 (** constr-based [idtac] *)
 Class cidtac {T} (msg : T) := Build_cidtac : True.
-Hint Extern 0 (cidtac ?msg) => idtac msg; exact I : typeclass_instances.
+Global Hint Extern 0 (cidtac ?msg) => idtac msg; exact I : typeclass_instances.
 (** constr-based [idtac] *)
 Class cidtac2 {T1 T2} (msg1 : T1) (msg2 : T2) := Build_cidtac2 : True.
-Hint Extern 0 (cidtac2 ?msg1 ?msg2) => idtac msg1 msg2; exact I : typeclass_instances.
+Global Hint Extern 0 (cidtac2 ?msg1 ?msg2) => idtac msg1 msg2; exact I : typeclass_instances.
 Class cidtac3 {T1 T2 T3} (msg1 : T1) (msg2 : T2) (msg3 : T3) := Build_cidtac3 : True.
-Hint Extern 0 (cidtac3 ?msg1 ?msg2 ?msg3) => idtac msg1 msg2 msg3; exact I : typeclass_instances.
+Global Hint Extern 0 (cidtac3 ?msg1 ?msg2 ?msg3) => idtac msg1 msg2 msg3; exact I : typeclass_instances.
 Class cidtac4 {T1 T2 T3 T4} (msg1 : T1) (msg2 : T2) (msg3 : T3) (msg4 : T4) := Build_cidtac4 : True.
-Hint Extern 0 (cidtac4 ?msg1 ?msg2 ?msg3 ?msg4) => idtac msg1 msg2 msg3 msg4; exact I : typeclass_instances.
+Global Hint Extern 0 (cidtac4 ?msg1 ?msg2 ?msg3 ?msg4) => idtac msg1 msg2 msg3 msg4; exact I : typeclass_instances.
 
 Class cfail {T} (msg : T) := Build_cfail : True.
-Hint Extern 0 (cfail ?msg) => idtac "Error:" msg; exact I : typeclass_instances.
+Global Hint Extern 0 (cfail ?msg) => idtac "Error:" msg; exact I : typeclass_instances.
 Class cfail2 {T1 T2} (msg1 : T1) (msg2 : T2) := Build_cfail2 : True.
-Hint Extern 0 (cfail2 ?msg1 ?msg2) => idtac "Error:" msg1 msg2; exact I : typeclass_instances.
+Global Hint Extern 0 (cfail2 ?msg1 ?msg2) => idtac "Error:" msg1 msg2; exact I : typeclass_instances.
 Class cfail3 {T1 T2 T3} (msg1 : T1) (msg2 : T2) (msg3 : T3) := Build_cfail3 : True.
-Hint Extern 0 (cfail3 ?msg1 ?msg2 ?msg3) => idtac "Error:" msg1 msg2 msg3; exact I : typeclass_instances.
+Global Hint Extern 0 (cfail3 ?msg1 ?msg2 ?msg3) => idtac "Error:" msg1 msg2 msg3; exact I : typeclass_instances.
 
 Ltac constr_run_tac tac :=
   let dummy := match goal with

--- a/src/Util/Tactics/DestructTrivial.v
+++ b/src/Util/Tactics/DestructTrivial.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 Ltac destruct_trivial_step :=
   match goal with
   | [ H : unit |- _ ] => clear H || destruct H

--- a/src/Util/Tactics/ESpecialize.v
+++ b/src/Util/Tactics/ESpecialize.v
@@ -1,2 +1,3 @@
+Require Export Crypto.Util.GlobalSettings.
 (** Like [specialize] but allows holes that get filled with evars. *)
 Tactic Notation "especialize" open_constr(H) := specialize H.

--- a/src/Util/Tactics/ETransitivity.v
+++ b/src/Util/Tactics/ETransitivity.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 Require Import Coq.Classes.RelationClasses.
 
 (** We call Coq's [etransitivity] for compatibility

--- a/src/Util/Tactics/EvarExists.v
+++ b/src/Util/Tactics/EvarExists.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 (** Like [eexists], but stuffs the new evar in a context variable *)
 Ltac evar_exists :=
   let T := fresh in

--- a/src/Util/Tactics/Forward.v
+++ b/src/Util/Tactics/Forward.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 (** [forward H] specializes non-dependent binders in a hypothesis [H]
     with side-conditions.  Side-conditions come after the main goal,
     like with [replace] and [rewrite].

--- a/src/Util/Tactics/GetGoal.v
+++ b/src/Util/Tactics/GetGoal.v
@@ -1,2 +1,3 @@
+Require Export Crypto.Util.GlobalSettings.
 Ltac get_goal :=
   match goal with |- ?G => G end.

--- a/src/Util/Tactics/HasBody.v
+++ b/src/Util/Tactics/HasBody.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 (** Checks if a hypothesis has a body *)
 
 Ltac has_body x := let test := eval unfold x in x in idtac.

--- a/src/Util/Tactics/NormalizeCommutativeIdentifier.v
+++ b/src/Util/Tactics/NormalizeCommutativeIdentifier.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 (** Rewrite with the commutative property to ensure that all appearences of an identifier show up the same way *)
 
 Ltac rewrite_with_comm id clem x y :=

--- a/src/Util/Tactics/OnSubterms.v
+++ b/src/Util/Tactics/OnSubterms.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 (** Execute [progress tac] on all subterms of the goal.  Useful for things like [ring_simplify]. *)
 Ltac tac_on_subterms tac :=
   repeat match goal with

--- a/src/Util/Tactics/PoseTermWithName.v
+++ b/src/Util/Tactics/PoseTermWithName.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 Ltac pose_term_with tac name :=
   let name := fresh name in
   let v := tac () in

--- a/src/Util/Tactics/PrintContext.v
+++ b/src/Util/Tactics/PrintContext.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 Ltac print_context _ :=
   lazymatch goal with
   | [ H : ?T |- False ]

--- a/src/Util/Tactics/Revert.v
+++ b/src/Util/Tactics/Revert.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 (** Like [Coq.Program.Tactics.revert_last], but only for non-dependent hypotheses *)
 Ltac revert_last_nondep :=
   match goal with

--- a/src/Util/Tactics/SetEvars.v
+++ b/src/Util/Tactics/SetEvars.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 Ltac set_evars :=
   repeat match goal with
          | [ |- context[?E] ] => is_evar E; let e := fresh "e" in set (e := E)

--- a/src/Util/Tactics/SideConditionsBeforeToAfter.v
+++ b/src/Util/Tactics/SideConditionsBeforeToAfter.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 (** If [tac_in H] operates in [H] and leaves side-conditions before
     the original goal, then
     [side_conditions_before_to_side_conditions_after tac_in H] does

--- a/src/Util/Tactics/SimplifyProjections.v
+++ b/src/Util/Tactics/SimplifyProjections.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 (** [simplify_projections] reduces terms of the form [fst (_, _)] (for
     any projection from [prod], [sig], [sigT], or [and]) *)
 Ltac pre_simplify_projection proj proj' uproj' :=

--- a/src/Util/Tactics/SimplifyRepeatedIfs.v
+++ b/src/Util/Tactics/SimplifyRepeatedIfs.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 Ltac simplify_repeated_ifs_step :=
   match goal with
   | [ |- context G[if ?b then ?x else ?y] ]

--- a/src/Util/Tactics/SubstEvars.v
+++ b/src/Util/Tactics/SubstEvars.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 Ltac subst_evars :=
   repeat match goal with
          | [ e := ?E |- _ ] => is_evar E; subst e

--- a/src/Util/Tactics/SubstLet.v
+++ b/src/Util/Tactics/SubstLet.v
@@ -1,1 +1,2 @@
+Require Export Crypto.Util.GlobalSettings.
 Ltac subst_let := repeat match goal with | x := _ |- _ => subst x end.

--- a/src/Util/Tactics/Test.v
+++ b/src/Util/Tactics/Test.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 (** Test if a tactic succeeds, but always roll-back the results *)
 Tactic Notation "test" tactic3(tac) :=
   try (first [ tac | fail 2 tac "does not succeed" ]; fail 0 tac "succeeds"; [](* test for [t] solved all goals *)).

--- a/src/Util/Tactics/TransparentAssert.v
+++ b/src/Util/Tactics/TransparentAssert.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 (** [transparent assert (H : T)] is like [assert (H : T)], but leaves the body transparent. *)
 Tactic Notation "transparent" "assert" "(" ident(name) ":" constr(type) ")" :=
   simple refine (let name := (_ : type) in _).

--- a/src/Util/Tactics/VM.v
+++ b/src/Util/Tactics/VM.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 (* Code by Jason Gross for COQBUG 4637: vm_compute in _ makes Defined slow *)
 
 (** First, work around COQBUG 4494, https://coq.inria.fr/bugs/show_bug.cgi?id=4494 (replace is slow and broken under binders *)

--- a/src/Util/Tuple.v
+++ b/src/Util/Tuple.v
@@ -1,4 +1,4 @@
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Relations.Relation_Definitions.
 Require Import Coq.Lists.List.
 Require Import Coq.micromega.Lia.

--- a/src/Util/Tuple.v
+++ b/src/Util/Tuple.v
@@ -1,7 +1,7 @@
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Relations.Relation_Definitions.
 Require Import Coq.Lists.List.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.Option.
 Require Import Crypto.Util.Prod.
 Require Import Crypto.Util.Tactics.DestructHead.

--- a/src/Util/Unit.v
+++ b/src/Util/Unit.v
@@ -1,4 +1,5 @@
-Require Import Coq.Classes.Morphisms.
+Require Export Crypto.Util.GlobalSettings.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Relations.Relation_Definitions.
 
 (* an equivalence for a relation on trivial things, like [unit] *)

--- a/src/Util/WordUtil.v
+++ b/src/Util/WordUtil.v
@@ -1,7 +1,7 @@
 Require Import Coq.Numbers.Natural.Peano.NPeano.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.NArith.NArith.
-Require Import Coq.Classes.RelationClasses.
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Program.Program.
 Require Import Coq.Numbers.Natural.Peano.NPeano Util.NatUtil.
 Require Import Coq.micromega.Psatz.
@@ -16,12 +16,15 @@ Require Import Crypto.Util.Sigma.
 
 Require Import Crypto.Util.ZUtil.LandLorShiftBounds.
 Require Import Crypto.Util.ZUtil.N2Z.
+Require Import Crypto.Util.ZUtil.Le.
 Require Import Crypto.Util.ZUtil.Definitions.
 
 Require Import bbv.WordScope.
 Require Import bbv.Nomega.
 
 Require Import Crypto.Util.FixCoqMistakes.
+
+Local Existing Instances N.le_preorder N.lt_strorder.
 
 Local Open Scope nat_scope.
 
@@ -30,10 +33,10 @@ Create HintDb push_wordToN discriminated.
 Create HintDb pull_ZToWord discriminated.
 Create HintDb push_ZToWord discriminated.
 
-Hint Extern 1 => autorewrite with pull_wordToN in * : pull_wordToN.
-Hint Extern 1 => autorewrite with push_wordToN in * : push_wordToN.
-Hint Extern 1 => autorewrite with pull_ZToWord in * : pull_ZToWord.
-Hint Extern 1 => autorewrite with push_ZToWord in * : push_ZToWord.
+Global Hint Extern 1 => autorewrite with pull_wordToN in * : pull_wordToN.
+Global Hint Extern 1 => autorewrite with push_wordToN in * : push_wordToN.
+Global Hint Extern 1 => autorewrite with pull_ZToWord in * : pull_ZToWord.
+Global Hint Extern 1 => autorewrite with push_ZToWord in * : push_ZToWord.
 
 Module Word.
   Fixpoint weqb_hetero sz1 sz2 (x : word sz1) (y : word sz2) : bool :=
@@ -772,7 +775,7 @@ Proof. intuition; subst; auto using split1_combine, split2_combine, combine_spli
 Class wordsize_eq (x y : nat) := wordsize_eq_to_eq : x = y.
 Ltac wordsize_eq_tac := cbv beta delta [wordsize_eq] in *; lia*.
 Ltac gt84_abstract t := t. (* TODO: when we drop Coq 8.4, use [abstract] here *)
-Hint Extern 100 (wordsize_eq _ _) => gt84_abstract wordsize_eq_tac : typeclass_instances.
+Global Hint Extern 100 (wordsize_eq _ _) => gt84_abstract wordsize_eq_tac : typeclass_instances.
 
 Fixpoint correct_wordsize_eq (x y : nat) : wordsize_eq x y -> x = y
   := match x, y with

--- a/src/Util/WordUtil.v
+++ b/src/Util/WordUtil.v
@@ -4,7 +4,7 @@ Require Import Coq.NArith.NArith.
 Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Program.Program.
 Require Import Coq.Numbers.Natural.Peano.NPeano Util.NatUtil.
-Require Import Coq.micromega.Psatz.
+Require Import Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Bool.Bool.
 
 Require Import Crypto.Util.Bool.

--- a/src/Util/ZBounded.v
+++ b/src/Util/ZBounded.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Crypto.Util.Tuple.
 Require Import Crypto.Util.Decidable.

--- a/src/Util/ZRange.v
+++ b/src/Util/ZRange.v
@@ -1,5 +1,6 @@
 Require Import Coq.micromega.Lia.
 Require Import Coq.ZArith.ZArith.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.Tuple.
 Require Import Crypto.Util.Decidable.
 Require Import Crypto.Util.Notations.
@@ -50,7 +51,7 @@ Section with_bitwidth.
 
   Lemma is_bounded_by_repeat_In_iff {n} vs bound
     : is_bounded_by (Tuple.repeat bound n) vs <-> (forall x, List.In x (Tuple.to_list _ vs) -> is_bounded_by' bound x).
-  Proof. apply fieldwise_In_to_list_repeat_l_iff. Qed.
+  Proof using Type. apply fieldwise_In_to_list_repeat_l_iff. Qed.
 End with_bitwidth.
 
 Lemma is_bounded_by_None_repeat_In_iff {n} vs l u

--- a/src/Util/ZRange.v
+++ b/src/Util/ZRange.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.Tuple.

--- a/src/Util/ZRange/BasicLemmas.v
+++ b/src/Util/ZRange/BasicLemmas.v
@@ -1,6 +1,5 @@
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.Classes.RelationClasses.
-Require Import Coq.micromega.Lia.
 Require Import Coq.micromega.Lia.
 Require Import Crypto.Util.ZRange.
 Require Import Crypto.Util.ZRange.Operations.
@@ -11,6 +10,7 @@ Require Import Crypto.Util.Tactics.SpecializeAllWays.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.Notations.
 Require Import Crypto.Util.Tactics.DestructHead.
+Local Existing Instance Z.le_preorder.
 
 Module ZRange.
   Import Operations.ZRange.

--- a/src/Util/ZRange/BasicLemmas.v
+++ b/src/Util/ZRange/BasicLemmas.v
@@ -1,6 +1,6 @@
 Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZRange.
 Require Import Crypto.Util.ZRange.Operations.
 Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.

--- a/src/Util/ZRange/CornersMonotoneBounds.v
+++ b/src/Util/ZRange/CornersMonotoneBounds.v
@@ -1,4 +1,4 @@
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.micromega.Psatz.
 Require Import Crypto.Util.ZUtil.Tactics.SplitMinMax.
@@ -16,7 +16,7 @@ Require Import Crypto.Util.Tactics.SpecializeAllWays.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.Tactics.UniquePose.
 Require Import Crypto.Util.Tactics.SpecializeBy.
-
+Local Existing Instance Z.le_preorder.
 Local Open Scope Z_scope.
 
 Module ZRange.

--- a/src/Util/ZRange/CornersMonotoneBounds.v
+++ b/src/Util/ZRange/CornersMonotoneBounds.v
@@ -1,6 +1,6 @@
 Require Import Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Psatz.
+Require Import Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Tactics.SplitMinMax.
 Require Import Crypto.Util.ZUtil.Stabilization.
 Require Import Crypto.Util.ZUtil.MulSplit.

--- a/src/Util/ZRange/LandLorBounds.v
+++ b/src/Util/ZRange/LandLorBounds.v
@@ -1,6 +1,6 @@
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Definitions.
 Require Import Crypto.Util.ZUtil.LandLorBounds.
 Require Import Crypto.Util.ZUtil.Morphisms.

--- a/src/Util/ZRange/LandLorBounds.v
+++ b/src/Util/ZRange/LandLorBounds.v
@@ -1,4 +1,4 @@
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.micromega.Lia.
 Require Import Crypto.Util.ZUtil.Definitions.

--- a/src/Util/ZRange/OperationsBounds.v
+++ b/src/Util/ZRange/OperationsBounds.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZRange.
 Require Import Crypto.Util.ZRange.Operations.
 Require Import Crypto.Util.ZRange.BasicLemmas.

--- a/src/Util/ZRange/SplitBounds.v
+++ b/src/Util/ZRange/SplitBounds.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZRange.
 Require Import Crypto.Util.ZRange.BasicLemmas.
 Require Import Crypto.Util.ZRange.Operations.

--- a/src/Util/ZUtil.v
+++ b/src/Util/ZUtil.v
@@ -1,5 +1,5 @@
 Require Coq.ZArith.Zpower Coq.ZArith.Znumtheory Coq.ZArith.ZArith Coq.ZArith.Zdiv.
-Require Coq.micromega.Lia Coq.micromega.Psatz Coq.Numbers.Natural.Peano.NPeano Coq.Arith.Arith.
+Require Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.Numbers.Natural.Peano.NPeano Coq.Arith.Arith.
 Require Crypto.Util.ZUtil.AddGetCarry.
 Require Crypto.Util.ZUtil.AddModulo.
 Require Crypto.Util.ZUtil.CC.

--- a/src/Util/ZUtil/AddGetCarry.v
+++ b/src/Util/ZUtil/AddGetCarry.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Definitions.
 Require Import Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.Prod.

--- a/src/Util/ZUtil/CC.v
+++ b/src/Util/ZUtil/CC.v
@@ -1,5 +1,5 @@
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
-Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.Tactics.DestructHead.
 Require Import Crypto.Util.ZUtil.Definitions.

--- a/src/Util/ZUtil/CC.v
+++ b/src/Util/ZUtil/CC.v
@@ -1,4 +1,4 @@
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.Tactics.DestructHead.
@@ -9,11 +9,11 @@ Require Import Crypto.Util.ZUtil.ZSimplify.Simple.
 Require Import Crypto.Util.ZUtil.Tactics.DivModToQuotRem.
 Require Import Crypto.Util.ZUtil.Tactics.ZeroBounds.
 Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
+Require Import Crypto.Util.Decidable.
 Local Open Scope Z_scope.
 
+Hint Rewrite Z.log2_pow2 Z.pow_1_r using solve [auto using Z.log2_nonneg with zarith] : push_Zpow.
 Module Z.
-  Hint Rewrite Z.log2_pow2 Z.pow_1_r using solve [auto using Z.log2_nonneg with zarith] : push_Zpow.
-
   Lemma cc_m_eq_full : forall s x, Z.cc_m s x = if (s =? 1) then x * 2 else x / (s / 2).
   Proof.
     intros; cbv [Z.cc_m].
@@ -55,26 +55,31 @@ Module Z.
     all: intros x0 x1 H; rewrite !cc_m_eq_full; break_innermost_match; Z.ltb_to_lt; [ nia | ].
     all: Z.div_mod_to_quot_rem; nia.
   Qed.
-  Hint Resolve cc_m_Proper_le_r_gen : zarith.
+  Global Hint Resolve cc_m_Proper_le_r_gen : zarith.
 
   Lemma cc_m_Proper_le_r s
     : Proper (Z.le ==> Z.le) (Definitions.Z.cc_m s)
       \/ Proper (Basics.flip Z.le ==> Z.le) (Definitions.Z.cc_m s).
   Proof. pose proof (cc_m_Proper_le_r_gen s); tauto. Qed.
-  Hint Resolve cc_m_Proper_le_r : zarith.
+  Global Hint Resolve cc_m_Proper_le_r : zarith.
 
   Lemma cc_m_Proper_le_r_pos s
     : Proper (Z.le ==> Z.le) (Definitions.Z.cc_m (Z.pos s)).
   Proof. pose proof (cc_m_Proper_le_r_gen (Z.pos s)); intuition lia. Qed.
-  Hint Resolve cc_m_Proper_le_r_pos : zarith.
+  Global Hint Resolve cc_m_Proper_le_r_pos : zarith.
 
   Lemma cc_m_Proper_le_r_neg s
     : Proper (Basics.flip Z.le ==> Z.le) (Definitions.Z.cc_m (Z.neg s)).
   Proof. pose proof (cc_m_Proper_le_r_gen (Z.neg s)); intuition lia. Qed.
-  Hint Resolve cc_m_Proper_le_r_neg : zarith.
+  Global Hint Resolve cc_m_Proper_le_r_neg : zarith.
 
   Lemma cc_m_Proper_le_r_0
     : Proper (Z.le ==> Z.le) (Definitions.Z.cc_m 0).
   Proof. pose proof (cc_m_Proper_le_r_gen 0); intuition lia. Qed.
-  Hint Resolve cc_m_Proper_le_r_0 : zarith.
+  Global Hint Resolve cc_m_Proper_le_r_0 : zarith.
 End Z.
+Global Hint Resolve Z.cc_m_Proper_le_r_gen : zarith.
+Global Hint Resolve Z.cc_m_Proper_le_r : zarith.
+Global Hint Resolve Z.cc_m_Proper_le_r_pos : zarith.
+Global Hint Resolve Z.cc_m_Proper_le_r_neg : zarith.
+Global Hint Resolve Z.cc_m_Proper_le_r_0 : zarith.

--- a/src/Util/ZUtil/DistrIf.v
+++ b/src/Util/ZUtil/DistrIf.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Hints.Core.
 Local Open Scope Z_scope.
 

--- a/src/Util/ZUtil/Div.v
+++ b/src/Util/ZUtil/Div.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.Znumtheory.
 Require Import Crypto.Util.ZUtil.Tactics.CompareToSgn.
 Require Import Crypto.Util.ZUtil.Tactics.DivModToQuotRem.

--- a/src/Util/ZUtil/Div.v
+++ b/src/Util/ZUtil/Div.v
@@ -111,7 +111,7 @@ Module Z.
     { subst; simpl; autorewrite with zsimplify; reflexivity. }
     { intros; apply Z.div_le_mono; lia. }
   Qed.
-  Hint Resolve div_le_mono_nonneg : zarith.
+  Global Hint Resolve div_le_mono_nonneg : zarith.
 
   Lemma div_le_mono_pow_pos a b c e : a <= b -> a / Z.pos c ^ e <= b / Z.pos c ^ e.
   Proof. auto with zarith. Qed.
@@ -121,7 +121,7 @@ Module Z.
     destruct (Z_zerop b); subst; rewrite ?Zdiv_0_r; [ reflexivity | ].
     intros; apply Z.div_pos; lia.
   Qed.
-  Hint Resolve div_nonneg : zarith.
+  Global Hint Resolve div_nonneg : zarith.
 
   Lemma div_add_exact x y d : d <> 0 -> x mod d = 0 -> (x + y) / d = x / d + y / d.
   Proof.
@@ -151,7 +151,7 @@ Module Z.
          rewrite Z.div_add_exact by (autorewrite with pull_Zmod zsimplify; auto).
          rewrite <- Z.div_sub_mod_exact by lia; lia.
   Qed.
-  Hint Resolve div_sub_mod_cond : zarith.
+  Global Hint Resolve div_sub_mod_cond : zarith.
 
   Lemma div_add_mod_cond_l : forall x y d, d <> 0 -> (x + y) / d = (x mod d + y) / d + x / d.
   Proof.
@@ -196,7 +196,7 @@ Module Z.
 
   Lemma div_lt_upper_bound' a b q : 0 < b -> a < q * b -> a / b < q.
   Proof. intros; apply Z.div_lt_upper_bound; nia. Qed.
-  Hint Resolve div_lt_upper_bound' : zarith.
+  Global Hint Resolve div_lt_upper_bound' : zarith.
 
   Lemma div_cross_le_abs a b c' d : c' <> 0 -> d <> 0 -> a * Z.sgn c' * Z.abs d <= b * Z.sgn d * Z.abs c' -> a / c' <= b / d.
   Proof.
@@ -260,11 +260,11 @@ Module Z.
   Proof.
     intros; subst; auto with zarith.
   Qed.
-  Hint Resolve div_same' : zarith.
+  Global Hint Resolve div_same' : zarith.
 
   Lemma div_opp_r a b : a / (-b) = ((-a) / b).
   Proof. Z.div_mod_to_quot_rem; nia. Qed.
-  Hint Resolve div_opp_r : zarith.
+  Global Hint Resolve div_opp_r : zarith.
 
   Lemma div_floor : forall a b c, 0 < b -> a < b * (Z.succ c) -> a / b <= c.
   Proof.
@@ -281,7 +281,7 @@ Module Z.
     transitivity (x * z / z); [ | rewrite Z.div_mul by lia; lia ].
     apply Z_div_le; nia.
   Qed.
-  Hint Resolve mul_div_le : zarith.
+  Global Hint Resolve mul_div_le : zarith.
 
   Lemma div_mul_diff_exact a b c
         (Ha : 0 <= a) (Hb : 0 < b) (Hc : 0 <= c)
@@ -334,7 +334,7 @@ Module Z.
   Proof.
     pose proof (Z.div_mul_le_le a b c); lia.
   Qed.
-  Hint Resolve div_mul_le_le_offset : zarith.
+  Global Hint Resolve div_mul_le_le_offset : zarith.
 
   Lemma div_x_y_x x y : 0 < x -> 0 < y -> x / y / x = 1 / y.
   Proof.
@@ -352,7 +352,7 @@ Module Z.
       instantiate; autorewrite with zsimplify; try reflexivity.
   Qed.
 
-  Hint Resolve (fun a b X H0 H1 => proj1 (Z.sub_pos_bound_div a b X H0 H1))
+  Global Hint Resolve (fun a b X H0 H1 => proj1 (Z.sub_pos_bound_div a b X H0 H1))
        (fun a b X H0 H1 => proj1 (Z.sub_pos_bound_div a b X H0 H1)) : zarith.
 
   Lemma sub_pos_bound_div_eq a b X : 0 <= a < X -> 0 <= b < X -> (a - b) / X = if a <? b then -1 else 0.
@@ -374,11 +374,11 @@ Module Z.
 
   Lemma div_small_sym a b : 0 <= a < b -> 0 = a / b.
   Proof. intros; symmetry; apply Z.div_small; assumption. Qed.
-  Hint Resolve div_small_sym : zarith.
+  Global Hint Resolve div_small_sym : zarith.
 
   Lemma mod_eq_le_div_1 a b : 0 < a <= b -> a mod b = 0 -> a / b = 1.
   Proof. intros; Z.div_mod_to_quot_rem; nia. Qed.
-  Hint Resolve mod_eq_le_div_1 : zarith.
+  Global Hint Resolve mod_eq_le_div_1 : zarith.
   Hint Rewrite mod_eq_le_div_1 using zutil_arith : zsimplify.
 
   Lemma div_small_neg x y : 0 < -x <= y -> x / y = -1.
@@ -398,16 +398,16 @@ Module Z.
     intros [? ?] [? ?]; eapply Z.le_lt_trans; [ | eassumption ].
     auto with zarith.
   Qed.
-  Hint Resolve mul_div_lt_by_le : zarith.
+  Global Hint Resolve mul_div_lt_by_le : zarith.
 
   Definition mul_div_le'
     := fun x y z w p H0 H1 H2 H3 => @Z.le_trans _ _ w (@Z.mul_div_le x y z H0 H1 H2 H3) p.
-  Hint Resolve mul_div_le' : zarith.
+  Global Hint Resolve mul_div_le' : zarith.
   Lemma mul_div_le'' x y z w : y <= w -> 0 <= x -> 0 <= y -> 0 < z -> x <= z -> x * y / z <= w.
   Proof.
     rewrite (Z.mul_comm x y); intros; apply mul_div_le'; assumption.
   Qed.
-  Hint Resolve mul_div_le'' : zarith.
+  Global Hint Resolve mul_div_le'' : zarith.
 
   Lemma div_between n a b : 0 <= n -> b <> 0 -> n * b <= a < (1 + n) * b -> a / b = n.
   Proof. intros; Z.div_mod_to_quot_rem_in_goal; nia. Qed.
@@ -427,3 +427,37 @@ Module Z.
   Lemma div_between_0_if a b : b <> 0 -> 0 <= a < 2 * b -> a / b = if b <=? a then 1 else 0.
   Proof. intros; rewrite (div_between_if 0) by lia; autorewrite with zsimplify_const; reflexivity. Qed.
 End Z.
+Hint Rewrite Z.div_mul' using zutil_arith : zsimplify.
+Hint Rewrite Z.div_add_l' Z.div_add' using zutil_arith : zsimplify.
+Hint Rewrite Z.div_sub Z.div_sub' using zutil_arith : zsimplify.
+Hint Rewrite Z.div_add_sub Z.div_add_sub' Z.div_add_sub_l Z.div_add_sub_l' using zutil_arith : zsimplify.
+Hint Rewrite Z.div_mul_skip Z.div_mul_skip' using zutil_arith : zsimplify.
+Hint Rewrite Z.div_mul_skip_pow using zutil_arith : zsimplify.
+Hint Rewrite Z.div_mul_skip_pow' using zutil_arith : zsimplify.
+Global Hint Resolve Z.div_le_mono_nonneg : zarith.
+Global Hint Resolve Z.div_nonneg : zarith.
+Hint Rewrite Z.div_add_exact using zutil_arith : zsimplify.
+Global Hint Resolve Z.div_sub_mod_cond : zarith.
+Global Hint Resolve Z.div_lt_upper_bound' : zarith.
+Hint Rewrite Z.div_opp_l_complete using zutil_arith : pull_Zopp.
+Hint Rewrite Z.div_opp_l_complete' using zutil_arith : push_Zopp.
+Hint Rewrite Z.div_opp using zutil_arith : zsimplify.
+Hint Rewrite Z.div_sub_1_0 using zutil_arith : zsimplify.
+Global Hint Resolve Z.div_same' : zarith.
+Global Hint Resolve Z.div_opp_r : zarith.
+Global Hint Resolve Z.mul_div_le : zarith.
+Global Hint Resolve Z.div_mul_le_le_offset : zarith.
+Hint Rewrite Z.div_x_y_x using zutil_arith : zsimplify.
+Global Hint Resolve (fun a b X H0 H1 => proj1 (Z.sub_pos_bound_div a b X H0 H1))
+       (fun a b X H0 H1 => proj1 (Z.sub_pos_bound_div a b X H0 H1)) : zarith.
+Hint Rewrite Z.sub_pos_bound_div_eq Z.add_opp_pos_bound_div_eq using zutil_arith : zstrip_div.
+Global Hint Resolve Z.div_small_sym : zarith.
+Global Hint Resolve Z.mod_eq_le_div_1 : zarith.
+Hint Rewrite Z.mod_eq_le_div_1 using zutil_arith : zsimplify.
+Hint Rewrite Z.div_small_neg using zutil_arith : zsimplify.
+Hint Rewrite Z.div_sub_small using zutil_arith : zsimplify.
+Global Hint Resolve Z.mul_div_lt_by_le : zarith.
+Global Hint Resolve Z.mul_div_le' : zarith.
+Global Hint Resolve Z.mul_div_le'' : zarith.
+Hint Rewrite Z.div_between using zutil_arith : zsimplify.
+Hint Rewrite Z.div_between_1 using zutil_arith : zsimplify.

--- a/src/Util/ZUtil/Div/Bootstrap.v
+++ b/src/Util/ZUtil/Div/Bootstrap.v
@@ -1,6 +1,6 @@
 (** Basic lemmas about [Z.div] for bootstrapping various tactics *)
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Hints.Core.
 Local Open Scope Z_scope.
 

--- a/src/Util/ZUtil/Div/Bootstrap.v
+++ b/src/Util/ZUtil/Div/Bootstrap.v
@@ -7,6 +7,6 @@ Local Open Scope Z_scope.
 Module Z.
   Lemma div_0_r_eq a b : b = 0 -> a / b = 0.
   Proof. intro; subst; auto with zarith. Qed.
-  Hint Resolve div_0_r_eq : zarith.
+  Global Hint Resolve div_0_r_eq : zarith.
   Hint Rewrite div_0_r_eq using assumption : zsimplify.
 End Z.

--- a/src/Util/ZUtil/Divide.v
+++ b/src/Util/ZUtil/Divide.v
@@ -1,6 +1,6 @@
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.ZArith.Znumtheory.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Hints.Core.
 Require Import Crypto.Util.ZUtil.Div.
 Require Import Crypto.Util.ZUtil.Tactics.DivideExistsMul.

--- a/src/Util/ZUtil/EquivModulo.v
+++ b/src/Util/ZUtil/EquivModulo.v
@@ -1,4 +1,4 @@
-Require Import Coq.Classes.Morphisms.
+Require Export Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Structures.Equalities.
 Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
 Require Import Crypto.Util.Notations.
@@ -20,30 +20,30 @@ Module Z.
     Local Instance equiv_modulo_Transitive : Transitive equiv_modulo := fun _ _ _ => @Logic.eq_trans _ _ _ _.
 
     Local Instance mul_mod_Proper : Proper (equiv_modulo ==> equiv_modulo ==> equiv_modulo) Z.mul.
-    Proof. unfold equiv_modulo, Proper, respectful; auto with zarith. Qed.
+    Proof using Type. unfold equiv_modulo, Proper, respectful; auto with zarith. Qed.
 
     Local Instance add_mod_Proper : Proper (equiv_modulo ==> equiv_modulo ==> equiv_modulo) Z.add.
-    Proof. unfold equiv_modulo, Proper, respectful; auto with zarith. Qed.
+    Proof using Type. unfold equiv_modulo, Proper, respectful; auto with zarith. Qed.
 
     Local Instance sub_mod_Proper : Proper (equiv_modulo ==> equiv_modulo ==> equiv_modulo) Z.sub.
-    Proof. unfold equiv_modulo, Proper, respectful; auto with zarith. Qed.
+    Proof using Type. unfold equiv_modulo, Proper, respectful; auto with zarith. Qed.
 
     Local Instance opp_mod_Proper : Proper (equiv_modulo ==> equiv_modulo) Z.opp.
-    Proof. unfold equiv_modulo, Proper, respectful; auto with zarith. Qed.
+    Proof using Type. unfold equiv_modulo, Proper, respectful; auto with zarith. Qed.
 
     Local Instance pow_mod_Proper : Proper (equiv_modulo ==> eq ==> equiv_modulo) Z.pow.
-    Proof.
+    Proof using Type.
       intros ?? H ???; subst; hnf in H |- *.
       rewrite Z.mod_pow_full, H, <- Z.mod_pow_full; reflexivity.
     Qed.
 
     Local Instance modulo_equiv_modulo_Proper
       : Proper (equiv_modulo ==> (fun x y => x = N /\ N = y) ==> Logic.eq) Z.modulo.
-    Proof.
+    Proof using Type.
       repeat intro; hnf in *; intuition congruence.
     Qed.
     Local Instance eq_to_ProperProxy : ProperProxy (fun x y : Z => x = N /\ N = y) N.
-    Proof. split; reflexivity. Qed.
+    Proof using Type. split; reflexivity. Qed.
 
     Lemma div_to_inv_modulo a x x' : x > 0 -> x * x' mod N = 1 mod N -> (a / x) == ((a - a mod x) * x').
     Proof using Type.
@@ -57,22 +57,22 @@ Module Z.
     Qed.
 
     Lemma equiv_modulo_mod_small x y : x  == y -> 0 <= x < N -> x = y mod N.
-    Proof. transitivity (x mod N); [rewrite Z.mod_small|]; auto. Qed.
+    Proof using Type. transitivity (x mod N); [rewrite Z.mod_small|]; auto. Qed.
   End equiv_modulo.
   Hint Rewrite div_to_inv_modulo using solve [ eassumption | lia ] : zstrip_div.
 
   Module EquivModuloInstances (dummy : Nop). (* work around https://coq.inria.fr/bugs/show_bug.cgi?id=4973 *)
-    Existing Instance equiv_modulo_Reflexive.
-    Existing Instance eq_Reflexive. (* prioritize [Reflexive eq] *)
-    Existing Instance equiv_modulo_Symmetric.
-    Existing Instance equiv_modulo_Transitive.
-    Existing Instance mul_mod_Proper.
-    Existing Instance add_mod_Proper.
-    Existing Instance sub_mod_Proper.
-    Existing Instance opp_mod_Proper.
-    Existing Instance pow_mod_Proper.
-    Existing Instance modulo_equiv_modulo_Proper.
-    Existing Instance eq_to_ProperProxy.
+    Global Existing Instance equiv_modulo_Reflexive.
+    Global Existing Instance eq_Reflexive. (* prioritize [Reflexive eq] *)
+    Global Existing Instance equiv_modulo_Symmetric.
+    Global Existing Instance equiv_modulo_Transitive.
+    Global Existing Instance mul_mod_Proper.
+    Global Existing Instance add_mod_Proper.
+    Global Existing Instance sub_mod_Proper.
+    Global Existing Instance opp_mod_Proper.
+    Global Existing Instance pow_mod_Proper.
+    Global Existing Instance modulo_equiv_modulo_Proper.
+    Global Existing Instance eq_to_ProperProxy.
   End EquivModuloInstances.
   Module RemoveEquivModuloInstances (dummy : Nop).
     Global Remove Hints equiv_modulo_Reflexive equiv_modulo_Symmetric equiv_modulo_Transitive mul_mod_Proper add_mod_Proper sub_mod_Proper opp_mod_Proper pow_mod_Proper modulo_equiv_modulo_Proper eq_to_ProperProxy : typeclass_instances.

--- a/src/Util/ZUtil/EquivModulo.v
+++ b/src/Util/ZUtil/EquivModulo.v
@@ -1,6 +1,6 @@
 Require Export Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Structures.Equalities.
-Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.Notations.
 Require Import Crypto.Util.ZUtil.Hints.Core.
 Require Import Crypto.Util.ZUtil.Hints.ZArith.

--- a/src/Util/ZUtil/Ge.v
+++ b/src/Util/ZUtil/Ge.v
@@ -1,8 +1,10 @@
-Require Import Coq.ZArith.ZArith Coq.Classes.RelationClasses.
+Require Export Crypto.Util.GlobalSettings.
+Require Import Coq.ZArith.ZArith Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 
 Local Open Scope Z_scope.
 
 Module Z.
+  Local Existing Instance Z.le_preorder.
   Lemma ge_refl x : x >= x.
   Proof. rewrite !Z.ge_le_iff; reflexivity. Qed.
   Lemma ge_trans n m p : n >= m -> m >= p -> n >= p.

--- a/src/Util/ZUtil/Hints.v
+++ b/src/Util/ZUtil/Hints.v
@@ -6,8 +6,8 @@ Require Export Crypto.Util.ZUtil.Hints.Ztestbit.
 Require Export Crypto.Util.ZUtil.Hints.PullPush.
 Require Export Crypto.Util.ZUtil.ZSimplify.Core.
 
-Hint Resolve (fun a b H => proj1 (Z.log2_lt_pow2 a b H)) (fun a b H => proj1 (Z.log2_le_pow2 a b H)) : concl_log2.
-Hint Resolve (fun a b H => proj2 (Z.log2_lt_pow2 a b H)) (fun a b H => proj2 (Z.log2_le_pow2 a b H)) : hyp_log2.
+Global Hint Resolve (fun a b H => proj1 (Z.log2_lt_pow2 a b H)) (fun a b H => proj1 (Z.log2_le_pow2 a b H)) : concl_log2.
+Global Hint Resolve (fun a b H => proj2 (Z.log2_lt_pow2 a b H)) (fun a b H => proj2 (Z.log2_le_pow2 a b H)) : hyp_log2.
 
 (** For the occasional lemma that can remove the use of [Z.div] *)
 Hint Rewrite Z.div_small_iff using zutil_arith : zstrip_div.

--- a/src/Util/ZUtil/Hints/Core.v
+++ b/src/Util/ZUtil/Hints/Core.v
@@ -1,12 +1,14 @@
+Require Export Crypto.Util.GlobalSettings.
 (** * Declaration of Hint Databases with lemmas about ℤ from the standard library *)
 Require Import Coq.micromega.Psatz Coq.micromega.Lia.
 Require Import Coq.ZArith.ZArith.
+Require Export Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 (* Should we [Require Import Coq.ZArith.Zhints.]? *)
 
-Hint Extern 1 => lia : lia.
-Hint Extern 1 => lra : lra.
-Hint Extern 1 => nia : nia.
-Hint Extern 1 => lia : lia.
+Global Hint Extern 1 => lia : lia.
+Global Hint Extern 1 => lra : lra.
+Global Hint Extern 1 => nia : nia.
+Global Hint Extern 1 => lia : lia.
 
 Ltac zutil_arith := solve [ lia | lia | auto with nocore ].
 Ltac zutil_arith_more_inequalities := solve [ zutil_arith | auto with zarith ].
@@ -59,32 +61,32 @@ Create HintDb Zshift_to_pow discriminated.
 Create HintDb Zpow_to_shift discriminated.
 Create HintDb pull_Zmax discriminated.
 Create HintDb push_Zmax discriminated.
-Hint Extern 1 => progress autorewrite with push_Zopp in * : push_Zopp.
-Hint Extern 1 => progress autorewrite with pull_Zopp in * : pull_Zopp.
-Hint Extern 1 => progress autorewrite with push_Zpow in * : push_Zpow.
-Hint Extern 1 => progress autorewrite with pull_Zpow in * : pull_Zpow.
-Hint Extern 1 => progress autorewrite with push_Zmul in * : push_Zmul.
-Hint Extern 1 => progress autorewrite with pull_Zmul in * : pull_Zmul.
-Hint Extern 1 => progress autorewrite with push_Zadd in * : push_Zadd.
-Hint Extern 1 => progress autorewrite with pull_Zadd in * : pull_Zadd.
-Hint Extern 1 => progress autorewrite with push_Zsub in * : push_Zsub.
-Hint Extern 1 => progress autorewrite with pull_Zsub in * : pull_Zsub.
-Hint Extern 1 => progress autorewrite with push_Zdiv in * : push_Zmul.
-Hint Extern 1 => progress autorewrite with pull_Zdiv in * : pull_Zmul.
-Hint Extern 1 => progress autorewrite with pull_Zmod in * : pull_Zmod.
-Hint Extern 1 => progress autorewrite with push_Zmod in * : push_Zmod.
-Hint Extern 1 => progress autorewrite with pull_Zof_nat in * : pull_Zof_nat.
-Hint Extern 1 => progress autorewrite with push_Zof_nat in * : push_Zof_nat.
-Hint Extern 1 => progress autorewrite with pull_Zshift in * : pull_Zshift.
-Hint Extern 1 => progress autorewrite with push_Zshift in * : push_Zshift.
-Hint Extern 1 => progress autorewrite with Zshift_to_pow in * : Zshift_to_pow.
-Hint Extern 1 => progress autorewrite with Zpow_to_shift in * : Zpow_to_shift.
-Hint Extern 1 => progress autorewrite with pull_Zof_N in * : pull_Zof_N.
-Hint Extern 1 => progress autorewrite with push_Zof_N in * : push_Zof_N.
-Hint Extern 1 => progress autorewrite with pull_Zto_N in * : pull_Zto_N.
-Hint Extern 1 => progress autorewrite with push_Zto_N in * : push_Zto_N.
-Hint Extern 1 => progress autorewrite with push_Zmax in * : push_Zmax.
-Hint Extern 1 => progress autorewrite with pull_Zmax in * : pull_Zmax.
+Global Hint Extern 1 => progress autorewrite with push_Zopp in * : push_Zopp.
+Global Hint Extern 1 => progress autorewrite with pull_Zopp in * : pull_Zopp.
+Global Hint Extern 1 => progress autorewrite with push_Zpow in * : push_Zpow.
+Global Hint Extern 1 => progress autorewrite with pull_Zpow in * : pull_Zpow.
+Global Hint Extern 1 => progress autorewrite with push_Zmul in * : push_Zmul.
+Global Hint Extern 1 => progress autorewrite with pull_Zmul in * : pull_Zmul.
+Global Hint Extern 1 => progress autorewrite with push_Zadd in * : push_Zadd.
+Global Hint Extern 1 => progress autorewrite with pull_Zadd in * : pull_Zadd.
+Global Hint Extern 1 => progress autorewrite with push_Zsub in * : push_Zsub.
+Global Hint Extern 1 => progress autorewrite with pull_Zsub in * : pull_Zsub.
+Global Hint Extern 1 => progress autorewrite with push_Zdiv in * : push_Zmul.
+Global Hint Extern 1 => progress autorewrite with pull_Zdiv in * : pull_Zmul.
+Global Hint Extern 1 => progress autorewrite with pull_Zmod in * : pull_Zmod.
+Global Hint Extern 1 => progress autorewrite with push_Zmod in * : push_Zmod.
+Global Hint Extern 1 => progress autorewrite with pull_Zof_nat in * : pull_Zof_nat.
+Global Hint Extern 1 => progress autorewrite with push_Zof_nat in * : push_Zof_nat.
+Global Hint Extern 1 => progress autorewrite with pull_Zshift in * : pull_Zshift.
+Global Hint Extern 1 => progress autorewrite with push_Zshift in * : push_Zshift.
+Global Hint Extern 1 => progress autorewrite with Zshift_to_pow in * : Zshift_to_pow.
+Global Hint Extern 1 => progress autorewrite with Zpow_to_shift in * : Zpow_to_shift.
+Global Hint Extern 1 => progress autorewrite with pull_Zof_N in * : pull_Zof_N.
+Global Hint Extern 1 => progress autorewrite with push_Zof_N in * : push_Zof_N.
+Global Hint Extern 1 => progress autorewrite with pull_Zto_N in * : pull_Zto_N.
+Global Hint Extern 1 => progress autorewrite with push_Zto_N in * : push_Zto_N.
+Global Hint Extern 1 => progress autorewrite with push_Zmax in * : push_Zmax.
+Global Hint Extern 1 => progress autorewrite with pull_Zmax in * : pull_Zmax.
 
 (** For the occasional lemma that can remove the use of [Z.div] *)
 Create HintDb zstrip_div.
@@ -175,3 +177,5 @@ Ltac Coq.omega.PreOmega.zify_nat_op ::=
   | |- context [ Z.of_nat ?a ] =>
     pose proof (Nat2Z.is_nonneg a); Coq.omega.PreOmega.hide_Z_of_nat a
  end.
+
+Global Existing Instance Z.le_preorder.

--- a/src/Util/ZUtil/Hints/Core.v
+++ b/src/Util/ZUtil/Hints/Core.v
@@ -1,6 +1,6 @@
 Require Export Crypto.Util.GlobalSettings.
 (** * Declaration of Hint Databases with lemmas about ℤ from the standard library *)
-Require Import Coq.micromega.Psatz Coq.micromega.Lia.
+Require Import Coq.micromega.Psatz Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Export Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 (* Should we [Require Import Coq.ZArith.Zhints.]? *)

--- a/src/Util/ZUtil/Hints/ZArith.v
+++ b/src/Util/ZUtil/Hints/ZArith.v
@@ -1,10 +1,10 @@
 Require Import Coq.ZArith.ZArith.
 Require Export Crypto.Util.ZUtil.Hints.Core.
 
-Hint Resolve Z.log2_nonneg Z.log2_up_nonneg Z.div_small Z.mod_small Z.pow_neg_r Z.pow_0_l Z.pow_pos_nonneg Z.lt_le_incl Z.pow_nonzero Z.div_le_upper_bound Z_div_exact_full_2 Z.div_same Z.div_lt_upper_bound Z.div_le_lower_bound Zplus_minus Zplus_gt_compat_l Zplus_gt_compat_r Zmult_gt_compat_l Zmult_gt_compat_r Z.pow_lt_mono_r Z.pow_lt_mono_l Z.pow_lt_mono Z.mul_lt_mono_nonneg Z.div_lt_upper_bound Z.div_pos Zmult_lt_compat_r Z.pow_le_mono_r Z.pow_le_mono_l Z.div_lt Z.div_le_compat_l Z.div_le_mono Z.max_le_compat Z.min_le_compat Z.log2_up_le_mono Z.pow_nonneg : zarith.
-Hint Resolve (fun a b H => proj1 (Z.mod_pos_bound a b H)) (fun a b H => proj2 (Z.mod_pos_bound a b H)) (fun a b pf => proj1 (Z.pow_gt_1 a b pf)) : zarith.
-Hint Resolve (fun n m => proj1 (Z.opp_le_mono n m)) : zarith.
-Hint Resolve (fun n m => proj1 (Z.pred_le_mono n m)) : zarith.
-Hint Resolve (fun a b => proj2 (Z.lor_nonneg a b)) : zarith.
+Global Hint Resolve Z.log2_nonneg Z.log2_up_nonneg Z.div_small Z.mod_small Z.pow_neg_r Z.pow_0_l Z.pow_pos_nonneg Z.lt_le_incl Z.pow_nonzero Z.div_le_upper_bound Z_div_exact_full_2 Z.div_same Z.div_lt_upper_bound Z.div_le_lower_bound Zplus_minus Zplus_gt_compat_l Zplus_gt_compat_r Zmult_gt_compat_l Zmult_gt_compat_r Z.pow_lt_mono_r Z.pow_lt_mono_l Z.pow_lt_mono Z.mul_lt_mono_nonneg Z.div_lt_upper_bound Z.div_pos Zmult_lt_compat_r Z.pow_le_mono_r Z.pow_le_mono_l Z.div_lt Z.div_le_compat_l Z.div_le_mono Z.max_le_compat Z.min_le_compat Z.log2_up_le_mono Z.pow_nonneg : zarith.
+Global Hint Resolve (fun a b H => proj1 (Z.mod_pos_bound a b H)) (fun a b H => proj2 (Z.mod_pos_bound a b H)) (fun a b pf => proj1 (Z.pow_gt_1 a b pf)) : zarith.
+Global Hint Resolve (fun n m => proj1 (Z.opp_le_mono n m)) : zarith.
+Global Hint Resolve (fun n m => proj1 (Z.pred_le_mono n m)) : zarith.
+Global Hint Resolve (fun a b => proj2 (Z.lor_nonneg a b)) : zarith.
 
-Hint Resolve Zmult_le_compat_r Zmult_le_compat_l Z_div_le Z.add_le_mono Z.sub_le_mono : zarith.
+Global Hint Resolve Zmult_le_compat_r Zmult_le_compat_l Z_div_le Z.add_le_mono Z.sub_le_mono : zarith.

--- a/src/Util/ZUtil/Land.v
+++ b/src/Util/ZUtil/Land.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Notations.
 Require Import Crypto.Util.ZUtil.Definitions.
 Local Open Scope bool_scope. Local Open Scope Z_scope.

--- a/src/Util/ZUtil/LandLorBounds.v
+++ b/src/Util/ZUtil/LandLorBounds.v
@@ -1,7 +1,8 @@
 Require Import Coq.micromega.Lia.
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Definitions.
+Require Import Crypto.Util.ZUtil.Pow.
 Require Import Crypto.Util.ZUtil.Pow2.
 Require Import Crypto.Util.ZUtil.Log2.
 Require Import Crypto.Util.ZUtil.Tactics.PeelLe.
@@ -32,17 +33,17 @@ Module Z.
     all: match goal with |- context[2^Z.log2_up ?x] => pose proof (Z.log2_up_le_full x) end.
     all: lia.
   Qed.
-  Hint Resolve round_lor_land_bound_bounds : zarith.
+  Global Hint Resolve round_lor_land_bound_bounds : zarith.
 
   Lemma round_lor_land_bound_bounds_pos x
   : (0 <= Z.pos x <= Z.round_lor_land_bound (Z.pos x)).
   Proof. generalize (round_lor_land_bound_bounds (Z.pos x)); lia. Qed.
-  Hint Resolve round_lor_land_bound_bounds_pos : zarith.
+  Global Hint Resolve round_lor_land_bound_bounds_pos : zarith.
 
   Lemma round_lor_land_bound_bounds_neg x
   : Z.round_lor_land_bound (Z.neg x) <= Z.neg x <= -1.
   Proof. generalize (round_lor_land_bound_bounds (Z.neg x)); lia. Qed.
-  Hint Resolve round_lor_land_bound_bounds_neg : zarith.
+  Global Hint Resolve round_lor_land_bound_bounds_neg : zarith.
 
   Local Ltac saturate :=
     repeat first [ progress cbv [Z.round_lor_land_bound Proper respectful Basics.flip] in *
@@ -223,11 +224,11 @@ Module Z.
     rewrite (Z.land_comm (Z.pos x)), Z.land_assoc.
     apply Z.land_upper_bound_l; rewrite ?Z.land_nonneg; t.
   Qed.
-  Hint Resolve land_round_bound_pos_r (fun v x => proj1 (land_round_bound_pos_r v x)) (fun v x => proj2 (land_round_bound_pos_r v x)) : zarith.
+  Global Hint Resolve land_round_bound_pos_r (fun v x => proj1 (land_round_bound_pos_r v x)) (fun v x => proj2 (land_round_bound_pos_r v x)) : zarith.
   Lemma land_round_bound_pos_l v x
     : 0 <= Z.land (Z.pos x) v <= Z.land (Z.round_lor_land_bound (Z.pos x)) v.
   Proof. rewrite <- !(Z.land_comm v); apply land_round_bound_pos_r. Qed.
-  Hint Resolve land_round_bound_pos_l (fun v x => proj1 (land_round_bound_pos_l v x)) (fun v x => proj2 (land_round_bound_pos_l v x)) : zarith.
+  Global Hint Resolve land_round_bound_pos_l (fun v x => proj1 (land_round_bound_pos_l v x)) (fun v x => proj2 (land_round_bound_pos_l v x)) : zarith.
 
   Lemma land_round_bound_neg_r v x
     : Z.land v (Z.round_lor_land_bound (Z.neg x)) <= Z.land v (Z.neg x) <= v.
@@ -239,11 +240,11 @@ Module Z.
     rewrite !Z.land_assoc.
     etransitivity; [ apply Z.land_le; cbn; lia | ]; lia.
   Qed.
-  Hint Resolve land_round_bound_neg_r (fun v x => proj1 (land_round_bound_neg_r v x)) (fun v x => proj2 (land_round_bound_neg_r v x)) : zarith.
+  Global Hint Resolve land_round_bound_neg_r (fun v x => proj1 (land_round_bound_neg_r v x)) (fun v x => proj2 (land_round_bound_neg_r v x)) : zarith.
   Lemma land_round_bound_neg_l v x
     : Z.land (Z.round_lor_land_bound (Z.neg x)) v <= Z.land (Z.neg x) v <= v.
   Proof. rewrite <- !(Z.land_comm v); apply land_round_bound_neg_r. Qed.
-  Hint Resolve land_round_bound_neg_l (fun v x => proj1 (land_round_bound_neg_l v x)) (fun v x => proj2 (land_round_bound_neg_l v x)) : zarith.
+  Global Hint Resolve land_round_bound_neg_l (fun v x => proj1 (land_round_bound_neg_l v x)) (fun v x => proj2 (land_round_bound_neg_l v x)) : zarith.
 
   Lemma lor_round_bound_neg_r v x
     : Z.lor v (Z.round_lor_land_bound (Z.neg x)) <= Z.lor v (Z.neg x) <= -1.
@@ -257,11 +258,11 @@ Module Z.
     Z.peel_le.
     apply Z.land_upper_bound_l; rewrite ?Z.land_nonneg; t.
   Qed.
-  Hint Resolve lor_round_bound_neg_r (fun v x => proj1 (lor_round_bound_neg_r v x)) (fun v x => proj2 (lor_round_bound_neg_r v x)) : zarith.
+  Global Hint Resolve lor_round_bound_neg_r (fun v x => proj1 (lor_round_bound_neg_r v x)) (fun v x => proj2 (lor_round_bound_neg_r v x)) : zarith.
   Lemma lor_round_bound_neg_l v x
     : Z.lor (Z.round_lor_land_bound (Z.neg x)) v <= Z.lor (Z.neg x) v <= -1.
   Proof. rewrite <- !(Z.lor_comm v); apply lor_round_bound_neg_r. Qed.
-  Hint Resolve lor_round_bound_neg_l (fun v x => proj1 (lor_round_bound_neg_l v x)) (fun v x => proj2 (lor_round_bound_neg_l v x)) : zarith.
+  Global Hint Resolve lor_round_bound_neg_l (fun v x => proj1 (lor_round_bound_neg_l v x)) (fun v x => proj2 (lor_round_bound_neg_l v x)) : zarith.
 
   Lemma lor_round_bound_pos_r v x
     : v <= Z.lor v (Z.pos x) <= Z.lor v (Z.round_lor_land_bound (Z.pos x)).
@@ -273,11 +274,11 @@ Module Z.
     rewrite !Z.lor_assoc.
     etransitivity; [ | apply Z.lor_lower; rewrite ?Z.lor_nonneg; cbn; lia ]; lia.
   Qed.
-  Hint Resolve lor_round_bound_pos_r (fun v x => proj1 (lor_round_bound_pos_r v x)) (fun v x => proj2 (lor_round_bound_pos_r v x)) : zarith.
+  Global Hint Resolve lor_round_bound_pos_r (fun v x => proj1 (lor_round_bound_pos_r v x)) (fun v x => proj2 (lor_round_bound_pos_r v x)) : zarith.
   Lemma lor_round_bound_pos_l v x
     : v <= Z.lor (Z.pos x) v <= Z.lor (Z.round_lor_land_bound (Z.pos x)) v.
   Proof. rewrite <- !(Z.lor_comm v); apply lor_round_bound_pos_r. Qed.
-  Hint Resolve lor_round_bound_pos_l (fun v x => proj1 (lor_round_bound_pos_l v x)) (fun v x => proj2 (lor_round_bound_pos_l v x)) : zarith.
+  Global Hint Resolve lor_round_bound_pos_l (fun v x => proj1 (lor_round_bound_pos_l v x)) (fun v x => proj2 (lor_round_bound_pos_l v x)) : zarith.
 
   Lemma land_round_bound_pos_r' v x : Z.land v (Z.pos x) <= Z.land v (Z.round_lor_land_bound (Z.pos x)). Proof. auto with zarith. Qed.
   Lemma land_round_bound_pos_l' v x : Z.land (Z.pos x) v <= Z.land (Z.round_lor_land_bound (Z.pos x)) v. Proof. auto with zarith. Qed.
@@ -288,3 +289,18 @@ Module Z.
   Lemma lor_round_bound_pos_r' v x : Z.lor v (Z.pos x) <= Z.lor v (Z.round_lor_land_bound (Z.pos x)). Proof. auto with zarith. Qed.
   Lemma lor_round_bound_pos_l' v x : Z.lor (Z.pos x) v <= Z.lor (Z.round_lor_land_bound (Z.pos x)) v. Proof. auto with zarith. Qed.
 End Z.
+Global Hint Resolve Z.round_lor_land_bound_bounds : zarith.
+Global Hint Resolve Z.round_lor_land_bound_bounds_pos : zarith.
+Global Hint Resolve Z.round_lor_land_bound_bounds_neg : zarith.
+Hint Rewrite Z.land_round_lor_land_bound_r : zsimplify_fast zsimplify.
+Hint Rewrite Z.land_round_lor_land_bound_l : zsimplify_fast zsimplify.
+Hint Rewrite Z.lor_round_lor_land_bound_r : zsimplify_fast zsimplify.
+Hint Rewrite Z.lor_round_lor_land_bound_l : zsimplify_fast zsimplify.
+Global Hint Resolve Z.land_round_bound_pos_r (fun v x => proj1 (Z.land_round_bound_pos_r v x)) (fun v x => proj2 (Z.land_round_bound_pos_r v x)) : zarith.
+Global Hint Resolve Z.land_round_bound_pos_l (fun v x => proj1 (Z.land_round_bound_pos_l v x)) (fun v x => proj2 (Z.land_round_bound_pos_l v x)) : zarith.
+Global Hint Resolve Z.land_round_bound_neg_r (fun v x => proj1 (Z.land_round_bound_neg_r v x)) (fun v x => proj2 (Z.land_round_bound_neg_r v x)) : zarith.
+Global Hint Resolve Z.land_round_bound_neg_l (fun v x => proj1 (Z.land_round_bound_neg_l v x)) (fun v x => proj2 (Z.land_round_bound_neg_l v x)) : zarith.
+Global Hint Resolve Z.lor_round_bound_neg_r (fun v x => proj1 (Z.lor_round_bound_neg_r v x)) (fun v x => proj2 (Z.lor_round_bound_neg_r v x)) : zarith.
+Global Hint Resolve Z.lor_round_bound_neg_l (fun v x => proj1 (Z.lor_round_bound_neg_l v x)) (fun v x => proj2 (Z.lor_round_bound_neg_l v x)) : zarith.
+Global Hint Resolve Z.lor_round_bound_pos_r (fun v x => proj1 (Z.lor_round_bound_pos_r v x)) (fun v x => proj2 (Z.lor_round_bound_pos_r v x)) : zarith.
+Global Hint Resolve Z.lor_round_bound_pos_l (fun v x => proj1 (Z.lor_round_bound_pos_l v x)) (fun v x => proj2 (Z.lor_round_bound_pos_l v x)) : zarith.

--- a/src/Util/ZUtil/LandLorBounds.v
+++ b/src/Util/ZUtil/LandLorBounds.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Definitions.

--- a/src/Util/ZUtil/LandLorShiftBounds.v
+++ b/src/Util/ZUtil/LandLorShiftBounds.v
@@ -1,6 +1,6 @@
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Hints.Core.
 Require Import Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.ZUtil.Definitions.

--- a/src/Util/ZUtil/LandLorShiftBounds.v
+++ b/src/Util/ZUtil/LandLorShiftBounds.v
@@ -1,4 +1,4 @@
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.micromega.Lia.
 Require Import Crypto.Util.ZUtil.Hints.Core.
@@ -32,7 +32,7 @@ Module Z.
            | |- _ => solve [apply Z.lor_nonneg; intuition auto]
            end.
   Qed.
-  Hint Resolve lor_range : zarith.
+  Global Hint Resolve lor_range : zarith.
 
   Lemma lor_shiftl_bounds : forall x y n m,
       (0 <= n)%Z -> (0 <= m)%Z ->
@@ -363,3 +363,4 @@ Module Z.
     destruct (0 <=? x), (x <? 0); try lia.
   Qed.
 End Z.
+Global Hint Resolve Z.lor_range : zarith.

--- a/src/Util/ZUtil/Le.v
+++ b/src/Util/ZUtil/Le.v
@@ -1,13 +1,17 @@
 Require Import Coq.ZArith.ZArith.
+Require Import Coq.Classes.RelationClasses.
+Require Import Coq.Lists.List.
 Require Import Coq.micromega.Lia.
 Require Import Crypto.Util.ZUtil.Hints.Core.
 Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
 Local Open Scope Z_scope.
 
+Global Existing Instance Z.le_preorder.
+
 Module Z.
   Lemma positive_is_nonzero : forall x, x > 0 -> x <> 0.
   Proof. intros; lia. Qed.
-  Hint Resolve positive_is_nonzero : zarith.
+  Global Hint Resolve positive_is_nonzero : zarith.
 
   Lemma le_lt_trans n m p : n <= m -> m < p -> n < p.
   Proof. lia. Qed.

--- a/src/Util/ZUtil/Le.v
+++ b/src/Util/ZUtil/Le.v
@@ -1,7 +1,7 @@
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.Classes.RelationClasses.
 Require Import Coq.Lists.List.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Hints.Core.
 Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
 Local Open Scope Z_scope.
@@ -66,3 +66,8 @@ Module Z.
   Lemma le_add_1_iff x y : x + 1 <= y <-> x < y.
   Proof. lia. Qed.
 End Z.
+Global Hint Resolve Z.positive_is_nonzero : zarith.
+Hint Rewrite Z.leb_add_same : zsimplify.
+Hint Rewrite Z.ltb_add_same : zsimplify.
+Hint Rewrite Z.geb_add_same : zsimplify.
+Hint Rewrite Z.gtb_add_same : zsimplify.

--- a/src/Util/ZUtil/Lnot.v
+++ b/src/Util/ZUtil/Lnot.v
@@ -1,6 +1,6 @@
 Require Export Crypto.Util.GlobalSettings.
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Local Open Scope Z_scope.
 
 Module Z.

--- a/src/Util/ZUtil/Lnot.v
+++ b/src/Util/ZUtil/Lnot.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.micromega.Lia.
 Local Open Scope Z_scope.

--- a/src/Util/ZUtil/Log2.v
+++ b/src/Util/ZUtil/Log2.v
@@ -1,4 +1,5 @@
 Require Import Coq.ZArith.ZArith.
+Require Import Coq.Classes.RelationClasses.
 Require Import Coq.micromega.Lia.
 Require Import Crypto.Util.ZUtil.Hints.
 Require Import Crypto.Util.ZUtil.Hints.Core.
@@ -8,12 +9,14 @@ Require Import Crypto.Util.ZUtil.ZSimplify.Core.
 Require Import Crypto.Util.ZUtil.ZSimplify.Simple.
 Local Open Scope Z_scope.
 
+Local Existing Instance Z.le_preorder.
+
 Module Z.
   Lemma log2_nonneg' n a : n <= 0 -> n <= Z.log2 a.
   Proof.
     intros; transitivity 0; auto with zarith.
   Qed.
-  Hint Resolve log2_nonneg' : zarith.
+  Global Hint Resolve log2_nonneg' : zarith.
 
   Lemma le_lt_to_log2 x y z : 0 <= z -> 0 < y -> 2^x <= y < 2^z -> x <= Z.log2 y < z.
   Proof.

--- a/src/Util/ZUtil/Log2.v
+++ b/src/Util/ZUtil/Log2.v
@@ -1,6 +1,6 @@
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.Classes.RelationClasses.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Hints.
 Require Import Crypto.Util.ZUtil.Hints.Core.
 Require Import Crypto.Util.ZUtil.Hints.ZArith.

--- a/src/Util/ZUtil/ModInv.v
+++ b/src/Util/ZUtil/ModInv.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 (*** Compute the modular inverse of a ℤ *)
 Require Import Coq.ZArith.ZArith.
 Local Open Scope Z_scope.

--- a/src/Util/ZUtil/Modulo.v
+++ b/src/Util/ZUtil/Modulo.v
@@ -1,3 +1,4 @@
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.Classes.RelationClasses.
 Require Import Coq.ZArith.ZArith Coq.micromega.Lia Coq.ZArith.Znumtheory Coq.ZArith.Zpow_facts.
 Require Import Crypto.Util.ZUtil.Hints.Core.
 Require Import Crypto.Util.ZUtil.ZSimplify.Core.
@@ -13,7 +14,6 @@ Local Open Scope Z_scope.
 Module Z.
   Lemma elim_mod : forall a b m, a = b -> a mod m = b mod m.
   Proof. intros; subst; auto. Qed.
-  Hint Resolve elim_mod : zarith.
 
   Lemma mod_add_full : forall a b c, (a + b * c) mod c = a mod c.
   Proof. intros a b c; destruct (Z_zerop c); try subst; autorewrite with zsimplify; reflexivity. Qed.
@@ -102,13 +102,13 @@ Module Z.
   Proof.
     intros H0 H1; rewrite Zmult_mod, H0, H1, <- Zmult_mod; reflexivity.
   Qed.
-  Hint Resolve f_equal_mul_mod : zarith.
+  Global Hint Resolve f_equal_mul_mod : zarith.
 
   Lemma f_equal_add_mod x y x' y' m : x mod m = x' mod m -> y mod m = y' mod m -> (x + y) mod m = (x' + y') mod m.
   Proof.
     intros H0 H1; rewrite Zplus_mod, H0, H1, <- Zplus_mod; reflexivity.
   Qed.
-  Hint Resolve f_equal_add_mod : zarith.
+  Global Hint Resolve f_equal_add_mod : zarith.
 
   Lemma f_equal_opp_mod x x' m : x mod m = x' mod m -> (-x) mod m = (-x') mod m.
   Proof.
@@ -118,13 +118,13 @@ Module Z.
     { rewrite !Z_mod_zero_opp_full by assumption; reflexivity. }
     { rewrite Z_mod_nz_opp_full, H, <- Z_mod_nz_opp_full by assumption; reflexivity. }
   Qed.
-  Hint Resolve f_equal_opp_mod : zarith.
+  Global Hint Resolve f_equal_opp_mod : zarith.
 
   Lemma f_equal_sub_mod x y x' y' m : x mod m = x' mod m -> y mod m = y' mod m -> (x - y) mod m = (x' - y') mod m.
   Proof.
     rewrite <- !Z.add_opp_r; auto with zarith.
   Qed.
-  Hint Resolve f_equal_sub_mod : zarith.
+  Global Hint Resolve f_equal_sub_mod : zarith.
 
   Lemma mul_div_eq : forall a m, m > 0 -> m * (a / m) = (a - a mod m).
   Proof.
@@ -280,7 +280,7 @@ Module Z.
 
   Lemma mod_opp_r a b : a mod (-b) = -((-a) mod b).
   Proof. pose proof (Z.div_opp_r a b); Z.div_mod_to_quot_rem; nia. Qed.
-  Hint Resolve mod_opp_r : zarith.
+  Global Hint Resolve mod_opp_r : zarith.
 
   Lemma mod_same_pow : forall a b c, 0 <= c <= b -> a ^ b mod a ^ c = 0.
   Proof.
@@ -290,7 +290,7 @@ Module Z.
     apply Z_mod_mult.
   Qed.
   Hint Rewrite mod_same_pow using zutil_arith : zsimplify.
-  Hint Resolve mod_same_pow : zarith.
+  Global Hint Resolve mod_same_pow : zarith.
 
   Lemma mod_opp_l_z_iff a b (H : b <> 0) : a mod b = 0 <-> (-a) mod b = 0.
   Proof.
@@ -300,15 +300,15 @@ Module Z.
 
   Lemma mod_small_sym a b : 0 <= a < b -> a = a mod b.
   Proof. intros; symmetry; apply Z.mod_small; assumption. Qed.
-  Hint Resolve mod_small_sym : zarith.
+  Global Hint Resolve mod_small_sym : zarith.
 
   Lemma mod_eq_le_to_eq a b : 0 < a <= b -> a mod b = 0 -> a = b.
   Proof. pose proof (Z.mod_eq_le_div_1 a b); intros; Z.div_mod_to_quot_rem; nia. Qed.
-  Hint Resolve mod_eq_le_to_eq : zarith.
+  Global Hint Resolve mod_eq_le_to_eq : zarith.
 
   Lemma mod_neq_0_le_to_neq a b : a mod b <> 0 -> a <> b.
   Proof. repeat intro; subst; autorewrite with zsimplify in *; lia. Qed.
-  Hint Resolve mod_neq_0_le_to_neq : zarith.
+  Global Hint Resolve mod_neq_0_le_to_neq : zarith.
 
   Lemma div_mod' a b : b <> 0 -> a = (a / b) * b + a mod b.
   Proof. intro; etransitivity; [ apply (Z.div_mod a b); assumption | lia ]. Qed.
@@ -326,7 +326,7 @@ Module Z.
   Proof.
     destruct (Z_zerop d); subst; push_Zmod; autorewrite with zsimplify; reflexivity.
   Qed.
-  Hint Resolve sub_mod_mod_0 : zarith.
+  Global Hint Resolve sub_mod_mod_0 : zarith.
   Hint Rewrite sub_mod_mod_0 : zsimplify.
 
   Lemma mod_small_n n a b : 0 <= n -> b <> 0 -> n * b <= a < (1 + n) * b -> a mod b = a - n * b.
@@ -335,7 +335,6 @@ Module Z.
 
   Lemma mod_small_1 a b : b <> 0 -> b <= a < 2 * b -> a mod b = a - b.
   Proof. intros; rewrite (mod_small_n 1) by lia; lia. Qed.
-  Hint Rewrite mod_small_1 using zutil_arith : zsimplify.
 
   Lemma mod_small_n_if n a b : 0 <= n -> b <> 0 -> n * b <= a < (2 + n) * b -> a mod b = a - (if (1 + n) * b <=? a then (1 + n) else n) * b.
   Proof. intros; erewrite Zmod_eq_full, Z.div_between_if by eassumption; autorewrite with zsimplify_const. reflexivity. Qed.
@@ -374,3 +373,43 @@ Module Z.
     reflexivity.
   Qed.
 End Z.
+
+Global Hint Resolve
+       Z.elim_mod
+       Z.f_equal_mul_mod
+       Z.f_equal_add_mod
+       Z.f_equal_opp_mod
+       Z.f_equal_sub_mod
+       Z.mod_opp_r
+       Z.mod_same_pow
+       Z.mod_small_sym
+       Z.mod_eq_le_to_eq
+       Z.mod_neq_0_le_to_neq
+       Z.sub_mod_mod_0
+  : zarith.
+Hint Rewrite
+     Z.mod_small_1
+     Z.mod_div_eq0
+     Z.mod_same_pow
+     Z.mod_small_n
+     using zutil_arith : zsimplify.
+Hint Rewrite
+     Z.mod_add_full
+     Z.mod_add_l_full
+     Z.mod_add'_full Z.mod_add_l'_full
+     Z.sub_mod_mod_0
+  : zsimplify.
+Hint Rewrite <-
+       Z.mod_opp_l_z_iff
+         Z.div_mod'
+         Z.div_mod''
+         Z.div_mod'''
+         using zutil_arith : zsimplify.
+Hint Rewrite
+     Z.mul_div_eq_full
+     Z.mul_div_eq Z.mul_div_eq'
+     using zutil_arith : zdiv_to_mod.
+Hint Rewrite <-
+       Z.mul_div_eq_full
+         Z.mul_div_eq'
+         using zutil_arith : zmod_to_div.

--- a/src/Util/ZUtil/Modulo.v
+++ b/src/Util/ZUtil/Modulo.v
@@ -1,12 +1,13 @@
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.Classes.RelationClasses.
-Require Import Coq.ZArith.ZArith Coq.micromega.Lia Coq.ZArith.Znumtheory Coq.ZArith.Zpow_facts.
-Require Import Crypto.Util.ZUtil.Hints.Core.
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.ZArith.Znumtheory Coq.ZArith.Zpow_facts.
+Require Import Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.ZUtil.ZSimplify.Core.
 Require Import Crypto.Util.ZUtil.Tactics.DivModToQuotRem.
 Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
 Require Import Crypto.Util.ZUtil.Tactics.ReplaceNegWithPos.
 Require Import Crypto.Util.ZUtil.Tactics.PullPush.Modulo.
 Require Import Crypto.Util.ZUtil.Div.
+Require Import Crypto.Util.ZUtil.Le.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.Tactics.DestructHead.
 Local Open Scope Z_scope.
@@ -84,6 +85,7 @@ Module Z.
   Qed.
 
   Lemma mod_to_nat x m (Hm:(0 < m)%Z) (Hx:(0 <= x)%Z) : (Z.to_nat x mod Z.to_nat m = Z.to_nat (x mod m))%nat.
+  Proof.
     pose proof Zdiv.mod_Zmod (Z.to_nat x) (Z.to_nat m) as H;
       rewrite !Z2Nat.id in H by lia.
     rewrite <-H by (change 0%nat with (Z.to_nat 0); rewrite Z2Nat.inj_iff; lia).

--- a/src/Util/ZUtil/Modulo/Bootstrap.v
+++ b/src/Util/ZUtil/Modulo/Bootstrap.v
@@ -8,7 +8,7 @@ Module Z.
   Lemma mod_0_r_eq a b : b = 0 -> a mod b = 
     ltac:(match eval hnf in (1 mod 0) with | 0 => exact 0 | _ => exact a end).
   Proof. intro; subst; auto with zarith. Qed.
-  Hint Resolve mod_0_r_eq : zarith.
+  Global Hint Resolve mod_0_r_eq : zarith.
   Hint Rewrite mod_0_r_eq using assumption : zsimplify.
 
   Lemma div_mod_cases x y : ((x = y * (x / y) + x mod y /\ (y < x mod y <= 0 \/ 0 <= x mod y < y))

--- a/src/Util/ZUtil/Modulo/Bootstrap.v
+++ b/src/Util/ZUtil/Modulo/Bootstrap.v
@@ -1,6 +1,6 @@
 (** Basic lemmas about [Z.modulo] for bootstrapping various tactics *)
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Hints.Core.
 Local Open Scope Z_scope.
 

--- a/src/Util/ZUtil/Modulo/PullPush.v
+++ b/src/Util/ZUtil/Modulo/PullPush.v
@@ -19,7 +19,7 @@ Module Z.
   Lemma mul_mod_full a b n : (a * b) mod n = ((a mod n) * (b mod n)) mod n.
   Proof. auto using Zmult_mod. Qed.
   Hint Rewrite <- mul_mod_full : pull_Zmod.
-  Hint Resolve mul_mod_full : zarith.
+  Global Hint Resolve mul_mod_full : zarith.
 
   Lemma mul_mod_l a b n : (a * b) mod n = ((a mod n) * b) mod n.
   Proof.
@@ -27,7 +27,7 @@ Module Z.
     autorewrite with zsimplify; reflexivity.
   Qed.
   Hint Rewrite <- mul_mod_l : pull_Zmod.
-  Hint Resolve mul_mod_l : zarith.
+  Global Hint Resolve mul_mod_l : zarith.
 
   Lemma mul_mod_r a b n : (a * b) mod n = (a * (b mod n)) mod n.
   Proof.
@@ -35,12 +35,12 @@ Module Z.
     autorewrite with zsimplify; reflexivity.
   Qed.
   Hint Rewrite <- mul_mod_r : pull_Zmod.
-  Hint Resolve mul_mod_r : zarith.
+  Global Hint Resolve mul_mod_r : zarith.
 
   Lemma add_mod_full a b n : (a + b) mod n = ((a mod n) + (b mod n)) mod n.
   Proof. auto using Zplus_mod. Qed.
   Hint Rewrite <- add_mod_full : pull_Zmod.
-  Hint Resolve add_mod_full : zarith.
+  Global Hint Resolve add_mod_full : zarith.
 
   Lemma add_mod_l a b n : (a + b) mod n = ((a mod n) + b) mod n.
   Proof.
@@ -48,7 +48,7 @@ Module Z.
     autorewrite with zsimplify; reflexivity.
   Qed.
   Hint Rewrite <- add_mod_l : pull_Zmod.
-  Hint Resolve add_mod_l : zarith.
+  Global Hint Resolve add_mod_l : zarith.
 
   Lemma add_mod_r a b n : (a + b) mod n = (a + (b mod n)) mod n.
   Proof.
@@ -56,7 +56,7 @@ Module Z.
     autorewrite with zsimplify; reflexivity.
   Qed.
   Hint Rewrite <- add_mod_r : pull_Zmod.
-  Hint Resolve add_mod_r : zarith.
+  Global Hint Resolve add_mod_r : zarith.
 
   Lemma opp_mod_mod a n : (-a) mod n = (-(a mod n)) mod n.
   Proof.
@@ -65,30 +65,30 @@ Module Z.
       autorewrite with zsimplify; lia.
   Qed.
   Hint Rewrite <- opp_mod_mod : pull_Zmod.
-  Hint Resolve opp_mod_mod : zarith.
+  Global Hint Resolve opp_mod_mod : zarith.
 
   (** Give alternate names for the next three lemmas, for consistency *)
   Lemma sub_mod_full a b n : (a - b) mod n = ((a mod n) - (b mod n)) mod n.
   Proof. auto using Zminus_mod. Qed.
   Hint Rewrite <- sub_mod_full : pull_Zmod.
-  Hint Resolve sub_mod_full : zarith.
+  Global Hint Resolve sub_mod_full : zarith.
 
   Lemma sub_mod_l a b n : (a - b) mod n = ((a mod n) - b) mod n.
   Proof. auto using Zminus_mod_idemp_l. Qed.
   Hint Rewrite <- sub_mod_l : pull_Zmod.
-  Hint Resolve sub_mod_l : zarith.
+  Global Hint Resolve sub_mod_l : zarith.
 
   Lemma sub_mod_r a b n : (a - b) mod n = (a - (b mod n)) mod n.
   Proof. auto using Zminus_mod_idemp_r. Qed.
   Hint Rewrite <- sub_mod_r : pull_Zmod.
-  Hint Resolve sub_mod_r : zarith.
+  Global Hint Resolve sub_mod_r : zarith.
 
   Lemma lnot_mod_mod v m : (Z.lnot (v mod m) mod m) = (Z.lnot v) mod m.
   Proof.
     cbv [Z.lnot]; etransitivity; rewrite <- !Z.sub_1_r, Z.sub_mod_full, Z.opp_mod_mod, ?Zmod_mod; reflexivity.
   Qed.
   Hint Rewrite lnot_mod_mod : pull_Zmod.
-  Hint Resolve lnot_mod_mod : zarith.
+  Global Hint Resolve lnot_mod_mod : zarith.
 
   Lemma mod_pow_full p q n : (p^q) mod n = ((p mod n)^q) mod n.
   Proof.
@@ -117,7 +117,7 @@ Module Z.
         reflexivity. } }
   Qed.
   Hint Rewrite <- mod_pow_full : pull_Zmod.
-  Hint Resolve mod_pow_full : zarith.
+  Global Hint Resolve mod_pow_full : zarith.
   Notation pow_mod_full := mod_pow_full.
 
   Definition NoZMod (x : Z) := True.
@@ -175,3 +175,43 @@ Module Z.
   Proof. intros; apply pow_mod_full. Qed.
   Hint Rewrite pow_mod_push using solve [ NoZMod ] : push_Zmod.
 End Z.
+Hint Rewrite Z.mod_r_distr_if : push_Zmod.
+Hint Rewrite <- Z.mod_r_distr_if : pull_Zmod.
+Hint Rewrite Z.mod_l_distr_if : push_Zmod.
+Hint Rewrite <- Z.mod_l_distr_if : pull_Zmod.
+Hint Rewrite <- Z.mul_mod_full : pull_Zmod.
+Global Hint Resolve Z.mul_mod_full : zarith.
+Hint Rewrite <- Z.mul_mod_l : pull_Zmod.
+Global Hint Resolve Z.mul_mod_l : zarith.
+Hint Rewrite <- Z.mul_mod_r : pull_Zmod.
+Global Hint Resolve Z.mul_mod_r : zarith.
+Hint Rewrite <- Z.add_mod_full : pull_Zmod.
+Global Hint Resolve Z.add_mod_full : zarith.
+Hint Rewrite <- Z.add_mod_l : pull_Zmod.
+Global Hint Resolve Z.add_mod_l : zarith.
+Hint Rewrite <- Z.add_mod_r : pull_Zmod.
+Global Hint Resolve Z.add_mod_r : zarith.
+Hint Rewrite <- Z.opp_mod_mod : pull_Zmod.
+Global Hint Resolve Z.opp_mod_mod : zarith.
+Hint Rewrite <- Z.sub_mod_full : pull_Zmod.
+Global Hint Resolve Z.sub_mod_full : zarith.
+Hint Rewrite <- Z.sub_mod_l : pull_Zmod.
+Global Hint Resolve Z.sub_mod_l : zarith.
+Hint Rewrite <- Z.sub_mod_r : pull_Zmod.
+Global Hint Resolve Z.sub_mod_r : zarith.
+Hint Rewrite Z.lnot_mod_mod : pull_Zmod.
+Global Hint Resolve Z.lnot_mod_mod : zarith.
+Hint Rewrite <- Z.mod_pow_full : pull_Zmod.
+Global Hint Resolve Z.mod_pow_full : zarith.
+Hint Rewrite Z.mul_mod_push using solve [ Z.NoZMod ] : push_Zmod.
+Hint Rewrite Z.add_mod_push using solve [ Z.NoZMod ] : push_Zmod.
+Hint Rewrite Z.mul_mod_l_push using solve [ Z.NoZMod ] : push_Zmod.
+Hint Rewrite Z.mul_mod_r_push using solve [ Z.NoZMod ] : push_Zmod.
+Hint Rewrite Z.add_mod_l_push using solve [ Z.NoZMod ] : push_Zmod.
+Hint Rewrite Z.add_mod_r_push using solve [ Z.NoZMod ] : push_Zmod.
+Hint Rewrite Z.sub_mod_push using solve [ Z.NoZMod ] : push_Zmod.
+Hint Rewrite Z.sub_mod_l_push using solve [ Z.NoZMod ] : push_Zmod.
+Hint Rewrite Z.sub_mod_r_push using solve [ Z.NoZMod ] : push_Zmod.
+Hint Rewrite Z.opp_mod_mod_push using solve [ Z.NoZMod ] : push_Zmod.
+Hint Rewrite Z.lnot_mod_mod_push using solve [ Z.NoZMod ] : push_Zmod.
+Hint Rewrite Z.pow_mod_push using solve [ Z.NoZMod ] : push_Zmod.

--- a/src/Util/ZUtil/Modulo/PullPush.v
+++ b/src/Util/ZUtil/Modulo/PullPush.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.Znumtheory Coq.ZArith.Zpow_facts.
 Require Import Crypto.Util.ZUtil.Hints.Core.
 Require Import Crypto.Util.ZUtil.ZSimplify.Core.

--- a/src/Util/ZUtil/Morphisms.v
+++ b/src/Util/ZUtil/Morphisms.v
@@ -2,7 +2,7 @@
 Require Import Coq.micromega.Lia.
 Require Import Coq.micromega.Lia.
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Classes.RelationPairs.
 Require Import Crypto.Util.ZUtil.Definitions.
 Require Import Crypto.Util.ZUtil.Div.
@@ -14,6 +14,7 @@ Require Import Crypto.Util.Tactics.UniquePose.
 Require Import Crypto.Util.Tactics.DestructHead.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Local Open Scope Z_scope.
+Global Existing Instance Z.le_preorder.
 
 Module Z.
   (** We prove a bunch of [Proper] lemmas, but do not make them
@@ -22,186 +23,186 @@ Module Z.
       [Local Existing Instances]. *)
   Lemma succ_le_Proper : Proper (Z.le ==> Z.le) Z.succ.
   Proof. repeat (lia || intro). Qed.
-  Hint Resolve succ_le_Proper : zarith.
+  Global Hint Resolve succ_le_Proper : zarith.
   Lemma add_le_Proper : Proper (Z.le ==> Z.le ==> Z.le) Z.add.
   Proof. repeat (lia || intro). Qed.
-  Hint Resolve add_le_Proper : zarith.
+  Global Hint Resolve add_le_Proper : zarith.
   Lemma add_le_Proper' x : Proper (Z.le ==> Z.le) (Z.add x).
   Proof. repeat (lia || intro). Qed.
-  Hint Resolve add_le_Proper' : zarith.
+  Global Hint Resolve add_le_Proper' : zarith.
   Lemma sub_le_ge_Proper : Proper (Z.le ==> Z.ge ==> Z.le) Z.sub.
   Proof. repeat (lia || intro). Qed.
-  Hint Resolve sub_le_ge_Proper : zarith.
+  Global Hint Resolve sub_le_ge_Proper : zarith.
   Lemma sub_le_flip_le_Proper : Proper (Z.le ==> Basics.flip Z.le ==> Z.le) Z.sub.
   Proof. unfold Basics.flip; repeat (lia || intro). Qed.
-  Hint Resolve sub_le_flip_le_Proper : zarith.
+  Global Hint Resolve sub_le_flip_le_Proper : zarith.
   Lemma sub_le_eq_Proper : Proper (Z.le ==> Logic.eq ==> Z.le) Z.sub.
   Proof. repeat (lia || intro). Qed.
-  Hint Resolve sub_le_eq_Proper : zarith.
+  Global Hint Resolve sub_le_eq_Proper : zarith.
   Lemma mul_Zpos_le_Proper p : Proper (Z.le ==> Z.le) (Z.mul (Z.pos p)).
   Proof. repeat (nia || intro). Qed.
-  Hint Resolve mul_Zpos_le_Proper : zarith.
+  Global Hint Resolve mul_Zpos_le_Proper : zarith.
   Lemma log2_up_le_Proper : Proper (Z.le ==> Z.le) Z.log2_up.
   Proof. intros ???; apply Z.log2_up_le_mono; assumption. Qed.
-  Hint Resolve log2_up_le_Proper : zarith.
+  Global Hint Resolve log2_up_le_Proper : zarith.
   Lemma log2_le_Proper : Proper (Z.le ==> Z.le) Z.log2.
   Proof. intros ???; apply Z.log2_le_mono; assumption. Qed.
-  Hint Resolve log2_le_Proper : zarith.
+  Global Hint Resolve log2_le_Proper : zarith.
   Lemma pow_Zpos_le_Proper x : Proper (Z.le ==> Z.le) (Z.pow (Z.pos x)).
   Proof. intros ???; apply Z.pow_le_mono_r; try reflexivity; try assumption. Qed.
-  Hint Resolve pow_Zpos_le_Proper : zarith.
+  Global Hint Resolve pow_Zpos_le_Proper : zarith.
   Lemma lt_le_flip_Proper_flip_impl
     : Proper (Z.le ==> Basics.flip Z.le ==> Basics.flip Basics.impl) Z.lt.
   Proof. unfold Basics.flip; repeat (lia || intro). Qed.
-  Hint Resolve lt_le_flip_Proper_flip_impl : zarith.
+  Global Hint Resolve lt_le_flip_Proper_flip_impl : zarith.
   Lemma le_Proper_ge_le_flip_impl : Proper (Z.le ==> Z.ge ==> Basics.flip Basics.impl) Z.le.
   Proof. intros ???????; lia. Qed.
-  Hint Resolve le_Proper_ge_le_flip_impl : zarith.
+  Global Hint Resolve le_Proper_ge_le_flip_impl : zarith.
   Lemma add_le_Proper_flip : Proper (Basics.flip Z.le ==> Basics.flip Z.le ==> Basics.flip Z.le) Z.add.
   Proof. unfold Basics.flip; repeat (lia || intro). Qed.
-  Hint Resolve add_le_Proper_flip : zarith.
+  Global Hint Resolve add_le_Proper_flip : zarith.
   Lemma sub_le_ge_Proper_flip : Proper (Basics.flip Z.le ==> Basics.flip Z.ge ==> Basics.flip Z.le) Z.sub.
   Proof. unfold Basics.flip; repeat (lia || intro). Qed.
-  Hint Resolve sub_le_ge_Proper_flip : zarith.
+  Global Hint Resolve sub_le_ge_Proper_flip : zarith.
   Lemma sub_flip_le_le_Proper_flip : Proper (Basics.flip Z.le ==> Z.le ==> Basics.flip Z.le) Z.sub.
   Proof. unfold Basics.flip; repeat (lia || intro). Qed.
-  Hint Resolve sub_flip_le_le_Proper_flip : zarith.
+  Global Hint Resolve sub_flip_le_le_Proper_flip : zarith.
   Lemma sub_le_eq_Proper_flip : Proper (Basics.flip Z.le ==> Logic.eq ==> Basics.flip Z.le) Z.sub.
   Proof. unfold Basics.flip; repeat (lia || intro). Qed.
-  Hint Resolve sub_le_eq_Proper_flip : zarith.
+  Global Hint Resolve sub_le_eq_Proper_flip : zarith.
   Lemma log2_up_le_Proper_flip : Proper (Basics.flip Z.le ==> Basics.flip Z.le) Z.log2_up.
   Proof. intros ???; apply Z.log2_up_le_mono; assumption. Qed.
-  Hint Resolve log2_up_le_Proper_flip : zarith.
+  Global Hint Resolve log2_up_le_Proper_flip : zarith.
   Lemma log2_le_Proper_flip : Proper (Basics.flip Z.le ==> Basics.flip Z.le) Z.log2.
   Proof. intros ???; apply Z.log2_le_mono; assumption. Qed.
-  Hint Resolve log2_le_Proper_flip : zarith.
+  Global Hint Resolve log2_le_Proper_flip : zarith.
   Lemma pow_Zpos_le_Proper_flip x : Proper (Basics.flip Z.le ==> Basics.flip Z.le) (Z.pow (Z.pos x)).
   Proof. intros ???; apply Z.pow_le_mono_r; try reflexivity; try assumption. Qed.
-  Hint Resolve pow_Zpos_le_Proper_flip : zarith.
+  Global Hint Resolve pow_Zpos_le_Proper_flip : zarith.
   Lemma add_with_carry_le_Proper : Proper (Z.le ==> Z.le ==> Z.le ==> Z.le) Z.add_with_carry.
   Proof. unfold Z.add_with_carry; repeat (lia || intro). Qed.
-  Hint Resolve add_with_carry_le_Proper : zarith.
+  Global Hint Resolve add_with_carry_le_Proper : zarith.
   Lemma sub_with_borrow_le_Proper : Proper (Basics.flip Z.le ==> Z.le ==> Basics.flip Z.le ==> Z.le) Z.sub_with_borrow.
   Proof. unfold Z.sub_with_borrow, Z.add_with_carry, Basics.flip; repeat (lia || intro). Qed.
-  Hint Resolve sub_with_borrow_le_Proper : zarith.
+  Global Hint Resolve sub_with_borrow_le_Proper : zarith.
   Lemma opp_flip_le_le_Proper : Proper (Basics.flip Z.le ==> Z.le) Z.opp.
   Proof. cbv [Basics.flip]; repeat (lia || intro). Qed.
-  Hint Resolve opp_flip_le_le_Proper : zarith.
+  Global Hint Resolve opp_flip_le_le_Proper : zarith.
   Lemma opp_le_flip_le_Proper : Proper (Z.le ==> Basics.flip Z.le) Z.opp.
   Proof. cbv [Basics.flip]; repeat (lia || intro). Qed.
-  Hint Resolve opp_le_flip_le_Proper : zarith.
+  Global Hint Resolve opp_le_flip_le_Proper : zarith.
   Lemma opp_le_ge_Proper : Proper (Z.le ==> Z.ge) Z.opp.
   Proof. cbv [Basics.flip]; repeat (lia || intro). Qed.
-  Hint Resolve opp_le_ge_Proper : zarith.
+  Global Hint Resolve opp_le_ge_Proper : zarith.
   Lemma opp_ge_le_Proper : Proper (Z.ge ==> Z.le) Z.opp.
   Proof. cbv [Basics.flip]; repeat (lia || intro). Qed.
-  Hint Resolve opp_ge_le_Proper : zarith.
+  Global Hint Resolve opp_ge_le_Proper : zarith.
   Lemma add_le_Proper'' x : Proper (Z.le ==> Z.le) (fun y => Z.add y x).
   Proof. repeat (lia || intro). Qed.
-  Hint Resolve add_le_Proper'' : zarith.
+  Global Hint Resolve add_le_Proper'' : zarith.
   Lemma sub_le_ge_Proper_r p : Proper (Z.le ==> Z.ge) (Z.sub p).
   Proof. repeat (lia || intro). Qed.
-  Hint Resolve sub_le_ge_Proper_r : zarith.
+  Global Hint Resolve sub_le_ge_Proper_r : zarith.
   Lemma sub_le_le_Proper_l p : Proper (Z.le ==> Z.le) (fun x => Z.sub x p).
   Proof. repeat (lia || intro). Qed.
-  Hint Resolve sub_le_le_Proper_l : zarith.
+  Global Hint Resolve sub_le_le_Proper_l : zarith.
   Lemma sub_le_flip_le_Proper_r p : Proper (Z.le ==> Basics.flip Z.le) (Z.sub p).
   Proof. unfold Basics.flip; repeat (lia || intro). Qed.
-  Hint Resolve sub_le_flip_le_Proper_r : zarith.
+  Global Hint Resolve sub_le_flip_le_Proper_r : zarith.
   Lemma sub_flip_le_le_Proper_r p : Proper (Basics.flip Z.le ==> Z.le) (Z.sub p).
   Proof. unfold Basics.flip; repeat (lia || intro). Qed.
-  Hint Resolve sub_flip_le_le_Proper_r : zarith.
+  Global Hint Resolve sub_flip_le_le_Proper_r : zarith.
   Lemma sub_ge_le_Proper_r p : Proper (Z.ge ==> Z.le) (Z.sub p).
   Proof. unfold Basics.flip; repeat (lia || intro). Qed.
-  Hint Resolve sub_ge_le_Proper_r : zarith.
+  Global Hint Resolve sub_ge_le_Proper_r : zarith.
   Lemma mul_Z0_le_Proper : Proper (Z.le ==> Z.le) (Z.mul Z0).
   Proof. repeat (nia || intro). Qed.
-  Hint Resolve mul_Z0_le_Proper : zarith.
+  Global Hint Resolve mul_Z0_le_Proper : zarith.
   Lemma mul_Zneg_le_flip_le_Proper p : Proper (Z.le ==> Basics.flip Z.le) (Z.mul (Zneg p)).
   Proof. cbv [Basics.flip]; repeat (nia || intro). Qed.
-  Hint Resolve mul_Zneg_le_flip_le_Proper : zarith.
+  Global Hint Resolve mul_Zneg_le_flip_le_Proper : zarith.
   Lemma mul_Zneg_le_ge_Proper p : Proper (Z.le ==> Z.ge) (Z.mul (Zneg p)).
   Proof. cbv [Basics.flip]; repeat (nia || intro). Qed.
-  Hint Resolve mul_Zneg_le_ge_Proper : zarith.
+  Global Hint Resolve mul_Zneg_le_ge_Proper : zarith.
   Lemma mul_Zneg_flip_le_le_Proper p : Proper (Basics.flip Z.le ==> Z.le) (Z.mul (Zneg p)).
   Proof. cbv [Basics.flip]; repeat (nia || intro). Qed.
-  Hint Resolve mul_Zneg_flip_le_le_Proper : zarith.
+  Global Hint Resolve mul_Zneg_flip_le_le_Proper : zarith.
   Lemma mul_Zneg_ge_le_Proper p : Proper (Z.ge ==> Z.le) (Z.mul (Zneg p)).
   Proof. cbv [Basics.flip]; repeat (nia || intro). Qed.
-  Hint Resolve mul_Zneg_ge_le_Proper : zarith.
+  Global Hint Resolve mul_Zneg_ge_le_Proper : zarith.
   Lemma mul_Zpos_le_Proper' p : Proper (Z.le ==> Z.le) (fun y => Z.mul y (Zpos p)).
   Proof. cbv [Basics.flip]; repeat (nia || intro). Qed.
-  Hint Resolve mul_Zpos_le_Proper' : zarith.
+  Global Hint Resolve mul_Zpos_le_Proper' : zarith.
   Lemma mul_Z0_le_Proper' : Proper (Z.le ==> Z.le) (fun y => Z.mul y Z0).
   Proof. repeat (nia || intro). Qed.
-  Hint Resolve mul_Z0_le_Proper' : zarith.
+  Global Hint Resolve mul_Z0_le_Proper' : zarith.
   Lemma mul_Zneg_le_flip_le_Proper' p : Proper (Z.le ==> Basics.flip Z.le) (fun y => Z.mul y (Zneg p)).
   Proof. cbv [Basics.flip]; repeat (nia || intro). Qed.
-  Hint Resolve mul_Zneg_le_flip_le_Proper' : zarith.
+  Global Hint Resolve mul_Zneg_le_flip_le_Proper' : zarith.
   Lemma mul_Zneg_le_ge_Proper' p : Proper (Z.le ==> Z.ge) (fun y => Z.mul y (Zneg p)).
   Proof. cbv [Basics.flip]; repeat (nia || intro). Qed.
-  Hint Resolve mul_Zneg_le_ge_Proper' : zarith.
+  Global Hint Resolve mul_Zneg_le_ge_Proper' : zarith.
   Lemma mul_Zneg_flip_le_le_Proper' p : Proper (Basics.flip Z.le ==> Z.le) (fun y => Z.mul y (Zneg p)).
   Proof. cbv [Basics.flip]; repeat (nia || intro). Qed.
-  Hint Resolve mul_Zneg_flip_le_le_Proper' : zarith.
+  Global Hint Resolve mul_Zneg_flip_le_le_Proper' : zarith.
   Lemma mul_Zneg_ge_le_Proper' p : Proper (Z.ge ==> Z.le) (fun y => Z.mul y (Zneg p)).
   Proof. cbv [Basics.flip]; repeat (nia || intro). Qed.
-  Hint Resolve mul_Zneg_ge_le_Proper' : zarith.
+  Global Hint Resolve mul_Zneg_ge_le_Proper' : zarith.
   Lemma div_Zpos_le_Proper_r p : Proper (Z.le ==> Z.le) (fun x => Z.div x (Zpos p)).
   Proof. repeat (nia || Z.div_mod_to_quot_rem || intro). Qed.
-  Hint Resolve div_Zpos_le_Proper_r : zarith.
+  Global Hint Resolve div_Zpos_le_Proper_r : zarith.
   Lemma div_Z0_le_Proper_r : Proper (Z.le ==> Z.le) (fun x => Z.div x Z0).
   Proof. repeat (nia || Z.div_mod_to_quot_rem || intro). Qed.
-  Hint Resolve div_Z0_le_Proper_r : zarith.
+  Global Hint Resolve div_Z0_le_Proper_r : zarith.
   Lemma div_Zneg_le_flip_le_Proper_r p : Proper (Z.le ==> Basics.flip Z.le) (fun x => Z.div x (Zneg p)).
   Proof. cbv [Basics.flip]; repeat (nia || Z.div_mod_to_quot_rem || intro). Qed.
-  Hint Resolve div_Zneg_le_flip_le_Proper_r : zarith.
+  Global Hint Resolve div_Zneg_le_flip_le_Proper_r : zarith.
   Lemma div_Zneg_flip_le_le_Proper_r p : Proper (Basics.flip Z.le ==> Z.le) (fun x => Z.div x (Zneg p)).
   Proof. cbv [Basics.flip]; repeat (nia || Z.div_mod_to_quot_rem || intro). Qed.
-  Hint Resolve div_Zneg_flip_le_le_Proper_r : zarith.
+  Global Hint Resolve div_Zneg_flip_le_le_Proper_r : zarith.
   Lemma div_Z0_le_Proper_l : Proper (Z.le ==> Z.le) (Z.div Z0).
   Proof. do 3 intro; destruct_head' Z; cbv; congruence. Qed.
-  Hint Resolve div_Z0_le_Proper_l : zarith.
+  Global Hint Resolve div_Z0_le_Proper_l : zarith.
   Local Ltac div_Proper_t :=
     let H := fresh in
     cbv [Basics.flip]; intros ?? H; apply Pos2Z.pos_le_pos in H;
     apply Z.div_cross_le_abs; cbn [Z.sgn Z.abs]; try nia.
   Lemma div_Zpos_Zpos_le_Proper_l p : Proper (Basics.flip Pos.le ==> Z.le) (fun x => Z.div (Zpos p) (Zpos x)).
   Proof. div_Proper_t. Qed.
-  Hint Resolve div_Zpos_Zpos_le_Proper_l : zarith.
+  Global Hint Resolve div_Zpos_Zpos_le_Proper_l : zarith.
   Lemma div_Zpos_Zneg_le_Proper_l p : Proper (Pos.le ==> Z.le) (fun x => Z.div (Zpos p) (Zneg x)).
   Proof. div_Proper_t. Qed.
-  Hint Resolve div_Zpos_Zneg_le_Proper_l : zarith.
+  Global Hint Resolve div_Zpos_Zneg_le_Proper_l : zarith.
   Lemma div_Zneg_Zpos_le_Proper_l p : Proper (Pos.le ==> Z.le) (fun x => Z.div (Zneg p) (Zpos x)).
   Proof. div_Proper_t. Qed.
-  Hint Resolve div_Zneg_Zpos_le_Proper_l : zarith.
+  Global Hint Resolve div_Zneg_Zpos_le_Proper_l : zarith.
   Lemma div_Zneg_Zneg_le_Proper_l p : Proper (Basics.flip Pos.le ==> Z.le) (fun x => Z.div (Zneg p) (Zneg x)).
   Proof. div_Proper_t. Qed.
-  Hint Resolve div_Zneg_Zneg_le_Proper_l : zarith.
+  Global Hint Resolve div_Zneg_Zneg_le_Proper_l : zarith.
   Lemma div_Z0_Zpos_le_Proper_l : Proper (Basics.flip Pos.le ==> Z.le) (fun x => Z.div Z0 (Zpos x)).
   Proof. div_Proper_t. Qed.
-  Hint Resolve div_Z0_Zpos_le_Proper_l : zarith.
+  Global Hint Resolve div_Z0_Zpos_le_Proper_l : zarith.
   Lemma div_Z0_Zneg_le_Proper_l : Proper (Pos.le ==> Z.le) (fun x => Z.div Z0 (Zneg x)).
   Proof. div_Proper_t. Qed.
-  Hint Resolve div_Z0_Zneg_le_Proper_l : zarith.
+  Global Hint Resolve div_Z0_Zneg_le_Proper_l : zarith.
   Lemma div_Zpos_Zpos_le_Proper_r x : Proper (Pos.le ==> Z.le) (fun p => Z.div (Zpos p) (Zpos x)).
   Proof. div_Proper_t. Qed.
-  Hint Resolve div_Zpos_Zpos_le_Proper_r : zarith.
+  Global Hint Resolve div_Zpos_Zpos_le_Proper_r : zarith.
   Lemma div_Zpos_Zneg_le_Proper_r x : Proper (Basics.flip Pos.le ==> Z.le) (fun p => Z.div (Zpos p) (Zneg x)).
   Proof. div_Proper_t. Qed.
-  Hint Resolve div_Zpos_Zneg_le_Proper_r : zarith.
+  Global Hint Resolve div_Zpos_Zneg_le_Proper_r : zarith.
   Lemma div_Zneg_Zpos_le_Proper_r x : Proper (Basics.flip Pos.le ==> Z.le) (fun p => Z.div (Zneg p) (Zpos x)).
   Proof. div_Proper_t. Qed.
-  Hint Resolve div_Zneg_Zpos_le_Proper_r : zarith.
+  Global Hint Resolve div_Zneg_Zpos_le_Proper_r : zarith.
   Lemma div_Zneg_Zneg_le_Proper_r x : Proper (Pos.le ==> Z.le) (fun p => Z.div (Zneg p) (Zneg x)).
   Proof. div_Proper_t. Qed.
-  Hint Resolve div_Zneg_Zneg_le_Proper_r : zarith.
+  Global Hint Resolve div_Zneg_Zneg_le_Proper_r : zarith.
   Lemma div_Zpos_Z0_le_Proper_r : Proper (Pos.le ==> Z.le) (fun p => Z.div (Zpos p) Z0).
   Proof. do 3 intro; cbv; congruence. Qed.
-  Hint Resolve div_Zpos_Z0_le_Proper_r : zarith.
+  Global Hint Resolve div_Zpos_Z0_le_Proper_r : zarith.
   Lemma div_Zneg_Z0_le_Proper_r : Proper (Basics.flip Pos.le ==> Z.le) (fun p => Z.div (Zneg p) Z0).
   Proof. do 3 intro; cbv; congruence. Qed.
-  Hint Resolve div_Zneg_Z0_le_Proper_r : zarith.
+  Global Hint Resolve div_Zneg_Z0_le_Proper_r : zarith.
   Local Ltac shift_t :=
     repeat first [ progress intros
                  | progress cbv [Proper respectful Basics.flip] in *
@@ -224,20 +225,20 @@ Module Z.
                  | apply Z.div_cross_le_abs; cbn [Z.sgn Z.abs]; nia ].
   Lemma shiftr_le_Proper_l : forall y : Z, Proper (Z.le ==> Z.le) (fun x : Z => Z.shiftr x y).
   Proof. shift_t. Qed.
-  Hint Resolve shiftr_le_Proper_l : zarith.
+  Global Hint Resolve shiftr_le_Proper_l : zarith.
   Lemma shiftl_le_Proper_l : forall y : Z, Proper (Z.le ==> Z.le) (fun x : Z => Z.shiftl x y).
   Proof. shift_t. Qed.
-  Hint Resolve shiftl_le_Proper_l : zarith.
+  Global Hint Resolve shiftl_le_Proper_l : zarith.
   Lemma shiftr_le_Proper_r x
         (R := fun b : bool => if b then Basics.flip Z.le else Z.le)
     : Proper (R (0 <=? x)%Z ==> Z.le) (Z.shiftr x).
   Proof. subst R; cbv beta; break_match; Z.ltb_to_lt; shift_t. Qed.
-  Hint Resolve shiftr_le_Proper_r : zarith.
+  Global Hint Resolve shiftr_le_Proper_r : zarith.
   Lemma shiftl_le_Proper_r x
         (R := fun b : bool => if b then Z.le else Basics.flip Z.le)
     : Proper (R (0 <=? x)%Z ==> Z.le) (Z.shiftl x).
   Proof. subst R; cbv beta; break_match; Z.ltb_to_lt; shift_t. Qed.
-  Hint Resolve shiftl_le_Proper_r : zarith.
+  Global Hint Resolve shiftl_le_Proper_r : zarith.
   Local Ltac shift_Proper_t' :=
     let H := fresh in
     cbv [Basics.flip]; intros ?? H; apply Pos2Z.pos_le_pos in H;
@@ -246,83 +247,170 @@ Module Z.
          lia).
   Lemma shiftr_Zpos_Zpos_le_Proper_l p : Proper (Basics.flip Pos.le ==> Z.le) (fun x => Z.shiftr (Zpos p) (Zpos x)).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftr_Zpos_Zpos_le_Proper_l : zarith.
+  Global Hint Resolve shiftr_Zpos_Zpos_le_Proper_l : zarith.
   Lemma shiftr_Zpos_Zneg_le_Proper_l p : Proper (Pos.le ==> Z.le) (fun x => Z.shiftr (Zpos p) (Zneg x)).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftr_Zpos_Zneg_le_Proper_l : zarith.
+  Global Hint Resolve shiftr_Zpos_Zneg_le_Proper_l : zarith.
   Lemma shiftr_Zneg_Zpos_le_Proper_l p : Proper (Pos.le ==> Z.le) (fun x => Z.shiftr (Zneg p) (Zpos x)).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftr_Zneg_Zpos_le_Proper_l : zarith.
+  Global Hint Resolve shiftr_Zneg_Zpos_le_Proper_l : zarith.
   Lemma shiftr_Zneg_Zneg_le_Proper_l p : Proper (Basics.flip Pos.le ==> Z.le) (fun x => Z.shiftr (Zneg p) (Zneg x)).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftr_Zneg_Zneg_le_Proper_l : zarith.
+  Global Hint Resolve shiftr_Zneg_Zneg_le_Proper_l : zarith.
   Lemma shiftr_Z0_Zpos_le_Proper_l : Proper (Basics.flip Pos.le ==> Z.le) (fun x => Z.shiftr Z0 (Zpos x)).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftr_Z0_Zpos_le_Proper_l : zarith.
+  Global Hint Resolve shiftr_Z0_Zpos_le_Proper_l : zarith.
   Lemma shiftr_Z0_Zneg_le_Proper_l : Proper (Pos.le ==> Z.le) (fun x => Z.shiftr Z0 (Zneg x)).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftr_Z0_Zneg_le_Proper_l : zarith.
+  Global Hint Resolve shiftr_Z0_Zneg_le_Proper_l : zarith.
   Lemma shiftr_Zpos_Zpos_le_Proper_r x : Proper (Pos.le ==> Z.le) (fun p => Z.shiftr (Zpos p) (Zpos x)).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftr_Zpos_Zpos_le_Proper_r : zarith.
+  Global Hint Resolve shiftr_Zpos_Zpos_le_Proper_r : zarith.
   Lemma shiftr_Zpos_Zneg_le_Proper_r x : Proper (Pos.le ==> Z.le) (fun p => Z.shiftr (Zpos p) (Zneg x)).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftr_Zpos_Zneg_le_Proper_r : zarith.
+  Global Hint Resolve shiftr_Zpos_Zneg_le_Proper_r : zarith.
   Lemma shiftr_Zneg_Zpos_le_Proper_r x : Proper (Basics.flip Pos.le ==> Z.le) (fun p => Z.shiftr (Zneg p) (Zpos x)).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftr_Zneg_Zpos_le_Proper_r : zarith.
+  Global Hint Resolve shiftr_Zneg_Zpos_le_Proper_r : zarith.
   Lemma shiftr_Zneg_Zneg_le_Proper_r x : Proper (Basics.flip Pos.le ==> Z.le) (fun p => Z.shiftr (Zneg p) (Zneg x)).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftr_Zneg_Zneg_le_Proper_r : zarith.
+  Global Hint Resolve shiftr_Zneg_Zneg_le_Proper_r : zarith.
   Lemma shiftr_Zpos_Z0_le_Proper_r : Proper (Pos.le ==> Z.le) (fun p => Z.shiftr (Zpos p) Z0).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftr_Zpos_Z0_le_Proper_r : zarith.
+  Global Hint Resolve shiftr_Zpos_Z0_le_Proper_r : zarith.
   Lemma shiftr_Zneg_Z0_le_Proper_r : Proper (Basics.flip Pos.le ==> Z.le) (fun p => Z.shiftr (Zneg p) Z0).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftr_Zneg_Z0_le_Proper_r : zarith.
+  Global Hint Resolve shiftr_Zneg_Z0_le_Proper_r : zarith.
   Lemma shiftl_Zpos_Zpos_le_Proper_l p : Proper (Pos.le ==> Z.le) (fun x => Z.shiftl (Zpos p) (Zpos x)).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftl_Zpos_Zpos_le_Proper_l : zarith.
+  Global Hint Resolve shiftl_Zpos_Zpos_le_Proper_l : zarith.
   Lemma shiftl_Zpos_Zneg_le_Proper_l p : Proper (Basics.flip Pos.le ==> Z.le) (fun x => Z.shiftl (Zpos p) (Zneg x)).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftl_Zpos_Zneg_le_Proper_l : zarith.
+  Global Hint Resolve shiftl_Zpos_Zneg_le_Proper_l : zarith.
   Lemma shiftl_Zneg_Zpos_le_Proper_l p : Proper (Basics.flip Pos.le ==> Z.le) (fun x => Z.shiftl (Zneg p) (Zpos x)).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftl_Zneg_Zpos_le_Proper_l : zarith.
+  Global Hint Resolve shiftl_Zneg_Zpos_le_Proper_l : zarith.
   Lemma shiftl_Zneg_Zneg_le_Proper_l p : Proper (Pos.le ==> Z.le) (fun x => Z.shiftl (Zneg p) (Zneg x)).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftl_Zneg_Zneg_le_Proper_l : zarith.
+  Global Hint Resolve shiftl_Zneg_Zneg_le_Proper_l : zarith.
   Lemma shiftl_Z0_Zpos_le_Proper_l : Proper (Pos.le ==> Z.le) (fun x => Z.shiftl Z0 (Zpos x)).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftl_Z0_Zpos_le_Proper_l : zarith.
+  Global Hint Resolve shiftl_Z0_Zpos_le_Proper_l : zarith.
   Lemma shiftl_Z0_Zneg_le_Proper_l : Proper (Basics.flip Pos.le ==> Z.le) (fun x => Z.shiftl Z0 (Zneg x)).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftl_Z0_Zneg_le_Proper_l : zarith.
+  Global Hint Resolve shiftl_Z0_Zneg_le_Proper_l : zarith.
   Lemma shiftl_Zpos_Zpos_le_Proper_r x : Proper (Pos.le ==> Z.le) (fun p => Z.shiftl (Zpos p) (Zpos x)).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftl_Zpos_Zpos_le_Proper_r : zarith.
+  Global Hint Resolve shiftl_Zpos_Zpos_le_Proper_r : zarith.
   Lemma shiftl_Zpos_Zneg_le_Proper_r x : Proper (Pos.le ==> Z.le) (fun p => Z.shiftl (Zpos p) (Zneg x)).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftl_Zpos_Zneg_le_Proper_r : zarith.
+  Global Hint Resolve shiftl_Zpos_Zneg_le_Proper_r : zarith.
   Lemma shiftl_Zneg_Zpos_le_Proper_r x : Proper (Basics.flip Pos.le ==> Z.le) (fun p => Z.shiftl (Zneg p) (Zpos x)).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftl_Zneg_Zpos_le_Proper_r : zarith.
+  Global Hint Resolve shiftl_Zneg_Zpos_le_Proper_r : zarith.
   Lemma shiftl_Zneg_Zneg_le_Proper_r x : Proper (Basics.flip Pos.le ==> Z.le) (fun p => Z.shiftl (Zneg p) (Zneg x)).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftl_Zneg_Zneg_le_Proper_r : zarith.
+  Global Hint Resolve shiftl_Zneg_Zneg_le_Proper_r : zarith.
   Lemma shiftl_Zpos_Z0_le_Proper_r : Proper (Pos.le ==> Z.le) (fun p => Z.shiftl (Zpos p) Z0).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftl_Zpos_Z0_le_Proper_r : zarith.
+  Global Hint Resolve shiftl_Zpos_Z0_le_Proper_r : zarith.
   Lemma shiftl_Zneg_Z0_le_Proper_r : Proper (Basics.flip Pos.le ==> Z.le) (fun p => Z.shiftl (Zneg p) Z0).
   Proof. shift_Proper_t'. Qed.
-  Hint Resolve shiftl_Zneg_Z0_le_Proper_r : zarith.
-
-  Hint Resolve Z.land_round_Proper_pos_r : zarith.
-  Hint Resolve Z.land_round_Proper_pos_l : zarith.
-  Hint Resolve Z.lor_round_Proper_pos_r : zarith.
-  Hint Resolve Z.lor_round_Proper_pos_l : zarith.
-  Hint Resolve Z.land_round_Proper_neg_r : zarith.
-  Hint Resolve Z.land_round_Proper_neg_l : zarith.
-  Hint Resolve Z.lor_round_Proper_neg_r : zarith.
-  Hint Resolve Z.lor_round_Proper_neg_l : zarith.
+  Global Hint Resolve shiftl_Zneg_Z0_le_Proper_r : zarith.
 End Z.
+
+Global Hint Resolve Z.succ_le_Proper : zarith.
+Global Hint Resolve Z.add_le_Proper : zarith.
+Global Hint Resolve Z.add_le_Proper' : zarith.
+Global Hint Resolve Z.sub_le_ge_Proper : zarith.
+Global Hint Resolve Z.sub_le_flip_le_Proper : zarith.
+Global Hint Resolve Z.sub_le_eq_Proper : zarith.
+Global Hint Resolve Z.mul_Zpos_le_Proper : zarith.
+Global Hint Resolve Z.log2_up_le_Proper : zarith.
+Global Hint Resolve Z.log2_le_Proper : zarith.
+Global Hint Resolve Z.pow_Zpos_le_Proper : zarith.
+Global Hint Resolve Z.lt_le_flip_Proper_flip_impl : zarith.
+Global Hint Resolve Z.le_Proper_ge_le_flip_impl : zarith.
+Global Hint Resolve Z.add_le_Proper_flip : zarith.
+Global Hint Resolve Z.sub_le_ge_Proper_flip : zarith.
+Global Hint Resolve Z.sub_flip_le_le_Proper_flip : zarith.
+Global Hint Resolve Z.sub_le_eq_Proper_flip : zarith.
+Global Hint Resolve Z.log2_up_le_Proper_flip : zarith.
+Global Hint Resolve Z.log2_le_Proper_flip : zarith.
+Global Hint Resolve Z.pow_Zpos_le_Proper_flip : zarith.
+Global Hint Resolve Z.add_with_carry_le_Proper : zarith.
+Global Hint Resolve Z.sub_with_borrow_le_Proper : zarith.
+Global Hint Resolve Z.opp_flip_le_le_Proper : zarith.
+Global Hint Resolve Z.opp_le_flip_le_Proper : zarith.
+Global Hint Resolve Z.opp_le_ge_Proper : zarith.
+Global Hint Resolve Z.opp_ge_le_Proper : zarith.
+Global Hint Resolve Z.add_le_Proper'' : zarith.
+Global Hint Resolve Z.sub_le_ge_Proper_r : zarith.
+Global Hint Resolve Z.sub_le_le_Proper_l : zarith.
+Global Hint Resolve Z.sub_le_flip_le_Proper_r : zarith.
+Global Hint Resolve Z.sub_flip_le_le_Proper_r : zarith.
+Global Hint Resolve Z.sub_ge_le_Proper_r : zarith.
+Global Hint Resolve Z.mul_Z0_le_Proper : zarith.
+Global Hint Resolve Z.mul_Zneg_le_flip_le_Proper : zarith.
+Global Hint Resolve Z.mul_Zneg_le_ge_Proper : zarith.
+Global Hint Resolve Z.mul_Zneg_flip_le_le_Proper : zarith.
+Global Hint Resolve Z.mul_Zneg_ge_le_Proper : zarith.
+Global Hint Resolve Z.mul_Zpos_le_Proper' : zarith.
+Global Hint Resolve Z.mul_Z0_le_Proper' : zarith.
+Global Hint Resolve Z.mul_Zneg_le_flip_le_Proper' : zarith.
+Global Hint Resolve Z.mul_Zneg_le_ge_Proper' : zarith.
+Global Hint Resolve Z.mul_Zneg_flip_le_le_Proper' : zarith.
+Global Hint Resolve Z.mul_Zneg_ge_le_Proper' : zarith.
+Global Hint Resolve Z.div_Zpos_le_Proper_r : zarith.
+Global Hint Resolve Z.div_Z0_le_Proper_r : zarith.
+Global Hint Resolve Z.div_Zneg_le_flip_le_Proper_r : zarith.
+Global Hint Resolve Z.div_Zneg_flip_le_le_Proper_r : zarith.
+Global Hint Resolve Z.div_Z0_le_Proper_l : zarith.
+Global Hint Resolve Z.div_Zpos_Zpos_le_Proper_l : zarith.
+Global Hint Resolve Z.div_Zpos_Zneg_le_Proper_l : zarith.
+Global Hint Resolve Z.div_Zneg_Zpos_le_Proper_l : zarith.
+Global Hint Resolve Z.div_Zneg_Zneg_le_Proper_l : zarith.
+Global Hint Resolve Z.div_Z0_Zpos_le_Proper_l : zarith.
+Global Hint Resolve Z.div_Z0_Zneg_le_Proper_l : zarith.
+Global Hint Resolve Z.div_Zpos_Zpos_le_Proper_r : zarith.
+Global Hint Resolve Z.div_Zpos_Zneg_le_Proper_r : zarith.
+Global Hint Resolve Z.div_Zneg_Zpos_le_Proper_r : zarith.
+Global Hint Resolve Z.div_Zneg_Zneg_le_Proper_r : zarith.
+Global Hint Resolve Z.div_Zpos_Z0_le_Proper_r : zarith.
+Global Hint Resolve Z.div_Zneg_Z0_le_Proper_r : zarith.
+Global Hint Resolve Z.shiftr_le_Proper_l : zarith.
+Global Hint Resolve Z.shiftl_le_Proper_l : zarith.
+Global Hint Resolve Z.shiftr_le_Proper_r : zarith.
+Global Hint Resolve Z.shiftl_le_Proper_r : zarith.
+Global Hint Resolve Z.shiftr_Zpos_Zpos_le_Proper_l : zarith.
+Global Hint Resolve Z.shiftr_Zpos_Zneg_le_Proper_l : zarith.
+Global Hint Resolve Z.shiftr_Zneg_Zpos_le_Proper_l : zarith.
+Global Hint Resolve Z.shiftr_Zneg_Zneg_le_Proper_l : zarith.
+Global Hint Resolve Z.shiftr_Z0_Zpos_le_Proper_l : zarith.
+Global Hint Resolve Z.shiftr_Z0_Zneg_le_Proper_l : zarith.
+Global Hint Resolve Z.shiftr_Zpos_Zpos_le_Proper_r : zarith.
+Global Hint Resolve Z.shiftr_Zpos_Zneg_le_Proper_r : zarith.
+Global Hint Resolve Z.shiftr_Zneg_Zpos_le_Proper_r : zarith.
+Global Hint Resolve Z.shiftr_Zneg_Zneg_le_Proper_r : zarith.
+Global Hint Resolve Z.shiftr_Zpos_Z0_le_Proper_r : zarith.
+Global Hint Resolve Z.shiftr_Zneg_Z0_le_Proper_r : zarith.
+Global Hint Resolve Z.shiftl_Zpos_Zpos_le_Proper_l : zarith.
+Global Hint Resolve Z.shiftl_Zpos_Zneg_le_Proper_l : zarith.
+Global Hint Resolve Z.shiftl_Zneg_Zpos_le_Proper_l : zarith.
+Global Hint Resolve Z.shiftl_Zneg_Zneg_le_Proper_l : zarith.
+Global Hint Resolve Z.shiftl_Z0_Zpos_le_Proper_l : zarith.
+Global Hint Resolve Z.shiftl_Z0_Zneg_le_Proper_l : zarith.
+Global Hint Resolve Z.shiftl_Zpos_Zpos_le_Proper_r : zarith.
+Global Hint Resolve Z.shiftl_Zpos_Zneg_le_Proper_r : zarith.
+Global Hint Resolve Z.shiftl_Zneg_Zpos_le_Proper_r : zarith.
+Global Hint Resolve Z.shiftl_Zneg_Zneg_le_Proper_r : zarith.
+Global Hint Resolve Z.shiftl_Zpos_Z0_le_Proper_r : zarith.
+Global Hint Resolve Z.shiftl_Zneg_Z0_le_Proper_r : zarith.
+Global Hint Resolve Z.land_round_Proper_pos_r : zarith.
+Global Hint Resolve Z.land_round_Proper_pos_l : zarith.
+Global Hint Resolve Z.lor_round_Proper_pos_r : zarith.
+Global Hint Resolve Z.lor_round_Proper_pos_l : zarith.
+Global Hint Resolve Z.land_round_Proper_neg_r : zarith.
+Global Hint Resolve Z.land_round_Proper_neg_l : zarith.
+Global Hint Resolve Z.lor_round_Proper_neg_r : zarith.
+Global Hint Resolve Z.lor_round_Proper_neg_l : zarith.

--- a/src/Util/ZUtil/Morphisms.v
+++ b/src/Util/ZUtil/Morphisms.v
@@ -1,6 +1,6 @@
 (** * [Proper] morphisms for ℤ constants *)
-Require Import Coq.micromega.Lia.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Classes.RelationPairs.

--- a/src/Util/ZUtil/Mul.v
+++ b/src/Util/ZUtil/Mul.v
@@ -1,6 +1,6 @@
 Require Export Crypto.Util.GlobalSettings.
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Local Open Scope Z_scope.
 
 Module Z.

--- a/src/Util/ZUtil/Mul.v
+++ b/src/Util/ZUtil/Mul.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.micromega.Lia.
 Local Open Scope Z_scope.

--- a/src/Util/ZUtil/MulSplit.v
+++ b/src/Util/ZUtil/MulSplit.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Definitions.
 Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
 Require Import Crypto.Util.Tactics.BreakMatch.

--- a/src/Util/ZUtil/N2Z.v
+++ b/src/Util/ZUtil/N2Z.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Hints.Core.
 Local Open Scope Z_scope.
 

--- a/src/Util/ZUtil/Odd.v
+++ b/src/Util/ZUtil/Odd.v
@@ -2,7 +2,7 @@ Require Export Crypto.Util.GlobalSettings.
 Require Import Coq.Bool.Bool.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.ZArith.Znumtheory.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Local Open Scope Z_scope.
 
 Module Z.

--- a/src/Util/ZUtil/Odd.v
+++ b/src/Util/ZUtil/Odd.v
@@ -1,3 +1,5 @@
+Require Export Crypto.Util.GlobalSettings.
+Require Import Coq.Bool.Bool.
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.ZArith.Znumtheory.
 Require Import Coq.micromega.Lia.

--- a/src/Util/ZUtil/Ones.v
+++ b/src/Util/ZUtil/Ones.v
@@ -19,14 +19,14 @@ Module Z.
   Proof.
     rewrite !Z.ones_equiv; auto with zarith.
   Qed.
-  Hint Resolve ones_le : zarith.
+  Global Hint Resolve ones_le : zarith.
 
   Lemma ones_lt_pow2 x y : 0 <= x <= y -> Z.ones x < 2^y.
   Proof.
     rewrite Z.ones_equiv, Z.lt_pred_le.
     auto with zarith.
   Qed.
-  Hint Resolve ones_lt_pow2 : zarith.
+  Global Hint Resolve ones_lt_pow2 : zarith.
 
   Lemma log2_ones_full x : Z.log2 (Z.ones x) = Z.max 0 (Z.pred x).
   Proof.
@@ -38,19 +38,19 @@ Module Z.
   Proof.
     rewrite log2_ones_full; apply Z.max_case_strong; lia.
   Qed.
-  Hint Resolve log2_ones_lt : zarith.
+  Global Hint Resolve log2_ones_lt : zarith.
 
   Lemma log2_ones_le x y : 0 <= x <= y -> Z.log2 (Z.ones x) <= y.
   Proof.
     rewrite log2_ones_full; apply Z.max_case_strong; lia.
   Qed.
-  Hint Resolve log2_ones_le : zarith.
+  Global Hint Resolve log2_ones_le : zarith.
 
   Lemma log2_ones_lt_nonneg x y : 0 < y -> x <= y -> Z.log2 (Z.ones x) < y.
   Proof.
     rewrite log2_ones_full; apply Z.max_case_strong; lia.
   Qed.
-  Hint Resolve log2_ones_lt_nonneg : zarith.
+  Global Hint Resolve log2_ones_lt_nonneg : zarith.
 
   Lemma ones_pred : forall i, 0 < i -> Z.ones (Z.pred i) = Z.shiftr (Z.ones i) 1.
   Proof.
@@ -86,7 +86,7 @@ Module Z.
       rewrite Z.ones_succ by assumption.
       Z.zero_bounds.
   Qed.
-  Hint Resolve ones_nonneg : zarith.
+  Global Hint Resolve ones_nonneg : zarith.
 
   Lemma ones_pos_pos : forall i, (0 < i) -> 0 < Z.ones i.
   Proof.
@@ -96,7 +96,7 @@ Module Z.
     apply Z.lt_succ_lt_pred.
     apply Z.pow_gt_1; lia.
   Qed.
-  Hint Resolve ones_pos_pos : zarith.
+  Global Hint Resolve ones_pos_pos : zarith.
 
   Lemma lnot_ones_equiv n : Z.lnot (Z.ones n) = -2^n.
   Proof. rewrite Z.ones_equiv, Z.lnot_equiv, <- ?Z.sub_1_r; lia. Qed.

--- a/src/Util/ZUtil/Ones.v
+++ b/src/Util/ZUtil/Ones.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Pow2.
 Require Import Crypto.Util.ZUtil.Log2.
 Require Import Crypto.Util.ZUtil.Lnot.

--- a/src/Util/ZUtil/Opp.v
+++ b/src/Util/ZUtil/Opp.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Hints.Core.
 Require Import Crypto.Util.ZUtil.ZSimplify.Core.
 Local Open Scope Z_scope.

--- a/src/Util/ZUtil/Peano.v
+++ b/src/Util/ZUtil/Peano.v
@@ -1,5 +1,5 @@
 (** * Basic Peano-arithmetic-like properties of ℤ *)
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.BinInt.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.HProp.

--- a/src/Util/ZUtil/Pow.v
+++ b/src/Util/ZUtil/Pow.v
@@ -8,7 +8,6 @@ Module Z.
   Proof.
     destruct n; intro H; try reflexivity; compute in H; congruence.
   Qed.
-  Hint Rewrite base_pow_neg using zutil_arith : zsimplify.
 
   Lemma nonneg_pow_pos a b : 0 < a -> 0 < a^b -> 0 <= b.
   Proof.
@@ -16,10 +15,10 @@ Module Z.
     erewrite Z.pow_neg_r in * by eassumption.
     lia.
   Qed.
-  Hint Resolve nonneg_pow_pos (fun n => nonneg_pow_pos 2 n Z.lt_0_2) : zarith.
+  Global Hint Resolve nonneg_pow_pos (fun n => nonneg_pow_pos 2 n Z.lt_0_2) : zarith.
   Lemma nonneg_pow_pos_helper a b dummy : 0 < a -> 0 <= dummy < a^b -> 0 <= b.
   Proof. eauto with zarith lia. Qed.
-  Hint Resolve nonneg_pow_pos_helper (fun n dummy => nonneg_pow_pos_helper 2 n dummy Z.lt_0_2) : zarith.
+  Global Hint Resolve nonneg_pow_pos_helper (fun n dummy => nonneg_pow_pos_helper 2 n dummy Z.lt_0_2) : zarith.
 
   Lemma div_pow2succ : forall n x, (0 <= x) ->
     n / 2 ^ Z.succ x = Z.div2 (n / 2 ^ x).
@@ -35,10 +34,13 @@ Module Z.
     := fun a b c y H0 H1 => @Logic.eq_trans _ _ _ y (@Z.pow_sub_r a b c H0 H1).
   Definition pow_sub_r'_sym
     := fun a b c y p H0 H1 => Logic.eq_sym (@Logic.eq_trans _ y _ _ (Logic.eq_sym p) (@Z.pow_sub_r a b c H0 H1)).
-  Hint Resolve pow_sub_r' pow_sub_r'_sym Z.eq_le_incl : zarith.
-  Hint Resolve (fun b => f_equal (fun e => b ^ e)) (fun e => f_equal (fun b => b ^ e)) : zarith.
 
   Lemma two_p_two_eq_four : 2^(2) = 4.
   Proof. reflexivity. Qed.
-  Hint Rewrite <- two_p_two_eq_four : push_Zpow.
 End Z.
+Hint Rewrite Z.base_pow_neg using zutil_arith : zsimplify.
+Hint Rewrite <- Z.two_p_two_eq_four : push_Zpow.
+Global Hint Resolve Z.pow_sub_r' Z.pow_sub_r'_sym Z.eq_le_incl : zarith.
+Global Hint Resolve (fun b => f_equal (fun e => b ^ e)) (fun e => f_equal (fun b => b ^ e)) : zarith.
+Global Hint Resolve Z.nonneg_pow_pos (fun n => Z.nonneg_pow_pos 2 n Z.lt_0_2) : zarith.
+Global Hint Resolve Z.nonneg_pow_pos_helper (fun n dummy => Z.nonneg_pow_pos_helper 2 n dummy Z.lt_0_2) : zarith.

--- a/src/Util/ZUtil/Pow.v
+++ b/src/Util/ZUtil/Pow.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Hints.Core.
 Local Open Scope Z_scope.
 

--- a/src/Util/ZUtil/Pow2.v
+++ b/src/Util/ZUtil/Pow2.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 Require Import Coq.micromega.Lia.
 Require Import Coq.ZArith.ZArith.
 Local Open Scope Z_scope.

--- a/src/Util/ZUtil/Pow2.v
+++ b/src/Util/ZUtil/Pow2.v
@@ -1,5 +1,5 @@
 Require Export Crypto.Util.GlobalSettings.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Local Open Scope Z_scope.
 

--- a/src/Util/ZUtil/Pow2Mod.v
+++ b/src/Util/ZUtil/Pow2Mod.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Definitions.
 Require Import Crypto.Util.ZUtil.Notations.
 Require Import Crypto.Util.ZUtil.Hints.Core.

--- a/src/Util/ZUtil/Pow2Mod.v
+++ b/src/Util/ZUtil/Pow2Mod.v
@@ -3,6 +3,7 @@ Require Import Coq.micromega.Lia.
 Require Import Crypto.Util.ZUtil.Definitions.
 Require Import Crypto.Util.ZUtil.Notations.
 Require Import Crypto.Util.ZUtil.Hints.Core.
+Require Import Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.ZUtil.Hints.Ztestbit.
 Require Import Crypto.Util.ZUtil.Tactics.ZeroBounds.
 Require Import Crypto.Util.ZUtil.Testbit.
@@ -52,7 +53,7 @@ Module Z.
     intros; rewrite Z.pow2_mod_spec by lia.
     auto with zarith.
   Qed.
-  Hint Resolve pow2_mod_pos_bound : zarith.
+  Global Hint Resolve pow2_mod_pos_bound : zarith.
 
   Lemma pow2_mod_id_iff : forall a n, 0 <= n ->
                                       (Z.pow2_mod a n = a <-> 0 <= a < 2 ^ n).
@@ -64,3 +65,5 @@ Module Z.
     split; intros; intuition lia.
   Qed.
 End Z.
+Hint Rewrite <- Z.pow2_mod_spec using zutil_arith : convert_to_Ztestbit.
+Global Hint Resolve Z.pow2_mod_pos_bound : zarith.

--- a/src/Util/ZUtil/Quot.v
+++ b/src/Util/ZUtil/Quot.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Hints.Core.
 Require Import Crypto.Util.ZUtil.Sgn.
 Require Import Crypto.Util.ZUtil.Modulo.

--- a/src/Util/ZUtil/Rshi.v
+++ b/src/Util/ZUtil/Rshi.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Util.ZUtil.ZSimplify.
 Require Import Crypto.Util.ZUtil.ZSimplify.Core.

--- a/src/Util/ZUtil/Rshi.v
+++ b/src/Util/ZUtil/Rshi.v
@@ -9,6 +9,7 @@ Require Import Crypto.Util.ZUtil.Tactics.LtbToLt.
 Require Import Crypto.Util.ZUtil.Tactics.PullPush.Modulo.
 Require Import Crypto.Util.ZUtil.Tactics.DivModToQuotRem.
 Require Import Crypto.Util.ZUtil.Hints.PullPush.
+Require Import Crypto.Util.Decidable.
 Local Open Scope Z_scope.
 
 Module Z.

--- a/src/Util/ZUtil/Sgn.v
+++ b/src/Util/ZUtil/Sgn.v
@@ -8,5 +8,5 @@ Module Z.
     generalize (Zdiv_sgn (Z.abs a) (Z.abs b)).
     destruct a, b; simpl; lia.
   Qed.
-  Hint Resolve div_abs_sgn_nonneg : zarith.
+  Global Hint Resolve div_abs_sgn_nonneg : zarith.
 End Z.

--- a/src/Util/ZUtil/Sgn.v
+++ b/src/Util/ZUtil/Sgn.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Hints.Core.
 Local Open Scope Z_scope.
 

--- a/src/Util/ZUtil/Shift.v
+++ b/src/Util/ZUtil/Shift.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.ZUtil.Ones.
 Require Import Crypto.Util.ZUtil.Definitions.

--- a/src/Util/ZUtil/Shift.v
+++ b/src/Util/ZUtil/Shift.v
@@ -1,9 +1,10 @@
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.micromega.Lia.
-Require Import Crypto.Util.ZUtil.Hints.Core.
+Require Import Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.ZUtil.Ones.
 Require Import Crypto.Util.ZUtil.Definitions.
 Require Import Crypto.Util.ZUtil.Testbit.
+Require Import Crypto.Util.ZUtil.Pow.
 Require Import Crypto.Util.ZUtil.Pow2Mod.
 Require Import Crypto.Util.ZUtil.Le.
 Require Import Crypto.Util.ZUtil.Div.
@@ -78,14 +79,14 @@ Module Z.
     rewrite !Z.shiftr_div_pow2, Z.pow_1_r by lia.
     apply Z.div_le_mono; lia.
   Qed.
-  Hint Resolve shiftr_1_r_le : zarith.
+  Global Hint Resolve shiftr_1_r_le : zarith.
 
   Lemma shiftr_le : forall a b i : Z, 0 <= i -> a <= b -> a >> i <= b >> i.
   Proof.
     intros a b i ?; revert a b. apply natlike_ind with (x := i); intros; auto.
     rewrite !shiftr_succ, shiftr_1_r_le; eauto. reflexivity.
   Qed.
-  Hint Resolve shiftr_le : zarith.
+  Global Hint Resolve shiftr_le : zarith.
 
   Lemma shiftr_ones' : forall a n, 0 <= a < 2 ^ n -> forall i, (0 <= i) ->
     Z.shiftr a i <= Z.ones (n - i) \/ n <= i.
@@ -118,7 +119,7 @@ Module Z.
       - rewrite Z.shiftr_eq_0; try lia; try reflexivity.
         apply Z.log2_lt_pow2; lia.
   Qed.
-  Hint Resolve shiftr_ones : zarith.
+  Global Hint Resolve shiftr_ones : zarith.
 
   Lemma shiftr_upper_bound : forall a n, 0 <= n -> 0 <= a <= 2 ^ n -> Z.shiftr a n <= 1.
   Proof.
@@ -134,7 +135,7 @@ Module Z.
       assert (0 < 2 ^ n) by (apply Z.pow_pos_nonneg; lia).
       rewrite Z.div_same;  lia.
   Qed.
-  Hint Resolve shiftr_upper_bound : zarith.
+  Global Hint Resolve shiftr_upper_bound : zarith.
 
   Lemma lor_shiftl : forall a b n, 0 <= n -> 0 <= a < 2 ^ n ->
     Z.lor a (Z.shiftl b n) = a + (Z.shiftl b n).
@@ -389,5 +390,31 @@ Module Z.
            | _ => solve [ auto with zarith lia ]
            end.
   Qed.
-  Hint Resolve shiftr_nonneg_le : zarith.
+  Global Hint Resolve shiftr_nonneg_le : zarith.
 End Z.
+Hint Rewrite Z.shiftr_add_shiftl_high using zutil_arith : pull_Zshift.
+Hint Rewrite <- Z.shiftr_add_shiftl_high using zutil_arith : push_Zshift.
+Hint Rewrite Z.shiftr_add_shiftl_low using zutil_arith : pull_Zshift.
+Hint Rewrite <- Z.shiftr_add_shiftl_low using zutil_arith : push_Zshift.
+Hint Rewrite Z.testbit_add_shiftl_high using zutil_arith : Ztestbit.
+Hint Rewrite Z.shiftr_succ using zutil_arith : push_Zshift.
+Hint Rewrite <- Z.shiftr_succ using zutil_arith : pull_Zshift.
+Global Hint Resolve Z.shiftr_1_r_le : zarith.
+Global Hint Resolve Z.shiftr_le : zarith.
+Global Hint Resolve Z.shiftr_ones : zarith.
+Global Hint Resolve Z.shiftr_upper_bound : zarith.
+Hint Rewrite <- Z.lor_shiftl using zutil_arith : convert_to_Ztestbit.
+Hint Rewrite <- Z.lor_shiftl' using zutil_arith : convert_to_Ztestbit.
+Hint Rewrite Z.shiftl_spec_full : Ztestbit_full.
+Hint Rewrite Z.shiftr_spec_full : Ztestbit_full.
+Hint Rewrite Z.testbit_add_shiftl_full using zutil_arith : Ztestbit.
+Hint Rewrite Z.shiftl_add using zutil_arith : push_Zshift.
+Hint Rewrite <- Z.shiftl_add using zutil_arith : pull_Zshift.
+Hint Rewrite Z.shiftr_add using zutil_arith : push_Zshift.
+Hint Rewrite <- Z.shiftr_add using zutil_arith : pull_Zshift.
+Hint Rewrite Z.shiftl_sub using zutil_arith : push_Zshift.
+Hint Rewrite <- Z.shiftl_sub using zutil_arith : pull_Zshift.
+Hint Rewrite Z.shiftr_sub using zutil_arith : push_Zshift.
+Hint Rewrite <- Z.shiftr_sub using zutil_arith : pull_Zshift.
+Hint Rewrite Z.pow2_bits_eqb using zutil_arith : Ztestbit.
+Global Hint Resolve Z.shiftr_nonneg_le : zarith.

--- a/src/Util/ZUtil/Sorting.v
+++ b/src/Util/ZUtil/Sorting.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
 Require Import Coq.Sorting.Mergesort Coq.Structures.Orders.
 

--- a/src/Util/ZUtil/Sorting.v
+++ b/src/Util/ZUtil/Sorting.v
@@ -1,5 +1,5 @@
 Require Export Crypto.Util.GlobalSettings.
-Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Sorting.Mergesort Coq.Structures.Orders.
 
 Module Z.

--- a/src/Util/ZUtil/Stabilization.v
+++ b/src/Util/ZUtil/Stabilization.v
@@ -1,6 +1,6 @@
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.micromega.Lia.
-Require Import Coq.Classes.Morphisms.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Hints.Core.
 Require Import Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.ZUtil.Tactics.ReplaceNegWithPos.

--- a/src/Util/ZUtil/Stabilization.v
+++ b/src/Util/ZUtil/Stabilization.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Hints.Core.
 Require Import Crypto.Util.ZUtil.Hints.ZArith.

--- a/src/Util/ZUtil/Tactics/CompareToSgn.v
+++ b/src/Util/ZUtil/Tactics/CompareToSgn.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 Require Import Coq.ZArith.ZArith.
 Module Z.
   Ltac compare_to_sgn :=

--- a/src/Util/ZUtil/Tactics/DivModToQuotRem.v
+++ b/src/Util/ZUtil/Tactics/DivModToQuotRem.v
@@ -1,7 +1,7 @@
 Require Import Coq.ZArith.ZArith.
 Require Import Crypto.Util.ZUtil.Div.Bootstrap.
 Require Import Crypto.Util.ZUtil.Modulo.Bootstrap.
-Require Import Crypto.Util.ZUtil.Hints.Core.
+Require Export Crypto.Util.ZUtil.Hints.Core.
 Local Open Scope Z_scope.
 
 Module Z.

--- a/src/Util/ZUtil/Tactics/DivideExistsMul.v
+++ b/src/Util/ZUtil/Tactics/DivideExistsMul.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
 Local Open Scope Z_scope.
 

--- a/src/Util/ZUtil/Tactics/DivideExistsMul.v
+++ b/src/Util/ZUtil/Tactics/DivideExistsMul.v
@@ -1,5 +1,5 @@
 Require Export Crypto.Util.GlobalSettings.
-Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Local Open Scope Z_scope.
 
 Module Z.

--- a/src/Util/ZUtil/Tactics/LinearSubstitute.v
+++ b/src/Util/ZUtil/Tactics/LinearSubstitute.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia Coq.ZArith.ZArith.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.ZArith.ZArith.
 Require Import Crypto.Util.Tactics.Contains.
 Require Import Crypto.Util.Tactics.Not.
 Local Open Scope Z_scope.

--- a/src/Util/ZUtil/Tactics/LtbToLt.v
+++ b/src/Util/ZUtil/Tactics/LtbToLt.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Crypto.Util.Bool.
 Local Open Scope Z_scope.

--- a/src/Util/ZUtil/Tactics/LtbToLt.v
+++ b/src/Util/ZUtil/Tactics/LtbToLt.v
@@ -70,8 +70,8 @@ Module Z.
     Lemma geb_ge_iff : R_Rb Z.geb Z.ge Z.lt. Proof. t. Qed.
     Lemma eqb_eq_iff : R_Rb Z.eqb (@Logic.eq Z) (fun x y => x <> y). Proof. t. Qed.
   End R_Rb.
-  Hint Rewrite ltb_lt_iff leb_le_iff gtb_gt_iff geb_ge_iff eqb_eq_iff : ltb_to_lt.
   Ltac ltb_to_lt_in_context :=
     repeat autorewrite with ltb_to_lt in *;
     cbv beta iota in *.
 End Z.
+Hint Rewrite Z.ltb_lt_iff Z.leb_le_iff Z.gtb_gt_iff Z.geb_ge_iff Z.eqb_eq_iff : ltb_to_lt.

--- a/src/Util/ZUtil/Tactics/PeelLe.v
+++ b/src/Util/ZUtil/Tactics/PeelLe.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Crypto.Util.ZUtil.Hints.Core.
+Require Export Crypto.Util.ZUtil.Hints.Core.
 
 Local Open Scope Z.
 

--- a/src/Util/ZUtil/Tactics/PrimeBound.v
+++ b/src/Util/ZUtil/Tactics/PrimeBound.v
@@ -1,5 +1,5 @@
 Require Export Crypto.Util.GlobalSettings.
-Require Import Coq.micromega.Lia Coq.ZArith.Znumtheory.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.ZArith.Znumtheory.
 
 Module Z.
   Ltac prime_bound := match goal with

--- a/src/Util/ZUtil/Tactics/PrimeBound.v
+++ b/src/Util/ZUtil/Tactics/PrimeBound.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 Require Import Coq.micromega.Lia Coq.ZArith.Znumtheory.
 
 Module Z.

--- a/src/Util/ZUtil/Tactics/PullPush/Modulo.v
+++ b/src/Util/ZUtil/Tactics/PullPush/Modulo.v
@@ -1,11 +1,12 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Crypto.Util.ZUtil.Hints.Core.
-Require Import Crypto.Util.ZUtil.Modulo.PullPush.
+Require Export Crypto.Util.ZUtil.Hints.Core.
+Require Export Crypto.Util.ZUtil.Hints.PullPush.
+Require Export Crypto.Util.ZUtil.Modulo.PullPush.
 Local Open Scope Z_scope.
 
 Ltac push_Zmod_step :=
   match goal with
-  | _ => progress autorewrite with push_Zmod
+  | _ => rewrite Z_mod_same_full
   | [ |- context[(?x * ?y) mod ?z] ]
     => first [ rewrite (Z.mul_mod_push x y z) by Z.NoZMod
             | rewrite (Z.mul_mod_l_push x y z) by Z.NoZMod
@@ -22,6 +23,7 @@ Ltac push_Zmod_step :=
     => rewrite (Z.opp_mod_mod_push y z) by Z.NoZMod
   | [ |- context[(?p^?q) mod ?z] ]
     => rewrite (Z.pow_mod_push p q z) by Z.NoZMod
+  | _ => progress autorewrite with push_Zmod
   end.
 Ltac push_Zmod := repeat push_Zmod_step.
 

--- a/src/Util/ZUtil/Tactics/ReplaceNegWithPos.v
+++ b/src/Util/ZUtil/Tactics/ReplaceNegWithPos.v
@@ -1,3 +1,4 @@
+Require Export Crypto.Util.GlobalSettings.
 Require Import Coq.micromega.Lia Coq.ZArith.ZArith.
 Local Open Scope Z_scope.
 

--- a/src/Util/ZUtil/Tactics/ReplaceNegWithPos.v
+++ b/src/Util/ZUtil/Tactics/ReplaceNegWithPos.v
@@ -1,5 +1,5 @@
 Require Export Crypto.Util.GlobalSettings.
-Require Import Coq.micromega.Lia Coq.ZArith.ZArith.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.ZArith.ZArith.
 Local Open Scope Z_scope.
 
 Module Z.

--- a/src/Util/ZUtil/Tactics/RewriteModSmall.v
+++ b/src/Util/ZUtil/Tactics/RewriteModSmall.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Export Crypto.Util.ZUtil.Hints.Core.
 Require Export Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.ZUtil.Tactics.DivModToQuotRem.

--- a/src/Util/ZUtil/Tactics/RewriteModSmall.v
+++ b/src/Util/ZUtil/Tactics/RewriteModSmall.v
@@ -1,6 +1,6 @@
 Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
-Require Import Crypto.Util.ZUtil.Hints.Core.
-Require Import Crypto.Util.ZUtil.Hints.ZArith.
+Require Export Crypto.Util.ZUtil.Hints.Core.
+Require Export Crypto.Util.ZUtil.Hints.ZArith.
 Require Import Crypto.Util.ZUtil.Tactics.DivModToQuotRem.
 Local Open Scope Z_scope.
 

--- a/src/Util/ZUtil/Tactics/SimplifyFractionsLe.v
+++ b/src/Util/ZUtil/Tactics/SimplifyFractionsLe.v
@@ -1,5 +1,5 @@
 Require Import Coq.ZArith.ZArith.
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Export Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Tactics.ZeroBounds.
 Require Import Crypto.Util.ZUtil.Div.

--- a/src/Util/ZUtil/Tactics/SimplifyFractionsLe.v
+++ b/src/Util/ZUtil/Tactics/SimplifyFractionsLe.v
@@ -1,7 +1,9 @@
 Require Import Coq.ZArith.ZArith.
 Require Import Coq.micromega.Lia.
+Require Export Coq.Classes.RelationClasses Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Tactics.ZeroBounds.
 Require Import Crypto.Util.ZUtil.Div.
+Require Export Crypto.Util.ZUtil.Le. (* for hints *)
 Local Open Scope Z_scope.
 
 Module Z.

--- a/src/Util/ZUtil/Tactics/SplitMinMax.v
+++ b/src/Util/ZUtil/Tactics/SplitMinMax.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.BinInt.
 Require Export Crypto.Util.GlobalSettings.
 

--- a/src/Util/ZUtil/Tactics/SplitMinMax.v
+++ b/src/Util/ZUtil/Tactics/SplitMinMax.v
@@ -1,5 +1,6 @@
 Require Import Coq.micromega.Lia.
 Require Import Coq.ZArith.BinInt.
+Require Export Crypto.Util.GlobalSettings.
 
 Ltac rewrite_min_max_side_condition_t := lia.
 

--- a/src/Util/ZUtil/Tactics/ZeroBounds.v
+++ b/src/Util/ZUtil/Tactics/ZeroBounds.v
@@ -1,7 +1,9 @@
+Require Export Coq.Classes.RelationClasses.
 Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
 Require Import Crypto.Util.ZUtil.Tactics.PrimeBound.
 Require Import Crypto.Util.ZUtil.Div.
 Local Open Scope Z_scope.
+Global Existing Instance Z.le_preorder.
 
 Module Z.
   (* prove that combinations of known positive/nonnegative numbers are positive/nonnegative *)
@@ -23,6 +25,6 @@ Module Z.
     end; try lia; try Z.prime_bound; auto.
 
   Ltac zero_bounds := try lia; try Z.prime_bound; zero_bounds'.
-
-  Hint Extern 1 => progress zero_bounds : zero_bounds.
 End Z.
+
+Global Hint Extern 1 => progress Z.zero_bounds : zero_bounds.

--- a/src/Util/ZUtil/Tactics/ZeroBounds.v
+++ b/src/Util/ZUtil/Tactics/ZeroBounds.v
@@ -1,5 +1,5 @@
 Require Export Coq.Classes.RelationClasses.
-Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Tactics.PrimeBound.
 Require Import Crypto.Util.ZUtil.Div.
 Local Open Scope Z_scope.

--- a/src/Util/ZUtil/Testbit.v
+++ b/src/Util/ZUtil/Testbit.v
@@ -1,4 +1,4 @@
-Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.ZArith.ZArith.
 Require Import Crypto.Util.ZUtil.Definitions.
 Require Import Crypto.Util.ZUtil.Hints.

--- a/src/Util/ZUtil/Z2Nat.v
+++ b/src/Util/ZUtil/Z2Nat.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.Classes.RelationClasses.
 Require Export Crypto.Util.GlobalSettings.
 

--- a/src/Util/ZUtil/Z2Nat.v
+++ b/src/Util/ZUtil/Z2Nat.v
@@ -1,4 +1,6 @@
 Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop Coq.Classes.RelationClasses.
+Require Export Crypto.Util.GlobalSettings.
 
 Local Open Scope Z_scope.
 Module Z2Nat.

--- a/src/Util/ZUtil/ZSimplify/Autogenerated.v
+++ b/src/Util/ZUtil/ZSimplify/Autogenerated.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Hints.Core.
 Require Import Crypto.Util.ZUtil.Tactics.DivModToQuotRem.
 Local Open Scope Z_scope.

--- a/src/Util/ZUtil/ZSimplify/Simple.v
+++ b/src/Util/ZUtil/ZSimplify/Simple.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith Coq.micromega.Lia.
+Require Import Coq.ZArith.ZArith Coq.micromega.Lia Coq.Classes.Morphisms Coq.Classes.Morphisms_Prop.
 Require Import Crypto.Util.ZUtil.Hints.Core.
 Local Open Scope Z_scope.
 

--- a/src/Util/ZUtil/Zselect.v
+++ b/src/Util/ZUtil/Zselect.v
@@ -1,4 +1,5 @@
 Require Import Coq.ZArith.ZArith.
+Require Import Coq.Classes.Morphisms.
 Require Import Crypto.Util.Decidable.
 Require Import Crypto.Util.ZUtil.Definitions.
 Require Import Crypto.Util.Tactics.BreakMatch.


### PR DESCRIPTION
We `Set Loose Hint Behavior "Strict"` to ensure that all modules that
declare hints are imported.  This is more strict than necessary for
compatibility with the eventual change of semantics from `Global` to
`Export`, but there's no way currently to just preemptively flip the
default behavior, alas.

I've unfortunately run out of time to work on this for now.

cc @ppedrot @Alizter  for visibility