### PR TITLE
Adapt w.r.t. coq/coq#16004.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ endif
 
 .DEFAULT_GOAL := coq
 
-WARNINGS := -deprecated-hint-rewrite-without-locality,+deprecated-hint-without-locality,+deprecated-instance-without-locality
+WARNINGS := -deprecated-hint-rewrite-without-locality,+deprecated-hint-without-locality,+deprecated-instance-without-locality,unsupported-attributes
 
 update-_CoqProject::
 	$(SHOW)'ECHO > _CoqProject'

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,6 +1,6 @@
 -R src Crypto
 -R bbv/src/bbv bbv
--arg -w -arg -deprecated-hint-rewrite-without-locality,+deprecated-hint-without-locality,+deprecated-instance-without-locality
+-arg -w -arg -deprecated-hint-rewrite-without-locality,+deprecated-hint-without-locality,+deprecated-instance-without-locality,unsupported-attributes
 bbv/src/bbv/BinNotation.v
 bbv/src/bbv/BinNotationZ.v
 bbv/src/bbv/DepEq.v

--- a/src/Arithmetic/Core.v
+++ b/src/Arithmetic/Core.v
@@ -330,6 +330,7 @@ Module B.
     Lemma eval_cons p q : eval (p::q) = (fst p) * (snd p) + eval q. Proof. reflexivity. Qed.
     Lemma eval_app p q: eval (p++q) = eval p + eval q.
     Proof. induction p; simpl eval; rewrite ?eval_nil, ?eval_cons; nsatz. Qed.
+#[global]
     Hint Rewrite eval_nil eval_cons eval_app : push_basesystem_eval.
 
     Definition multerm (t t' : limb) : limb :=
@@ -339,6 +340,7 @@ Module B.
     Proof.
       induction q; cbv [multerm]; simpl List.map;
         autorewrite with push_basesystem_eval cancel_pair; nsatz.
+#[global]
     Qed. Hint Rewrite eval_map_multerm : push_basesystem_eval.
 
     Definition mul_cps (p q:list limb) {T} (f : list limb->T) :=
@@ -348,10 +350,12 @@ Module B.
     Lemma mul_cps_id p q: forall {T} f, @mul_cps p q T f = f (mul p q).
     Proof. cbv [mul_cps mul]; prove_id. Qed.
     Local Hint Opaque mul : uncps.
+#[global]
     Hint Rewrite mul_cps_id : uncps.
 
     Lemma eval_mul p q: eval (mul p q) = eval p * eval q.
     Proof. cbv [mul mul_cps]; induction p; prove_eval. Qed.
+#[global]
     Hint Rewrite eval_mul : push_basesystem_eval.
 
     Section split_cps.
@@ -383,6 +387,7 @@ Module B.
                end.
     Qed.
     Local Hint Opaque split : uncps.
+#[global]
     Hint Rewrite split_cps_id : uncps.
 
     Lemma eval_split s p (s_nonzero:s<>0):
@@ -393,6 +398,7 @@ Module B.
         H:_ |- _ =>
         unique pose proof (Z_div_exact_full_2 _ _ s_nonzero H)
         end; nsatz.
+#[global]
     Qed. Hint Rewrite @eval_split using auto : push_basesystem_eval.
 
     Definition reduce_cps (s:Z) (c:list limb) (p:list limb)
@@ -406,6 +412,7 @@ Module B.
       @reduce_cps s c p T f = f (reduce s c p).
     Proof. cbv [reduce_cps reduce]; prove_id. Qed.
     Local Hint Opaque reduce : uncps.
+#[global]
     Hint Rewrite reduce_cps_id : uncps.
 
     Lemma reduction_rule a b s c m (m_eq:Z.pos m = s - c):
@@ -422,6 +429,7 @@ Module B.
       cbv [reduce reduce_cps mod_eq]; prove_eval.
         erewrite <-reduction_rule by eauto; prove_eval.
     Qed.
+#[global]
     Hint Rewrite eval_reduce using (lia || assumption) : push_basesystem_eval.
     (* Why TF does this hint get picked up outside the section (while other eval_ hints do not?) *)
 
@@ -433,11 +441,13 @@ Module B.
     Lemma negate_snd_id p {T} f : @negate_snd_cps p T f = f (negate_snd p).
     Proof. cbv [negate_snd_cps negate_snd]; prove_id. Qed.
     Local Hint Opaque negate_snd : uncps.
+#[global]
     Hint Rewrite negate_snd_id : uncps.
 
     Lemma eval_negate_snd p : eval (negate_snd p) = - eval p.
     Proof.
       cbv [negate_snd_cps negate_snd]; induction p; prove_eval.
+#[global]
     Qed. Hint Rewrite eval_negate_snd : push_basesystem_eval.
 
     Section Carries.
@@ -504,10 +514,12 @@ Module B.
     intros; autorewrite with uncps push_id; try reflexivity.
 
   Module Import Hints1.
+#[global]
     Hint Rewrite
          @Associational.reduce_cps_id
          @Associational.split_cps_id
          @Associational.mul_cps_id : uncps.
+#[global]
     Hint Rewrite
          @Associational.carry_cps_id
          @Associational.carryterm_cps_id
@@ -971,6 +983,7 @@ Module B.
 
 
     End Positional.
+#[global]
     Hint Rewrite eval_unit eval_single : push_basesystem_eval.
 
     (* Helper lemmas and definitions for [eval] that to be in a
@@ -1065,6 +1078,7 @@ Module B.
            Positional.unbalanced_sub_cps
            Positional.opp_cps
     .
+#[global]
     Hint Rewrite
          @Associational.reduce_cps_id
          @Associational.split_cps_id
@@ -1076,6 +1090,7 @@ Module B.
          @Positional.sub_id
          @Positional.select_id
       : uncps.
+#[global]
     Hint Rewrite
          @Associational.carry_cps_id
          @Associational.carryterm_cps_id
@@ -1083,6 +1098,7 @@ Module B.
          @Positional.chained_carries_id
          @Positional.chained_carries_reduce_id
          using div_mod_cps_t : uncps.
+#[global]
     Hint Rewrite
          @Associational.eval_mul
          @Positional.eval_single
@@ -1159,6 +1175,7 @@ End DivMod.
 
 Module Export Hints1.
   Global Hint Opaque div modulo : uncps.
+#[global]
   Hint Rewrite @div_id @modulo_id : uncps.
 End Hints1.
 
@@ -1383,19 +1400,31 @@ Module Export Hints.
   Export Crypto.Arithmetic.PrimeFieldTheorems.Hints.
   Export Tuple.Hints.
   Global Existing Instance mod_eq_equiv.
+#[global]
   Hint Rewrite Associational.eval_nil Associational.eval_cons Associational.eval_app : push_basesystem_eval.
+#[global]
   Hint Rewrite Associational.eval_map_multerm : push_basesystem_eval.
+#[global]
   Hint Rewrite Associational.mul_cps_id : uncps.
+#[global]
   Hint Rewrite Associational.eval_mul : push_basesystem_eval.
+#[global]
   Hint Rewrite Associational.split_cps_id : uncps.
+#[global]
   Hint Rewrite @Associational.eval_split using auto : push_basesystem_eval.
+#[global]
   Hint Rewrite Associational.reduce_cps_id : uncps.
+#[global]
   Hint Rewrite Associational.eval_reduce using (lia || assumption) : push_basesystem_eval.
+#[global]
   Hint Rewrite Associational.negate_snd_id : uncps.
+#[global]
   Hint Rewrite Associational.eval_negate_snd : push_basesystem_eval.
+#[global]
   Hint Rewrite Positional.eval_unit Positional.eval_single : push_basesystem_eval.
   Export B.Hints.
   Global Hint Opaque div modulo : uncps.
+#[global]
   Hint Rewrite @div_id @modulo_id : uncps.
 
   Global Hint Unfold
@@ -1461,8 +1490,12 @@ Module Export Hints.
          Z.add_get_carry_full Z.add_get_carry_full_cps Z.mul_split Z.mul_split_cps Z.mul_split_cps'
     : basesystem_partial_evaluation_unfolder.
 
+#[global]
   Hint Rewrite <-@F.of_Z_add : pull_FofZ.
+#[global]
   Hint Rewrite <-@F.of_Z_mul : pull_FofZ.
+#[global]
   Hint Rewrite <-@F.of_Z_sub : pull_FofZ.
+#[global]
   Hint Rewrite <-@F_of_Z_opp : pull_FofZ.
 End Hints.

--- a/src/Arithmetic/CoreUnfolder.v
+++ b/src/Arithmetic/CoreUnfolder.v
@@ -86,84 +86,98 @@ done
     Definition eval := parameterize_from_sig eval_sig.
     Definition eval_eq := parameterize_eq eval eval_sig.
     Global Hint Unfold eval : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- eval_eq : pattern_runtime.
 
     Definition multerm_sig := parameterize_sig (@Core.B.Associational.multerm).
     Definition multerm := parameterize_from_sig multerm_sig.
     Definition multerm_eq := parameterize_eq multerm multerm_sig.
     Global Hint Unfold multerm : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- multerm_eq : pattern_runtime.
 
     Definition mul_cps_sig := parameterize_sig (@Core.B.Associational.mul_cps).
     Definition mul_cps := parameterize_from_sig mul_cps_sig.
     Definition mul_cps_eq := parameterize_eq mul_cps mul_cps_sig.
     Global Hint Unfold mul_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- mul_cps_eq : pattern_runtime.
 
     Definition mul_sig := parameterize_sig (@Core.B.Associational.mul).
     Definition mul := parameterize_from_sig mul_sig.
     Definition mul_eq := parameterize_eq mul mul_sig.
     Global Hint Unfold mul : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- mul_eq : pattern_runtime.
 
     Definition split_cps_sig := parameterize_sig (@Core.B.Associational.split_cps).
     Definition split_cps := parameterize_from_sig split_cps_sig.
     Definition split_cps_eq := parameterize_eq split_cps split_cps_sig.
     Global Hint Unfold split_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- split_cps_eq : pattern_runtime.
 
     Definition split_sig := parameterize_sig (@Core.B.Associational.split).
     Definition split := parameterize_from_sig split_sig.
     Definition split_eq := parameterize_eq split split_sig.
     Global Hint Unfold split : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- split_eq : pattern_runtime.
 
     Definition reduce_cps_sig := parameterize_sig (@Core.B.Associational.reduce_cps).
     Definition reduce_cps := parameterize_from_sig reduce_cps_sig.
     Definition reduce_cps_eq := parameterize_eq reduce_cps reduce_cps_sig.
     Global Hint Unfold reduce_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- reduce_cps_eq : pattern_runtime.
 
     Definition reduce_sig := parameterize_sig (@Core.B.Associational.reduce).
     Definition reduce := parameterize_from_sig reduce_sig.
     Definition reduce_eq := parameterize_eq reduce reduce_sig.
     Global Hint Unfold reduce : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- reduce_eq : pattern_runtime.
 
     Definition negate_snd_cps_sig := parameterize_sig (@Core.B.Associational.negate_snd_cps).
     Definition negate_snd_cps := parameterize_from_sig negate_snd_cps_sig.
     Definition negate_snd_cps_eq := parameterize_eq negate_snd_cps negate_snd_cps_sig.
     Global Hint Unfold negate_snd_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- negate_snd_cps_eq : pattern_runtime.
 
     Definition negate_snd_sig := parameterize_sig (@Core.B.Associational.negate_snd).
     Definition negate_snd := parameterize_from_sig negate_snd_sig.
     Definition negate_snd_eq := parameterize_eq negate_snd negate_snd_sig.
     Global Hint Unfold negate_snd : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- negate_snd_eq : pattern_runtime.
 
     Definition carryterm_cps_sig := parameterize_sig (@Core.B.Associational.carryterm_cps).
     Definition carryterm_cps := parameterize_from_sig carryterm_cps_sig.
     Definition carryterm_cps_eq := parameterize_eq carryterm_cps carryterm_cps_sig.
     Global Hint Unfold carryterm_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- carryterm_cps_eq : pattern_runtime.
 
     Definition carryterm_sig := parameterize_sig (@Core.B.Associational.carryterm).
     Definition carryterm := parameterize_from_sig carryterm_sig.
     Definition carryterm_eq := parameterize_eq carryterm carryterm_sig.
     Global Hint Unfold carryterm : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- carryterm_eq : pattern_runtime.
 
     Definition carry_cps_sig := parameterize_sig (@Core.B.Associational.carry_cps).
     Definition carry_cps := parameterize_from_sig carry_cps_sig.
     Definition carry_cps_eq := parameterize_eq carry_cps carry_cps_sig.
     Global Hint Unfold carry_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- carry_cps_eq : pattern_runtime.
 
     Definition carry_sig := parameterize_sig (@Core.B.Associational.carry).
     Definition carry := parameterize_from_sig carry_sig.
     Definition carry_eq := parameterize_eq carry carry_sig.
     Global Hint Unfold carry : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- carry_eq : pattern_runtime.
 
   End Associational.
@@ -172,204 +186,238 @@ done
     Definition to_associational_cps := parameterize_from_sig to_associational_cps_sig.
     Definition to_associational_cps_eq := parameterize_eq to_associational_cps to_associational_cps_sig.
     Global Hint Unfold to_associational_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- to_associational_cps_eq : pattern_runtime.
 
     Definition to_associational_sig := parameterize_sig (@Core.B.Positional.to_associational).
     Definition to_associational := parameterize_from_sig to_associational_sig.
     Definition to_associational_eq := parameterize_eq to_associational to_associational_sig.
     Global Hint Unfold to_associational : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- to_associational_eq : pattern_runtime.
 
     Definition eval_sig := parameterize_sig (@Core.B.Positional.eval).
     Definition eval := parameterize_from_sig eval_sig.
     Definition eval_eq := parameterize_eq eval eval_sig.
     Global Hint Unfold eval : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- eval_eq : pattern_runtime.
 
     Definition zeros_sig := parameterize_sig (@Core.B.Positional.zeros).
     Definition zeros := parameterize_from_sig zeros_sig.
     Definition zeros_eq := parameterize_eq zeros zeros_sig.
     Global Hint Unfold zeros : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- zeros_eq : pattern_runtime.
 
     Definition add_to_nth_cps_sig := parameterize_sig (@Core.B.Positional.add_to_nth_cps).
     Definition add_to_nth_cps := parameterize_from_sig add_to_nth_cps_sig.
     Definition add_to_nth_cps_eq := parameterize_eq add_to_nth_cps add_to_nth_cps_sig.
     Global Hint Unfold add_to_nth_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- add_to_nth_cps_eq : pattern_runtime.
 
     Definition add_to_nth_sig := parameterize_sig (@Core.B.Positional.add_to_nth).
     Definition add_to_nth := parameterize_from_sig add_to_nth_sig.
     Definition add_to_nth_eq := parameterize_eq add_to_nth add_to_nth_sig.
     Global Hint Unfold add_to_nth : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- add_to_nth_eq : pattern_runtime.
 
     Definition place_cps_sig := parameterize_sig (@Core.B.Positional.place_cps).
     Definition place_cps := parameterize_from_sig place_cps_sig.
     Definition place_cps_eq := parameterize_eq place_cps place_cps_sig.
     Global Hint Unfold place_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- place_cps_eq : pattern_runtime.
 
     Definition place_sig := parameterize_sig (@Core.B.Positional.place).
     Definition place := parameterize_from_sig place_sig.
     Definition place_eq := parameterize_eq place place_sig.
     Global Hint Unfold place : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- place_eq : pattern_runtime.
 
     Definition from_associational_cps_sig := parameterize_sig (@Core.B.Positional.from_associational_cps).
     Definition from_associational_cps := parameterize_from_sig from_associational_cps_sig.
     Definition from_associational_cps_eq := parameterize_eq from_associational_cps from_associational_cps_sig.
     Global Hint Unfold from_associational_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- from_associational_cps_eq : pattern_runtime.
 
     Definition from_associational_sig := parameterize_sig (@Core.B.Positional.from_associational).
     Definition from_associational := parameterize_from_sig from_associational_sig.
     Definition from_associational_eq := parameterize_eq from_associational from_associational_sig.
     Global Hint Unfold from_associational : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- from_associational_eq : pattern_runtime.
 
     Definition carry_cps_sig := parameterize_sig (@Core.B.Positional.carry_cps).
     Definition carry_cps := parameterize_from_sig carry_cps_sig.
     Definition carry_cps_eq := parameterize_eq carry_cps carry_cps_sig.
     Global Hint Unfold carry_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- carry_cps_eq : pattern_runtime.
 
     Definition carry_sig := parameterize_sig (@Core.B.Positional.carry).
     Definition carry := parameterize_from_sig carry_sig.
     Definition carry_eq := parameterize_eq carry carry_sig.
     Global Hint Unfold carry : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- carry_eq : pattern_runtime.
 
     Definition chained_carries_cps_sig := parameterize_sig (@Core.B.Positional.chained_carries_cps).
     Definition chained_carries_cps := parameterize_from_sig chained_carries_cps_sig.
     Definition chained_carries_cps_eq := parameterize_eq chained_carries_cps chained_carries_cps_sig.
     Global Hint Unfold chained_carries_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- chained_carries_cps_eq : pattern_runtime.
 
     Definition chained_carries_sig := parameterize_sig (@Core.B.Positional.chained_carries).
     Definition chained_carries := parameterize_from_sig chained_carries_sig.
     Definition chained_carries_eq := parameterize_eq chained_carries chained_carries_sig.
     Global Hint Unfold chained_carries : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- chained_carries_eq : pattern_runtime.
 
     Definition encode_sig := parameterize_sig (@Core.B.Positional.encode).
     Definition encode := parameterize_from_sig encode_sig.
     Definition encode_eq := parameterize_eq encode encode_sig.
     Global Hint Unfold encode : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- encode_eq : pattern_runtime.
 
     Definition add_cps_sig := parameterize_sig (@Core.B.Positional.add_cps).
     Definition add_cps := parameterize_from_sig add_cps_sig.
     Definition add_cps_eq := parameterize_eq add_cps add_cps_sig.
     Global Hint Unfold add_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- add_cps_eq : pattern_runtime.
 
     Definition mul_cps_sig := parameterize_sig (@Core.B.Positional.mul_cps).
     Definition mul_cps := parameterize_from_sig mul_cps_sig.
     Definition mul_cps_eq := parameterize_eq mul_cps mul_cps_sig.
     Global Hint Unfold mul_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- mul_cps_eq : pattern_runtime.
 
     Definition reduce_cps_sig := parameterize_sig (@Core.B.Positional.reduce_cps).
     Definition reduce_cps := parameterize_from_sig reduce_cps_sig.
     Definition reduce_cps_eq := parameterize_eq reduce_cps reduce_cps_sig.
     Global Hint Unfold reduce_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- reduce_cps_eq : pattern_runtime.
 
     Definition carry_reduce_cps_sig := parameterize_sig (@Core.B.Positional.carry_reduce_cps).
     Definition carry_reduce_cps := parameterize_from_sig carry_reduce_cps_sig.
     Definition carry_reduce_cps_eq := parameterize_eq carry_reduce_cps carry_reduce_cps_sig.
     Global Hint Unfold carry_reduce_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- carry_reduce_cps_eq : pattern_runtime.
 
     Definition chained_carries_reduce_cps_step_sig := parameterize_sig (@Core.B.Positional.chained_carries_reduce_cps_step).
     Definition chained_carries_reduce_cps_step := parameterize_from_sig chained_carries_reduce_cps_step_sig.
     Definition chained_carries_reduce_cps_step_eq := parameterize_eq chained_carries_reduce_cps_step chained_carries_reduce_cps_step_sig.
     Global Hint Unfold chained_carries_reduce_cps_step : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- chained_carries_reduce_cps_step_eq : pattern_runtime.
 
     Definition chained_carries_reduce_cps_sig := parameterize_sig (@Core.B.Positional.chained_carries_reduce_cps).
     Definition chained_carries_reduce_cps := parameterize_from_sig chained_carries_reduce_cps_sig.
     Definition chained_carries_reduce_cps_eq := parameterize_eq chained_carries_reduce_cps chained_carries_reduce_cps_sig.
     Global Hint Unfold chained_carries_reduce_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- chained_carries_reduce_cps_eq : pattern_runtime.
 
     Definition chained_carries_reduce_sig := parameterize_sig (@Core.B.Positional.chained_carries_reduce).
     Definition chained_carries_reduce := parameterize_from_sig chained_carries_reduce_sig.
     Definition chained_carries_reduce_eq := parameterize_eq chained_carries_reduce chained_carries_reduce_sig.
     Global Hint Unfold chained_carries_reduce : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- chained_carries_reduce_eq : pattern_runtime.
 
     Definition negate_snd_cps_sig := parameterize_sig (@Core.B.Positional.negate_snd_cps).
     Definition negate_snd_cps := parameterize_from_sig negate_snd_cps_sig.
     Definition negate_snd_cps_eq := parameterize_eq negate_snd_cps negate_snd_cps_sig.
     Global Hint Unfold negate_snd_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- negate_snd_cps_eq : pattern_runtime.
 
     Definition split_cps_sig := parameterize_sig (@Core.B.Positional.split_cps).
     Definition split_cps := parameterize_from_sig split_cps_sig.
     Definition split_cps_eq := parameterize_eq split_cps split_cps_sig.
     Global Hint Unfold split_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- split_cps_eq : pattern_runtime.
 
     Definition scmul_cps_sig := parameterize_sig (@Core.B.Positional.scmul_cps).
     Definition scmul_cps := parameterize_from_sig scmul_cps_sig.
     Definition scmul_cps_eq := parameterize_eq scmul_cps scmul_cps_sig.
     Global Hint Unfold scmul_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- scmul_cps_eq : pattern_runtime.
 
     Definition unbalanced_sub_cps_sig := parameterize_sig (@Core.B.Positional.unbalanced_sub_cps).
     Definition unbalanced_sub_cps := parameterize_from_sig unbalanced_sub_cps_sig.
     Definition unbalanced_sub_cps_eq := parameterize_eq unbalanced_sub_cps unbalanced_sub_cps_sig.
     Global Hint Unfold unbalanced_sub_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- unbalanced_sub_cps_eq : pattern_runtime.
 
     Definition sub_cps_sig := parameterize_sig (@Core.B.Positional.sub_cps).
     Definition sub_cps := parameterize_from_sig sub_cps_sig.
     Definition sub_cps_eq := parameterize_eq sub_cps sub_cps_sig.
     Global Hint Unfold sub_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- sub_cps_eq : pattern_runtime.
 
     Definition sub_sig := parameterize_sig (@Core.B.Positional.sub).
     Definition sub := parameterize_from_sig sub_sig.
     Definition sub_eq := parameterize_eq sub sub_sig.
     Global Hint Unfold sub : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- sub_eq : pattern_runtime.
 
     Definition opp_cps_sig := parameterize_sig (@Core.B.Positional.opp_cps).
     Definition opp_cps := parameterize_from_sig opp_cps_sig.
     Definition opp_cps_eq := parameterize_eq opp_cps opp_cps_sig.
     Global Hint Unfold opp_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- opp_cps_eq : pattern_runtime.
 
     Definition Fencode_sig := parameterize_sig (@Core.B.Positional.Fencode).
     Definition Fencode := parameterize_from_sig Fencode_sig.
     Definition Fencode_eq := parameterize_eq Fencode Fencode_sig.
     Global Hint Unfold Fencode : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- Fencode_eq : pattern_runtime.
 
     Definition Fdecode_sig := parameterize_sig (@Core.B.Positional.Fdecode).
     Definition Fdecode := parameterize_from_sig Fdecode_sig.
     Definition Fdecode_eq := parameterize_eq Fdecode Fdecode_sig.
     Global Hint Unfold Fdecode : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- Fdecode_eq : pattern_runtime.
 
     Definition eval_from_sig := parameterize_sig (@Core.B.Positional.eval_from).
     Definition eval_from := parameterize_from_sig eval_from_sig.
     Definition eval_from_eq := parameterize_eq eval_from eval_from_sig.
     Global Hint Unfold eval_from : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- eval_from_eq : pattern_runtime.
 
     Definition select_cps_sig := parameterize_sig (@Core.B.Positional.select_cps).
     Definition select_cps := parameterize_from_sig select_cps_sig.
     Definition select_cps_eq := parameterize_eq select_cps select_cps_sig.
     Global Hint Unfold select_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- select_cps_eq : pattern_runtime.
 
     Definition select_sig := parameterize_sig (@Core.B.Positional.select).
     Definition select := parameterize_from_sig select_sig.
     Definition select_eq := parameterize_eq select select_sig.
     Global Hint Unfold select : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- select_eq : pattern_runtime.
 
   End Positional.
@@ -379,22 +427,26 @@ Definition modulo_cps_sig := parameterize_sig (@Core.modulo_cps).
 Definition modulo_cps := parameterize_from_sig modulo_cps_sig.
 Definition modulo_cps_eq := parameterize_eq modulo_cps modulo_cps_sig.
 Global Hint Unfold modulo_cps : basesystem_partial_evaluation_unfolder.
+#[global]
 Hint Rewrite <- modulo_cps_eq : pattern_runtime.
 
 Definition div_cps_sig := parameterize_sig (@Core.div_cps).
 Definition div_cps := parameterize_from_sig div_cps_sig.
 Definition div_cps_eq := parameterize_eq div_cps div_cps_sig.
 Global Hint Unfold div_cps : basesystem_partial_evaluation_unfolder.
+#[global]
 Hint Rewrite <- div_cps_eq : pattern_runtime.
 
 Definition modulo_sig := parameterize_sig (@Core.modulo).
 Definition modulo := parameterize_from_sig modulo_sig.
 Definition modulo_eq := parameterize_eq modulo modulo_sig.
 Global Hint Unfold modulo : basesystem_partial_evaluation_unfolder.
+#[global]
 Hint Rewrite <- modulo_eq : pattern_runtime.
 
 Definition div_sig := parameterize_sig (@Core.div).
 Definition div := parameterize_from_sig div_sig.
 Definition div_eq := parameterize_eq div div_sig.
 Global Hint Unfold div : basesystem_partial_evaluation_unfolder.
+#[global]
 Hint Rewrite <- div_eq : pattern_runtime.

--- a/src/Arithmetic/Karatsuba.v
+++ b/src/Arithmetic/Karatsuba.v
@@ -211,8 +211,10 @@ Context (weight : nat -> Z)
   Qed.
 End Karatsuba.
 Global Hint Opaque karatsuba_mul goldilocks_mul : uncps.
+#[global]
 Hint Rewrite karatsuba_mul_id goldilocks_mul_id : uncps.
 
+#[global]
 Hint Rewrite
      @eval_karatsuba_mul
      @eval_goldilocks_mul

--- a/src/Arithmetic/MontgomeryReduction/WordByWord/Proofs.v
+++ b/src/Arithmetic/MontgomeryReduction/WordByWord/Proofs.v
@@ -326,4 +326,5 @@ Section WordByWordMontgomery.
   End nonzero.
 End WordByWordMontgomery.
 
+#[global]
 Hint Rewrite redc_body_cps_id redc_loop_cps_id pre_redc_cps_id redc_cps_id add_cps_id sub_cps_id opp_cps_id : uncps.

--- a/src/Arithmetic/Saturated/AddSub.v
+++ b/src/Arithmetic/Saturated/AddSub.v
@@ -277,8 +277,11 @@ Module Export Hints.
   Export Crypto.Util.Tuple.Hints Crypto.Util.LetIn.Hints.
 
   Global Hint Opaque B.Positional.sat_sub B.Positional.sat_add B.Positional.chain_op B.Positional.chain_op' : uncps.
+#[global]
   Hint Rewrite @B.Positional.sat_sub_id @B.Positional.sat_add_id : uncps.
+#[global]
   Hint Rewrite @B.Positional.chain_op_id @B.Positional.chain_op' using (assumption || (intros; autorewrite with uncps; reflexivity)) : uncps.
+#[global]
   Hint Rewrite @B.Positional.sat_sub_mod @B.Positional.sat_sub_div @B.Positional.sat_add_mod @B.Positional.sat_add_div using (lia || assumption) : push_basesystem_eval.
 
   Global Hint Unfold

--- a/src/Arithmetic/Saturated/Core.v
+++ b/src/Arithmetic/Saturated/Core.v
@@ -472,16 +472,19 @@ Module Export Hints.
   Export Crypto.Util.NatUtil.Hints.
   Export Field.Hints.
 
+#[global]
   Hint Rewrite
        @Columns.compact_digit_id
        @Columns.compact_step_id
        @Columns.compact_id
        using (assumption || (intros; autorewrite with uncps; reflexivity))
     : uncps.
+#[global]
   Hint Rewrite
        @Columns.cons_to_nth_id
        @Columns.from_associational_id
     : uncps.
+#[global]
   Hint Rewrite
        @Columns.compact_mod
        @Columns.compact_div

--- a/src/Arithmetic/Saturated/CoreUnfolder.v
+++ b/src/Arithmetic/Saturated/CoreUnfolder.v
@@ -20,78 +20,91 @@ echo "End Columns."
   Definition eval := parameterize_from_sig eval_sig.
   Definition eval_eq := parameterize_eq eval eval_sig.
   Global Hint Unfold eval : basesystem_partial_evaluation_unfolder.
+#[global]
   Hint Rewrite <- eval_eq : pattern_runtime.
 
   Definition eval_from_sig := parameterize_sig (@Core.Columns.eval_from).
   Definition eval_from := parameterize_from_sig eval_from_sig.
   Definition eval_from_eq := parameterize_eq eval_from eval_from_sig.
   Global Hint Unfold eval_from : basesystem_partial_evaluation_unfolder.
+#[global]
   Hint Rewrite <- eval_from_eq : pattern_runtime.
 
   Definition compact_digit_cps_sig := parameterize_sig (@Core.Columns.compact_digit_cps).
   Definition compact_digit_cps := parameterize_from_sig compact_digit_cps_sig.
   Definition compact_digit_cps_eq := parameterize_eq compact_digit_cps compact_digit_cps_sig.
   Global Hint Unfold compact_digit_cps : basesystem_partial_evaluation_unfolder.
+#[global]
   Hint Rewrite <- compact_digit_cps_eq : pattern_runtime.
 
   Definition compact_digit_sig := parameterize_sig (@Core.Columns.compact_digit).
   Definition compact_digit := parameterize_from_sig compact_digit_sig.
   Definition compact_digit_eq := parameterize_eq compact_digit compact_digit_sig.
   Global Hint Unfold compact_digit : basesystem_partial_evaluation_unfolder.
+#[global]
   Hint Rewrite <- compact_digit_eq : pattern_runtime.
 
   Definition compact_step_cps_sig := parameterize_sig (@Core.Columns.compact_step_cps).
   Definition compact_step_cps := parameterize_from_sig compact_step_cps_sig.
   Definition compact_step_cps_eq := parameterize_eq compact_step_cps compact_step_cps_sig.
   Global Hint Unfold compact_step_cps : basesystem_partial_evaluation_unfolder.
+#[global]
   Hint Rewrite <- compact_step_cps_eq : pattern_runtime.
 
   Definition compact_step_sig := parameterize_sig (@Core.Columns.compact_step).
   Definition compact_step := parameterize_from_sig compact_step_sig.
   Definition compact_step_eq := parameterize_eq compact_step compact_step_sig.
   Global Hint Unfold compact_step : basesystem_partial_evaluation_unfolder.
+#[global]
   Hint Rewrite <- compact_step_eq : pattern_runtime.
 
   Definition compact_cps_sig := parameterize_sig (@Core.Columns.compact_cps).
   Definition compact_cps := parameterize_from_sig compact_cps_sig.
   Definition compact_cps_eq := parameterize_eq compact_cps compact_cps_sig.
   Global Hint Unfold compact_cps : basesystem_partial_evaluation_unfolder.
+#[global]
   Hint Rewrite <- compact_cps_eq : pattern_runtime.
 
   Definition compact_sig := parameterize_sig (@Core.Columns.compact).
   Definition compact := parameterize_from_sig compact_sig.
   Definition compact_eq := parameterize_eq compact compact_sig.
   Global Hint Unfold compact : basesystem_partial_evaluation_unfolder.
+#[global]
   Hint Rewrite <- compact_eq : pattern_runtime.
 
   Definition cons_to_nth_cps_sig := parameterize_sig (@Core.Columns.cons_to_nth_cps).
   Definition cons_to_nth_cps := parameterize_from_sig cons_to_nth_cps_sig.
   Definition cons_to_nth_cps_eq := parameterize_eq cons_to_nth_cps cons_to_nth_cps_sig.
   Global Hint Unfold cons_to_nth_cps : basesystem_partial_evaluation_unfolder.
+#[global]
   Hint Rewrite <- cons_to_nth_cps_eq : pattern_runtime.
 
   Definition cons_to_nth_sig := parameterize_sig (@Core.Columns.cons_to_nth).
   Definition cons_to_nth := parameterize_from_sig cons_to_nth_sig.
   Definition cons_to_nth_eq := parameterize_eq cons_to_nth cons_to_nth_sig.
   Global Hint Unfold cons_to_nth : basesystem_partial_evaluation_unfolder.
+#[global]
   Hint Rewrite <- cons_to_nth_eq : pattern_runtime.
 
   Definition nils_sig := parameterize_sig (@Core.Columns.nils).
   Definition nils := parameterize_from_sig nils_sig.
   Definition nils_eq := parameterize_eq nils nils_sig.
   Global Hint Unfold nils : basesystem_partial_evaluation_unfolder.
+#[global]
   Hint Rewrite <- nils_eq : pattern_runtime.
 
   Definition from_associational_cps_sig := parameterize_sig (@Core.Columns.from_associational_cps).
   Definition from_associational_cps := parameterize_from_sig from_associational_cps_sig.
   Definition from_associational_cps_eq := parameterize_eq from_associational_cps from_associational_cps_sig.
   Global Hint Unfold from_associational_cps : basesystem_partial_evaluation_unfolder.
+#[global]
   Hint Rewrite <- from_associational_cps_eq : pattern_runtime.
 
   Definition from_associational_sig := parameterize_sig (@Core.Columns.from_associational).
   Definition from_associational := parameterize_from_sig from_associational_sig.
   Definition from_associational_eq := parameterize_eq from_associational from_associational_sig.
   Global Hint Unfold from_associational : basesystem_partial_evaluation_unfolder.
+#[global]
   Hint Rewrite <- from_associational_eq : pattern_runtime.
 
 End Columns.

--- a/src/Arithmetic/Saturated/Freeze.v
+++ b/src/Arithmetic/Saturated/Freeze.v
@@ -128,7 +128,9 @@ Section Freeze.
   Qed.
 End Freeze.
 Global Hint Opaque freeze_cps : uncps.
+#[global]
 Hint Rewrite @freeze_id : uncps.
+#[global]
 Hint Rewrite @eval_freeze
      using (assumption || reflexivity || auto || eassumption || lia) : push_basesystem_eval.
 

--- a/src/Arithmetic/Saturated/FreezeUnfolder.v
+++ b/src/Arithmetic/Saturated/FreezeUnfolder.v
@@ -18,10 +18,12 @@ Definition freeze_cps_sig := parameterize_sig (@Freeze.freeze_cps).
 Definition freeze_cps := parameterize_from_sig freeze_cps_sig.
 Definition freeze_cps_eq := parameterize_eq freeze_cps freeze_cps_sig.
 Global Hint Unfold freeze_cps : basesystem_partial_evaluation_unfolder.
+#[global]
 Hint Rewrite <- freeze_cps_eq : pattern_runtime.
 
 Definition freeze_sig := parameterize_sig (@Freeze.freeze).
 Definition freeze := parameterize_from_sig freeze_sig.
 Definition freeze_eq := parameterize_eq freeze freeze_sig.
 Global Hint Unfold freeze : basesystem_partial_evaluation_unfolder.
+#[global]
 Hint Rewrite <- freeze_eq : pattern_runtime.

--- a/src/Arithmetic/Saturated/MontgomeryAPI.v
+++ b/src/Arithmetic/Saturated/MontgomeryAPI.v
@@ -689,6 +689,7 @@ Module Export Hints.
   Export Crypto.Util.ZUtil.Tactics.LtbToLt.Hints.
   Export Crypto.Util.ZUtil.Opp.Hints.
 
+#[global]
   Hint Rewrite nonzero_id join0_id divmod_id drop_high_id scmul_id add_id add_S1_id add_S2_id sub_then_maybe_add_id conditional_sub_id : uncps.
 
   Global Hint Unfold

--- a/src/Arithmetic/Saturated/MulSplit.v
+++ b/src/Arithmetic/Saturated/MulSplit.v
@@ -99,7 +99,9 @@ Module Export Hints.
   Export Crypto.Util.LetIn.Hints Crypto.Util.CPSUtil.Hints.
 
   Global Hint Opaque B.Associational.sat_mul B.Associational.sat_multerm : uncps.
+#[global]
   Hint Rewrite @B.Associational.sat_mul_id @B.Associational.sat_multerm_id using (assumption || (intros; autorewrite with uncps; reflexivity)) : uncps.
+#[global]
   Hint Rewrite @B.Associational.eval_sat_mul @B.Associational.eval_map_sat_multerm using (lia || assumption) : push_basesystem_eval.
 
   Global Hint Unfold

--- a/src/Arithmetic/Saturated/MulSplitUnfolder.v
+++ b/src/Arithmetic/Saturated/MulSplitUnfolder.v
@@ -21,24 +21,28 @@ echo "End B."
     Definition sat_multerm_cps := parameterize_from_sig sat_multerm_cps_sig.
     Definition sat_multerm_cps_eq := parameterize_eq sat_multerm_cps sat_multerm_cps_sig.
     Global Hint Unfold sat_multerm_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- sat_multerm_cps_eq : pattern_runtime.
 
     Definition sat_multerm_sig := parameterize_sig (@MulSplit.B.Associational.sat_multerm).
     Definition sat_multerm := parameterize_from_sig sat_multerm_sig.
     Definition sat_multerm_eq := parameterize_eq sat_multerm sat_multerm_sig.
     Global Hint Unfold sat_multerm : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- sat_multerm_eq : pattern_runtime.
 
     Definition sat_mul_cps_sig := parameterize_sig (@MulSplit.B.Associational.sat_mul_cps).
     Definition sat_mul_cps := parameterize_from_sig sat_mul_cps_sig.
     Definition sat_mul_cps_eq := parameterize_eq sat_mul_cps sat_mul_cps_sig.
     Global Hint Unfold sat_mul_cps : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- sat_mul_cps_eq : pattern_runtime.
 
     Definition sat_mul_sig := parameterize_sig (@MulSplit.B.Associational.sat_mul).
     Definition sat_mul := parameterize_from_sig sat_mul_sig.
     Definition sat_mul_eq := parameterize_eq sat_mul sat_mul_sig.
     Global Hint Unfold sat_mul : basesystem_partial_evaluation_unfolder.
+#[global]
     Hint Rewrite <- sat_mul_eq : pattern_runtime.
 
   End Associational.

--- a/src/Arithmetic/Saturated/WrappersUnfolder.v
+++ b/src/Arithmetic/Saturated/WrappersUnfolder.v
@@ -22,24 +22,28 @@ echo "End Columns."
   Definition add_cps := parameterize_from_sig add_cps_sig.
   Definition add_cps_eq := parameterize_eq add_cps add_cps_sig.
   Global Hint Unfold add_cps : basesystem_partial_evaluation_unfolder.
+#[global]
   Hint Rewrite <- add_cps_eq : pattern_runtime.
 
   Definition unbalanced_sub_cps_sig := parameterize_sig (@Wrappers.Columns.unbalanced_sub_cps).
   Definition unbalanced_sub_cps := parameterize_from_sig unbalanced_sub_cps_sig.
   Definition unbalanced_sub_cps_eq := parameterize_eq unbalanced_sub_cps unbalanced_sub_cps_sig.
   Global Hint Unfold unbalanced_sub_cps : basesystem_partial_evaluation_unfolder.
+#[global]
   Hint Rewrite <- unbalanced_sub_cps_eq : pattern_runtime.
 
   Definition mul_cps_sig := parameterize_sig (@Wrappers.Columns.mul_cps).
   Definition mul_cps := parameterize_from_sig mul_cps_sig.
   Definition mul_cps_eq := parameterize_eq mul_cps mul_cps_sig.
   Global Hint Unfold mul_cps : basesystem_partial_evaluation_unfolder.
+#[global]
   Hint Rewrite <- mul_cps_eq : pattern_runtime.
 
   Definition conditional_add_cps_sig := parameterize_sig (@Wrappers.Columns.conditional_add_cps).
   Definition conditional_add_cps := parameterize_from_sig conditional_add_cps_sig.
   Definition conditional_add_cps_eq := parameterize_eq conditional_add_cps conditional_add_cps_sig.
   Global Hint Unfold conditional_add_cps : basesystem_partial_evaluation_unfolder.
+#[global]
   Hint Rewrite <- conditional_add_cps_eq : pattern_runtime.
 
 End Columns.

--- a/src/Compilers/CommonSubexpressionEliminationInterp.v
+++ b/src/Compilers/CommonSubexpressionEliminationInterp.v
@@ -216,4 +216,5 @@ Section symbolic.
   Qed.
 End symbolic.
 
+#[global]
 Hint Rewrite @InterpCSE using solve_wf_side_condition : reflective_interp.

--- a/src/Compilers/EtaInterp.v
+++ b/src/Compilers/EtaInterp.v
@@ -115,4 +115,5 @@ Section language.
   Proof using Type. apply eq_interp_eta. Qed.
 End language.
 
+#[global]
 Hint Rewrite @eq_interp_flat_type_eta @eq_interp_flat_type_eta' @interpf_exprf_eta @interpf_exprf_eta' @interp_expr_eta @interp_expr_eta' @InterpExprEta @InterpExprEta' @InterpExprEta_arrow @InterpExprEta'_arrow @eq_interp_eta @eq_InterpEta : reflective_interp.

--- a/src/Compilers/ExprInversion.v
+++ b/src/Compilers/ExprInversion.v
@@ -253,6 +253,7 @@ Global Arguments invert_Pairs {_ _ _ _} _.
 Global Arguments invert_PairsConst {_ _ _ _} _ {T} _.
 Global Arguments invert_Abs {_ _ _ _} _ _.
 
+#[global]
 Hint Rewrite @InterpCompose : reflective_rewrite.
 
 Module Export Notations.

--- a/src/Compilers/InlineConstAndOpByRewriteInterp.v
+++ b/src/Compilers/InlineConstAndOpByRewriteInterp.v
@@ -133,5 +133,6 @@ Module Export Rewrite.
     Qed.
   End language.
 
+#[global]
   Hint Rewrite @InterpInlineConstAndOp @InterpInlineConstAndOpGen using assumption : reflective_interp.
 End Rewrite.

--- a/src/Compilers/InlineInterp.v
+++ b/src/Compilers/InlineInterp.v
@@ -135,4 +135,5 @@ Section language.
   Qed.
 End language.
 
+#[global]
 Hint Rewrite @InterpInlineConst @interp_inline_const @interpf_inline_constf using solve_wf_side_condition : reflective_interp.

--- a/src/Compilers/InterpProofs.v
+++ b/src/Compilers/InterpProofs.v
@@ -62,5 +62,7 @@ Section language.
   Qed.
 End language.
 
+#[global]
 Hint Rewrite @interpf_LetIn @interpf_SmartVarf : reflective_interp.
+#[global]
 Hint Rewrite @interpf_SmartVarVarf using assumption : reflective_interp.

--- a/src/Compilers/LinearizeInterp.v
+++ b/src/Compilers/LinearizeInterp.v
@@ -132,5 +132,7 @@ Section language.
     := InterpLinearize_gen_ind _ P.
 End language.
 
+#[global]
 Hint Rewrite @interpf_under_letsf : reflective_interp.
+#[global]
 Hint Rewrite @InterpLinearize_gen @interp_linearize_gen @interpf_linearizef_gen @InterpLinearize @interp_linearize @interpf_linearizef @InterpANormal @interp_a_normal @interpf_a_normalf : reflective_interp.

--- a/src/Compilers/Reify.v
+++ b/src/Compilers/Reify.v
@@ -85,6 +85,7 @@ Ltac refresh x :=
   not_x.
 Class reify_internal {varT} (var : varT) {eT} (e : eT) {T : Type} := Build_reify_internal : T.
 Class reify {varT} (var : varT) {eT} (e : eT) {T : Type} := Build_reify : T.
+#[global]
 Typeclasses Opaque reify_internal reify.
 Definition reify_var_for_in_is base_type_code {T} (x : T) (t : flat_type base_type_code) {eT} (e : eT) := False.
 Arguments reify_var_for_in_is _ {T} _ _ {eT} _.
@@ -376,6 +377,7 @@ Global Hint Extern 0 (reify_internal (@exprf ?base_type_code ?interp_base_type ?
 (** For reification including [Abs] *)
 Class reify_abs_internal {varT} (var : varT) {eT} (e : eT) {T : Type} := Build_reify_abs_internal : T.
 Class reify_abs {varT} (var : varT) {eT} (e : eT) {T : Type} := Build_reify_abs : T.
+#[global]
 Typeclasses Opaque reify_abs_internal reify_abs.
 Ltac reify_abs base_type_code interp_base_type op var e :=
   let reify_rec e := reify_abs base_type_code interp_base_type op var e in

--- a/src/Compilers/RewriterInterp.v
+++ b/src/Compilers/RewriterInterp.v
@@ -47,4 +47,5 @@ Section language.
   Qed.
 End language.
 
+#[global]
 Hint Rewrite @InterpRewriteOp using assumption : reflective_interp.

--- a/src/Compilers/Z/ArithmeticSimplifierInterp.v
+++ b/src/Compilers/Z/ArithmeticSimplifierInterp.v
@@ -244,4 +244,5 @@ Proof.
                      | progress pull_Zmod ].
 Qed.
 
+#[global]
 Hint Rewrite @InterpSimplifyArith : reflective_interp.

--- a/src/Compilers/Z/CommonSubexpressionEliminationInterp.v
+++ b/src/Compilers/Z/CommonSubexpressionEliminationInterp.v
@@ -20,4 +20,5 @@ Proof.
   apply InterpCSE_gen; auto.
 Qed.
 
+#[global]
 Hint Rewrite @InterpCSE using solve_wf_side_condition : reflective_interp.

--- a/src/Compilers/Z/InlineConstAndOpByRewriteInterp.v
+++ b/src/Compilers/Z/InlineConstAndOpByRewriteInterp.v
@@ -8,5 +8,6 @@ Module Export Rewrite.
   : forall x, Interp (InlineConstAndOp e) x = Interp e x
     := @InterpInlineConstAndOp _ _ _ _ _ t e Syntax.Util.make_const_correct.
 
+#[global]
   Hint Rewrite @InterpInlineConstAndOp : reflective_interp.
 End Rewrite.

--- a/src/Compilers/Z/InlineConstAndOpInterp.v
+++ b/src/Compilers/Z/InlineConstAndOpInterp.v
@@ -8,4 +8,5 @@ Definition InterpInlineConstAndOp {t} (e : Expr t) (Hwf : Wf e)
   : forall x, Interp (InlineConstAndOp e) x = Interp e x
   := @InterpInlineConstAndOp _ _ _ _ _ t e Hwf Syntax.Util.make_const_correct.
 
+#[global]
 Hint Rewrite @InterpInlineConstAndOp using solve_wf_side_condition : reflective_interp.

--- a/src/Compilers/Z/InlineInterp.v
+++ b/src/Compilers/Z/InlineInterp.v
@@ -12,4 +12,5 @@ Definition InterpInlineConst {interp_base_type interp_op} {t} (e : Expr t) (Hwf 
   : forall x, Compilers.Syntax.Interp interp_op (InlineConst e) x = Compilers.Syntax.Interp interp_op e x
   := @InterpInlineConst _ interp_base_type _ _ _ t e Hwf.
 
+#[global]
 Hint Rewrite @InterpInlineConstAndOpp @InterpInlineConst using solve_wf_side_condition : reflective_interp.

--- a/src/Compilers/Z/RewriteAddToAdcInterp.v
+++ b/src/Compilers/Z/RewriteAddToAdcInterp.v
@@ -68,4 +68,5 @@ Section language.
   Qed.
 End language.
 
+#[global]
 Hint Rewrite @InterpRewriteAdc using solve_wf_side_condition : reflective_interp.

--- a/src/Compilers/ZExtended/InlineConstAndOpByRewriteInterp.v
+++ b/src/Compilers/ZExtended/InlineConstAndOpByRewriteInterp.v
@@ -11,5 +11,6 @@ Module Export Rewrite.
     clear; abstract (intros []; intros; reflexivity).
   Defined.
 
+#[global]
   Hint Rewrite @InterpInlineConstAndOp : reflective_interp.
 End Rewrite.

--- a/src/Compilers/ZExtended/InlineConstAndOpInterp.v
+++ b/src/Compilers/ZExtended/InlineConstAndOpInterp.v
@@ -11,4 +11,5 @@ Proof.
   clear; abstract (intros []; intros; reflexivity).
 Defined.
 
+#[global]
 Hint Rewrite @InterpInlineConstAndOp using solve_wf_side_condition : reflective_interp.

--- a/src/Demo.v
+++ b/src/Demo.v
@@ -25,6 +25,7 @@ Module Associational.
   Proof. induction p; rewrite <-?List.app_comm_cons;
            rewrite ?eval_nil, ?eval_cons; nsatz.              Qed.
 
+#[global]
   Hint Rewrite eval_nil eval_cons eval_app : push_eval.
   Local Ltac push := autorewrite with
       push_eval push_map push_partition push_flat_map
@@ -33,6 +34,7 @@ Module Associational.
   Lemma eval_map_mul (a x:Z) (p:list (Z*Z))
   : eval (List.map (fun t => (a*fst t, x*snd t)) p) = a*x*eval p.
   Proof. induction p; push; nsatz.                            Qed.
+#[global]
   Hint Rewrite eval_map_mul : push_eval.
 
   Definition mul (p q:list (Z*Z)) : list (Z*Z) :=
@@ -42,6 +44,7 @@ Module Associational.
     q) p.
   Lemma eval_mul p q : eval (mul p q) = eval p * eval q.
   Proof. induction p; cbv [mul]; push; nsatz.                 Qed.
+#[global]
   Hint Rewrite eval_mul : push_eval.
 
   Example base10_2digit_mul (a0:Z) (a1:Z) (b0:Z) (b1:Z) :
@@ -79,11 +82,16 @@ Module Associational.
     eval (reduce s c p) mod (s - eval c) = eval p mod (s - eval c).
   Proof. cbv [reduce]; push.
          rewrite <-reduction_rule, eval_split; trivial.      Qed.
+#[global]
   Hint Rewrite eval_reduce : push_eval.
 End Associational.
+#[global]
 Hint Rewrite Associational.eval_nil Associational.eval_cons Associational.eval_app : push_eval.
+#[global]
 Hint Rewrite Associational.eval_map_mul : push_eval.
+#[global]
 Hint Rewrite Associational.eval_mul : push_eval.
+#[global]
 Hint Rewrite Associational.eval_reduce : push_eval.
 
 Module Positional. Section Positional.

--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -74,6 +74,7 @@ Module Associational.
   Proof using Type. induction p; rewrite <-?List.app_comm_cons;
            rewrite ?eval_nil, ?eval_cons; nsatz.              Qed.
 
+#[global]
   Hint Rewrite eval_nil eval_cons eval_app : push_eval.
   Local Ltac push := autorewrite with
       push_eval push_map push_partition push_flat_map
@@ -82,6 +83,7 @@ Module Associational.
   Lemma eval_map_mul (a x:Z) (p:list (Z*Z))
   : eval (List.map (fun t => (a*fst t, x*snd t)) p) = a*x*eval p.
   Proof using Type. induction p; push; nsatz.                            Qed.
+#[global]
   Hint Rewrite eval_map_mul : push_eval.
 
   Definition mul (p q:list (Z*Z)) : list (Z*Z) :=
@@ -91,12 +93,14 @@ Module Associational.
     q) p.
   Lemma eval_mul p q : eval (mul p q) = eval p * eval q.
   Proof using Type. induction p; cbv [mul]; push; nsatz.                 Qed.
+#[global]
   Hint Rewrite eval_mul : push_eval.
 
   Definition negate_snd (p:list (Z*Z)) : list (Z*Z) :=
     map (fun cx => (fst cx, -snd cx)) p.
   Lemma eval_negate_snd p : eval (negate_snd p) = - eval p.
   Proof using Type. induction p; cbv [negate_snd]; push; nsatz.          Qed.
+#[global]
   Hint Rewrite eval_negate_snd : push_eval.
 
   Example base10_2digit_mul (a0:Z) (a1:Z) (b0:Z) (b1:Z) :
@@ -134,6 +138,7 @@ Module Associational.
     eval (reduce s c p) mod (s - eval c) = eval p mod (s - eval c).
   Proof using Type. cbv [reduce]; push.
          rewrite <-reduction_rule, eval_split; trivial.      Qed.
+#[global]
   Hint Rewrite eval_reduce : push_eval.
 
   Definition bind_snd (p : list (Z*Z)) :=
@@ -175,10 +180,15 @@ Module Associational.
     Hint Rewrite eval_carry using auto : push_eval.
   End Carries.
   Module Export Hints.
+#[global]
     Hint Rewrite eval_nil eval_cons eval_app : push_eval.
+#[global]
     Hint Rewrite eval_map_mul : push_eval.
+#[global]
     Hint Rewrite eval_mul : push_eval.
+#[global]
     Hint Rewrite eval_negate_snd : push_eval.
+#[global]
     Hint Rewrite eval_reduce : push_eval.
   End Hints.
 End Associational.
@@ -476,6 +486,7 @@ Module Positional. Section Positional.
 End Positional.
 (* Hint Rewrite disappears after the end of a section *)
 Module Export Hints.
+#[global]
   Hint Rewrite length_zeros length_add_to_nth length_from_associational @length_add @length_carry_reduce @length_chained_carries @length_encode @length_sub @length_opp : distr_length.
 End Hints.
 End Positional.

--- a/src/LegacyArithmetic/Double/Proofs/Decode.v
+++ b/src/LegacyArithmetic/Double/Proofs/Decode.v
@@ -134,8 +134,11 @@ Global Hint Extern 1 (@is_add_with_carry _ _ (@tuple_decoder ?n ?W ?decode 1) ?a
 Global Hint Resolve (fun n W decode pf => (@tuple_is_decode n W decode 2 pf : @is_decode (2 * n) (tuple W 2) (@tuple_decoder n W decode 2))) : typeclass_instances.
 Global Hint Extern 3 (@is_decode _ (tuple ?W ?k) _) => let kv := (eval simpl in (Z.of_nat k)) in apply (fun n decode pf => (@tuple_is_decode n W decode k pf : @is_decode (kv * n) (tuple W k) (@tuple_decoder n W decode k : decoder (kv * n)%Z (tuple W k)))) : typeclass_instances.
 
+#[global]
 Hint Rewrite @tuple_decoder_S @tuple_decoder_O @tuple_decoder_m1 @tuple_decoder_n_O using solve [ auto with zarith ] : simpl_tuple_decoder.
+#[global]
 Hint Rewrite Z.mul_1_l : simpl_tuple_decoder.
+#[global]
 Hint Rewrite
      (fun n W (decode : decoder n W) w pf => (@tuple_decoder_S n W decode 0 w pf : @Interface.decode (2 * n) (tuple W 2) (@tuple_decoder n W decode 2) w = _))
      (fun n W (decode : decoder n W) w pf => (@tuple_decoder_S n W decode 0 w pf : @Interface.decode (2 * n) (W * W) (@tuple_decoder n W decode 2) w = _))
@@ -143,6 +146,7 @@ Hint Rewrite
      using solve [ auto with zarith ]
   : simpl_tuple_decoder.
 
+#[global]
 Hint Rewrite @tuple_decoder_S @tuple_decoder_O @tuple_decoder_m1 using solve [ auto with zarith ] : simpl_tuple_decoder.
 
 Global Instance tuple_decoder_mod : forall {n W} {decode : decoder n W} {k} {isdecode : is_decode decode} (w : tuple W (S (S k))),
@@ -210,8 +214,11 @@ Module Export Hints.
   Global Hint Resolve (fun n W decode pf => (@tuple_is_decode n W decode 2 pf : @is_decode (2 * n) (tuple W 2) (@tuple_decoder n W decode 2))) : typeclass_instances.
   Global Hint Extern 3 (@is_decode _ (tuple ?W ?k) _) => let kv := (eval simpl in (Z.of_nat k)) in apply (fun n decode pf => (@tuple_is_decode n W decode k pf : @is_decode (kv * n) (tuple W k) (@tuple_decoder n W decode k : decoder (kv * n)%Z (tuple W k)))) : typeclass_instances.
 
+#[global]
   Hint Rewrite @tuple_decoder_S @tuple_decoder_O @tuple_decoder_m1 @tuple_decoder_n_O using solve [ auto with zarith ] : simpl_tuple_decoder.
+#[global]
   Hint Rewrite Z.mul_1_l : simpl_tuple_decoder.
+#[global]
   Hint Rewrite
        (fun n W (decode : decoder n W) w pf => (@tuple_decoder_S n W decode 0 w pf : @Interface.decode (2 * n) (tuple W 2) (@tuple_decoder n W decode 2) w = _))
        (fun n W (decode : decoder n W) w pf => (@tuple_decoder_S n W decode 0 w pf : @Interface.decode (2 * n) (W * W) (@tuple_decoder n W decode 2) w = _))
@@ -219,6 +226,7 @@ Module Export Hints.
        using solve [ auto with zarith ]
     : simpl_tuple_decoder.
 
+#[global]
   Hint Rewrite @tuple_decoder_S @tuple_decoder_O @tuple_decoder_m1 using solve [ auto with zarith ] : simpl_tuple_decoder.
 
   Global Existing Instances

--- a/src/LegacyArithmetic/Interface.v
+++ b/src/LegacyArithmetic/Interface.v
@@ -70,6 +70,7 @@ Module Import BoundedRewriteNotations.
 End BoundedRewriteNotations.
 
 (** This is required for typeclass resolution to be fast. *)
+#[global]
 Typeclasses Opaque decode.
 
 Section InstructionGallery.
@@ -459,6 +460,7 @@ Module Export Hints.
   Global Existing Instance decode_range_bound.
   Global Hint Extern 0 (bounded_le_cls _ _) => unfold bounded_le_cls; bounded_solver_tac : typeclass_instances.
   Global Arguments bounded_le_cls / _ _.
+#[global]
   Typeclasses Opaque decode.
   Global Existing Instances
          fancy_machine.decode

--- a/src/LegacyArithmetic/Pow2BaseProofs.v
+++ b/src/LegacyArithmetic/Pow2BaseProofs.v
@@ -426,20 +426,33 @@ Section Pow2BaseProofs.
 
 End Pow2BaseProofs.
 Module Import Hints2.
+#[global]
   Hint Rewrite base_from_limb_widths_cons base_from_limb_widths_nil : push_base_from_limb_widths.
+#[global]
   Hint Rewrite <- base_from_limb_widths_cons : pull_base_from_limb_widths.
 
+#[global]
   Hint Rewrite <- @firstn_base_from_limb_widths : push_base_from_limb_widths.
+#[global]
   Hint Rewrite <- @firstn_base_from_limb_widths : pull_firstn.
+#[global]
   Hint Rewrite @firstn_base_from_limb_widths : pull_base_from_limb_widths.
+#[global]
   Hint Rewrite @firstn_base_from_limb_widths : push_firstn.
+#[global]
   Hint Rewrite <- @skipn_base_from_limb_widths : push_base_from_limb_widths.
+#[global]
   Hint Rewrite <- @skipn_base_from_limb_widths : pull_skipn.
+#[global]
   Hint Rewrite @skipn_base_from_limb_widths : pull_base_from_limb_widths.
+#[global]
   Hint Rewrite @skipn_base_from_limb_widths : push_skipn.
 
+#[global]
   Hint Rewrite @base_from_limb_widths_length : distr_length.
+#[global]
   Hint Rewrite @upper_bound_nil @upper_bound_cons @upper_bound_app using solve [ eauto with znonzero ] : push_upper_bound.
+#[global]
   Hint Rewrite <- @upper_bound_cons @upper_bound_app using solve [ eauto with znonzero ] : pull_upper_bound.
 End Hints2.
 

--- a/src/LegacyArithmetic/ZBounded.v
+++ b/src/LegacyArithmetic/ZBounded.v
@@ -116,7 +116,9 @@ Qed.
 
 Create HintDb push_zlike_decode discriminated.
 Create HintDb pull_zlike_decode discriminated.
+#[global]
 Hint Rewrite @Mod_SmallBound_correct @DivBy_SmallBound_correct @DivBy_SmallerBound_correct @Mul_correct @CarryAdd_correct_fst @CarryAdd_correct_snd @CarrySubSmall_correct_fst @CarrySubSmall_correct_snd  @ConditionalSubtract_correct @ConditionalSubtractModulus_correct @ConditionalSubtractModulus_correct' @modulus_digits_correct using solve [ typeclasses eauto ] : push_zlike_decode.
+#[global]
 Hint Rewrite <- @Mod_SmallBound_correct @DivBy_SmallBound_correct @DivBy_SmallerBound_correct @Mul_correct @CarryAdd_correct_fst @CarryAdd_correct_snd @CarrySubSmall_correct_fst @CarrySubSmall_correct_snd @ConditionalSubtract_correct @ConditionalSubtractModulus_correct @modulus_digits_correct using solve [ typeclasses eauto ] : pull_zlike_decode.
 
 Ltac get_modulus :=

--- a/src/Specific/Framework/ArithmeticSynthesis/Freeze.v
+++ b/src/Specific/Framework/ArithmeticSynthesis/Freeze.v
@@ -16,6 +16,7 @@ Require Import Crypto.Util.Tactics.CacheTerm.
 
 Module Export Exports.
   Global Hint Opaque freeze : uncps.
+#[global]
   Hint Rewrite freeze_id : uncps.
 End Exports.
 

--- a/src/Util/Bool.v
+++ b/src/Util/Bool.v
@@ -90,9 +90,13 @@ Module Export Hints.
   Global Hint Extern 1 => progress autorewrite with bool_congr_setoid in * : bool_congr_setoid.
   Global Hint Extern 2 => progress rewrite_strat topdown hints bool_congr_setoid : bool_congr_setoid.
 
+#[global]
   Hint Rewrite Bool.andb_diag Bool.orb_diag Bool.eqb_reflx Bool.negb_involutive Bool.eqb_negb1 Bool.eqb_negb2 Bool.orb_true_r Bool.orb_true_l Bool.orb_false_r Bool.orb_false_l Bool.orb_negb_r Bool.andb_false_r Bool.andb_false_l Bool.andb_true_r Bool.andb_false_r Bool.andb_negb_r Bool.xorb_false_r Bool.xorb_false_l Bool.xorb_true_r Bool.xorb_true_l Bool.xorb_nilpotent : bool_congr.
+#[global]
   Hint Rewrite Bool.negb_if : boolsimplify.
+#[global]
   Hint Rewrite <- Bool.andb_if Bool.andb_lazy_alt Bool.orb_lazy_alt : boolsimplify.
+#[global]
   Hint Rewrite Bool.not_true_iff_false Bool.not_false_iff_true Bool.eqb_true_iff Bool.eqb_false_iff Bool.negb_true_iff Bool.negb_false_iff Bool.orb_true_iff Bool.orb_false_iff Bool.andb_true_iff Bool.andb_false_iff Bool.xorb_negb_negb : bool_congr_setoid.
 
   Global Hint Extern 1 => progress autorewrite with push_orb in * : push_orb.
@@ -101,15 +105,26 @@ Module Export Hints.
   Global Hint Extern 1 => progress autorewrite with pull_andb in * : pull_andb.
   Global Hint Extern 1 => progress autorewrite with push_negb in * : push_negb.
   Global Hint Extern 1 => progress autorewrite with pull_negb in * : pull_negb.
+#[global]
   Hint Rewrite Bool.negb_orb Bool.negb_andb : push_negb.
+#[global]
   Hint Rewrite Bool.xorb_negb_negb : pull_negb.
+#[global]
   Hint Rewrite <- Bool.negb_orb Bool.negb_andb Bool.negb_xorb_l Bool.negb_xorb_r : pull_negb.
+#[global]
   Hint Rewrite Bool.andb_orb_distrib_r Bool.andb_orb_distrib_l : push_andb.
+#[global]
   Hint Rewrite <- Bool.orb_andb_distrib_r Bool.orb_andb_distrib_l : push_andb.
+#[global]
   Hint Rewrite Bool.orb_andb_distrib_r Bool.orb_andb_distrib_l : pull_andb.
+#[global]
   Hint Rewrite <- Bool.andb_orb_distrib_r Bool.andb_orb_distrib_l : pull_andb.
+#[global]
   Hint Rewrite Bool.orb_andb_distrib_r Bool.orb_andb_distrib_l : push_orb.
+#[global]
   Hint Rewrite <- Bool.andb_orb_distrib_r Bool.andb_orb_distrib_l : push_orb.
+#[global]
   Hint Rewrite <- Bool.orb_andb_distrib_r Bool.orb_andb_distrib_l : pull_orb.
+#[global]
   Hint Rewrite Bool.andb_orb_distrib_r Bool.andb_orb_distrib_l : pull_orb.
 End Hints.

--- a/src/Util/CPSUtil.v
+++ b/src/Util/CPSUtil.v
@@ -13,6 +13,7 @@ Create HintDb push_id discriminated.
 Create HintDb uncps discriminated.
 
 Lemma push_id {A} (a:A) : id a = a. reflexivity. Qed.
+#[global]
 Hint Rewrite @push_id : push_id.
 
 Definition id_with_alt_cps' {R A} (value value_for_alt : (A -> A) -> A) (f : A -> R) : R
@@ -25,18 +26,22 @@ Definition id_with_alt_cps {R A} (value value_for_alt : forall R, (A -> R) -> R)
 Definition id_with_alt_cps'_correct {R A} value value_for_alt f
   : @id_with_alt_cps' R A value value_for_alt f = f (id_with_alt (value id) (value_for_alt id))
   := eq_refl.
+#[global]
 Hint Rewrite @id_with_alt_cps'_correct : uncps.
 Definition id_with_alt_cps''_correct {R A} value value_for_alt f
   : @id_with_alt_cps'' R A value value_for_alt f = id_with_alt (value f) (value_for_alt f)
   := eq_refl.
+#[global]
 Hint Rewrite @id_with_alt_cps''_correct : uncps.
 Definition id_with_alt_cps_correct {R A} value value_for_alt f
   : @id_with_alt_cps R A value value_for_alt f = f (id_with_alt (value _ id) (value_for_alt _ id))
   := eq_refl.
+#[global]
 Hint Rewrite @id_with_alt_cps_correct : uncps.
 Definition id_with_alt_cps'_correct_gen {R A} (value value_for_alt : forall R, (A -> R) -> R) f
   : @id_with_alt_cps' R A (value _) (value_for_alt _) f = f (id_with_alt (value _ id) (value_for_alt _ id))
   := eq_refl.
+#[global]
 Hint Rewrite @id_with_alt_cps'_correct_gen : uncps.
 Definition id_with_alt_cps''_correct_gen {R A} (value value_for_alt : forall R, (A -> R) -> R) f
            (Hvalue : value _ f = f (value _ id))
@@ -44,6 +49,7 @@ Definition id_with_alt_cps''_correct_gen {R A} (value value_for_alt : forall R, 
 Proof.
   cbv [id_with_alt_cps'' id_with_alt]; assumption.
 Defined.
+#[global]
 Hint Rewrite @id_with_alt_cps''_correct_gen : uncps.
 
 Definition id_tuple'_with_alt_cps' {R A n}
@@ -62,11 +68,13 @@ Definition id_tuple_with_alt_cps' {R A n}
 Definition id_tuple'_with_alt_cps'_correct {R A n} value value_for_alt f
   : @id_tuple'_with_alt_cps' R A n value value_for_alt f = f (id_tuple'_with_alt (value id) (value_for_alt id))
   := eq_refl.
+#[global]
 Hint Rewrite @id_tuple'_with_alt_cps'_correct : uncps.
 
 Definition id_tuple_with_alt_cps'_correct {R A n} value value_for_alt f
   : @id_tuple_with_alt_cps' R A n value value_for_alt f = f (id_tuple_with_alt (value id) (value_for_alt id))
   := eq_refl.
+#[global]
 Hint Rewrite @id_tuple_with_alt_cps'_correct : uncps.
 
 Definition id_tuple'_with_alt_cps'' {R A n}
@@ -83,11 +91,13 @@ Definition id_tuple_with_alt_cps'' {R A n}
 Definition id_tuple'_with_alt_cps''_correct {R A n} value value_for_alt f
   : @id_tuple'_with_alt_cps'' R A n value value_for_alt f = id_with_alt (value f) (value_for_alt f)
   := eq_refl.
+#[global]
 Hint Rewrite @id_tuple'_with_alt_cps''_correct : uncps.
 
 Definition id_tuple_with_alt_cps''_correct {R A n} value value_for_alt f
   : @id_tuple_with_alt_cps'' R A n value value_for_alt f = id_with_alt (value f) (value_for_alt f)
   := eq_refl.
+#[global]
 Hint Rewrite @id_tuple_with_alt_cps''_correct : uncps.
 
 Definition id_tuple'_with_alt_cps''_correct_gen {R A n}
@@ -99,6 +109,7 @@ Proof.
   rewrite ?unfold_id_tuple'_with_alt, ?unfold_id_tuple_with_alt, ?unfold_id_with_alt, Hvalue.
   reflexivity.
 Qed.
+#[global]
 Hint Rewrite @id_tuple'_with_alt_cps''_correct_gen : uncps.
 
 Definition id_tuple_with_alt_cps''_correct_gen {R A n}
@@ -110,6 +121,7 @@ Proof.
   rewrite ?unfold_id_tuple_with_alt, ?unfold_id_tuple_with_alt, ?unfold_id_with_alt, Hvalue.
   reflexivity.
 Qed.
+#[global]
 Hint Rewrite @id_tuple_with_alt_cps''_correct_gen : uncps.
 
 Definition id_tuple'_with_alt_cps {R A n}
@@ -126,11 +138,13 @@ Definition id_tuple_with_alt_cps {R A n}
 Definition id_tuple'_with_alt_cps_correct {R A n} value value_for_alt f
   : @id_tuple'_with_alt_cps R A n value value_for_alt f = f (id_tuple'_with_alt (value _ id) (value_for_alt _ id))
   := eq_refl.
+#[global]
 Hint Rewrite @id_tuple'_with_alt_cps_correct : uncps.
 
 Definition id_tuple_with_alt_cps_correct {R A n} value value_for_alt f
   : @id_tuple_with_alt_cps R A n value value_for_alt f = f (id_tuple_with_alt (value _ id) (value_for_alt _ id))
   := eq_refl.
+#[global]
 Hint Rewrite @id_tuple_with_alt_cps_correct : uncps.
 
 Lemma update_nth_id {T} i (xs:list T) : ListUtil.update_nth i id xs = xs.
@@ -173,6 +187,7 @@ Fixpoint map_cps {A B} (g : A->B) ls
 Lemma map_cps_correct {A B} g ls: forall {T} f,
     @map_cps A B g ls T f = f (map g ls).
 Proof. induction ls as [|?? IHls]; simpl; intros; rewrite ?IHls; reflexivity. Qed.
+#[global]
 Hint Rewrite @map_cps_correct : uncps.
 
 Fixpoint firstn_cps {A} (n:nat) (l:list A) {T} (f:list A->T) :=
@@ -186,6 +201,7 @@ Fixpoint firstn_cps {A} (n:nat) (l:list A) {T} (f:list A->T) :=
 Lemma firstn_cps_correct {A} n l T f :
   @firstn_cps A n l T f = f (firstn n l).
 Proof. induction n; destruct l; reflexivity. Qed.
+#[global]
 Hint Rewrite @firstn_cps_correct : uncps.
 
 Fixpoint flat_map_cps_specialized {T A B} (g:A->(list B->T)->T) (ls : list A) (f:list B->T)  :=
@@ -213,6 +229,7 @@ Proof.
   rewrite H; erewrite IHls by eassumption.
   reflexivity.
 Qed.
+#[global]
 Hint Rewrite @flat_map_cps_correct using (intros; autorewrite with uncps; auto): uncps.
 
 Fixpoint from_list_default'_cps {A} (d y:A) n xs {T}:
@@ -247,6 +264,7 @@ Proof.
   destruct n; intros; simpl; [reflexivity|].
   break_match; auto using from_list_default'_cps_correct.
 Qed.
+#[global]
 Hint Rewrite @from_list_default_cps_correct : uncps.
 Fixpoint to_list'_cps {A} n
          {T} (f:list A -> T) : Tuple.tuple' A n -> T :=
@@ -273,6 +291,7 @@ Definition to_list_cps {A} n t {T} f :=
 Lemma to_list_cps_correct {A} n t {T} f :
   @to_list_cps A n t T f = f (Tuple.to_list n t).
 Proof. cbv [to_list_cps to_list_cps' Tuple.to_list]; break_match; auto using to_list'_cps_correct. Qed.
+#[global]
 Hint Rewrite @to_list_cps_correct : uncps.
 
 Definition on_tuple_cps {A B} (d:B) (g:list A ->forall {T},(list B->T)->T) {n m}
@@ -287,6 +306,7 @@ Proof.
   rewrite to_list_cps_correct, Hg, from_list_default_cps_correct.
   rewrite (Tuple.from_list_default_eq _ _ _ (H _ (Tuple.length_to_list _))).
   reflexivity.
+#[global]
 Qed.  Hint Rewrite @on_tuple_cps_correct using (intros; autorewrite with uncps; auto): uncps.
 
 Fixpoint update_nth_cps {A} n (g:A->A) xs {T} (f:list A->T) :=
@@ -305,6 +325,7 @@ Fixpoint update_nth_cps {A} n (g:A->A) xs {T} (f:list A->T) :=
 Lemma update_nth_cps_correct {A} n g: forall xs T f,
     @update_nth_cps A n g xs T f = f (update_nth n g xs).
 Proof. induction n; intros; simpl; break_match; try apply IHn; reflexivity. Qed.
+#[global]
 Hint Rewrite @update_nth_cps_correct : uncps.
 
 Fixpoint combine_cps {A B} (la :list A) (lb : list B)
@@ -323,6 +344,7 @@ Proof.
   induction la; simpl combine_cps; simpl combine; intros;
     try break_match; try apply IHla; reflexivity.
 Qed.
+#[global]
 Hint Rewrite @combine_cps_correct: uncps.
 
 (* differs from fold_right_cps in that the functional argument `g` is also a CPS function *)
@@ -354,6 +376,7 @@ Proof.
   rewrite H; erewrite IHl by eassumption.
   rewrite H; reflexivity.
 Qed.
+#[global]
 Hint Rewrite @fold_right_cps2_correct using (intros; autorewrite with uncps; auto): uncps.
 
 Definition fold_right_no_starter {A} (f:A->A->A) ls : option A :=
@@ -387,6 +410,7 @@ Fixpoint fold_right_cps {A B} (g:B->A->A) (a0:A) (l:list B) {T} (f:A->T) :=
 Lemma fold_right_cps_correct {A B} g a0 l: forall {T} f,
     @fold_right_cps A B g a0 l T f = f (List.fold_right g a0 l).
 Proof. induction l as [|? l IHl]; intros; simpl; rewrite ?IHl; auto. Qed.
+#[global]
 Hint Rewrite @fold_right_cps_correct : uncps.
 
 Definition fold_right_no_starter_cps {A} g ls {T} (f:option A->T) :=
@@ -399,6 +423,7 @@ Lemma fold_right_no_starter_cps_correct {A} g ls {T} f :
 Proof.
   cbv [fold_right_no_starter_cps fold_right_no_starter]; break_match; reflexivity.
 Qed.
+#[global]
 Hint Rewrite @fold_right_no_starter_cps_correct : uncps.
 
 Import Tuple.
@@ -415,6 +440,7 @@ Module Tuple.
   Proof.
     induction n; simpl map_cps; intros; try destruct t;
     [|rewrite IHn, <-map_append,<-subst_append]; reflexivity.
+#[global]
   Qed. Hint Rewrite @map_cps_correct : uncps.
 
   Fixpoint map2_cps {n A B C} (g:A->B->C) (xs:tuple A n) (ys:tuple B n) {T} :
@@ -429,6 +455,7 @@ Module Tuple.
   Proof.
     induction n; simpl map2_cps; intros; try destruct xs, ys;
     [|rewrite IHn, <-map2_append,<-!subst_append]; reflexivity.
+#[global]
   Qed. Hint Rewrite @map2_cps_correct : uncps.
 
   Section internal_mapi_with_cps.
@@ -481,6 +508,7 @@ Module Tuple.
   (H:forall i s a R (ret:_->R), f i s a R ret = ret (f i s a _ id))
   : @mapi_with_cps S A B n f start xs T ret = ret (mapi_with (fun i s a => f i s a _ id) start xs).
   Proof. destruct n; simpl; rewrite ?mapi_with'_cps_correct by assumption; reflexivity. Qed.
+#[global]
   Hint Rewrite @mapi_with_cps_correct @mapi_with'_cps_correct
        using (intros; autorewrite with uncps; auto): uncps.
 
@@ -534,6 +562,7 @@ Module Tuple.
   (H:forall i s a R (ret:_->R), f i s a R ret = ret (f i s a _ id))
   : @mapi_with_cps2 S A B n f start xs T ret = ret (mapi_with (fun i s a => f i s a _ id) start xs).
   Proof. destruct n; simpl; rewrite ?mapi_with'_cps2_correct by assumption; reflexivity. Qed.
+#[global]
   Hint Rewrite @mapi_with_cps2_correct @mapi_with'_cps2_correct
        using (intros; autorewrite with uncps; auto): uncps.
 
@@ -648,7 +677,9 @@ Module Tuple.
     destruct p; simpl in *; rewrite IHn; simpl; reflexivity.
   Qed.
 End Tuple.
+#[global]
 Hint Rewrite @Tuple.map_cps_correct @Tuple.left_append_cps_correct @Tuple.left_tl_cps_correct @Tuple.left_hd_cps_correct @Tuple.tl_cps_correct @Tuple.hd_cps_correct : uncps.
+#[global]
 Hint Rewrite @Tuple.mapi_with_cps_correct @Tuple.mapi_with'_cps_correct @Tuple.mapi_with_cps2_correct @Tuple.mapi_with'_cps2_correct
      using (intros; autorewrite with uncps; auto): uncps.
 
@@ -657,38 +688,69 @@ Module Export Hints.
   Export Crypto.Util.LetIn.Hints.
   Export Crypto.Util.Tuple.Hints.
 
+#[global]
   Hint Rewrite @push_id : push_id.
+#[global]
   Hint Rewrite @id_with_alt_cps'_correct : uncps.
+#[global]
   Hint Rewrite @id_with_alt_cps''_correct : uncps.
+#[global]
   Hint Rewrite @id_with_alt_cps_correct : uncps.
+#[global]
   Hint Rewrite @id_with_alt_cps'_correct_gen : uncps.
+#[global]
   Hint Rewrite @id_with_alt_cps''_correct_gen : uncps.
+#[global]
   Hint Rewrite @id_tuple'_with_alt_cps'_correct : uncps.
+#[global]
   Hint Rewrite @id_tuple_with_alt_cps'_correct : uncps.
+#[global]
   Hint Rewrite @id_tuple'_with_alt_cps''_correct : uncps.
+#[global]
   Hint Rewrite @id_tuple_with_alt_cps''_correct : uncps.
+#[global]
   Hint Rewrite @id_tuple'_with_alt_cps''_correct_gen : uncps.
+#[global]
   Hint Rewrite @id_tuple_with_alt_cps''_correct_gen : uncps.
+#[global]
   Hint Rewrite @id_tuple'_with_alt_cps_correct : uncps.
+#[global]
   Hint Rewrite @id_tuple_with_alt_cps_correct : uncps.
+#[global]
   Hint Rewrite @map_cps_correct : uncps.
+#[global]
   Hint Rewrite @firstn_cps_correct : uncps.
+#[global]
   Hint Rewrite @flat_map_cps_correct using (intros; autorewrite with uncps; auto): uncps.
+#[global]
   Hint Rewrite @from_list_default_cps_correct : uncps.
+#[global]
   Hint Rewrite @to_list_cps_correct : uncps.
+#[global]
   Hint Rewrite @on_tuple_cps_correct using (intros; autorewrite with uncps; auto): uncps.
+#[global]
   Hint Rewrite @update_nth_cps_correct : uncps.
+#[global]
   Hint Rewrite @combine_cps_correct: uncps.
+#[global]
   Hint Rewrite @fold_right_cps2_correct using (intros; autorewrite with uncps; auto): uncps.
+#[global]
   Hint Rewrite @fold_right_cps_correct : uncps.
+#[global]
   Hint Rewrite @fold_right_no_starter_cps_correct : uncps.
+#[global]
   Hint Rewrite @Tuple.map_cps_correct : uncps.
+#[global]
   Hint Rewrite @Tuple.map2_cps_correct : uncps.
+#[global]
   Hint Rewrite @Tuple.mapi_with_cps_correct @Tuple.mapi_with'_cps_correct
        using (intros; autorewrite with uncps; auto): uncps.
+#[global]
   Hint Rewrite @Tuple.mapi_with_cps2_correct @Tuple.mapi_with'_cps2_correct
        using (intros; autorewrite with uncps; auto): uncps.
+#[global]
   Hint Rewrite @Tuple.map_cps_correct @Tuple.left_append_cps_correct @Tuple.left_tl_cps_correct @Tuple.left_hd_cps_correct @Tuple.tl_cps_correct @Tuple.hd_cps_correct : uncps.
+#[global]
   Hint Rewrite @Tuple.mapi_with_cps_correct @Tuple.mapi_with'_cps_correct @Tuple.mapi_with_cps2_correct @Tuple.mapi_with'_cps2_correct
        using (intros; autorewrite with uncps; auto): uncps.
 End Hints.

--- a/src/Util/Decidable/Decidable2Bool.v
+++ b/src/Util/Decidable/Decidable2Bool.v
@@ -17,18 +17,21 @@ Lemma dec_Z_lt_to_bool a b
 Proof.
   destruct (Z.ltb a b) eqn:?; break_match; Z.ltb_to_lt; try reflexivity; lia.
 Qed.
+#[global]
 Hint Rewrite dec_Z_lt_to_bool : dec2bool.
 Lemma dec_Z_le_to_bool a b
   : (if dec (a <= b) then true else false) = Z.leb a b.
 Proof.
   destruct (Z.leb a b) eqn:?; break_match; Z.ltb_to_lt; try reflexivity; lia.
 Qed.
+#[global]
 Hint Rewrite dec_Z_le_to_bool : dec2bool.
 Lemma dec_Z_eq_to_bool a b
   : (if dec (a = b) then true else false) = Z.eqb a b.
 Proof.
   destruct (Z.eqb a b) eqn:?; break_match; Z.ltb_to_lt; try reflexivity; lia.
 Qed.
+#[global]
 Hint Rewrite dec_Z_eq_to_bool : dec2bool.
 Lemma dec_nat_eq_to_bool a b
   : (if dec (a = b) then true else false) = Nat.eqb a b.
@@ -37,12 +40,14 @@ Proof.
   { apply beq_nat_true in H; congruence. }
   { rewrite Nat.eqb_refl in H; congruence. }
 Qed.
+#[global]
 Hint Rewrite dec_nat_eq_to_bool : dec2bool.
 Lemma dec_bool_eq_to_bool_if a b
   : (if dec (a = b :> bool) then true else false) = if b then a else negb a.
 Proof.
   destruct a, b; reflexivity.
 Qed.
+#[global]
 Hint Rewrite dec_bool_eq_to_bool_if : dec2bool.
 Lemma dec_not_negb {P} {H : Decidable P}
   : (if dec (not P) then true else false)
@@ -50,6 +55,7 @@ Lemma dec_not_negb {P} {H : Decidable P}
 Proof.
   do 2 edestruct dec; try reflexivity; tauto.
 Qed.
+#[global]
 Hint Rewrite @dec_not_negb : dec2bool.
 Lemma dec_Q_le_to_bool a b
   : (if dec (a <= b)%Q then true else false) = Qle_bool a b.
@@ -57,29 +63,35 @@ Proof.
   destruct (Qle_bool a b) eqn:?; cbv [Qle Qle_bool] in *;
     break_match; Z.ltb_to_lt; try reflexivity; lia.
 Qed.
+#[global]
 Hint Rewrite dec_Q_le_to_bool : dec2bool.
 Lemma dec_True_to_bool
   : (if dec True then true else false) = true.
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite dec_True_to_bool : dec2bool.
 Lemma dec_False_to_bool
   : (if dec False then true else false) = false.
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite dec_False_to_bool : dec2bool.
 Lemma dec_ifb_to_bool {b : bool} {A B} {HA : Decidable A} {HB : Decidable B}
   : (if dec (if b then A else B) then true else false)
     = if b then (if dec A then true else false) else (if dec B then true else false).
 Proof. destruct b; reflexivity. Qed.
+#[global]
 Hint Rewrite @dec_ifb_to_bool : dec2bool.
 Lemma dec_and_to_bool {A B} {HA : Decidable A} {HB : Decidable B}
   : (if dec (A /\ B) then true else false)
     = andb (if dec A then true else false) (if dec B then true else false).
 Proof. do 3 edestruct dec; try reflexivity; tauto. Qed.
+#[global]
 Hint Rewrite @dec_and_to_bool : dec2bool.
 Lemma dec_or_to_bool {A B} {HA : Decidable A} {HB : Decidable B}
   : (if dec (A \/ B) then true else false)
     = orb (if dec A then true else false) (if dec B then true else false).
 Proof. do 3 edestruct dec; try reflexivity; tauto. Qed.
+#[global]
 Hint Rewrite @dec_or_to_bool : dec2bool.
 Lemma dec_fieldwise_to_bool {A B R n} {H : forall x y, Decidable (R x y)} x y
   : (if dec (@Tuple.fieldwise A B n R x y) then true else false)
@@ -93,6 +105,7 @@ Proof.
     { exfalso; apply H', H''. }
     { intros; edestruct dec; split; auto; discriminate. } }
 Qed.
+#[global]
 Hint Rewrite @dec_fieldwise_to_bool : dec2bool.
 Lemma dec_tuple_eq_to_bool T {H : DecidableRel (@eq T)} n (x y : Tuple.tuple T n)
   : (if dec (x = y) then true else false) = Tuple.fieldwiseb (fun x y => if dec (x = y) then true else false) x y.
@@ -103,6 +116,7 @@ Proof.
           | rewrite <- H''; clear H''; symmetry; rewrite Tuple.fieldwiseb_fieldwise ];
     try eassumption; eauto; intros; destruct dec; split; auto; congruence.
 Qed.
+#[global]
 Hint Rewrite dec_tuple_eq_to_bool : dec2bool.
 
 Require Import Crypto.Util.ListUtil.Forall.
@@ -116,6 +130,7 @@ Proof.
       | rewrite <- Forall_Forallb_iff; [ eassumption | ] ];
       intros; cbv beta; destruct (dec _); intuition; try congruence.
 Qed.
+#[global]
 Hint Rewrite @dec_Forall_to_bool : dec2bool.
 
 Ltac dec2bool_split_hyp H :=

--- a/src/Util/FixedWordSizesEquality.v
+++ b/src/Util/FixedWordSizesEquality.v
@@ -646,8 +646,12 @@ Module Export Hints.
   Export Crypto.Util.ZUtil.Le.Hints.
   Export Crypto.Util.ZUtil.Log2.Hints.
   Export Crypto.Util.ZUtil.Z2Nat.Hints.
+#[global]
   Hint Rewrite wadd_def_ZToWord wsub_def_ZToWord wmul_def_ZToWord wland_def_ZToWord wlor_def_ZToWord wshl_def_ZToWord wshr_def_ZToWord : pull_ZToWord.
+#[global]
   Hint Rewrite <- wadd_def_ZToWord wsub_def_ZToWord wmul_def_ZToWord wland_def_ZToWord wlor_def_ZToWord wshl_def_ZToWord wshr_def_ZToWord : push_ZToWord.
+#[global]
   Hint Rewrite wadd_def_ZToWord_log wsub_def_ZToWord wmul_def_ZToWord_log wland_def_ZToWord_log wlor_def_ZToWord_log wshl_def_ZToWord_log wshr_def_ZToWord_log : pull_ZToWord_log.
+#[global]
   Hint Rewrite <- wadd_def_ZToWord_log wsub_def_ZToWord wmul_def_ZToWord_log wland_def_ZToWord_log wlor_def_ZToWord_log wshl_def_ZToWord_log wshr_def_ZToWord_log : push_ZToWord_log.
 End Hints.

--- a/src/Util/LetInMonad.v
+++ b/src/Util/LetInMonad.v
@@ -54,18 +54,22 @@ Local Ltac t := repeat t_step.
 
 Lemma denote_bind A B v f : denote (@bind A B v f) = denote (f (denote v)).
 Proof. induction v; t. Qed.
+#[global]
 Hint Rewrite denote_bind : push_denote.
 
 Lemma denote_under_lets A B v f : denote (@under_lets A B v f) = denote (f (denote v)).
 Proof. induction v; t. Qed.
+#[global]
 Hint Rewrite denote_under_lets : push_denote.
 
 Lemma denote_lift A B (f : A -> B) v : denote (lift f v) = f (denote v).
 Proof. unfold lift; t. Qed.
+#[global]
 Hint Rewrite denote_lift : push_denote.
 
 Lemma denote_lift2 A B C (f : A -> B -> C) x y : denote (lift2 f x y) = f (denote x) (denote y).
 Proof. unfold lift2; t. Qed.
+#[global]
 Hint Rewrite denote_lift2 : push_denote.
 
 Module Import List.
@@ -85,6 +89,7 @@ Module Import List.
 
   Lemma denote_flat_map A B f ls : denote (@flat_map A B f ls) = Lists.List.flat_map (fun x => denote (f x)) (denote ls).
   Proof. unfold flat_map; t; induction (denote ls); t. Qed.
+#[global]
   Hint Rewrite denote_flat_map : push_denote.
 End List.
 

--- a/src/Util/ListUtil.v
+++ b/src/Util/ListUtil.v
@@ -68,6 +68,7 @@ Create HintDb push_update_nth discriminated.
 Create HintDb znonzero discriminated.
 
 Module Export Hints1.
+#[global]
   Hint Rewrite
        @app_length
        @rev_length
@@ -117,7 +118,9 @@ Module Export List.
     Lemma map_repeat x n : map f (List.repeat x n) = List.repeat (f x) n.
     Proof using Type. induction n; simpl List.repeat; simpl map; congruence. Qed.
   End Map.
+#[global]
   Hint Rewrite @map_cons @map_nil @map_repeat : push_map.
+#[global]
   Hint Rewrite @map_app : push_map.
 
   Section FlatMap.
@@ -127,9 +130,11 @@ Module Export List.
       (List.flat_map f (x::xs) = (f x++List.flat_map f xs))%list.
     Proof. reflexivity. Qed.
   End FlatMap.
+#[global]
   Hint Rewrite @flat_map_cons @flat_map_nil : push_flat_map.
 
   Lemma rev_cons {A} x ls : @rev A (x :: ls) = rev ls ++ [x]. Proof. reflexivity. Qed.
+#[global]
   Hint Rewrite @rev_cons : list.
 
   Section FoldRight.
@@ -147,6 +152,7 @@ Module Export List.
       rewrite !fold_left_rev_right; reflexivity.
     Qed.
   End FoldRight.
+#[global]
   Hint Rewrite @fold_right_nil @fold_right_cons @fold_right_snoc : simpl_fold_right push_fold_right.
 
   Section Partition.
@@ -158,6 +164,7 @@ Module Export List.
                                              else ((fst (partition f xs)), x :: (snd (partition f xs))).
     Proof. cbv [partition]; break_match; reflexivity.           Qed.
   End Partition.
+#[global]
   Hint Rewrite @partition_nil @partition_cons : push_partition.
 
   Lemma in_seq len start n :
@@ -266,13 +273,21 @@ Module Export List.
 
 End List.
 
+#[global]
 Hint Rewrite @firstn_skipn : simpl_firstn.
+#[global]
 Hint Rewrite @firstn_skipn : simpl_skipn.
+#[global]
 Hint Rewrite @firstn_nil @firstn_cons @List.firstn_all @firstn_O @firstn_app_2 @List.firstn_firstn : push_firstn.
+#[global]
 Hint Rewrite @firstn_nil @firstn_cons @List.firstn_all @firstn_O @firstn_app_2 @List.firstn_firstn : simpl_firstn.
+#[global]
 Hint Rewrite @firstn_app : push_firstn.
+#[global]
 Hint Rewrite <- @firstn_cons @firstn_app @List.firstn_firstn : pull_firstn.
+#[global]
 Hint Rewrite @firstn_all2 @removelast_firstn @firstn_removelast using lia : push_firstn.
+#[global]
 Hint Rewrite @firstn_all2 @removelast_firstn @firstn_removelast using lia : simpl_firstn.
 
 Local Arguments value / _ _.
@@ -347,25 +362,32 @@ Ltac boring_list :=
 Lemma nth_default_cons : forall {T} (x u0 : T) us, nth_default x (u0 :: us) 0 = u0.
 Proof. auto. Qed.
 
+#[global]
 Hint Rewrite @nth_default_cons : simpl_nth_default.
+#[global]
 Hint Rewrite @nth_default_cons : push_nth_default.
 
 Lemma nth_default_cons_S : forall {A} us (u0 : A) n d,
   nth_default d (u0 :: us) (S n) = nth_default d us n.
 Proof. boring. Qed.
 
+#[global]
 Hint Rewrite @nth_default_cons_S : simpl_nth_default.
+#[global]
 Hint Rewrite @nth_default_cons_S : push_nth_default.
 
 Lemma nth_default_nil : forall {T} n (d : T), nth_default d nil n = d.
 Proof. induction n; boring. Qed.
 
+#[global]
 Hint Rewrite @nth_default_nil : simpl_nth_default.
+#[global]
 Hint Rewrite @nth_default_nil : push_nth_default.
 
 Lemma nth_error_nil_error : forall {A} n, nth_error (@nil A) n = None.
 Proof. induction n; boring. Qed.
 
+#[global]
 Hint Rewrite @nth_error_nil_error : simpl_nth_error.
 
 Ltac nth_tac' :=
@@ -419,6 +441,7 @@ Proof.
   induction i as [|? IHi]; destruct xs; nth_tac'; rewrite IHi by lia; auto.
 Qed.
 Global Hint Resolve nth_error_length_error.
+#[global]
 Hint Rewrite @nth_error_length_error using lia : simpl_nth_error.
 
 Lemma map_nth_default : forall (A B : Type) (f : A -> B) n x y l,
@@ -434,6 +457,7 @@ Proof.
   lia.
 Qed.
 
+#[global]
 Hint Rewrite @map_nth_default using lia : push_nth_default.
 
 Ltac nth_tac :=
@@ -481,6 +505,7 @@ Lemma simpl_set_nth_S {T} x n
       end.
 Proof. intro; rewrite unfold_set_nth; reflexivity. Qed.
 
+#[global]
 Hint Rewrite @simpl_set_nth_S @simpl_set_nth_0 : simpl_set_nth.
 
 Lemma update_nth_ext {T} f g n
@@ -508,18 +533,21 @@ Proof.
       try congruence; assumption.
 Qed.
 
+#[global]
 Hint Rewrite @update_nth_id_eq_specific using congruence : simpl_update_nth.
 
 Lemma update_nth_id_eq : forall {T} f (H : forall x, f x = x) n (xs : list T),
     update_nth n f xs = xs.
 Proof. intros; apply update_nth_id_eq_specific; trivial. Qed.
 
+#[global]
 Hint Rewrite @update_nth_id_eq using congruence : simpl_update_nth.
 
 Lemma update_nth_id : forall {T} n (xs : list T),
     update_nth n (fun x => x) xs = xs.
 Proof. intros; apply update_nth_id_eq; trivial. Qed.
 
+#[global]
 Hint Rewrite @update_nth_id : simpl_update_nth.
 
 Lemma nth_update_nth : forall m {T} (xs:list T) (n:nat) (f:T -> T),
@@ -535,7 +563,9 @@ Proof.
         edestruct eq_nat_dec; reflexivity. }
 Qed.
 
+#[global]
 Hint Rewrite @nth_update_nth : push_nth_error.
+#[global]
 Hint Rewrite <- @nth_update_nth : pull_nth_error.
 
 Lemma length_update_nth : forall {T} i f (xs:list T), length (update_nth i f xs) = length xs.
@@ -543,6 +573,7 @@ Proof.
   induction i, xs; boring.
 Qed.
 
+#[global]
 Hint Rewrite @length_update_nth : distr_length.
 
 Lemma nth_set_nth : forall m {T} (xs:list T) (n:nat) x,
@@ -558,11 +589,13 @@ Proof.
           | exfalso; apply p; congruence ].
 Qed.
 
+#[global]
 Hint Rewrite @nth_set_nth : push_nth_error.
 
 Lemma length_set_nth : forall {T} i x (xs:list T), length (set_nth i x xs) = length xs.
 Proof. intros; apply length_update_nth. Qed.
 
+#[global]
 Hint Rewrite @length_set_nth : distr_length.
 
 Lemma nth_error_length_exists_value : forall {A} (i : nat) (xs : list A),
@@ -584,6 +617,7 @@ Proof.
   unfold nth_default; boring.
 Qed.
 
+#[global]
 Hint Rewrite @nth_error_value_eq_nth_default using eassumption : simpl_nth_default.
 
 Lemma skipn0 : forall {T} (xs:list T), skipn 0 xs = xs.
@@ -770,6 +804,7 @@ Proof.
   destruct (lt_dec n (length xs)); auto.
 Qed.
 
+#[global]
 Hint Rewrite @nth_default_app : push_nth_default.
 
 Lemma combine_truncate_r : forall {A B} (xs : list A) (ys : list B),
@@ -800,24 +835,31 @@ Lemma map_snd_combine {A B} (xs:list A) (ys:list B) : List.map snd (List.combine
 Proof.
   revert xs; induction ys; destruct xs; simpl; solve [ trivial | congruence ].
 Qed.
+#[global]
 Hint Rewrite @map_fst_combine @map_snd_combine : push_map.
 
 Lemma skipn_nil : forall {A} n, skipn n nil = @nil A.
 Proof. destruct n; auto. Qed.
 
+#[global]
 Hint Rewrite @skipn_nil : simpl_skipn.
+#[global]
 Hint Rewrite @skipn_nil : push_skipn.
 
 Lemma skipn_0 : forall {A} xs, @skipn A 0 xs = xs.
 Proof. reflexivity. Qed.
 
+#[global]
 Hint Rewrite @skipn_0 : simpl_skipn.
+#[global]
 Hint Rewrite @skipn_0 : push_skipn.
 
 Lemma skipn_cons_S : forall {A} n x xs, @skipn A (S n) (x::xs) = @skipn A n xs.
 Proof. reflexivity. Qed.
 
+#[global]
 Hint Rewrite @skipn_cons_S : simpl_skipn.
+#[global]
 Hint Rewrite @skipn_cons_S : push_skipn.
 
 Lemma skipn_app : forall {A} n (xs ys : list A),
@@ -826,6 +868,7 @@ Proof.
   induction n, xs, ys; boring.
 Qed.
 
+#[global]
 Hint Rewrite @skipn_app : push_skipn.
 
 Lemma skipn_skipn {A} n1 n2 (ls : list A)
@@ -836,8 +879,11 @@ Proof.
       boring.
 Qed.
 
+#[global]
 Hint Rewrite @skipn_skipn : simpl_skipn.
+#[global]
 Hint Rewrite <- @skipn_skipn : push_skipn.
+#[global]
 Hint Rewrite @skipn_skipn : pull_skipn.
 
 Lemma skipn_firstn {A} (ls : list A) n m
@@ -853,7 +899,9 @@ Qed.
 Lemma firstn_skipn_add' {A} (ls : list A) n m
   : firstn n (skipn m ls) = skipn m (firstn (n + m) ls).
 Proof. rewrite firstn_skipn_add; do 2 f_equal; auto with arith. Qed.
+#[global]
 Hint Rewrite <- @firstn_skipn_add @firstn_skipn_add' : simpl_firstn.
+#[global]
 Hint Rewrite <- @firstn_skipn_add @firstn_skipn_add' : simpl_skipn.
 
 Lemma firstn_app_inleft : forall {A} n (xs ys : list A), (n <= length xs)%nat ->
@@ -862,7 +910,9 @@ Proof.
   induction n, xs, ys; boring; try lia.
 Qed.
 
+#[global]
 Hint Rewrite @firstn_app_inleft using solve [ distr_length ] : simpl_firstn.
+#[global]
 Hint Rewrite @firstn_app_inleft using solve [ distr_length ] : push_firstn.
 
 Lemma skipn_app_inleft : forall {A} n (xs ys : list A), (n <= length xs)%nat ->
@@ -871,18 +921,23 @@ Proof.
   induction n, xs, ys; boring; try lia.
 Qed.
 
+#[global]
 Hint Rewrite @skipn_app_inleft using solve [ distr_length ] : push_skipn.
 
 Lemma firstn_map : forall {A B} (f : A -> B) n (xs : list A), firstn n (map f xs) = map f (firstn n xs).
 Proof. induction n, xs; boring. Qed.
 
+#[global]
 Hint Rewrite @firstn_map : push_firstn.
+#[global]
 Hint Rewrite <- @firstn_map : pull_firstn.
 
 Lemma skipn_map : forall {A B} (f : A -> B) n (xs : list A), skipn n (map f xs) = map f (skipn n xs).
 Proof. induction n, xs; boring. Qed.
 
+#[global]
 Hint Rewrite @skipn_map : push_skipn.
+#[global]
 Hint Rewrite <- @skipn_map : pull_skipn.
 
 Lemma firstn_all : forall {A} n (xs:list A), n = length xs -> firstn n xs = xs.
@@ -890,7 +945,9 @@ Proof.
   induction n, xs; boring; lia.
 Qed.
 
+#[global]
 Hint Rewrite @firstn_all using solve [ distr_length ] : simpl_firstn.
+#[global]
 Hint Rewrite @firstn_all using solve [ distr_length ] : push_firstn.
 
 Lemma skipn_all : forall {T} n (xs:list T),
@@ -900,7 +957,9 @@ Proof.
   induction n, xs; boring; lia.
 Qed.
 
+#[global]
 Hint Rewrite @skipn_all using solve [ distr_length ] : simpl_skipn.
+#[global]
 Hint Rewrite @skipn_all using solve [ distr_length ] : push_skipn.
 
 Lemma firstn_app_sharp : forall {A} n (l l': list A),
@@ -911,7 +970,9 @@ Proof.
   rewrite firstn_app_inleft; auto using firstn_all; lia.
 Qed.
 
+#[global]
 Hint Rewrite @firstn_app_sharp using solve [ distr_length ] : simpl_firstn.
+#[global]
 Hint Rewrite @firstn_app_sharp using solve [ distr_length ] : push_firstn.
 
 Lemma skipn_app_sharp : forall {A} n (l l': list A),
@@ -922,7 +983,9 @@ Proof.
   rewrite skipn_app_inleft; try rewrite skipn_all; auto; lia.
 Qed.
 
+#[global]
 Hint Rewrite @skipn_app_sharp using solve [ distr_length ] : simpl_skipn.
+#[global]
 Hint Rewrite @skipn_app_sharp using solve [ distr_length ] : push_skipn.
 
 Lemma skipn_length : forall {A} n (xs : list A),
@@ -931,12 +994,14 @@ Proof.
   induction n, xs; boring.
 Qed.
 
+#[global]
 Hint Rewrite @skipn_length : distr_length.
 
 Lemma length_cons : forall {T} (x:T) xs, length (x::xs) = S (length xs).
   reflexivity.
 Qed.
 
+#[global]
 Hint Rewrite @length_cons : distr_length.
 
 Lemma length_cons_full {T} n (x:list T) (t:T) (H: length (t :: x) = S n)
@@ -955,6 +1020,7 @@ Qed.
 
 Lemma length_tl {A} ls : length (@tl A ls) = (length ls - 1)%nat.
 Proof. destruct ls; cbn [tl length]; lia. Qed.
+#[global]
 Hint Rewrite @length_tl : distr_length.
 
 Lemma length_snoc : forall {T} xs (x:T),
@@ -966,6 +1032,7 @@ Qed.
 Lemma combine_cons : forall {A B} a b (xs:list A) (ys:list B),
   combine (a :: xs) (b :: ys) = (a,b) :: combine xs ys.
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite @combine_cons : push_combine.
 
 Lemma firstn_combine : forall {A B} n (xs:list A) (ys:list B),
@@ -974,7 +1041,9 @@ Proof.
   induction n, xs, ys; boring.
 Qed.
 
+#[global]
 Hint Rewrite @firstn_combine : push_firstn.
+#[global]
 Hint Rewrite <- @firstn_combine : pull_firstn.
 
 Lemma combine_nil_r : forall {A B} (xs:list A),
@@ -982,6 +1051,7 @@ Lemma combine_nil_r : forall {A B} (xs:list A),
 Proof.
   induction xs; boring.
 Qed.
+#[global]
 Hint Rewrite @combine_nil_r : push_combine.
 
 Lemma combine_snoc {A B} xs : forall ys x y,
@@ -991,6 +1061,7 @@ Proof.
   induction xs; intros; destruct ys; distr_length; cbn;
     try rewrite IHxs by lia; reflexivity.
 Qed.
+#[global]
 Hint Rewrite @combine_snoc using (solve [distr_length]) : push_combine.
 
 Lemma skipn_combine : forall {A B} n (xs:list A) (ys:list B),
@@ -1000,7 +1071,9 @@ Proof.
   rewrite combine_nil_r; reflexivity.
 Qed.
 
+#[global]
 Hint Rewrite @skipn_combine : push_skipn.
+#[global]
 Hint Rewrite <- @skipn_combine : pull_skipn.
 
 Lemma break_list_last: forall {T} (xs:list T),
@@ -1036,6 +1109,7 @@ Proof.
   auto.
 Qed.
 
+#[global]
 Hint Rewrite @nil_length0 : distr_length.
 
 Lemma nth_error_Some_nth_default : forall {T} i x (l : list T), (i < length l)%nat ->
@@ -1051,11 +1125,13 @@ Qed.
 Lemma update_nth_cons : forall {T} f (u0 : T) us, update_nth 0 f (u0 :: us) = (f u0) :: us.
 Proof. reflexivity. Qed.
 
+#[global]
 Hint Rewrite @update_nth_cons : simpl_update_nth.
 
 Lemma set_nth_cons : forall {T} (x u0 : T) us, set_nth 0 x (u0 :: us) = x :: us.
 Proof. intros; apply update_nth_cons. Qed.
 
+#[global]
 Hint Rewrite @set_nth_cons : simpl_set_nth.
 
 Lemma cons_update_nth : forall {T} n f (y : T) us,
@@ -1064,6 +1140,7 @@ Proof.
   induction n; boring.
 Qed.
 
+#[global]
 Hint Rewrite <- @cons_update_nth : simpl_update_nth.
 
 Lemma update_nth_nil : forall {T} n f, update_nth n f (@nil T) = @nil T.
@@ -1071,17 +1148,20 @@ Proof.
   induction n; boring.
 Qed.
 
+#[global]
 Hint Rewrite @update_nth_nil : simpl_update_nth.
 
 Lemma cons_set_nth : forall {T} n (x y : T) us,
   y :: set_nth n x us = set_nth (S n) x (y :: us).
 Proof. intros; apply cons_update_nth. Qed.
 
+#[global]
 Hint Rewrite <- @cons_set_nth : simpl_set_nth.
 
 Lemma set_nth_nil : forall {T} n (x : T), set_nth n x nil = nil.
 Proof. intros; apply update_nth_nil. Qed.
 
+#[global]
 Hint Rewrite @set_nth_nil : simpl_set_nth.
 
 Lemma skipn_nth_default : forall {T} n us (d : T), (n < length us)%nat ->
@@ -1105,6 +1185,7 @@ Proof.
   congruence.
 Qed.
 
+#[global]
 Hint Rewrite @nth_default_out_of_bounds using lia : simpl_nth_default.
 
 Ltac nth_error_inbounds :=
@@ -1200,6 +1281,7 @@ Proof.
   nth_tac.
 Qed.
 
+#[global]
 Hint Rewrite @map_nth_default_always : push_nth_default.
 
 Lemma map_S_seq {A} (f:nat->A) len : forall start,
@@ -1282,6 +1364,7 @@ Proof.
   assert (n = m) by lia; subst; reflexivity.
 Qed.
 
+#[global]
 Hint Rewrite @firstn_firstn using lia : push_firstn.
 
 Lemma firstn_succ : forall {A} (d : A) n l, (n < length l)%nat ->
@@ -1301,6 +1384,7 @@ Proof.
   revert k a; induction b as [|? IHb], k; simpl; try reflexivity.
   intros; rewrite IHb; reflexivity.
 Qed.
+#[global]
 Hint Rewrite @firstn_seq : push_firstn.
 
 Lemma skipn_seq k a b
@@ -1316,6 +1400,7 @@ Proof.
   rewrite IHn by lia; reflexivity.
 Qed.
 
+#[global]
 Hint Rewrite @update_nth_out_of_bounds using lia : simpl_update_nth.
 
 
@@ -1335,6 +1420,7 @@ Proof.
                    | lia ].
 Qed.
 
+#[global]
 Hint Rewrite @update_nth_nth_default_full : push_nth_default.
 
 Lemma update_nth_nth_default : forall {A} (d:A) n f l i, (0 <= i < length l)%nat ->
@@ -1342,6 +1428,7 @@ Lemma update_nth_nth_default : forall {A} (d:A) n f l i, (0 <= i < length l)%nat
   if (eq_nat_dec i n) then f (nth_default d l i) else nth_default d l i.
 Proof. intros; rewrite update_nth_nth_default_full; repeat break_match; boring. Qed.
 
+#[global]
 Hint Rewrite @update_nth_nth_default using (lia || distr_length; lia) : push_nth_default.
 
 Lemma set_nth_nth_default_full : forall {A} (d:A) n v l i,
@@ -1352,6 +1439,7 @@ Lemma set_nth_nth_default_full : forall {A} (d:A) n v l i,
   else d.
 Proof. intros; apply update_nth_nth_default_full; assumption. Qed.
 
+#[global]
 Hint Rewrite @set_nth_nth_default_full : push_nth_default.
 
 Lemma set_nth_nth_default : forall {A} (d:A) n x l i, (0 <= i < length l)%nat ->
@@ -1359,6 +1447,7 @@ Lemma set_nth_nth_default : forall {A} (d:A) n x l i, (0 <= i < length l)%nat ->
   if (eq_nat_dec i n) then x else nth_default d l i.
 Proof. intros; apply update_nth_nth_default; assumption. Qed.
 
+#[global]
 Hint Rewrite @set_nth_nth_default using (lia || distr_length; lia) : push_nth_default.
 
 Lemma nth_default_preserves_properties : forall {A} (P : A -> Prop) l n d,
@@ -1414,6 +1503,7 @@ Proof.
   autorewrite with push_firstn; reflexivity.
 Qed.
 
+#[global]
 Hint Rewrite @sum_firstn_all_succ using lia : simpl_sum_firstn.
 
 Lemma sum_firstn_all : forall n l, (length l <= n)%nat ->
@@ -1423,6 +1513,7 @@ Proof.
   autorewrite with push_firstn; reflexivity.
 Qed.
 
+#[global]
 Hint Rewrite @sum_firstn_all using lia : simpl_sum_firstn.
 
 Lemma sum_firstn_succ_default : forall l i,
@@ -1434,6 +1525,7 @@ Proof.
   rewrite IHl; lia.
 Qed.
 
+#[global]
 Hint Rewrite @sum_firstn_succ_default : simpl_sum_firstn.
 
 Lemma sum_firstn_0 : forall xs,
@@ -1442,6 +1534,7 @@ Proof.
   destruct xs; reflexivity.
 Qed.
 
+#[global]
 Hint Rewrite @sum_firstn_0 : simpl_sum_firstn.
 
 Lemma sum_firstn_succ : forall l i x,
@@ -1452,6 +1545,7 @@ Proof.
   erewrite nth_error_value_eq_nth_default by eassumption; reflexivity.
 Qed.
 
+#[global]
 Hint Rewrite @sum_firstn_succ using congruence : simpl_sum_firstn.
 
 Lemma sum_firstn_succ_cons : forall x xs i,
@@ -1460,12 +1554,14 @@ Proof.
   unfold sum_firstn; simpl; reflexivity.
 Qed.
 
+#[global]
 Hint Rewrite @sum_firstn_succ_cons : simpl_sum_firstn.
 
 Lemma sum_firstn_nil : forall i,
   sum_firstn nil i = 0%Z.
 Proof. destruct i; reflexivity. Qed.
 
+#[global]
 Hint Rewrite @sum_firstn_nil : simpl_sum_firstn.
 
 Lemma sum_firstn_succ_default_rev : forall l i,
@@ -1508,18 +1604,22 @@ Proof.
   intros; rewrite sum_firstn_app; autorewrite with simpl_sum_firstn.
   do 2 f_equal; lia.
 Qed.
+#[global]
 Hint Rewrite @sum_firstn_app_sum : simpl_sum_firstn.
 
 Lemma sum_cons xs x : sum (x :: xs) = (x + sum xs)%Z.
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite sum_cons : push_sum.
 
 Lemma sum_nil : sum nil = 0%Z.
 Proof. reflexivity. Qed.
+#[global]
 Hint Rewrite sum_nil : push_sum.
 
 Lemma sum_app x y : sum (x ++ y) = (sum x + sum y)%Z.
 Proof. induction x; rewrite ?app_nil_l, <-?app_comm_cons; autorewrite with push_sum; lia. Qed.
+#[global]
 Hint Rewrite sum_app : push_sum.
 
 Lemma nth_error_skipn : forall {A} n (l : list A) m,
@@ -1528,6 +1628,7 @@ Proof.
 induction n as [|n IHn]; destruct l; boring.
 apply nth_error_nil_error.
 Qed.
+#[global]
 Hint Rewrite @nth_error_skipn : push_nth_error.
 
 Lemma nth_default_skipn : forall {A} (l : list A) d n m, nth_default d (skipn n l) m = nth_default d l (n + m).
@@ -1536,6 +1637,7 @@ cbv [nth_default]; intros.
 rewrite nth_error_skipn.
 reflexivity.
 Qed.
+#[global]
 Hint Rewrite @nth_default_skipn : push_nth_default.
 
 Lemma sum_firstn_skipn : forall l n m, sum_firstn l (n + m) = (sum_firstn l n + sum_firstn (skipn n l) m)%Z.
@@ -1554,6 +1656,7 @@ Proof.
   rewrite nth_error_seq.
   break_innermost_match; solve [ trivial | lia ].
 Qed.
+#[global]
 Hint Rewrite @nth_default_seq_inbounds using lia : push_nth_default.
 
 Lemma sum_firstn_prefix_le' : forall l n m, (forall x, In x l -> (0 <= x)%Z) ->
@@ -1618,6 +1721,7 @@ Lemma sum_firstn_app_hint : forall xs ys n, NotSum xs n ->
   sum_firstn (xs ++ ys) n = (sum_firstn xs n + sum_firstn ys (n - length xs))%Z.
 Proof. auto using sum_firstn_app. Qed.
 
+#[global]
 Hint Rewrite sum_firstn_app_hint using solve [ NotSum ] : simpl_sum_firstn.
 
 
@@ -1707,9 +1811,13 @@ Proof.
     congruence.
 Qed.
 
+#[global]
 Hint Rewrite @firstn_update_nth : push_firstn.
+#[global]
 Hint Rewrite @firstn_update_nth : pull_update_nth.
+#[global]
 Hint Rewrite <- @firstn_update_nth : pull_firstn.
+#[global]
 Hint Rewrite <- @firstn_update_nth : push_update_nth.
 
 Require Import Coq.Lists.SetoidList.
@@ -1775,6 +1883,7 @@ Proof.
   + rewrite firstn_all2 by lia.
     auto.
 Qed.
+#[global]
 Hint Rewrite @nth_default_firstn : push_nth_default.
 
 Lemma nth_error_repeat {T} x n i v : nth_error (@repeat T x n) i = Some v -> v = x.
@@ -1782,6 +1891,7 @@ Proof.
   revert n x v; induction i as [|i IHi]; destruct n; simpl in *; eauto; congruence.
 Qed.
 
+#[global]
 Hint Rewrite repeat_length : distr_length.
 
 Lemma repeat_spec_iff : forall {A} (ls : list A) x n,
@@ -1806,11 +1916,13 @@ Proof. destruct n; reflexivity. Qed.
 Lemma firstn_repeat : forall {A} x n k, firstn k (@repeat A x n) = repeat x (min k n).
 Proof. induction n, k; boring. Qed.
 
+#[global]
 Hint Rewrite @firstn_repeat : push_firstn.
 
 Lemma skipn_repeat : forall {A} x n k, skipn k (@repeat A x n) = repeat x (n - k).
 Proof. induction n, k; boring. Qed.
 
+#[global]
 Hint Rewrite @skipn_repeat : push_skipn.
 
 Global Instance Proper_map {A B} {RA RB} {Equivalence_RB:Equivalence RB}
@@ -1996,6 +2108,7 @@ Proof. induction ls as [|x xs IHxs]; cbn; [ | rewrite IHxs ]; reflexivity. Qed.
 Lemma flat_map_app A B (f : A -> list B) xs ys
   : flat_map f (xs ++ ys) = flat_map f xs ++ flat_map f ys.
 Proof. induction xs as [|x xs IHxs]; cbn; rewrite ?IHxs, <- ?app_assoc; reflexivity. Qed.
+#[global]
 Hint Rewrite flat_map_app : push_flat_map.
 Lemma map_flat_map A B C (f : A -> list B) (g : B -> C) xs
   : map g (flat_map f xs) = flat_map (fun x => map g (f x)) xs.
@@ -2221,124 +2334,236 @@ Module Export Hints.
   Global Existing Instance list_rect_Proper.
   Global Existing Instance list_case_Proper.
   Export Hints1.
+#[global]
   Hint Rewrite @map_cons @map_nil @map_repeat : push_map.
+#[global]
   Hint Rewrite @map_app : push_map.
+#[global]
   Hint Rewrite @flat_map_cons @flat_map_nil : push_flat_map.
+#[global]
   Hint Rewrite @rev_cons : list.
+#[global]
   Hint Rewrite @fold_right_nil @fold_right_cons @fold_right_snoc : simpl_fold_right push_fold_right.
+#[global]
   Hint Rewrite @partition_nil @partition_cons : push_partition.
+#[global]
   Hint Rewrite @firstn_skipn : simpl_firstn.
+#[global]
   Hint Rewrite @firstn_skipn : simpl_skipn.
+#[global]
   Hint Rewrite @firstn_nil @firstn_cons @List.firstn_all @firstn_O @firstn_app_2 @List.firstn_firstn : push_firstn.
+#[global]
   Hint Rewrite @firstn_nil @firstn_cons @List.firstn_all @firstn_O @firstn_app_2 @List.firstn_firstn : simpl_firstn.
+#[global]
   Hint Rewrite @firstn_app : push_firstn.
+#[global]
   Hint Rewrite <- @firstn_cons @firstn_app @List.firstn_firstn : pull_firstn.
+#[global]
   Hint Rewrite @firstn_all2 @removelast_firstn @firstn_removelast using lia : push_firstn.
+#[global]
   Hint Rewrite @firstn_all2 @removelast_firstn @firstn_removelast using lia : simpl_firstn.
   Global Hint Unfold splice_nth.
+#[global]
   Hint Rewrite @nth_default_cons : simpl_nth_default.
+#[global]
   Hint Rewrite @nth_default_cons : push_nth_default.
+#[global]
   Hint Rewrite @nth_default_cons_S : simpl_nth_default.
+#[global]
   Hint Rewrite @nth_default_cons_S : push_nth_default.
+#[global]
   Hint Rewrite @nth_default_nil : simpl_nth_default.
+#[global]
   Hint Rewrite @nth_default_nil : push_nth_default.
+#[global]
   Hint Rewrite @nth_error_nil_error : simpl_nth_error.
   Global Hint Resolve nth_error_length_error.
+#[global]
   Hint Rewrite @nth_error_length_error using lia : simpl_nth_error.
+#[global]
   Hint Rewrite @map_nth_default using lia : push_nth_default.
+#[global]
   Hint Rewrite @simpl_set_nth_S @simpl_set_nth_0 : simpl_set_nth.
   Global Existing Instance update_nth_Proper.
   Global Existing Instance update_nth_Proper_eq | 1.
+#[global]
   Hint Rewrite @update_nth_id_eq_specific using congruence : simpl_update_nth.
+#[global]
   Hint Rewrite @update_nth_id_eq using congruence : simpl_update_nth.
+#[global]
   Hint Rewrite @update_nth_id : simpl_update_nth.
+#[global]
   Hint Rewrite @nth_update_nth : push_nth_error.
+#[global]
   Hint Rewrite <- @nth_update_nth : pull_nth_error.
+#[global]
   Hint Rewrite @length_update_nth : distr_length.
+#[global]
   Hint Rewrite @nth_set_nth : push_nth_error.
+#[global]
   Hint Rewrite @length_set_nth : distr_length.
+#[global]
   Hint Rewrite @nth_error_value_eq_nth_default using eassumption : simpl_nth_default.
+#[global]
   Hint Rewrite @nth_default_app : push_nth_default.
+#[global]
   Hint Rewrite @map_fst_combine @map_snd_combine : push_map.
+#[global]
   Hint Rewrite @skipn_nil : simpl_skipn.
+#[global]
   Hint Rewrite @skipn_nil : push_skipn.
+#[global]
   Hint Rewrite @skipn_0 : simpl_skipn.
+#[global]
   Hint Rewrite @skipn_0 : push_skipn.
+#[global]
   Hint Rewrite @skipn_cons_S : simpl_skipn.
+#[global]
   Hint Rewrite @skipn_cons_S : push_skipn.
+#[global]
   Hint Rewrite @skipn_app : push_skipn.
+#[global]
   Hint Rewrite @skipn_skipn : simpl_skipn.
+#[global]
   Hint Rewrite <- @skipn_skipn : push_skipn.
+#[global]
   Hint Rewrite @skipn_skipn : pull_skipn.
+#[global]
   Hint Rewrite <- @firstn_skipn_add @firstn_skipn_add' : simpl_firstn.
+#[global]
   Hint Rewrite <- @firstn_skipn_add @firstn_skipn_add' : simpl_skipn.
+#[global]
   Hint Rewrite @firstn_app_inleft using solve [ distr_length ] : simpl_firstn.
+#[global]
   Hint Rewrite @firstn_app_inleft using solve [ distr_length ] : push_firstn.
+#[global]
   Hint Rewrite @skipn_app_inleft using solve [ distr_length ] : push_skipn.
+#[global]
   Hint Rewrite @firstn_map : push_firstn.
+#[global]
   Hint Rewrite <- @firstn_map : pull_firstn.
+#[global]
   Hint Rewrite @skipn_map : push_skipn.
+#[global]
   Hint Rewrite <- @skipn_map : pull_skipn.
+#[global]
   Hint Rewrite @firstn_all using solve [ distr_length ] : simpl_firstn.
+#[global]
   Hint Rewrite @firstn_all using solve [ distr_length ] : push_firstn.
+#[global]
   Hint Rewrite @skipn_all using solve [ distr_length ] : simpl_skipn.
+#[global]
   Hint Rewrite @skipn_all using solve [ distr_length ] : push_skipn.
+#[global]
   Hint Rewrite @firstn_app_sharp using solve [ distr_length ] : simpl_firstn.
+#[global]
   Hint Rewrite @firstn_app_sharp using solve [ distr_length ] : push_firstn.
+#[global]
   Hint Rewrite @skipn_app_sharp using solve [ distr_length ] : simpl_skipn.
+#[global]
   Hint Rewrite @skipn_app_sharp using solve [ distr_length ] : push_skipn.
+#[global]
   Hint Rewrite @skipn_length : distr_length.
+#[global]
   Hint Rewrite @length_cons : distr_length.
+#[global]
   Hint Rewrite @length_tl : distr_length.
+#[global]
   Hint Rewrite @combine_cons : push_combine.
+#[global]
   Hint Rewrite @firstn_combine : push_firstn.
+#[global]
   Hint Rewrite <- @firstn_combine : pull_firstn.
+#[global]
   Hint Rewrite @combine_nil_r : push_combine.
+#[global]
   Hint Rewrite @combine_snoc using (solve [distr_length]) : push_combine.
+#[global]
   Hint Rewrite @skipn_combine : push_skipn.
+#[global]
   Hint Rewrite <- @skipn_combine : pull_skipn.
+#[global]
   Hint Rewrite @nil_length0 : distr_length.
+#[global]
   Hint Rewrite @update_nth_cons : simpl_update_nth.
+#[global]
   Hint Rewrite @set_nth_cons : simpl_set_nth.
+#[global]
   Hint Rewrite <- @cons_update_nth : simpl_update_nth.
+#[global]
   Hint Rewrite @update_nth_nil : simpl_update_nth.
+#[global]
   Hint Rewrite <- @cons_set_nth : simpl_set_nth.
+#[global]
   Hint Rewrite @set_nth_nil : simpl_set_nth.
+#[global]
   Hint Rewrite @nth_default_out_of_bounds using lia : simpl_nth_default.
   Global Hint Resolve @nth_default_in_bounds : simpl_nth_default.
+#[global]
   Hint Rewrite @map_nth_default_always : push_nth_default.
+#[global]
   Hint Rewrite @firstn_firstn using lia : push_firstn.
+#[global]
   Hint Rewrite @firstn_seq : push_firstn.
+#[global]
   Hint Rewrite @update_nth_out_of_bounds using lia : simpl_update_nth.
+#[global]
   Hint Rewrite @update_nth_nth_default_full : push_nth_default.
+#[global]
   Hint Rewrite @update_nth_nth_default using (lia || distr_length; lia) : push_nth_default.
+#[global]
   Hint Rewrite @set_nth_nth_default_full : push_nth_default.
+#[global]
   Hint Rewrite @set_nth_nth_default using (lia || distr_length; lia) : push_nth_default.
+#[global]
   Hint Rewrite @sum_firstn_all_succ using lia : simpl_sum_firstn.
+#[global]
   Hint Rewrite @sum_firstn_all using lia : simpl_sum_firstn.
+#[global]
   Hint Rewrite @sum_firstn_succ_default : simpl_sum_firstn.
+#[global]
   Hint Rewrite @sum_firstn_0 : simpl_sum_firstn.
+#[global]
   Hint Rewrite @sum_firstn_succ using congruence : simpl_sum_firstn.
+#[global]
   Hint Rewrite @sum_firstn_succ_cons : simpl_sum_firstn.
+#[global]
   Hint Rewrite @sum_firstn_nil : simpl_sum_firstn.
   Global Hint Resolve sum_firstn_nonnegative : znonzero.
+#[global]
   Hint Rewrite @sum_firstn_app_sum : simpl_sum_firstn.
+#[global]
   Hint Rewrite sum_cons : push_sum.
+#[global]
   Hint Rewrite sum_nil : push_sum.
+#[global]
   Hint Rewrite sum_app : push_sum.
+#[global]
   Hint Rewrite @nth_error_skipn : push_nth_error.
+#[global]
   Hint Rewrite @nth_default_skipn : push_nth_default.
+#[global]
   Hint Rewrite @nth_default_seq_inbounds using lia : push_nth_default.
+#[global]
   Hint Rewrite sum_firstn_app_hint using solve [ NotSum ] : simpl_sum_firstn.
+#[global]
   Hint Rewrite @map2_length : distr_length.
+#[global]
   Hint Rewrite @firstn_update_nth : push_firstn.
+#[global]
   Hint Rewrite @firstn_update_nth : pull_update_nth.
+#[global]
   Hint Rewrite <- @firstn_update_nth : pull_firstn.
+#[global]
   Hint Rewrite <- @firstn_update_nth : push_update_nth.
   Global Existing Instance Proper_nth_default.
+#[global]
   Hint Rewrite @nth_default_firstn : push_nth_default.
+#[global]
   Hint Rewrite repeat_length : distr_length.
+#[global]
   Hint Rewrite @firstn_repeat : push_firstn.
+#[global]
   Hint Rewrite @skipn_repeat : push_skipn.
   Global Existing Instance Proper_map.
   Global Existing Instance flat_map_Proper.
@@ -2348,5 +2573,6 @@ Module Export Hints.
   Global Existing Instance partition_Proper_eq | 1.
   Global Existing Instance fold_right_Proper | 1.
   Global Existing Instance fold_right_Proper_eq | 1.
+#[global]
   Hint Rewrite flat_map_app : push_flat_map.
 End Hints.

--- a/src/Util/NUtil.v
+++ b/src/Util/NUtil.v
@@ -28,6 +28,7 @@ Module N.
     auto.
   Qed.
 
+#[global]
   Hint Rewrite
     N.succ_double_spec
     N.add_1_r
@@ -120,6 +121,7 @@ Module N.
   End ZN.
 
 End N.
+#[global]
 Hint Rewrite
      N.succ_double_spec
      N.add_1_r

--- a/src/Util/NatUtil.v
+++ b/src/Util/NatUtil.v
@@ -20,8 +20,10 @@ Global Hint Resolve Nat.min_l Nat.min_r Nat.le_min_l Nat.le_min_r: arith.
 Global Hint Resolve mod_bound_pos plus_le_compat : arith.
 Global Hint Resolve (fun x y p q => proj1 (@Nat.mod_bound_pos x y p q)) (fun x y p q => proj2 (@Nat.mod_bound_pos x y p q)) : arith.
 
+#[global]
 Hint Rewrite @mod_small @mod_mod @mod_1_l @mod_1_r succ_pred using lia : natsimplify.
 
+#[global]
 Hint Rewrite sub_diag add_0_l add_0_r sub_0_r sub_succ : natsimplify.
 
 Local Open Scope nat_scope.
@@ -241,17 +243,20 @@ Proof.
   destruct a; simpl; lia.
 Qed.
 
+#[global]
 Hint Rewrite S_pred_nonzero using lia : natsimplify.
 
 Lemma mod_same_eq a b : a <> 0 -> a = b -> b mod a = 0.
 Proof. intros; subst; apply mod_same; assumption. Qed.
 
+#[global]
 Hint Rewrite @mod_same_eq using lia : natsimplify.
 Global Hint Resolve mod_same_eq : arith.
 
 Lemma mod_mod_eq a b c : a <> 0 -> b = c mod a -> b mod a = b.
 Proof. intros; subst; autorewrite with natsimplify; reflexivity. Qed.
 
+#[global]
 Hint Rewrite @mod_mod_eq using (reflexivity || lia) : natsimplify.
 
 Local Arguments minus !_ !_.
@@ -268,6 +273,7 @@ Proof.
       try congruence; try reflexivity.
 Qed.
 
+#[global]
 Hint Rewrite S_mod_full using lia : natsimplify.
 
 Lemma S_mod a b : a <> 0 -> S (b mod a) <> a -> (S b) mod a = S (b mod a).
@@ -276,6 +282,7 @@ Proof.
   edestruct eq_nat_dec; lia.
 Qed.
 
+#[global]
 Hint Rewrite S_mod using (lia || autorewrite with natsimplify; lia) : natsimplify.
 
 Lemma eq_nat_dec_refl x : eq_nat_dec x x = left (Logic.eq_refl x).
@@ -284,6 +291,7 @@ Proof.
   apply f_equal, Eqdep_dec.UIP_dec, eq_nat_dec.
 Qed.
 
+#[global]
 Hint Rewrite eq_nat_dec_refl : natsimplify.
 
 (** Helper to get around the lack of function extensionality *)
@@ -305,6 +313,7 @@ Proof.
   edestruct eq_nat_dec_right_val; assumption.
 Qed.
 
+#[global]
 Hint Rewrite eq_nat_dec_S_n : natsimplify.
 
 Lemma eq_nat_dec_n_S n : eq_nat_dec n (S n) = right (proj1_sig (@eq_nat_dec_right_val _ _ (n_Sn n))).
@@ -312,8 +321,10 @@ Proof.
   edestruct eq_nat_dec_right_val; assumption.
 Qed.
 
+#[global]
 Hint Rewrite eq_nat_dec_n_S : natsimplify.
 
+#[global]
 Hint Rewrite Max.max_0_l Max.max_0_r Max.max_idempotent Min.min_0_l Min.min_0_r Min.min_idempotent : natsimplify.
 
 (** Helper to get around the lack of function extensionality *)
@@ -329,6 +340,7 @@ Definition lt_dec_right_val n m (pf0 : ~n < m) : { pf | lt_dec n m = right pf }
 
 Lemma lt_dec_irrefl n : lt_dec n n = right (proj1_sig (@lt_dec_right_val _ _ (lt_irrefl n))).
 Proof. edestruct lt_dec_right_val; assumption. Qed.
+#[global]
 Hint Rewrite lt_dec_irrefl : natsimplify.
 
 Lemma not_lt_n_pred_n n : ~n < pred n.
@@ -336,6 +348,7 @@ Proof. destruct n; simpl; lia. Qed.
 
 Lemma lt_dec_n_pred_n n : lt_dec n (pred n) = right (proj1_sig (@lt_dec_right_val _ _ (not_lt_n_pred_n n))).
 Proof. edestruct lt_dec_right_val; assumption. Qed.
+#[global]
 Hint Rewrite lt_dec_n_pred_n : natsimplify.
 
 Lemma le_dec_refl n : le_dec n n = left (le_refl n).
@@ -343,6 +356,7 @@ Proof.
   edestruct le_dec; try ((idtac + exfalso); lia).
   apply f_equal, le_unique.
 Qed.
+#[global]
 Hint Rewrite le_dec_refl : natsimplify.
 
 Lemma le_dec_pred_l n : le_dec (pred n) n = left (le_pred_l n).
@@ -350,6 +364,7 @@ Proof.
   edestruct le_dec; [ | destruct n; simpl in *; (idtac + exfalso); lia ].
   apply f_equal, le_unique.
 Qed.
+#[global]
 Hint Rewrite le_dec_pred_l : natsimplify.
 
 Lemma le_pred_plus_same n : n <= pred (n + n).
@@ -360,18 +375,22 @@ Proof.
   edestruct le_dec; [ | destruct n; simpl in *; (idtac + exfalso); lia ].
   apply f_equal, le_unique.
 Qed.
+#[global]
 Hint Rewrite le_dec_pred_plus_same : natsimplify.
 
 Lemma minus_S_diag x : (S x - x = 1)%nat.
 Proof. lia. Qed.
+#[global]
 Hint Rewrite minus_S_diag : natsimplify.
 
 Lemma min_idempotent_S_l x : min (S x) x = x.
 Proof. lia *. Qed.
+#[global]
 Hint Rewrite min_idempotent_S_l : natsimplify.
 
 Lemma min_idempotent_S_r x : min x (S x) = x.
 Proof. lia *. Qed.
+#[global]
 Hint Rewrite min_idempotent_S_r : natsimplify.
 
 Lemma mod_pow_same b e : b <> 0 -> e <> 0 -> b^e mod b = 0.
@@ -457,7 +476,9 @@ Module Export Hints.
   Global Hint Resolve Nat.min_l Nat.min_r Nat.le_min_l Nat.le_min_r: arith.
   Global Hint Resolve mod_bound_pos plus_le_compat : arith.
   Global Hint Resolve (fun x y p q => proj1 (@Nat.mod_bound_pos x y p q)) (fun x y p q => proj2 (@Nat.mod_bound_pos x y p q)) : arith.
+#[global]
   Hint Rewrite @mod_small @mod_mod @mod_1_l @mod_1_r succ_pred using lia : natsimplify.
+#[global]
   Hint Rewrite sub_diag add_0_l add_0_r sub_0_r sub_succ : natsimplify.
   Global Existing Instances
          nat_rect_Proper
@@ -465,22 +486,39 @@ Module Export Hints.
   .
   Global Existing Instance nat_rect_Proper_nondep_gen | 100.
   Global Hint Resolve pow_nonzero : arith.
+#[global]
   Hint Rewrite S_pred_nonzero using lia : natsimplify.
+#[global]
   Hint Rewrite @mod_same_eq using lia : natsimplify.
   Global Hint Resolve mod_same_eq : arith.
+#[global]
   Hint Rewrite @mod_mod_eq using (reflexivity || lia) : natsimplify.
+#[global]
   Hint Rewrite S_mod_full using lia : natsimplify.
+#[global]
   Hint Rewrite S_mod using (lia || autorewrite with natsimplify; lia) : natsimplify.
+#[global]
   Hint Rewrite eq_nat_dec_refl : natsimplify.
+#[global]
   Hint Rewrite eq_nat_dec_S_n : natsimplify.
+#[global]
   Hint Rewrite eq_nat_dec_n_S : natsimplify.
+#[global]
   Hint Rewrite Max.max_0_l Max.max_0_r Max.max_idempotent Min.min_0_l Min.min_0_r Min.min_idempotent : natsimplify.
+#[global]
   Hint Rewrite lt_dec_irrefl : natsimplify.
+#[global]
   Hint Rewrite lt_dec_n_pred_n : natsimplify.
+#[global]
   Hint Rewrite le_dec_refl : natsimplify.
+#[global]
   Hint Rewrite le_dec_pred_l : natsimplify.
+#[global]
   Hint Rewrite le_dec_pred_plus_same : natsimplify.
+#[global]
   Hint Rewrite minus_S_diag : natsimplify.
+#[global]
   Hint Rewrite min_idempotent_S_l : natsimplify.
+#[global]
   Hint Rewrite min_idempotent_S_r : natsimplify.
 End Hints.

--- a/src/Util/PointedProp.v
+++ b/src/Util/PointedProp.v
@@ -107,69 +107,83 @@ Global Hint Extern 1 => progress autorewrite with push_eq_Some_trivial in * : pu
 Lemma to_prop_and P Q : to_prop (P /\ Q)%pointed_prop
                         <-> (to_prop P /\ to_prop Q).
 Proof. destruct P, Q; simpl; tauto. Qed.
+#[global]
 Hint Rewrite to_prop_and : push_to_prop.
 
 Lemma to_prop_or P Q : to_prop (P \/ Q)%pointed_prop
                        <-> (to_prop P \/ to_prop Q).
 Proof. destruct P, Q; simpl; tauto. Qed.
+#[global]
 Hint Rewrite to_prop_or : push_to_prop.
 
 Lemma to_prop_impl P Q : to_prop (impl_pointed_Prop P Q)%pointed_prop
                          <-> (to_prop P -> to_prop Q).
 Proof. destruct P, Q; simpl; tauto. Qed.
+#[global]
 Hint Rewrite to_prop_impl : push_to_prop.
 
 Lemma prop_of_option_and P Q : prop_of_option (P /\ Q)%option_pointed_prop
                                <-> (prop_of_option P /\ prop_of_option Q).
 Proof. destruct P, Q; simpl; autorewrite with push_to_prop; tauto. Qed.
+#[global]
 Hint Rewrite prop_of_option_and : push_prop_of_option.
 
 Lemma prop_of_option_or P Q : prop_of_option (P \/ Q)%option_pointed_prop
                                <-> (prop_of_option P \/ prop_of_option Q).
 Proof. destruct P, Q; simpl; autorewrite with push_to_prop; tauto. Qed.
+#[global]
 Hint Rewrite prop_of_option_or : push_prop_of_option.
 
 Lemma prop_of_option_impl P Q : prop_of_option (impl_option_pointed_Prop P Q)%option_pointed_prop
                                <-> (prop_of_option P -> prop_of_option Q).
 Proof. destruct P as [ [|P] |], Q as [ [|Q] |]; simpl; tauto. Qed.
+#[global]
 Hint Rewrite prop_of_option_impl : push_prop_of_option.
 
 Lemma prop_of_option_not P : prop_of_option (~P)%option_pointed_prop
                                <-> (~prop_of_option P).
 Proof. destruct P as [ [|] | ]; simpl; tauto. Qed.
+#[global]
 Hint Rewrite prop_of_option_not : push_prop_of_option.
 
 Lemma eq_trivial_and P Q : (P /\ Q)%pointed_prop = trivial
                            <-> (P = trivial /\ Q = trivial).
 Proof. destruct P, Q; simpl; intuition congruence. Qed.
+#[global]
 Hint Rewrite eq_trivial_and : push_eq_trivial.
 
 Lemma eq_trivial_or P Q : (P \/ Q)%pointed_prop = trivial
                           <-> (P = trivial \/ Q = trivial).
 Proof. destruct P, Q; simpl; intuition congruence. Qed.
+#[global]
 Hint Rewrite eq_trivial_or : push_eq_trivial.
 
 Lemma eq_trivial_impl P Q : (impl_pointed_Prop P Q)%pointed_prop = trivial
                          <-> Q = trivial.
 Proof. destruct P, Q; simpl; intuition congruence. Qed.
+#[global]
 Hint Rewrite eq_trivial_impl : push_eq_trivial.
 
 Lemma eq_Some_trivial_and P Q : (P /\ Q)%option_pointed_prop = Some trivial
                                <-> (P = Some trivial /\ Q = Some trivial).
 Proof. destruct P as [ []|], Q as [ []|]; simpl; intuition congruence. Qed.
+#[global]
 Hint Rewrite eq_Some_trivial_and : push_eq_Some_trivial.
 
 Lemma eq_Some_trivial_or P Q : (P \/ Q)%option_pointed_prop = Some trivial
                                <-> (P = Some trivial \/ Q = Some trivial).
 Proof. destruct P as [ []|], Q as [ []|]; simpl; intuition congruence. Qed.
+#[global]
 Hint Rewrite eq_Some_trivial_or : push_eq_Some_trivial.
 
 Lemma eq_Some_trivial_impl P Q : (impl_option_pointed_Prop P Q)%option_pointed_prop = Some trivial
                                <-> (P = None \/ Q = Some trivial).
 Proof. destruct P as [ [|P] |], Q as [ [|Q] |]; simpl; intuition congruence. Qed.
+#[global]
 Hint Rewrite eq_Some_trivial_impl : push_eq_Some_trivial.
 
 Lemma eq_Some_trivial_not P : (~P)%option_pointed_prop = Some trivial
                                <-> P = None.
 Proof. destruct P as [ [|] | ]; simpl; intuition congruence. Qed.
+#[global]
 Hint Rewrite eq_Some_trivial_not : push_eq_Some_trivial.

--- a/src/Util/PrimitiveProd.v
+++ b/src/Util/PrimitiveProd.v
@@ -74,6 +74,7 @@ Local Arguments f_equal {_ _} _ {_ _} _.
 
 Definition fst_pair {A B} (a:A) (b:B) : fst (a,b) = a := eq_refl.
 Definition snd_pair {A B} (a:A) (b:B) : snd (a,b) = b := eq_refl.
+#[global]
 Create HintDb cancel_primpair discriminated. Hint Rewrite @fst_pair @snd_pair : cancel_primpair.
 
 (** ** Equality for [prod] *)

--- a/src/Util/PrimitiveSigma.v
+++ b/src/Util/PrimitiveSigma.v
@@ -97,6 +97,7 @@ Local Arguments f_equal {_ _} _ {_ _} _.
 
 Definition projT1_existT {A B} (a:A) (b:B a) : projT1 (existT B a b) = a := eq_refl.
 Definition projT2_existT {A B} (a:A) (b:B a) : projT2 (existT B a b) = b := eq_refl.
+#[global]
 Create HintDb cancel_primsig discriminated. Hint Rewrite @projT1_existT @projT2_existT : cancel_primsig.
 
 (** ** Equality for [sigT] *)

--- a/src/Util/Prod.v
+++ b/src/Util/Prod.v
@@ -159,6 +159,7 @@ Ltac subst_prod_step :=
 Ltac subst_prod := repeat subst_prod_step.
 
 Module Export Hints.
+#[global]
   Hint Rewrite @fst_pair @snd_pair : cancel_pair.
   Global Hint Extern 2 (Proper _ prod) => apply iffTp_iffTp_prod_Proper : typeclass_instances.
   Global Hint Extern 2 (Proper _ (fun A => prod A)) => refine iff_iffTp_prod_Proper : typeclass_instances.

--- a/src/Util/Tuple.v
+++ b/src/Util/Tuple.v
@@ -144,12 +144,14 @@ Qed.
 
 Lemma length_to_list' T n t : length (@to_list' T n t) = S n.
 Proof. induction n; simpl in *; trivial; destruct t; simpl; congruence. Qed.
+#[global]
 Hint Rewrite length_to_list' : distr_length.
 
 Lemma length_to_list : forall {T} {n} (xs:tuple T n), length (to_list n xs) = n.
 Proof.
   destruct n; [ reflexivity | apply length_to_list' ].
 Qed.
+#[global]
 Hint Rewrite @length_to_list : distr_length.
 
 Lemma from_list'_to_list' : forall T n (xs:tuple' T n),
@@ -1183,7 +1185,9 @@ Module Export Hints.
   Export Crypto.Util.FixCoqMistakes.
   Export Crypto.Util.Decidable.Hints.
   Export Crypto.Util.ListUtil.Hints.
+#[global]
   Hint Rewrite length_to_list' : distr_length.
+#[global]
   Hint Rewrite @length_to_list : distr_length.
   Global Existing Instance Reflexive_fieldwise' | 5.
   Global Existing Instance Symmetric_fieldwise' | 5.

--- a/src/Util/WordUtil.v
+++ b/src/Util/WordUtil.v
@@ -746,6 +746,7 @@ Section WordBounds.
 End WordBounds.
 
 Module Export Hints2.
+#[global]
   Hint Rewrite NToWord_wordToN : pull_wordToN.
 End Hints2.
 
@@ -812,6 +813,7 @@ Lemma wordToN_cast_word {n} (w:word n) m pf :
   wordToN (@cast_word n m pf w) = wordToN w.
 Proof. destruct pf; rewrite cast_word_refl; trivial. Qed.
 Module Export Hints4.
+#[global]
   Hint Rewrite @wordToN_cast_word : push_wordToN.
 End Hints4.
 
@@ -1057,19 +1059,29 @@ Section Bounds.
 End Bounds.
 
 Module Export Hints5.
+#[global]
   Hint Rewrite @wordToN_wplus using word_util_arith : push_wordToN.
+#[global]
   Hint Rewrite <- @wordToN_wplus using word_util_arith : pull_wordToN.
 
+#[global]
   Hint Rewrite @wordToN_wminus using word_util_arith : push_wordToN.
+#[global]
   Hint Rewrite <- @wordToN_wminus using word_util_arith : pull_wordToN.
 
+#[global]
   Hint Rewrite @wordToN_wmult using word_util_arith : push_wordToN.
+#[global]
   Hint Rewrite <- @wordToN_wmult using word_util_arith : pull_wordToN.
 
+#[global]
   Hint Rewrite @wordToN_wand using word_util_arith : push_wordToN.
+#[global]
   Hint Rewrite <- @wordToN_wand using word_util_arith : pull_wordToN.
 
+#[global]
   Hint Rewrite @wordToN_wor using word_util_arith : push_wordToN.
+#[global]
   Hint Rewrite <- @wordToN_wor using word_util_arith : pull_wordToN.
 End Hints5.
 

--- a/src/Util/ZUtil/AddGetCarry.v
+++ b/src/Util/ZUtil/AddGetCarry.v
@@ -68,21 +68,25 @@ Module Z.
   Lemma add_get_carry_full_mod s x y :
     fst (Z.add_get_carry_full s x y)  = (x + y) mod s.
   Proof. easypeasy. Qed.
+#[global]
   Hint Rewrite add_get_carry_full_mod : to_div_mod.
 
   Lemma add_get_carry_full_div s x y :
     snd (Z.add_get_carry_full s x y)  = (x + y) / s.
   Proof. easypeasy. Qed.
+#[global]
   Hint Rewrite add_get_carry_full_div : to_div_mod.
 
   Lemma add_with_get_carry_full_mod s c x y :
     fst (Z.add_with_get_carry_full s c x y)  = (c + x + y) mod s.
   Proof. easypeasy. Qed.
+#[global]
   Hint Rewrite add_with_get_carry_full_mod : to_div_mod.
 
   Lemma add_with_get_carry_full_div s c x y :
     snd (Z.add_with_get_carry_full s c x y)  = (c + x + y) / s.
   Proof. easypeasy. Qed.
+#[global]
   Hint Rewrite add_with_get_carry_full_div : to_div_mod.
 
   Lemma sub_with_borrow_to_add_get_carry c x y
@@ -92,21 +96,25 @@ Module Z.
   Lemma sub_get_borrow_full_mod s x y :
     fst (Z.sub_get_borrow_full s x y)  = (x - y) mod s.
   Proof. easypeasy. Qed.
+#[global]
   Hint Rewrite sub_get_borrow_full_mod : to_div_mod.
 
   Lemma sub_get_borrow_full_div s x y :
     snd (Z.sub_get_borrow_full s x y)  = - ((x - y) / s).
   Proof. easypeasy. Qed.
+#[global]
   Hint Rewrite sub_get_borrow_full_div : to_div_mod.
 
   Lemma sub_with_get_borrow_full_mod s c x y :
     fst (Z.sub_with_get_borrow_full s c x y)  = (x - y - c) mod s.
   Proof. easypeasy. Qed.
+#[global]
   Hint Rewrite sub_with_get_borrow_full_mod : to_div_mod.
 
   Lemma sub_with_get_borrow_full_div s c x y :
     snd (Z.sub_with_get_borrow_full s c x y)  = - ((x - y - c) / s).
   Proof. easypeasy. Qed.
+#[global]
   Hint Rewrite sub_with_get_borrow_full_div : to_div_mod.
 
 End Z.
@@ -116,12 +124,20 @@ Module Export Hints.
   Export Crypto.Util.ZUtil.Tactics.PullPush.Modulo.Hints.
   Export Crypto.Util.ZUtil.Tactics.DivModToQuotRem.Hints.
   Export Crypto.Util.ZUtil.Tactics.LtbToLt.Hints.
+#[global]
   Hint Rewrite Z.add_get_carry_full_mod : to_div_mod.
+#[global]
   Hint Rewrite Z.add_get_carry_full_div : to_div_mod.
+#[global]
   Hint Rewrite Z.add_with_get_carry_full_mod : to_div_mod.
+#[global]
   Hint Rewrite Z.add_with_get_carry_full_div : to_div_mod.
+#[global]
   Hint Rewrite Z.sub_get_borrow_full_mod : to_div_mod.
+#[global]
   Hint Rewrite Z.sub_get_borrow_full_div : to_div_mod.
+#[global]
   Hint Rewrite Z.sub_with_get_borrow_full_mod : to_div_mod.
+#[global]
   Hint Rewrite Z.sub_with_get_borrow_full_div : to_div_mod.
 End Hints.

--- a/src/Util/ZUtil/CC.v
+++ b/src/Util/ZUtil/CC.v
@@ -13,6 +13,7 @@ Require Import Crypto.Util.Decidable.
 Local Open Scope Z_scope.
 
 Module Z.
+#[global]
   Hint Rewrite Z.log2_pow2 Z.pow_1_r using solve [auto using Z.log2_nonneg with zarith] : push_Zpow.
   Lemma cc_m_eq_full : forall s x, Z.cc_m s x = if (s =? 1) then x * 2 else x / (s / 2).
   Proof.
@@ -89,6 +90,7 @@ Module Export Hints.
   Export Crypto.Util.ZUtil.Tactics.ZeroBounds.Hints.
   Export Crypto.Util.ZUtil.Tactics.LtbToLt.Hints.
   Export Crypto.Util.ZUtil.Hints.PullPush.
+#[global]
   Hint Rewrite Z.log2_pow2 Z.pow_1_r using solve [auto using Z.log2_nonneg with zarith] : push_Zpow.
   Global Hint Resolve Z.cc_m_Proper_le_r_gen : zarith.
   Global Hint Resolve Z.cc_m_Proper_le_r : zarith.

--- a/src/Util/ZUtil/CPS.v
+++ b/src/Util/ZUtil/CPS.v
@@ -12,12 +12,14 @@ Module Z.
     := f (Z.eq_dec x y).
   Definition eq_dec_cps_correct {T} x y f : @eq_dec_cps T x y f = f (Z.eq_dec x y)
     := eq_refl.
+#[global]
   Hint Rewrite @eq_dec_cps_correct : uncps.
 
   Definition eqb_cps {T} (x y : Z) (f : bool -> T) : T
     := f (Z.eqb x y).
   Definition eqb_cps_correct {T} x y f : @eqb_cps T x y f = f (Z.eqb x y)
     := eq_refl.
+#[global]
   Hint Rewrite @eqb_cps_correct : uncps.
 
   Local Ltac prove_cps_correct _ :=
@@ -39,18 +41,21 @@ Module Z.
   Definition get_carry_cps_correct {T} bitwidth v f
     : @get_carry_cps T bitwidth v f = f (Z.get_carry bitwidth v)
     := eq_refl.
+#[global]
   Hint Rewrite @get_carry_cps_correct : uncps.
   Definition add_with_get_carry_cps {T} (bitwidth : Z) (c : Z) (x y : Z) (f : Z * Z -> T) : T
     := f (Z.add_with_get_carry bitwidth c x y).
   Definition add_with_get_carry_cps_correct {T} bitwidth c x y f
     : @add_with_get_carry_cps T bitwidth c x y f = f (Z.add_with_get_carry bitwidth c x y)
     := eq_refl.
+#[global]
   Hint Rewrite @add_with_get_carry_cps_correct : uncps.
   Definition add_get_carry_cps {T} (bitwidth : Z) (x y : Z) (f : Z * Z -> T) : T
     := f (Z.add_get_carry bitwidth x y).
   Definition add_get_carry_cps_correct {T} bitwidth x y f
     : @add_get_carry_cps T bitwidth x y f = f (Z.add_get_carry bitwidth x y)
     := eq_refl.
+#[global]
   Hint Rewrite @add_get_carry_cps_correct : uncps.
 
   Definition get_borrow_cps {T} (bitwidth : Z) (v : Z) (f : Z * Z -> T)
@@ -58,18 +63,21 @@ Module Z.
   Definition get_borrow_cps_correct {T} bitwidth v f
     : @get_borrow_cps T bitwidth v f = f (Z.get_borrow bitwidth v)
     := eq_refl.
+#[global]
   Hint Rewrite @get_borrow_cps_correct : uncps.
   Definition sub_with_get_borrow_cps {T} (bitwidth : Z) (c : Z) (x y : Z) (f : Z * Z -> T) : T
     := f (Z.sub_with_get_borrow bitwidth c x y).
   Definition sub_with_get_borrow_cps_correct {T} (bitwidth : Z) (c : Z) (x y : Z) (f : Z * Z -> T)
     : @sub_with_get_borrow_cps T bitwidth c x y f = f (Z.sub_with_get_borrow bitwidth c x y)
     := eq_refl.
+#[global]
   Hint Rewrite @sub_with_get_borrow_cps_correct : uncps.
   Definition sub_get_borrow_cps {T} (bitwidth : Z) (x y : Z) (f : Z * Z -> T) : T
     := f (Z.sub_get_borrow bitwidth x y).
   Definition sub_get_borrow_cps_correct {T} (bitwidth : Z) (x y : Z) (f : Z * Z -> T)
     : @sub_get_borrow_cps T bitwidth x y f = f (Z.sub_get_borrow bitwidth x y)
     := eq_refl.
+#[global]
   Hint Rewrite @sub_get_borrow_cps_correct : uncps.
 
   (* splits at [bound], not [2^bitwidth]; wrapper to make add_getcarry
@@ -84,6 +92,7 @@ Module Z.
   Lemma add_get_carry_full_cps_correct {T} (bound : Z) (x y : Z) (f : Z * Z -> T)
     : @add_get_carry_full_cps T bound x y f = f (Z.add_get_carry_full bound x y).
   Proof. prove_cps_correct (). Qed.
+#[global]
   Hint Rewrite @add_get_carry_full_cps_correct : uncps.
   Definition add_with_get_carry_full_cps {T} (bound : Z) (c x y : Z) (f : Z * Z -> T) : T
     := eqb_cps
@@ -95,6 +104,7 @@ Module Z.
   Lemma add_with_get_carry_full_cps_correct {T} (bound : Z) (c x y : Z) (f : Z * Z -> T)
     : @add_with_get_carry_full_cps T bound c x y f = f (Z.add_with_get_carry_full bound c x y).
   Proof. prove_cps_correct (). Qed.
+#[global]
   Hint Rewrite @add_with_get_carry_full_cps_correct : uncps.
   Definition sub_get_borrow_full_cps {T} (bound : Z) (x y : Z) (f : Z * Z -> T) : T
     := eqb_cps
@@ -106,6 +116,7 @@ Module Z.
   Lemma sub_get_borrow_full_cps_correct {T} (bound : Z) (x y : Z) (f : Z * Z -> T)
     : @sub_get_borrow_full_cps T bound x y f = f (Z.sub_get_borrow_full bound x y).
   Proof. prove_cps_correct (). Qed.
+#[global]
   Hint Rewrite @sub_get_borrow_full_cps_correct : uncps.
   Definition sub_with_get_borrow_full_cps {T} (bound : Z) (c x y : Z) (f : Z * Z -> T) : T
     := eqb_cps
@@ -117,6 +128,7 @@ Module Z.
   Lemma sub_with_get_borrow_full_cps_correct {T} (bound : Z) (c x y : Z) (f : Z * Z -> T)
     : @sub_with_get_borrow_full_cps T bound c x y f = f (Z.sub_with_get_borrow_full bound c x y).
   Proof. prove_cps_correct (). Qed.
+#[global]
   Hint Rewrite @sub_with_get_borrow_full_cps_correct : uncps.
 
   Definition mul_split_at_bitwidth_cps {T} (bitwidth : Z) (x y : Z) (f : Z * Z -> T) : T
@@ -130,6 +142,7 @@ Module Z.
   Definition mul_split_at_bitwidth_cps_correct {T} (bitwidth : Z) (x y : Z) (f : Z * Z -> T)
     : @mul_split_at_bitwidth_cps T bitwidth x y f = f (Z.mul_split_at_bitwidth bitwidth x y)
     := eq_refl.
+#[global]
   Hint Rewrite @mul_split_at_bitwidth_cps_correct : uncps.
   Definition mul_split_cps {T} (s x y : Z) (f : Z * Z -> T) : T
     := eqb_cps
@@ -141,6 +154,7 @@ Module Z.
   Lemma mul_split_cps_correct {T} (s x y : Z) (f : Z * Z -> T)
     : @mul_split_cps T s x y f = f (Z.mul_split s x y).
   Proof. prove_cps_correct (). Qed.
+#[global]
   Hint Rewrite @mul_split_cps_correct : uncps.
 
   Definition mul_split_cps' {T} (s x y : Z) (f : Z * Z -> T) : T
@@ -153,6 +167,7 @@ Module Z.
   Lemma mul_split_cps'_correct {T} (s x y : Z) (f : Z * Z -> T)
     : @mul_split_cps' T s x y f = f (Z.mul_split s x y).
   Proof. prove_cps_correct (). Qed.
+#[global]
   Hint Rewrite @mul_split_cps'_correct : uncps.
 End Z.
 
@@ -160,19 +175,34 @@ Module Export Hints.
   Export Crypto.Util.FixCoqMistakes.
   Export Crypto.Util.ZUtil.Definitions.Hints.
   Export Crypto.Util.ZUtil.Tactics.LtbToLt.Hints.
+#[global]
   Hint Rewrite @Z.eq_dec_cps_correct : uncps.
+#[global]
   Hint Rewrite @Z.eqb_cps_correct : uncps.
+#[global]
   Hint Rewrite @Z.get_carry_cps_correct : uncps.
+#[global]
   Hint Rewrite @Z.add_with_get_carry_cps_correct : uncps.
+#[global]
   Hint Rewrite @Z.add_get_carry_cps_correct : uncps.
+#[global]
   Hint Rewrite @Z.get_borrow_cps_correct : uncps.
+#[global]
   Hint Rewrite @Z.sub_with_get_borrow_cps_correct : uncps.
+#[global]
   Hint Rewrite @Z.sub_get_borrow_cps_correct : uncps.
+#[global]
   Hint Rewrite @Z.add_get_carry_full_cps_correct : uncps.
+#[global]
   Hint Rewrite @Z.add_with_get_carry_full_cps_correct : uncps.
+#[global]
   Hint Rewrite @Z.sub_get_borrow_full_cps_correct : uncps.
+#[global]
   Hint Rewrite @Z.sub_with_get_borrow_full_cps_correct : uncps.
+#[global]
   Hint Rewrite @Z.mul_split_at_bitwidth_cps_correct : uncps.
+#[global]
   Hint Rewrite @Z.mul_split_cps_correct : uncps.
+#[global]
   Hint Rewrite @Z.mul_split_cps'_correct : uncps.
 End Hints.

--- a/src/Util/ZUtil/DistrIf.v
+++ b/src/Util/ZUtil/DistrIf.v
@@ -6,69 +6,105 @@ Local Open Scope Z_scope.
 Module Z.
   Definition opp_distr_if (b : bool) x y : -(if b then x else y) = if b then -x else -y.
   Proof. destruct b; reflexivity. Qed.
+#[global]
   Hint Rewrite opp_distr_if : push_Zopp.
+#[global]
   Hint Rewrite <- opp_distr_if : pull_Zopp.
 
   Lemma mul_r_distr_if (b : bool) x y z : z * (if b then x else y) = if b then z * x else z * y.
   Proof. destruct b; reflexivity. Qed.
+#[global]
   Hint Rewrite mul_r_distr_if : push_Zmul.
+#[global]
   Hint Rewrite <- mul_r_distr_if : pull_Zmul.
 
   Lemma mul_l_distr_if (b : bool) x y z : (if b then x else y) * z = if b then x * z else y * z.
   Proof. destruct b; reflexivity. Qed.
+#[global]
   Hint Rewrite mul_l_distr_if : push_Zmul.
+#[global]
   Hint Rewrite <- mul_l_distr_if : pull_Zmul.
 
   Lemma add_r_distr_if (b : bool) x y z : z + (if b then x else y) = if b then z + x else z + y.
   Proof. destruct b; reflexivity. Qed.
+#[global]
   Hint Rewrite add_r_distr_if : push_Zadd.
+#[global]
   Hint Rewrite <- add_r_distr_if : pull_Zadd.
 
   Lemma add_l_distr_if (b : bool) x y z : (if b then x else y) + z = if b then x + z else y + z.
   Proof. destruct b; reflexivity. Qed.
+#[global]
   Hint Rewrite add_l_distr_if : push_Zadd.
+#[global]
   Hint Rewrite <- add_l_distr_if : pull_Zadd.
 
   Lemma sub_r_distr_if (b : bool) x y z : z - (if b then x else y) = if b then z - x else z - y.
   Proof. destruct b; reflexivity. Qed.
+#[global]
   Hint Rewrite sub_r_distr_if : push_Zsub.
+#[global]
   Hint Rewrite <- sub_r_distr_if : pull_Zsub.
 
   Lemma sub_l_distr_if (b : bool) x y z : (if b then x else y) - z = if b then x - z else y - z.
   Proof. destruct b; reflexivity. Qed.
+#[global]
   Hint Rewrite sub_l_distr_if : push_Zsub.
+#[global]
   Hint Rewrite <- sub_l_distr_if : pull_Zsub.
 
   Lemma div_r_distr_if (b : bool) x y z : z / (if b then x else y) = if b then z / x else z / y.
   Proof. destruct b; reflexivity. Qed.
+#[global]
   Hint Rewrite div_r_distr_if : push_Zdiv.
+#[global]
   Hint Rewrite <- div_r_distr_if : pull_Zdiv.
 
   Lemma div_l_distr_if (b : bool) x y z : (if b then x else y) / z = if b then x / z else y / z.
   Proof. destruct b; reflexivity. Qed.
+#[global]
   Hint Rewrite div_l_distr_if : push_Zdiv.
+#[global]
   Hint Rewrite <- div_l_distr_if : pull_Zdiv.
 End Z.
 
 Module Export Hints.
   Export Crypto.Util.FixCoqMistakes.
   Export Crypto.Util.ZUtil.Hints.Core.
+#[global]
   Hint Rewrite Z.opp_distr_if : push_Zopp.
+#[global]
   Hint Rewrite <- Z.opp_distr_if : pull_Zopp.
+#[global]
   Hint Rewrite Z.mul_r_distr_if : push_Zmul.
+#[global]
   Hint Rewrite <- Z.mul_r_distr_if : pull_Zmul.
+#[global]
   Hint Rewrite Z.mul_l_distr_if : push_Zmul.
+#[global]
   Hint Rewrite <- Z.mul_l_distr_if : pull_Zmul.
+#[global]
   Hint Rewrite Z.add_r_distr_if : push_Zadd.
+#[global]
   Hint Rewrite <- Z.add_r_distr_if : pull_Zadd.
+#[global]
   Hint Rewrite Z.add_l_distr_if : push_Zadd.
+#[global]
   Hint Rewrite <- Z.add_l_distr_if : pull_Zadd.
+#[global]
   Hint Rewrite Z.sub_r_distr_if : push_Zsub.
+#[global]
   Hint Rewrite <- Z.sub_r_distr_if : pull_Zsub.
+#[global]
   Hint Rewrite Z.sub_l_distr_if : push_Zsub.
+#[global]
   Hint Rewrite <- Z.sub_l_distr_if : pull_Zsub.
+#[global]
   Hint Rewrite Z.div_r_distr_if : push_Zdiv.
+#[global]
   Hint Rewrite <- Z.div_r_distr_if : pull_Zdiv.
+#[global]
   Hint Rewrite Z.div_l_distr_if : push_Zdiv.
+#[global]
   Hint Rewrite <- Z.div_l_distr_if : pull_Zdiv.
 End Hints.

--- a/src/Util/ZUtil/Div.v
+++ b/src/Util/ZUtil/Div.v
@@ -15,6 +15,7 @@ Local Open Scope Z_scope.
 Module Z.
   Lemma div_mul' : forall a b : Z, b <> 0 -> (b * a) / b = a.
   Proof. intros. rewrite Z.mul_comm. apply Z.div_mul; auto. Qed.
+#[global]
   Hint Rewrite div_mul' using zutil_arith : zsimplify.
 
   Local Ltac replace_to_const c :=
@@ -49,6 +50,7 @@ Module Z.
   Lemma div_add_l' a b c : b <> 0 -> (b * a + c) / b = a + c / b.
   Proof. intro; rewrite <- Z.div_add_l, (Z.mul_comm b); lia. Qed.
 
+#[global]
   Hint Rewrite div_add_l' div_add' using zutil_arith : zsimplify.
 
   Lemma div_sub a b c : c <> 0 -> (a - b * c) / c = a / c - b.
@@ -57,6 +59,7 @@ Module Z.
   Lemma div_sub' a b c : c <> 0 -> (a - c * b) / c = a / c - b.
   Proof. intro; rewrite <- div_sub, (Z.mul_comm c); try lia. Qed.
 
+#[global]
   Hint Rewrite div_sub div_sub' using zutil_arith : zsimplify.
 
   Lemma div_add_sub_l a b c d : b <> 0 -> (a * b + c - d) / b = a + (c - d) / b.
@@ -71,6 +74,7 @@ Module Z.
   Lemma div_add_sub' a b c d : c <> 0 -> (a + c * b - d) / c = (a - d) / c + b.
   Proof. rewrite (Z.add_comm _ (_ * _)), (Z.add_comm (_ / _)); apply Z.div_add_sub_l'. Qed.
 
+#[global]
   Hint Rewrite Z.div_add_sub Z.div_add_sub' Z.div_add_sub_l Z.div_add_sub_l' using zutil_arith : zsimplify.
 
   Lemma div_mul_skip a b k : 0 < b -> 0 < k -> a * b / k / b = a / k.
@@ -85,6 +89,7 @@ Module Z.
     autorewrite with zsimplify; reflexivity.
   Qed.
 
+#[global]
   Hint Rewrite Z.div_mul_skip Z.div_mul_skip' using zutil_arith : zsimplify.
 
   Lemma div_mul_skip_pow base e0 e1 x y : 0 < y -> 0 < base -> 0 <= e1 <= e0 -> x * base^e0 / y / base^e1 = x * base^(e0 - e1) / y.
@@ -95,6 +100,7 @@ Module Z.
     rewrite !Z.mul_assoc.
     autorewrite with zsimplify; lia.
   Qed.
+#[global]
   Hint Rewrite div_mul_skip_pow using zutil_arith : zsimplify.
 
   Lemma div_mul_skip_pow' base e0 e1 x y : 0 < y -> 0 < base -> 0 <= e1 <= e0 -> base^e0 * x / y / base^e1 = base^(e0 - e1) * x / y.
@@ -103,6 +109,7 @@ Module Z.
     rewrite (Z.mul_comm (base^e0) x), div_mul_skip_pow by lia.
     auto using f_equal2 with lia.
   Qed.
+#[global]
   Hint Rewrite div_mul_skip_pow' using zutil_arith : zsimplify.
 
   Lemma div_le_mono_nonneg a b c : 0 <= c -> a <= b -> a / c <= b / c.
@@ -128,6 +135,7 @@ Module Z.
     intros; rewrite (Z_div_exact_full_2 x d) at 1 by assumption.
     rewrite Z.div_add_l' by assumption; lia.
   Qed.
+#[global]
   Hint Rewrite div_add_exact using zutil_arith : zsimplify.
 
   Lemma Z_divide_div_mul_exact' a b c : b <> 0 -> (b | a) -> a * c / b = c * (a / b).
@@ -241,7 +249,9 @@ Module Z.
     destruct (Z_zerop (a mod b)); autorewrite with zsimplify pull_Zopp; lia.
   Qed.
 
+#[global]
   Hint Rewrite Z.div_opp_l_complete using zutil_arith : pull_Zopp.
+#[global]
   Hint Rewrite Z.div_opp_l_complete' using zutil_arith : push_Zopp.
 
   Lemma div_opp a : a <> 0 -> -a / a = -1.
@@ -249,11 +259,13 @@ Module Z.
     intros; autorewrite with pull_Zopp zsimplify; lia.
   Qed.
 
+#[global]
   Hint Rewrite Z.div_opp using zutil_arith : zsimplify.
 
   Lemma div_sub_1_0 x : x > 0 -> (x - 1) / x = 0.
   Proof. auto with zarith lia. Qed.
 
+#[global]
   Hint Rewrite div_sub_1_0 using zutil_arith : zsimplify.
 
   Lemma div_same' a b : b <> 0 -> a = b -> a / b = 1.
@@ -341,6 +353,7 @@ Module Z.
     intros; rewrite Z.div_div, (Z.mul_comm y x), <- Z.div_div, Z.div_same by lia.
     reflexivity.
   Qed.
+#[global]
   Hint Rewrite div_x_y_x using zutil_arith : zsimplify.
 
   Lemma sub_pos_bound_div a b X : 0 <= a < X -> 0 <= b < X -> -1 <= (a - b) / X <= 0.
@@ -370,6 +383,7 @@ Module Z.
     apply Z.sub_pos_bound_div_eq.
   Qed.
 
+#[global]
   Hint Rewrite Z.sub_pos_bound_div_eq Z.add_opp_pos_bound_div_eq using zutil_arith : zstrip_div.
 
   Lemma div_small_sym a b : 0 <= a < b -> 0 = a / b.
@@ -379,10 +393,12 @@ Module Z.
   Lemma mod_eq_le_div_1 a b : 0 < a <= b -> a mod b = 0 -> a / b = 1.
   Proof. intros; Z.div_mod_to_quot_rem; nia. Qed.
   Global Hint Resolve mod_eq_le_div_1 : zarith.
+#[global]
   Hint Rewrite mod_eq_le_div_1 using zutil_arith : zsimplify.
 
   Lemma div_small_neg x y : 0 < -x <= y -> x / y = -1.
   Proof. intros; Z.div_mod_to_quot_rem; nia. Qed.
+#[global]
   Hint Rewrite div_small_neg using zutil_arith : zsimplify.
 
   Lemma div_sub_small x y z : 0 <= x < z -> 0 <= y <= z -> (x - y) / z = if x <? y then -1 else 0.
@@ -391,6 +407,7 @@ Module Z.
     (destruct (x <? y) eqn:?);
       intros; autorewrite with zsimplify; try lia.
   Qed.
+#[global]
   Hint Rewrite div_sub_small using zutil_arith : zsimplify.
 
   Lemma mul_div_lt_by_le x y z b : 0 <= y < z -> 0 <= x < b -> x * y / z < b.
@@ -411,10 +428,12 @@ Module Z.
 
   Lemma div_between n a b : 0 <= n -> b <> 0 -> n * b <= a < (1 + n) * b -> a / b = n.
   Proof. intros; Z.div_mod_to_quot_rem_in_goal; nia. Qed.
+#[global]
   Hint Rewrite div_between using zutil_arith : zsimplify.
 
   Lemma div_between_1 a b : b <> 0 -> b <= a < 2 * b -> a / b = 1.
   Proof. intros; rewrite (div_between 1) by lia; reflexivity. Qed.
+#[global]
   Hint Rewrite div_between_1 using zutil_arith : zsimplify.
 
   Lemma div_between_if n a b : 0 <= n -> b <> 0 -> n * b <= a < (2 + n) * b -> (a / b = if (1 + n) * b <=? a then 1 + n else n)%Z.
@@ -438,38 +457,57 @@ Module Export Hints.
   Export ZUtil.Hints.PullPush.
   Export ZUtil.Hints.
   Export ZUtil.ZSimplify.Core.
+#[global]
   Hint Rewrite Z.div_mul' using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.div_add_l' Z.div_add' using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.div_sub Z.div_sub' using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.div_add_sub Z.div_add_sub' Z.div_add_sub_l Z.div_add_sub_l' using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.div_mul_skip Z.div_mul_skip' using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.div_mul_skip_pow using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.div_mul_skip_pow' using zutil_arith : zsimplify.
   Global Hint Resolve Z.div_le_mono_nonneg : zarith.
   Global Hint Resolve Z.div_nonneg : zarith.
+#[global]
   Hint Rewrite Z.div_add_exact using zutil_arith : zsimplify.
   Global Hint Resolve Z.div_sub_mod_cond : zarith.
   Global Hint Resolve Z.div_lt_upper_bound' : zarith.
+#[global]
   Hint Rewrite Z.div_opp_l_complete using zutil_arith : pull_Zopp.
+#[global]
   Hint Rewrite Z.div_opp_l_complete' using zutil_arith : push_Zopp.
+#[global]
   Hint Rewrite Z.div_opp using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.div_sub_1_0 using zutil_arith : zsimplify.
   Global Hint Resolve Z.div_same' : zarith.
   Global Hint Resolve Z.div_opp_r : zarith.
   Global Hint Resolve Z.mul_div_le : zarith.
   Global Hint Resolve Z.div_mul_le_le_offset : zarith.
+#[global]
   Hint Rewrite Z.div_x_y_x using zutil_arith : zsimplify.
   Global Hint Resolve (fun a b X H0 H1 => proj1 (Z.sub_pos_bound_div a b X H0 H1))
          (fun a b X H0 H1 => proj1 (Z.sub_pos_bound_div a b X H0 H1)) : zarith.
+#[global]
   Hint Rewrite Z.sub_pos_bound_div_eq Z.add_opp_pos_bound_div_eq using zutil_arith : zstrip_div.
   Global Hint Resolve Z.div_small_sym : zarith.
   Global Hint Resolve Z.mod_eq_le_div_1 : zarith.
+#[global]
   Hint Rewrite Z.mod_eq_le_div_1 using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.div_small_neg using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.div_sub_small using zutil_arith : zsimplify.
   Global Hint Resolve Z.mul_div_lt_by_le : zarith.
   Global Hint Resolve Z.mul_div_le' : zarith.
   Global Hint Resolve Z.mul_div_le'' : zarith.
+#[global]
   Hint Rewrite Z.div_between using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.div_between_1 using zutil_arith : zsimplify.
 End Hints.

--- a/src/Util/ZUtil/Div/Bootstrap.v
+++ b/src/Util/ZUtil/Div/Bootstrap.v
@@ -13,5 +13,6 @@ Module Export Hints.
   Export Crypto.Util.FixCoqMistakes.
   Export Crypto.Util.ZUtil.Hints.Core.
   Global Hint Resolve Z.div_0_r_eq : zarith.
+#[global]
   Hint Rewrite Z.div_0_r_eq using assumption : zsimplify.
 End Hints.

--- a/src/Util/ZUtil/EquivModulo.v
+++ b/src/Util/ZUtil/EquivModulo.v
@@ -59,6 +59,7 @@ Module Z.
     Lemma equiv_modulo_mod_small x y : x  == y -> 0 <= x < N -> x = y mod N.
     Proof using Type. transitivity (x mod N); [rewrite Z.mod_small|]; auto. Qed.
   End equiv_modulo.
+#[global]
   Hint Rewrite div_to_inv_modulo using solve [ eassumption | lia ] : zstrip_div.
 
   Module EquivModuloInstances (dummy : Nop). (* work around https://coq.inria.fr/bugs/show_bug.cgi?id=4973 *)
@@ -94,5 +95,6 @@ Module Export Hints.
   Export Crypto.Util.ZUtil.Hints.ZArith.
   Export Crypto.Util.ZUtil.Modulo.Hints.
   Export Crypto.Util.ZUtil.Modulo.PullPush.Hints.
+#[global]
   Hint Rewrite Z.div_to_inv_modulo using solve [ eassumption | lia ] : zstrip_div.
 End Hints.

--- a/src/Util/ZUtil/Hints.v
+++ b/src/Util/ZUtil/Hints.v
@@ -10,4 +10,5 @@ Global Hint Resolve (fun a b H => proj1 (Z.log2_lt_pow2 a b H)) (fun a b H => pr
 Global Hint Resolve (fun a b H => proj2 (Z.log2_lt_pow2 a b H)) (fun a b H => proj2 (Z.log2_le_pow2 a b H)) : hyp_log2.
 
 (** For the occasional lemma that can remove the use of [Z.div] *)
+#[global]
 Hint Rewrite Z.div_small_iff using zutil_arith : zstrip_div.

--- a/src/Util/ZUtil/Hints/PullPush.v
+++ b/src/Util/ZUtil/Hints/PullPush.v
@@ -2,37 +2,71 @@ Require Import Coq.ZArith.ZArith.
 Require Export Crypto.Util.ZUtil.Hints.Core.
 
 (** "push" means transform [-f x] to [f (-x)]; "pull" means go the other way *)
+#[global]
 Hint Rewrite Z.div_opp_l_nz Z.div_opp_l_z using zutil_arith : pull_Zopp.
+#[global]
 Hint Rewrite Z.mul_opp_l : pull_Zopp.
+#[global]
 Hint Rewrite <- Z.opp_add_distr : pull_Zopp.
+#[global]
 Hint Rewrite <- Z.div_opp_l_nz Z.div_opp_l_z using zutil_arith : push_Zopp.
+#[global]
 Hint Rewrite <- Z.mul_opp_l : push_Zopp.
+#[global]
 Hint Rewrite Z.opp_add_distr : push_Zopp.
+#[global]
 Hint Rewrite Z.pow_sub_r Z.pow_div_l Z.pow_twice_r Z.pow_mul_l Z.pow_add_r using zutil_arith : push_Zpow.
+#[global]
 Hint Rewrite <- Z.pow_sub_r Z.pow_div_l Z.pow_mul_l Z.pow_add_r Z.pow_twice_r using zutil_arith : pull_Zpow.
+#[global]
 Hint Rewrite Z.mul_add_distr_l Z.mul_add_distr_r Z.mul_sub_distr_l Z.mul_sub_distr_r : push_Zmul.
+#[global]
 Hint Rewrite <- Z.mul_add_distr_l Z.mul_add_distr_r Z.mul_sub_distr_l Z.mul_sub_distr_r : pull_Zmul.
+#[global]
 Hint Rewrite Z.div_div using zutil_arith : pull_Zdiv.
+#[global]
 Hint Rewrite <- Z.div_div using zutil_arith : push_Zdiv.
+#[global]
 Hint Rewrite <- Z.mul_mod Z.add_mod Zminus_mod using zutil_arith : pull_Zmod.
+#[global]
 Hint Rewrite Zminus_mod_idemp_l Zminus_mod_idemp_r : pull_Zmod.
+#[global]
 Hint Rewrite Z_mod_nz_opp_full using zutil_arith : push_Zmod.
+#[global]
 Hint Rewrite Z_mod_same_full : push_Zmod.
+#[global]
 Hint Rewrite Nat2Z.id : push_Zof_nat.
+#[global]
 Hint Rewrite N2Z.id : push_Zto_N.
+#[global]
 Hint Rewrite N2Z.id : pull_Zof_N.
+#[global]
 Hint Rewrite N2Z.inj_pos N2Z.inj_abs_N N2Z.inj_add N2Z.inj_mul N2Z.inj_sub_max N2Z.inj_succ N2Z.inj_pred_max N2Z.inj_min N2Z.inj_max N2Z.inj_div N2Z.inj_quot N2Z.inj_rem N2Z.inj_div2 N2Z.inj_pow N2Z.inj_0 nat_N_Z : push_Zof_N.
+#[global]
 Hint Rewrite N2Z.inj_compare N2Z.inj_testbit : pull_Zof_N.
+#[global]
 Hint Rewrite <- N2Z.inj_abs_N N2Z.inj_add N2Z.inj_mul N2Z.inj_sub_max N2Z.inj_succ N2Z.inj_pred_max N2Z.inj_min N2Z.inj_max N2Z.inj_div N2Z.inj_quot N2Z.inj_rem N2Z.inj_div2 N2Z.inj_pow : pull_Zof_N.
+#[global]
 Hint Rewrite Nat2Z.inj_0 Nat2Z.inj_succ Nat2Z.inj_abs_nat Nat2Z.inj_add Nat2Z.inj_mul Nat2Z.inj_sub_max Nat2Z.inj_pred_max Nat2Z.inj_min Nat2Z.inj_max Zabs2Nat.id_abs Zabs2Nat.id : push_Zof_nat.
+#[global]
 Hint Rewrite <- Nat2Z.inj_0 Nat2Z.inj_succ Nat2Z.inj_abs_nat Nat2Z.inj_add Nat2Z.inj_mul Nat2Z.inj_sub_max Nat2Z.inj_pred_max Nat2Z.inj_min Nat2Z.inj_max Zabs2Nat.id_abs Zabs2Nat.id : pull_Zof_nat.
+#[global]
 Hint Rewrite Z.shiftr_shiftl_l Z.shiftr_shiftl_r Z.shiftr_shiftr Z.shiftl_shiftl using zutil_arith : pull_Zshift.
+#[global]
 Hint Rewrite <- Z.shiftr_lxor Z.shiftr_land Z.shiftr_lor Z.shiftr_ldiff Z.lnot_shiftr Z.ldiff_ones_r Z.shiftl_lxor Z.shiftl_land Z.shiftl_lor Z.shiftl_ldiff using zutil_arith : pull_Zshift.
+#[global]
 Hint Rewrite Z.shiftr_lxor Z.shiftr_land Z.shiftr_lor Z.shiftr_ldiff Z.lnot_shiftr Z.ldiff_ones_r Z.shiftl_lxor Z.shiftl_land Z.shiftl_lor Z.shiftl_ldiff using zutil_arith : push_Zshift.
+#[global]
 Hint Rewrite <- Z.shiftr_shiftl_l Z.shiftr_shiftl_r Z.shiftr_shiftr Z.shiftl_shiftl using zutil_arith : push_Zshift.
+#[global]
 Hint Rewrite Z.shiftr_opp_r Z.shiftl_opp_r Z.shiftr_0_r Z.shiftr_0_l Z.shiftl_0_r Z.shiftl_0_l : push_Zshift.
+#[global]
 Hint Rewrite Z.shiftl_1_l Z.shiftr_div_pow2 Z.shiftr_mul_pow2 Z.shiftl_mul_pow2 Z.shiftl_div_pow2 Z.opp_involutive using zutil_arith : Zshift_to_pow.
+#[global]
 Hint Rewrite <- Z.shiftr_opp_r using zutil_arith : Zshift_to_pow.
+#[global]
 Hint Rewrite <- Z.shiftr_div_pow2 Z.shiftr_mul_pow2 Z.shiftl_mul_pow2 Z.shiftl_div_pow2 using zutil_arith : Zpow_to_shift.
+#[global]
 Hint Rewrite Z.add_max_distr_r Z.add_max_distr_l : push_Zmax.
+#[global]
 Hint Rewrite <- Z.add_max_distr_r Z.add_max_distr_l : pull_Zmax.

--- a/src/Util/ZUtil/Hints/Ztestbit.v
+++ b/src/Util/ZUtil/Hints/Ztestbit.v
@@ -1,11 +1,17 @@
 Require Import Coq.ZArith.ZArith.
 Require Export Crypto.Util.ZUtil.Hints.Core.
 
+#[global]
 Hint Rewrite <- Z.shiftr_div_pow2 Z.shiftr_mul_pow2 Z.shiftl_mul_pow2 Z.shiftl_div_pow2 using zutil_arith : convert_to_Ztestbit.
 
+#[global]
 Hint Rewrite Z.testbit_0_l Z.land_spec Z.lor_spec : Ztestbit.
+#[global]
 Hint Rewrite Z.testbit_0_l Z.land_spec Z.lor_spec : Ztestbit_full.
+#[global]
 Hint Rewrite Z.shiftl_spec Z.shiftr_spec using zutil_arith : Ztestbit.
+#[global]
 Hint Rewrite Z.testbit_neg_r using zutil_arith : Ztestbit.
+#[global]
 Hint Rewrite Bool.andb_true_r Bool.andb_false_r Bool.orb_true_r Bool.orb_false_r
              Bool.andb_true_l Bool.andb_false_l Bool.orb_true_l Bool.orb_false_l : Ztestbit.

--- a/src/Util/ZUtil/Land.v
+++ b/src/Util/ZUtil/Land.v
@@ -15,10 +15,12 @@ Module Z.
 
   Lemma land_m1'_l a : Z.land (-1) a = a.
   Proof. apply Z.land_m1_l. Qed.
+#[global]
   Hint Rewrite Z.land_m1_l land_m1'_l : zsimplify_const zsimplify zsimplify_fast.
 
   Lemma land_m1'_r a : Z.land a (-1) = a.
   Proof. apply Z.land_m1_r. Qed.
+#[global]
   Hint Rewrite Z.land_m1_r land_m1'_r : zsimplify_const zsimplify zsimplify_fast.
 
   Lemma sub_1_lt_le x y : (x - 1 < y) <-> (x <= y).
@@ -29,6 +31,8 @@ Module Export Hints.
   Export Crypto.Util.FixCoqMistakes.
   Export Crypto.Util.ZUtil.Notations.Hints.
   Export Crypto.Util.ZUtil.Definitions.Hints.
+#[global]
   Hint Rewrite Z.land_m1_l Z.land_m1'_l : zsimplify_const zsimplify zsimplify_fast.
+#[global]
   Hint Rewrite Z.land_m1_r Z.land_m1'_r : zsimplify_const zsimplify zsimplify_fast.
 End Hints.

--- a/src/Util/ZUtil/LandLorBounds.v
+++ b/src/Util/ZUtil/LandLorBounds.v
@@ -200,19 +200,23 @@ Module Z.
   Lemma land_round_lor_land_bound_r x
     : Z.land x (Z.round_lor_land_bound x) = if (0 <=? x) then x else Z.round_lor_land_bound x.
   Proof. t. Qed.
+#[global]
   Hint Rewrite land_round_lor_land_bound_r : zsimplify_fast zsimplify.
   Lemma land_round_lor_land_bound_l x
     : Z.land (Z.round_lor_land_bound x) x = if (0 <=? x) then x else Z.round_lor_land_bound x.
   Proof. rewrite Z.land_comm, land_round_lor_land_bound_r; reflexivity. Qed.
+#[global]
   Hint Rewrite land_round_lor_land_bound_l : zsimplify_fast zsimplify.
 
   Lemma lor_round_lor_land_bound_r x
     : Z.lor x (Z.round_lor_land_bound x) = if (0 <=? x) then Z.round_lor_land_bound x else x.
   Proof. t. Qed.
+#[global]
   Hint Rewrite lor_round_lor_land_bound_r : zsimplify_fast zsimplify.
   Lemma lor_round_lor_land_bound_l x
     : Z.lor (Z.round_lor_land_bound x) x = if (0 <=? x) then Z.round_lor_land_bound x else x.
   Proof. rewrite Z.lor_comm, lor_round_lor_land_bound_r; reflexivity. Qed.
+#[global]
   Hint Rewrite lor_round_lor_land_bound_l : zsimplify_fast zsimplify.
 
   Lemma land_round_bound_pos_r v x
@@ -312,9 +316,13 @@ Module Export Hints.
   Global Hint Resolve Z.round_lor_land_bound_bounds : zarith.
   Global Hint Resolve Z.round_lor_land_bound_bounds_pos : zarith.
   Global Hint Resolve Z.round_lor_land_bound_bounds_neg : zarith.
+#[global]
   Hint Rewrite Z.land_round_lor_land_bound_r : zsimplify_fast zsimplify.
+#[global]
   Hint Rewrite Z.land_round_lor_land_bound_l : zsimplify_fast zsimplify.
+#[global]
   Hint Rewrite Z.lor_round_lor_land_bound_r : zsimplify_fast zsimplify.
+#[global]
   Hint Rewrite Z.lor_round_lor_land_bound_l : zsimplify_fast zsimplify.
   Global Hint Resolve Z.land_round_bound_pos_r (fun v x => proj1 (Z.land_round_bound_pos_r v x)) (fun v x => proj2 (Z.land_round_bound_pos_r v x)) : zarith.
   Global Hint Resolve Z.land_round_bound_pos_l (fun v x => proj1 (Z.land_round_bound_pos_l v x)) (fun v x => proj2 (Z.land_round_bound_pos_l v x)) : zarith.

--- a/src/Util/ZUtil/Le.v
+++ b/src/Util/ZUtil/Le.v
@@ -45,18 +45,22 @@ Module Z.
 
   Lemma leb_add_same x y : (x <=? y + x) = (0 <=? y).
   Proof. destruct (x <=? y + x) eqn:?, (0 <=? y) eqn:?; Z.ltb_to_lt; try reflexivity; lia. Qed.
+#[global]
   Hint Rewrite leb_add_same : zsimplify.
 
   Lemma ltb_add_same x y : (x <? y + x) = (0 <? y).
   Proof. destruct (x <? y + x) eqn:?, (0 <? y) eqn:?; Z.ltb_to_lt; try reflexivity; lia. Qed.
+#[global]
   Hint Rewrite ltb_add_same : zsimplify.
 
   Lemma geb_add_same x y : (x >=? y + x) = (0 >=? y).
   Proof. destruct (x >=? y + x) eqn:?, (0 >=? y) eqn:?; Z.ltb_to_lt; try reflexivity; lia. Qed.
+#[global]
   Hint Rewrite geb_add_same : zsimplify.
 
   Lemma gtb_add_same x y : (x >? y + x) = (0 >? y).
   Proof. destruct (x >? y + x) eqn:?, (0 >? y) eqn:?; Z.ltb_to_lt; try reflexivity; lia. Qed.
+#[global]
   Hint Rewrite gtb_add_same : zsimplify.
 
   Lemma sub_pos_bound a b X : 0 <= a < X -> 0 <= b < X -> -X < a - b < X.
@@ -74,8 +78,12 @@ Module Export Hints.
   Export ZUtil.Hints.Core.
   Export LtbToLt.Hints.
   Global Hint Resolve Z.positive_is_nonzero : zarith.
+#[global]
   Hint Rewrite Z.leb_add_same : zsimplify.
+#[global]
   Hint Rewrite Z.ltb_add_same : zsimplify.
+#[global]
   Hint Rewrite Z.geb_add_same : zsimplify.
+#[global]
   Hint Rewrite Z.gtb_add_same : zsimplify.
 End Hints.

--- a/src/Util/ZUtil/Log2.v
+++ b/src/Util/ZUtil/Log2.v
@@ -33,6 +33,7 @@ Module Z.
     }
     { subst; compute; reflexivity. }
   Qed.
+#[global]
   Hint Rewrite log2_pred_pow2_full : zsimplify.
 
   Lemma log2_up_le_full a : a <= 2^Z.log2_up a.
@@ -62,7 +63,9 @@ Module Z.
 
   Lemma max_log2_up x y : Z.max (Z.log2_up x) (Z.log2_up y) = Z.log2_up (Z.max x y).
   Proof. apply Z.max_monotone; intros ??; apply Z.log2_up_le_mono. Qed.
+#[global]
   Hint Rewrite max_log2_up : push_Zmax.
+#[global]
   Hint Rewrite <- max_log2_up : pull_Zmax.
 
   Lemma log2_up_le_full_max a : Z.max a 1 <= 2^Z.log2_up a.
@@ -100,7 +103,10 @@ Module Export Hints.
   Export Crypto.Util.ZUtil.ZSimplify.Core.
   Export Crypto.Util.ZUtil.ZSimplify.Simple.Hints.
   Global Hint Resolve Z.log2_nonneg' : zarith.
+#[global]
   Hint Rewrite Z.log2_pred_pow2_full : zsimplify.
+#[global]
   Hint Rewrite Z.max_log2_up : push_Zmax.
+#[global]
   Hint Rewrite <- Z.max_log2_up : pull_Zmax.
 End Hints.

--- a/src/Util/ZUtil/Modulo.v
+++ b/src/Util/ZUtil/Modulo.v
@@ -18,16 +18,19 @@ Module Z.
 
   Lemma mod_add_full : forall a b c, (a + b * c) mod c = a mod c.
   Proof. intros a b c; destruct (Z_zerop c); try subst; autorewrite with zsimplify; reflexivity. Qed.
+#[global]
   Hint Rewrite mod_add_full : zsimplify.
 
   Lemma mod_add_l_full : forall a b c, (a * b + c) mod b = c mod b.
   Proof. intros a b c; rewrite (Z.add_comm _ c); autorewrite with zsimplify; reflexivity. Qed.
+#[global]
   Hint Rewrite mod_add_l_full : zsimplify.
 
   Lemma mod_add'_full : forall a b c, (a + b * c) mod b = a mod b.
   Proof. intros a b c; rewrite (Z.mul_comm _ c); autorewrite with zsimplify; reflexivity. Qed.
   Lemma mod_add_l'_full : forall a b c, (a * b + c) mod a = c mod a.
   Proof. intros a b c; rewrite (Z.mul_comm _ b); autorewrite with zsimplify; reflexivity. Qed.
+#[global]
   Hint Rewrite mod_add'_full mod_add_l'_full : zsimplify.
 
   Lemma mod_add_l : forall a b c, b <> 0 -> (a * b + c) mod b = c mod b.
@@ -97,7 +100,9 @@ Module Z.
     intros a m H. rewrite (Z_div_mod_eq_full a m) at 2 by auto. ring.
   Qed.
 
+#[global]
   Hint Rewrite mul_div_eq_full using zutil_arith : zdiv_to_mod.
+#[global]
   Hint Rewrite <-mul_div_eq_full using zutil_arith : zmod_to_div.
 
   Lemma f_equal_mul_mod x y x' y' m : x mod m = x' mod m -> y mod m = y' mod m -> (x * y) mod m = (x' * y') mod m.
@@ -142,7 +147,9 @@ Module Z.
     ring.
   Qed.
 
+#[global]
   Hint Rewrite mul_div_eq mul_div_eq' using zutil_arith : zdiv_to_mod.
+#[global]
   Hint Rewrite <- mul_div_eq' using zutil_arith : zmod_to_div.
 
   Lemma mod_div_eq0 : forall a b, 0 < b -> (a mod b) / b = 0.
@@ -151,6 +158,7 @@ Module Z.
     apply Z.div_small.
     auto using Z.mod_pos_bound.
   Qed.
+#[global]
   Hint Rewrite mod_div_eq0 using zutil_arith : zsimplify.
 
   Local Lemma mod_pull_div_helper a b c X
@@ -291,6 +299,7 @@ Module Z.
     rewrite Z.pow_add_r by lia.
     apply Z_mod_mult.
   Qed.
+#[global]
   Hint Rewrite mod_same_pow using zutil_arith : zsimplify.
   Global Hint Resolve mod_same_pow : zarith.
 
@@ -298,6 +307,7 @@ Module Z.
   Proof.
     split; intro H'; apply Z.mod_opp_l_z in H'; rewrite ?Z.opp_involutive in H'; assumption.
   Qed.
+#[global]
   Hint Rewrite <- mod_opp_l_z_iff using zutil_arith : zsimplify.
 
   Lemma mod_small_sym a b : 0 <= a < b -> a = a mod b.
@@ -314,14 +324,17 @@ Module Z.
 
   Lemma div_mod' a b : b <> 0 -> a = (a / b) * b + a mod b.
   Proof. intro; etransitivity; [ apply (Z.div_mod a b); assumption | lia ]. Qed.
+#[global]
   Hint Rewrite <- div_mod' using zutil_arith : zsimplify.
 
   Lemma div_mod'' a b : b <> 0 -> a = a mod b + b * (a / b).
   Proof. intro; etransitivity; [ apply (Z.div_mod a b); assumption | lia ]. Qed.
+#[global]
   Hint Rewrite <- div_mod'' using zutil_arith : zsimplify.
 
   Lemma div_mod''' a b : b <> 0 -> a = a mod b + (a / b) * b.
   Proof. intro; etransitivity; [ apply (Z.div_mod a b); assumption | lia ]. Qed.
+#[global]
   Hint Rewrite <- div_mod''' using zutil_arith : zsimplify.
 
   Lemma sub_mod_mod_0 x d : (x - x mod d) mod d = 0.
@@ -329,10 +342,12 @@ Module Z.
     destruct (Z_zerop d); subst; push_Zmod; autorewrite with zsimplify; reflexivity.
   Qed.
   Global Hint Resolve sub_mod_mod_0 : zarith.
+#[global]
   Hint Rewrite sub_mod_mod_0 : zsimplify.
 
   Lemma mod_small_n n a b : 0 <= n -> b <> 0 -> n * b <= a < (1 + n) * b -> a mod b = a - n * b.
   Proof. intros; erewrite Zmod_eq_full, Z.div_between by eassumption. reflexivity. Qed.
+#[global]
   Hint Rewrite mod_small_n using zutil_arith : zsimplify.
 
   Lemma mod_small_1 a b : b <> 0 -> b <= a < 2 * b -> a mod b = a - b.
@@ -398,28 +413,33 @@ Module Export Hints.
          Z.mod_neq_0_le_to_neq
          Z.sub_mod_mod_0
     : zarith.
+#[global]
   Hint Rewrite
        Z.mod_small_1
        Z.mod_div_eq0
        Z.mod_same_pow
        Z.mod_small_n
        using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite
        Z.mod_add_full
        Z.mod_add_l_full
        Z.mod_add'_full Z.mod_add_l'_full
        Z.sub_mod_mod_0
     : zsimplify.
+#[global]
   Hint Rewrite <-
          Z.mod_opp_l_z_iff
            Z.div_mod'
            Z.div_mod''
            Z.div_mod'''
            using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite
        Z.mul_div_eq_full
        Z.mul_div_eq Z.mul_div_eq'
        using zutil_arith : zdiv_to_mod.
+#[global]
   Hint Rewrite <-
          Z.mul_div_eq_full
            Z.mul_div_eq'

--- a/src/Util/ZUtil/Modulo/Bootstrap.v
+++ b/src/Util/ZUtil/Modulo/Bootstrap.v
@@ -24,5 +24,6 @@ Module Export Hints.
   Export Crypto.Util.FixCoqMistakes.
   Export Crypto.Util.ZUtil.Hints.Core.
   Global Hint Resolve Z.mod_0_r_eq : zarith.
+#[global]
   Hint Rewrite Z.mod_0_r_eq using assumption : zsimplify.
 End Hints.

--- a/src/Util/ZUtil/Modulo/PullPush.v
+++ b/src/Util/ZUtil/Modulo/PullPush.v
@@ -7,17 +7,22 @@ Local Open Scope Z_scope.
 Module Z.
   Lemma mod_r_distr_if (b : bool) x y z : z mod (if b then x else y) = if b then z mod x else z mod y.
   Proof. destruct b; reflexivity. Qed.
+#[global]
   Hint Rewrite mod_r_distr_if : push_Zmod.
+#[global]
   Hint Rewrite <- mod_r_distr_if : pull_Zmod.
 
   Lemma mod_l_distr_if (b : bool) x y z : (if b then x else y) mod z = if b then x mod z else y mod z.
   Proof. destruct b; reflexivity. Qed.
+#[global]
   Hint Rewrite mod_l_distr_if : push_Zmod.
+#[global]
   Hint Rewrite <- mod_l_distr_if : pull_Zmod.
 
   (** Version without the [n <> 0] assumption *)
   Lemma mul_mod_full a b n : (a * b) mod n = ((a mod n) * (b mod n)) mod n.
   Proof. auto using Zmult_mod. Qed.
+#[global]
   Hint Rewrite <- mul_mod_full : pull_Zmod.
   Global Hint Resolve mul_mod_full : zarith.
 
@@ -26,6 +31,7 @@ Module Z.
     intros; rewrite (mul_mod_full a b), (mul_mod_full (a mod n) b).
     autorewrite with zsimplify; reflexivity.
   Qed.
+#[global]
   Hint Rewrite <- mul_mod_l : pull_Zmod.
   Global Hint Resolve mul_mod_l : zarith.
 
@@ -34,11 +40,13 @@ Module Z.
     intros; rewrite (mul_mod_full a b), (mul_mod_full a (b mod n)).
     autorewrite with zsimplify; reflexivity.
   Qed.
+#[global]
   Hint Rewrite <- mul_mod_r : pull_Zmod.
   Global Hint Resolve mul_mod_r : zarith.
 
   Lemma add_mod_full a b n : (a + b) mod n = ((a mod n) + (b mod n)) mod n.
   Proof. auto using Zplus_mod. Qed.
+#[global]
   Hint Rewrite <- add_mod_full : pull_Zmod.
   Global Hint Resolve add_mod_full : zarith.
 
@@ -47,6 +55,7 @@ Module Z.
     intros; rewrite (add_mod_full a b), (add_mod_full (a mod n) b).
     autorewrite with zsimplify; reflexivity.
   Qed.
+#[global]
   Hint Rewrite <- add_mod_l : pull_Zmod.
   Global Hint Resolve add_mod_l : zarith.
 
@@ -55,6 +64,7 @@ Module Z.
     intros; rewrite (add_mod_full a b), (add_mod_full a (b mod n)).
     autorewrite with zsimplify; reflexivity.
   Qed.
+#[global]
   Hint Rewrite <- add_mod_r : pull_Zmod.
   Global Hint Resolve add_mod_r : zarith.
 
@@ -64,22 +74,26 @@ Module Z.
       [ | rewrite !Z_mod_nz_opp_full ];
       autorewrite with zsimplify; lia.
   Qed.
+#[global]
   Hint Rewrite <- opp_mod_mod : pull_Zmod.
   Global Hint Resolve opp_mod_mod : zarith.
 
   (** Give alternate names for the next three lemmas, for consistency *)
   Lemma sub_mod_full a b n : (a - b) mod n = ((a mod n) - (b mod n)) mod n.
   Proof. auto using Zminus_mod. Qed.
+#[global]
   Hint Rewrite <- sub_mod_full : pull_Zmod.
   Global Hint Resolve sub_mod_full : zarith.
 
   Lemma sub_mod_l a b n : (a - b) mod n = ((a mod n) - b) mod n.
   Proof. auto using Zminus_mod_idemp_l. Qed.
+#[global]
   Hint Rewrite <- sub_mod_l : pull_Zmod.
   Global Hint Resolve sub_mod_l : zarith.
 
   Lemma sub_mod_r a b n : (a - b) mod n = (a - (b mod n)) mod n.
   Proof. auto using Zminus_mod_idemp_r. Qed.
+#[global]
   Hint Rewrite <- sub_mod_r : pull_Zmod.
   Global Hint Resolve sub_mod_r : zarith.
 
@@ -87,6 +101,7 @@ Module Z.
   Proof.
     cbv [Z.lnot]; etransitivity; rewrite <- !Z.sub_1_r, Z.sub_mod_full, Z.opp_mod_mod, ?Zmod_mod; reflexivity.
   Qed.
+#[global]
   Hint Rewrite lnot_mod_mod : pull_Zmod.
   Global Hint Resolve lnot_mod_mod : zarith.
 
@@ -116,6 +131,7 @@ Module Z.
       { rewrite Z.pow_opp_odd, !Z.opp_involutive, <- Zpower_mod, Z.pow_opp_odd, ?Z.opp_involutive by (assumption || lia).
         reflexivity. } }
   Qed.
+#[global]
   Hint Rewrite <- mod_pow_full : pull_Zmod.
   Global Hint Resolve mod_pow_full : zarith.
   Notation pow_mod_full := mod_pow_full.
@@ -129,94 +145,134 @@ Module Z.
 
   Lemma mul_mod_push a b n : NoZMod a -> NoZMod b -> (a * b) mod n = ((a mod n) * (b mod n)) mod n.
   Proof. intros; apply mul_mod_full; assumption. Qed.
+#[global]
   Hint Rewrite mul_mod_push using solve [ NoZMod ] : push_Zmod.
 
   Lemma add_mod_push a b n : NoZMod a -> NoZMod b -> (a + b) mod n = ((a mod n) + (b mod n)) mod n.
   Proof. intros; apply add_mod_full; assumption. Qed.
+#[global]
   Hint Rewrite add_mod_push using solve [ NoZMod ] : push_Zmod.
 
   Lemma mul_mod_l_push a b n : NoZMod a -> (a * b) mod n = ((a mod n) * b) mod n.
   Proof. intros; apply mul_mod_l; assumption. Qed.
+#[global]
   Hint Rewrite mul_mod_l_push using solve [ NoZMod ] : push_Zmod.
 
   Lemma mul_mod_r_push a b n : NoZMod b -> (a * b) mod n = (a * (b mod n)) mod n.
   Proof. intros; apply mul_mod_r; assumption. Qed.
+#[global]
   Hint Rewrite mul_mod_r_push using solve [ NoZMod ] : push_Zmod.
 
   Lemma add_mod_l_push a b n : NoZMod a -> (a + b) mod n = ((a mod n) + b) mod n.
   Proof. intros; apply add_mod_l; assumption. Qed.
+#[global]
   Hint Rewrite add_mod_l_push using solve [ NoZMod ] : push_Zmod.
 
   Lemma add_mod_r_push a b n : NoZMod b -> (a + b) mod n = (a + (b mod n)) mod n.
   Proof. intros; apply add_mod_r; assumption. Qed.
+#[global]
   Hint Rewrite add_mod_r_push using solve [ NoZMod ] : push_Zmod.
 
   Lemma sub_mod_push a b n : NoZMod a -> NoZMod b -> (a - b) mod n = ((a mod n) - (b mod n)) mod n.
   Proof. intros; apply Zminus_mod; assumption. Qed.
+#[global]
   Hint Rewrite sub_mod_push using solve [ NoZMod ] : push_Zmod.
 
   Lemma sub_mod_l_push a b n : NoZMod a -> (a - b) mod n = ((a mod n) - b) mod n.
   Proof. intros; symmetry; apply Zminus_mod_idemp_l; assumption. Qed.
+#[global]
   Hint Rewrite sub_mod_l_push using solve [ NoZMod ] : push_Zmod.
 
   Lemma sub_mod_r_push a b n : NoZMod b -> (a - b) mod n = (a - (b mod n)) mod n.
   Proof. intros; symmetry; apply Zminus_mod_idemp_r; assumption. Qed.
+#[global]
   Hint Rewrite sub_mod_r_push using solve [ NoZMod ] : push_Zmod.
 
   Lemma opp_mod_mod_push a n : NoZMod a -> (-a) mod n = (-(a mod n)) mod n.
   Proof. intros; apply opp_mod_mod; assumption. Qed.
+#[global]
   Hint Rewrite opp_mod_mod_push using solve [ NoZMod ] : push_Zmod.
 
   Lemma lnot_mod_mod_push v m : NoZMod v -> (Z.lnot v) mod m = (Z.lnot (v mod m) mod m).
   Proof. intros; symmetry; apply lnot_mod_mod. Qed.
+#[global]
   Hint Rewrite lnot_mod_mod_push using solve [ NoZMod ] : push_Zmod.
 
   Lemma pow_mod_push p q n : NoZMod p -> (p^q) mod n = ((p mod n)^q) mod n.
   Proof. intros; apply pow_mod_full. Qed.
+#[global]
   Hint Rewrite pow_mod_push using solve [ NoZMod ] : push_Zmod.
 End Z.
 
 Module Export Hints.
   Export Crypto.Util.ZUtil.Hints.Core.
   Export Crypto.Util.ZUtil.ZSimplify.Core.
+#[global]
   Hint Rewrite Z.mod_r_distr_if : push_Zmod.
+#[global]
   Hint Rewrite <- Z.mod_r_distr_if : pull_Zmod.
+#[global]
   Hint Rewrite Z.mod_l_distr_if : push_Zmod.
+#[global]
   Hint Rewrite <- Z.mod_l_distr_if : pull_Zmod.
+#[global]
   Hint Rewrite <- Z.mul_mod_full : pull_Zmod.
   Global Hint Resolve Z.mul_mod_full : zarith.
+#[global]
   Hint Rewrite <- Z.mul_mod_l : pull_Zmod.
   Global Hint Resolve Z.mul_mod_l : zarith.
+#[global]
   Hint Rewrite <- Z.mul_mod_r : pull_Zmod.
   Global Hint Resolve Z.mul_mod_r : zarith.
+#[global]
   Hint Rewrite <- Z.add_mod_full : pull_Zmod.
   Global Hint Resolve Z.add_mod_full : zarith.
+#[global]
   Hint Rewrite <- Z.add_mod_l : pull_Zmod.
   Global Hint Resolve Z.add_mod_l : zarith.
+#[global]
   Hint Rewrite <- Z.add_mod_r : pull_Zmod.
   Global Hint Resolve Z.add_mod_r : zarith.
+#[global]
   Hint Rewrite <- Z.opp_mod_mod : pull_Zmod.
   Global Hint Resolve Z.opp_mod_mod : zarith.
+#[global]
   Hint Rewrite <- Z.sub_mod_full : pull_Zmod.
   Global Hint Resolve Z.sub_mod_full : zarith.
+#[global]
   Hint Rewrite <- Z.sub_mod_l : pull_Zmod.
   Global Hint Resolve Z.sub_mod_l : zarith.
+#[global]
   Hint Rewrite <- Z.sub_mod_r : pull_Zmod.
   Global Hint Resolve Z.sub_mod_r : zarith.
+#[global]
   Hint Rewrite Z.lnot_mod_mod : pull_Zmod.
   Global Hint Resolve Z.lnot_mod_mod : zarith.
+#[global]
   Hint Rewrite <- Z.mod_pow_full : pull_Zmod.
   Global Hint Resolve Z.mod_pow_full : zarith.
+#[global]
   Hint Rewrite Z.mul_mod_push using solve [ Z.NoZMod ] : push_Zmod.
+#[global]
   Hint Rewrite Z.add_mod_push using solve [ Z.NoZMod ] : push_Zmod.
+#[global]
   Hint Rewrite Z.mul_mod_l_push using solve [ Z.NoZMod ] : push_Zmod.
+#[global]
   Hint Rewrite Z.mul_mod_r_push using solve [ Z.NoZMod ] : push_Zmod.
+#[global]
   Hint Rewrite Z.add_mod_l_push using solve [ Z.NoZMod ] : push_Zmod.
+#[global]
   Hint Rewrite Z.add_mod_r_push using solve [ Z.NoZMod ] : push_Zmod.
+#[global]
   Hint Rewrite Z.sub_mod_push using solve [ Z.NoZMod ] : push_Zmod.
+#[global]
   Hint Rewrite Z.sub_mod_l_push using solve [ Z.NoZMod ] : push_Zmod.
+#[global]
   Hint Rewrite Z.sub_mod_r_push using solve [ Z.NoZMod ] : push_Zmod.
+#[global]
   Hint Rewrite Z.opp_mod_mod_push using solve [ Z.NoZMod ] : push_Zmod.
+#[global]
   Hint Rewrite Z.lnot_mod_mod_push using solve [ Z.NoZMod ] : push_Zmod.
+#[global]
   Hint Rewrite Z.pow_mod_push using solve [ Z.NoZMod ] : push_Zmod.
 End Hints.

--- a/src/Util/ZUtil/MulSplit.v
+++ b/src/Util/ZUtil/MulSplit.v
@@ -21,12 +21,14 @@ Module Z.
     unfold Z.mul_split; break_match; Z.ltb_to_lt;
       [ rewrite mul_split_at_bitwidth_mod; congruence | reflexivity ].
   Qed.
+#[global]
   Hint Rewrite mul_split_mod : to_div_mod.
   Lemma mul_split_div s x y : snd (Z.mul_split s x y)  = (x * y) / s.
   Proof.
     unfold Z.mul_split; break_match; Z.ltb_to_lt;
       [ rewrite mul_split_at_bitwidth_div; congruence | reflexivity ].
   Qed.
+#[global]
   Hint Rewrite mul_split_div : to_div_mod.
 End Z.
 
@@ -34,6 +36,8 @@ Module Export Hints.
   Export Crypto.Util.FixCoqMistakes.
   Export Crypto.Util.ZUtil.Definitions.Hints.
   Export Crypto.Util.ZUtil.Tactics.LtbToLt.Hints.
+#[global]
   Hint Rewrite Z.mul_split_mod : to_div_mod.
+#[global]
   Hint Rewrite Z.mul_split_div : to_div_mod.
 End Hints.

--- a/src/Util/ZUtil/N2Z.v
+++ b/src/Util/ZUtil/N2Z.v
@@ -6,12 +6,16 @@ Local Open Scope Z_scope.
 Module N2Z.
   Lemma inj_land n m : Z.of_N (N.land n m) = Z.land (Z.of_N n) (Z.of_N m).
   Proof. destruct n, m; reflexivity. Qed.
+#[global]
   Hint Rewrite inj_land : push_Zof_N.
+#[global]
   Hint Rewrite <- inj_land : pull_Zof_N.
 
   Lemma inj_lor n m : Z.of_N (N.lor n m) = Z.lor (Z.of_N n) (Z.of_N m).
   Proof. destruct n, m; reflexivity. Qed.
+#[global]
   Hint Rewrite inj_lor : push_Zof_N.
+#[global]
   Hint Rewrite <- inj_lor : pull_Zof_N.
 
   Lemma inj_shiftl: forall x y, Z.of_N (N.shiftl x y) = Z.shiftl (Z.of_N x) (Z.of_N y).
@@ -36,7 +40,9 @@ Module N2Z.
         rewrite Z2N.id in g; [symmetry|assumption].
         apply Z.testbit_neg_r; lia.
   Qed.
+#[global]
   Hint Rewrite inj_shiftl : push_Zof_N.
+#[global]
   Hint Rewrite <- inj_shiftl : pull_Zof_N.
 
   Lemma inj_shiftr: forall x y, Z.of_N (N.shiftr x y) = Z.shiftr (Z.of_N x) (Z.of_N y).
@@ -49,19 +55,29 @@ Module N2Z.
     rewrite N2Z.inj_add; f_equal.
     apply Z2N.id; assumption.
   Qed.
+#[global]
   Hint Rewrite inj_shiftr : push_Zof_N.
+#[global]
   Hint Rewrite <- inj_shiftr : pull_Zof_N.
 End N2Z.
 
 Module Export Hints.
   Export Crypto.Util.FixCoqMistakes.
   Export Crypto.Util.ZUtil.Hints.Core.
+#[global]
   Hint Rewrite N2Z.inj_land : push_Zof_N.
+#[global]
   Hint Rewrite <- N2Z.inj_land : pull_Zof_N.
+#[global]
   Hint Rewrite N2Z.inj_lor : push_Zof_N.
+#[global]
   Hint Rewrite <- N2Z.inj_lor : pull_Zof_N.
+#[global]
   Hint Rewrite N2Z.inj_shiftl : push_Zof_N.
+#[global]
   Hint Rewrite <- N2Z.inj_shiftl : pull_Zof_N.
+#[global]
   Hint Rewrite N2Z.inj_shiftr : push_Zof_N.
+#[global]
   Hint Rewrite <- N2Z.inj_shiftr : pull_Zof_N.
 End Hints.

--- a/src/Util/ZUtil/Ones.v
+++ b/src/Util/ZUtil/Ones.v
@@ -32,6 +32,7 @@ Module Z.
   Proof.
     rewrite Z.ones_equiv, Z.log2_pred_pow2_full; reflexivity.
   Qed.
+#[global]
   Hint Rewrite log2_ones_full : zsimplify.
 
   Lemma log2_ones_lt x y : 0 < x <= y -> Z.log2 (Z.ones x) < y.
@@ -65,6 +66,7 @@ Module Z.
     rewrite <-Z.pow_add_r by (pose proof (Pos2Z.is_pos p); lia).
     f_equal. lia.
   Qed.
+#[global]
   Hint Rewrite <- ones_pred using zutil_arith : push_Zshift.
 
   Lemma ones_succ : forall x, (0 <= x) ->
@@ -135,6 +137,7 @@ Module Z.
                    | [ |- context[2^?x] ] => unique pose proof (Z.pow2_gt_0 x ltac:(lia))
                    end ].
   Qed.
+#[global]
   Hint Rewrite land_ones_ones : zsimplify.
 
   Lemma lor_ones_ones n m
@@ -173,6 +176,7 @@ Module Z.
                      | [ |- context[2^?x] ] => unique pose proof (Z.pow2_gt_0 x ltac:(lia))
                      end ].
   Qed.
+#[global]
   Hint Rewrite lor_ones_ones : zsimplify.
 
   Lemma lor_pow2_mod_pow2_r x e (He : 0 <= e) : Z.lor x (2^e-1) mod (2^e) = 2^e-1.
@@ -188,12 +192,16 @@ Module Z.
     rewrite Z.land_ones by assumption.
     rewrite Z.lor_ones_low; auto with zarith.
   Qed.
+#[global]
   Hint Rewrite lor_pow2_mod_pow2_r using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite lor_pow2_mod_pow2_r using assumption : zsimplify_fast.
 
   Lemma lor_pow2_mod_pow2_l x e (He : 0 <= e) : Z.lor (2^e-1) x mod (2^e) = 2^e-1.
   Proof. rewrite Z.lor_comm; apply lor_pow2_mod_pow2_r; assumption. Qed.
+#[global]
   Hint Rewrite lor_pow2_mod_pow2_l using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite lor_pow2_mod_pow2_l using assumption : zsimplify_fast.
 
   Lemma lor_pow2_div_pow2_r x e (He : 0 <= e) : (Z.lor x (2^e-1)) / (2^e) = x / 2^e.
@@ -205,12 +213,16 @@ Module Z.
     rewrite (Z.div_small (_-1) _), Z.lor_0_r by lia.
     reflexivity.
   Qed.
+#[global]
   Hint Rewrite lor_pow2_div_pow2_r using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite lor_pow2_div_pow2_r using assumption : zsimplify_fast.
 
   Lemma lor_pow2_div_pow2_l x e (He : 0 <= e) : (Z.lor (2^e-1) x) / (2^e) = x / 2^e.
   Proof. rewrite Z.lor_comm; apply lor_pow2_div_pow2_r; assumption. Qed.
+#[global]
   Hint Rewrite lor_pow2_div_pow2_l using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite lor_pow2_div_pow2_l using assumption : zsimplify_fast.
 End Z.
 
@@ -225,21 +237,33 @@ Module Export Hints.
   Export Crypto.Util.ZUtil.Tactics.ZeroBounds.Hints.
   Global Hint Resolve Z.ones_le : zarith.
   Global Hint Resolve Z.ones_lt_pow2 : zarith.
+#[global]
   Hint Rewrite Z.log2_ones_full : zsimplify.
   Global Hint Resolve Z.log2_ones_lt : zarith.
   Global Hint Resolve Z.log2_ones_le : zarith.
   Global Hint Resolve Z.log2_ones_lt_nonneg : zarith.
+#[global]
   Hint Rewrite <- Z.ones_pred using zutil_arith : push_Zshift.
   Global Hint Resolve Z.ones_nonneg : zarith.
   Global Hint Resolve Z.ones_pos_pos : zarith.
+#[global]
   Hint Rewrite Z.land_ones_ones : zsimplify.
+#[global]
   Hint Rewrite Z.lor_ones_ones : zsimplify.
+#[global]
   Hint Rewrite Z.lor_pow2_mod_pow2_r using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.lor_pow2_mod_pow2_r using assumption : zsimplify_fast.
+#[global]
   Hint Rewrite Z.lor_pow2_mod_pow2_l using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.lor_pow2_mod_pow2_l using assumption : zsimplify_fast.
+#[global]
   Hint Rewrite Z.lor_pow2_div_pow2_r using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.lor_pow2_div_pow2_r using assumption : zsimplify_fast.
+#[global]
   Hint Rewrite Z.lor_pow2_div_pow2_l using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.lor_pow2_div_pow2_l using assumption : zsimplify_fast.
 End Hints.

--- a/src/Util/ZUtil/Opp.v
+++ b/src/Util/ZUtil/Opp.v
@@ -7,6 +7,7 @@ Local Open Scope Z_scope.
 Module Z.
   Lemma opp_eq_0_iff a : -a = 0 <-> a = 0.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite opp_eq_0_iff : zsimplify.
 End Z.
 
@@ -14,5 +15,6 @@ Module Export Hints.
   Export Crypto.Util.FixCoqMistakes.
   Export Crypto.Util.ZUtil.Hints.Core.
   Export Crypto.Util.ZUtil.ZSimplify.Core.
+#[global]
   Hint Rewrite Z.opp_eq_0_iff : zsimplify.
 End Hints.

--- a/src/Util/ZUtil/Pow.v
+++ b/src/Util/ZUtil/Pow.v
@@ -40,7 +40,9 @@ Module Z.
 End Z.
 Module Export Hints.
   Export ZUtil.Hints.Core.
+#[global]
   Hint Rewrite Z.base_pow_neg using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite <- Z.two_p_two_eq_four : push_Zpow.
   Global Hint Resolve Z.pow_sub_r' Z.pow_sub_r'_sym Z.eq_le_incl : zarith.
   Global Hint Resolve (fun b => f_equal (fun e => b ^ e)) (fun e => f_equal (fun b => b ^ e)) : zarith.

--- a/src/Util/ZUtil/Pow2Mod.v
+++ b/src/Util/ZUtil/Pow2Mod.v
@@ -17,6 +17,7 @@ Module Z.
     unfold Z.pow2_mod.
     rewrite Z.land_ones; auto.
   Qed.
+#[global]
   Hint Rewrite <- Z.pow2_mod_spec using zutil_arith : convert_to_Ztestbit.
 
   Lemma pow2_mod_0_r : forall a, Z.pow2_mod a 0 = 0.
@@ -72,6 +73,7 @@ Module Export Hints.
   Export Crypto.Util.ZUtil.Hints.Ztestbit.
   Export Crypto.Util.ZUtil.Tactics.ZeroBounds.Hints.
   Export Crypto.Util.ZUtil.Testbit.Hints.
+#[global]
   Hint Rewrite <- Z.pow2_mod_spec using zutil_arith : convert_to_Ztestbit.
   Global Hint Resolve Z.pow2_mod_pos_bound : zarith.
 End Hints.

--- a/src/Util/ZUtil/Shift.v
+++ b/src/Util/ZUtil/Shift.v
@@ -26,7 +26,9 @@ Module Z.
       [assumption || apply Z.pow_nonzero || apply Z.pow_pos_nonneg; lia].
     f_equal; ring.
   Qed.
+#[global]
   Hint Rewrite Z.shiftr_add_shiftl_high using zutil_arith : pull_Zshift.
+#[global]
   Hint Rewrite <- Z.shiftr_add_shiftl_high using zutil_arith : push_Zshift.
 
   Lemma shiftr_add_shiftl_low : forall n m a b, 0 <= m <= n -> 0 <= a < 2 ^ n ->
@@ -39,7 +41,9 @@ Module Z.
     rewrite Z.mul_assoc, Z.div_add by (apply Z.pow_nonzero; lia).
     repeat f_equal; ring.
   Qed.
+#[global]
   Hint Rewrite Z.shiftr_add_shiftl_low using zutil_arith : pull_Zshift.
+#[global]
   Hint Rewrite <- Z.shiftr_add_shiftl_low using zutil_arith : push_Zshift.
 
   Lemma testbit_add_shiftl_high : forall i, (0 <= i) -> forall a b n, (0 <= n <= i) ->
@@ -60,6 +64,7 @@ Module Z.
     rewrite <-Z.pow_add_r by lia.
     replace (1 + (n - 1)) with n by ring; lia.
   Qed.
+#[global]
   Hint Rewrite testbit_add_shiftl_high using zutil_arith : Ztestbit.
 
   Lemma shiftr_succ : forall n x,
@@ -69,7 +74,9 @@ Module Z.
     rewrite Z.shiftr_shiftr by lia.
     reflexivity.
   Qed.
+#[global]
   Hint Rewrite Z.shiftr_succ using zutil_arith : push_Zshift.
+#[global]
   Hint Rewrite <- Z.shiftr_succ using zutil_arith : pull_Zshift.
 
   Lemma shiftr_1_r_le : forall a b, a <= b ->
@@ -155,6 +162,7 @@ Module Z.
       split; try eapply Z.lt_le_trans with (m := 2 ^ n); try lia.
       apply Z.pow_le_mono_r; lia.
   Qed.
+#[global]
   Hint Rewrite <- Z.lor_shiftl using zutil_arith : convert_to_Ztestbit.
 
   Lemma lor_shiftl' : forall a b n, 0 <= n -> 0 <= a < 2 ^ n ->
@@ -162,6 +170,7 @@ Module Z.
   Proof.
     intros; rewrite Z.lor_comm, Z.add_comm; apply lor_shiftl; assumption.
   Qed.
+#[global]
   Hint Rewrite <- Z.lor_shiftl' using zutil_arith : convert_to_Ztestbit.
 
   Lemma shiftl_spec_full a n m
@@ -173,6 +182,7 @@ Module Z.
   Proof.
     repeat break_match; auto using Z.shiftl_spec_low, Z.shiftl_spec, Z.testbit_neg_r with lia.
   Qed.
+#[global]
   Hint Rewrite shiftl_spec_full : Ztestbit_full.
 
   Lemma shiftr_spec_full a n m
@@ -184,6 +194,7 @@ Module Z.
   Proof.
     rewrite <- Z.shiftl_opp_r, shiftl_spec_full, Z.sub_opp_r; reflexivity.
   Qed.
+#[global]
   Hint Rewrite shiftr_spec_full : Ztestbit_full.
 
   Lemma testbit_add_shiftl_full i (Hi : 0 <= i) a b n (Ha : 0 <= a < 2^n)
@@ -194,6 +205,7 @@ Module Z.
     assert (0 <= n) by eauto 2 with zarith.
     pose proof (Zlt_cases i n); break_match; autorewrite with Ztestbit; reflexivity.
   Qed.
+#[global]
   Hint Rewrite testbit_add_shiftl_full using zutil_arith : Ztestbit.
 
   Lemma land_add_land : forall n m a b, (m <= n)%nat ->
@@ -215,22 +227,30 @@ Module Z.
 
   Lemma shiftl_add x y z : 0 <= z -> (x + y) << z = (x << z) + (y << z).
   Proof. intros; autorewrite with Zshift_to_pow; lia. Qed.
+#[global]
   Hint Rewrite shiftl_add using zutil_arith : push_Zshift.
+#[global]
   Hint Rewrite <- shiftl_add using zutil_arith : pull_Zshift.
 
   Lemma shiftr_add x y z : z <= 0 -> (x + y) >> z = (x >> z) + (y >> z).
   Proof. intros; autorewrite with Zshift_to_pow; lia. Qed.
+#[global]
   Hint Rewrite shiftr_add using zutil_arith : push_Zshift.
+#[global]
   Hint Rewrite <- shiftr_add using zutil_arith : pull_Zshift.
 
   Lemma shiftl_sub x y z : 0 <= z -> (x - y) << z = (x << z) - (y << z).
   Proof. intros; autorewrite with Zshift_to_pow; lia. Qed.
+#[global]
   Hint Rewrite shiftl_sub using zutil_arith : push_Zshift.
+#[global]
   Hint Rewrite <- shiftl_sub using zutil_arith : pull_Zshift.
 
   Lemma shiftr_sub x y z : z <= 0 -> (x - y) >> z = (x >> z) - (y >> z).
   Proof. intros; autorewrite with Zshift_to_pow; lia. Qed.
+#[global]
   Hint Rewrite shiftr_sub using zutil_arith : push_Zshift.
+#[global]
   Hint Rewrite <- shiftr_sub using zutil_arith : pull_Zshift.
 
   Lemma compare_add_shiftl : forall x1 y1 x2 y2 n, 0 <= n ->
@@ -346,6 +366,7 @@ Module Z.
       lia.
   Qed.
 
+#[global]
   Hint Rewrite Z.pow2_bits_eqb using zutil_arith : Ztestbit.
   Lemma pow_2_shiftr : forall n, 0 <= n -> (2 ^ n) >> n = 1.
   Proof.
@@ -405,30 +426,51 @@ Module Export Hints.
   Export Crypto.Util.ZUtil.Div.Hints.
   Export Crypto.Util.ZUtil.Tactics.ZeroBounds.Hints.
   Export Crypto.Util.ZUtil.Notations.Hints.
+#[global]
   Hint Rewrite Z.shiftr_add_shiftl_high using zutil_arith : pull_Zshift.
+#[global]
   Hint Rewrite <- Z.shiftr_add_shiftl_high using zutil_arith : push_Zshift.
+#[global]
   Hint Rewrite Z.shiftr_add_shiftl_low using zutil_arith : pull_Zshift.
+#[global]
   Hint Rewrite <- Z.shiftr_add_shiftl_low using zutil_arith : push_Zshift.
+#[global]
   Hint Rewrite Z.testbit_add_shiftl_high using zutil_arith : Ztestbit.
+#[global]
   Hint Rewrite Z.shiftr_succ using zutil_arith : push_Zshift.
+#[global]
   Hint Rewrite <- Z.shiftr_succ using zutil_arith : pull_Zshift.
   Global Hint Resolve Z.shiftr_1_r_le : zarith.
   Global Hint Resolve Z.shiftr_le : zarith.
   Global Hint Resolve Z.shiftr_ones : zarith.
   Global Hint Resolve Z.shiftr_upper_bound : zarith.
+#[global]
   Hint Rewrite <- Z.lor_shiftl using zutil_arith : convert_to_Ztestbit.
+#[global]
   Hint Rewrite <- Z.lor_shiftl' using zutil_arith : convert_to_Ztestbit.
+#[global]
   Hint Rewrite Z.shiftl_spec_full : Ztestbit_full.
+#[global]
   Hint Rewrite Z.shiftr_spec_full : Ztestbit_full.
+#[global]
   Hint Rewrite Z.testbit_add_shiftl_full using zutil_arith : Ztestbit.
+#[global]
   Hint Rewrite Z.shiftl_add using zutil_arith : push_Zshift.
+#[global]
   Hint Rewrite <- Z.shiftl_add using zutil_arith : pull_Zshift.
+#[global]
   Hint Rewrite Z.shiftr_add using zutil_arith : push_Zshift.
+#[global]
   Hint Rewrite <- Z.shiftr_add using zutil_arith : pull_Zshift.
+#[global]
   Hint Rewrite Z.shiftl_sub using zutil_arith : push_Zshift.
+#[global]
   Hint Rewrite <- Z.shiftl_sub using zutil_arith : pull_Zshift.
+#[global]
   Hint Rewrite Z.shiftr_sub using zutil_arith : push_Zshift.
+#[global]
   Hint Rewrite <- Z.shiftr_sub using zutil_arith : pull_Zshift.
+#[global]
   Hint Rewrite Z.pow2_bits_eqb using zutil_arith : Ztestbit.
   Global Hint Resolve Z.shiftr_nonneg_le : zarith.
 End Hints.

--- a/src/Util/ZUtil/Tactics/LtbToLt.v
+++ b/src/Util/ZUtil/Tactics/LtbToLt.v
@@ -77,5 +77,6 @@ Module Z.
 End Z.
 Module Export Hints.
   Export Crypto.Util.FixCoqMistakes.
+#[global]
   Hint Rewrite Z.ltb_lt_iff Z.leb_le_iff Z.gtb_gt_iff Z.geb_ge_iff Z.eqb_eq_iff : ltb_to_lt.
 End Hints.

--- a/src/Util/ZUtil/Testbit.v
+++ b/src/Util/ZUtil/Testbit.v
@@ -18,6 +18,7 @@ Module Z.
     + apply Z.ones_spec_low. lia.
     + apply Z.ones_spec_high. lia.
   Qed.
+#[global]
   Hint Rewrite ones_spec using zutil_arith : Ztestbit.
 
   Lemma ones_spec_full : forall n m, Z.testbit (Z.ones n) m
@@ -34,6 +35,7 @@ Module Z.
     destruct m; simpl in *; try reflexivity.
     exfalso; auto using Zlt_neg_0.
   Qed.
+#[global]
   Hint Rewrite ones_spec_full : Ztestbit_full.
 
   Lemma testbit_pow2_mod : forall a n i, 0 <= n ->
@@ -48,6 +50,7 @@ Module Z.
           | |- _ => progress autorewrite with Ztestbit
           end.
   Qed.
+#[global]
   Hint Rewrite testbit_pow2_mod using zutil_arith : Ztestbit.
 
   Lemma testbit_pow2_mod_full : forall a n i,
@@ -62,6 +65,7 @@ Module Z.
       autorewrite with Ztestbit;
       reflexivity.
   Qed.
+#[global]
   Hint Rewrite testbit_pow2_mod_full : Ztestbit_full.
 
   Lemma bits_above_pow2 a n : 0 <= a < 2^n -> Z.testbit a n = false.
@@ -70,6 +74,7 @@ Module Z.
     destruct (Z_zerop a); subst; autorewrite with Ztestbit; trivial.
     apply Z.bits_above_log2; auto with zarith concl_log2.
   Qed.
+#[global]
   Hint Rewrite bits_above_pow2 using zutil_arith : Ztestbit.
 
   Lemma testbit_low : forall n x i, (0 <= i < n) ->
@@ -91,6 +96,7 @@ Module Z.
     rewrite Z.mod_add by (pose proof (Z.pow_pos_nonneg 2 n); lia).
     auto using Z.mod_pow2_bits_low.
   Qed.
+#[global]
   Hint Rewrite testbit_add_shiftl_low using zutil_arith : Ztestbit.
 
   Lemma testbit_sub_pow2 n i x (i_range:0 <= i < n) (x_range:0 < x < 2 ^ n) :
@@ -135,10 +141,16 @@ Module Export Hints.
   Export Crypto.Util.ZUtil.Div.Hints.
   Export Crypto.Util.ZUtil.Tactics.ZeroBounds.Hints.
   Export Crypto.Util.ZUtil.Tactics.LtbToLt.Hints.
+#[global]
   Hint Rewrite Z.ones_spec using zutil_arith : Ztestbit.
+#[global]
   Hint Rewrite Z.ones_spec_full : Ztestbit_full.
+#[global]
   Hint Rewrite Z.testbit_pow2_mod using zutil_arith : Ztestbit.
+#[global]
   Hint Rewrite Z.testbit_pow2_mod_full : Ztestbit_full.
+#[global]
   Hint Rewrite Z.bits_above_pow2 using zutil_arith : Ztestbit.
+#[global]
   Hint Rewrite Z.testbit_add_shiftl_low using zutil_arith : Ztestbit.
 End Hints.

--- a/src/Util/ZUtil/Z2Nat.v
+++ b/src/Util/ZUtil/Z2Nat.v
@@ -31,7 +31,9 @@ Module Z.
     intros; apply Z2Nat.inj...
     rewrite <- pow_Z2N_Zpow, !Nat2Z.id...
   Qed.
+#[global]
   Hint Rewrite pow_Zpow : push_Zof_nat.
+#[global]
   Hint Rewrite <- pow_Zpow : pull_Zof_nat.
 
   Lemma Zpow_sub_1_nat_pow a v
@@ -44,14 +46,20 @@ Module Z.
       by (change 1%nat with (Z.to_nat (Z.pos a)^0)%nat; apply Nat.pow_le_mono_r; simpl; lia).
     reflexivity.
   Qed.
+#[global]
   Hint Rewrite Zpow_sub_1_nat_pow : pull_Zof_nat.
+#[global]
   Hint Rewrite <- Zpow_sub_1_nat_pow : push_Zof_nat.
 End Z.
 
 Module Export Hints.
   Export Crypto.Util.FixCoqMistakes.
+#[global]
   Hint Rewrite Z.pow_Zpow : push_Zof_nat.
+#[global]
   Hint Rewrite <- Z.pow_Zpow : pull_Zof_nat.
+#[global]
   Hint Rewrite Z.Zpow_sub_1_nat_pow : pull_Zof_nat.
+#[global]
   Hint Rewrite <- Z.Zpow_sub_1_nat_pow : push_Zof_nat.
 End Hints.

--- a/src/Util/ZUtil/ZSimplify/Autogenerated.v
+++ b/src/Util/ZUtil/ZSimplify/Autogenerated.v
@@ -112,267 +112,355 @@ simplify_div_" <> ExprToName[#1] <>
 >> *)
   Lemma simplify_div_ppX_dX a X : X <> 0 -> (a * X) / X = a.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppX_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pXp_dX a X : X <> 0 -> (X * a) / X = a.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pXp_dX using zutil_arith : zsimplify.
   Lemma simplify_div_ppX_pdX a b X : X <> 0 -> (a * X + b) / X = a + b / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppX_pdX using zutil_arith : zsimplify.
   Lemma simplify_div_pXp_pdX a b X : X <> 0 -> (X * a + b) / X = a + b / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pXp_pdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppX_ppdX a b c X : X <> 0 -> (a * X + b + c) / X = a + (b + c) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppX_ppdX using zutil_arith : zsimplify.
   Lemma simplify_div_pXp_ppdX a b c X : X <> 0 -> (X * a + b + c) / X = a + (b + c) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pXp_ppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppX_pppdX a b c d X : X <> 0 -> (a * X + b + c + d) / X = a + (b + c + d) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppX_pppdX using zutil_arith : zsimplify.
   Lemma simplify_div_pXp_pppdX a b c d X : X <> 0 -> (X * a + b + c + d) / X = a + (b + c + d) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pXp_pppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppX_ppppdX a b c d e X : X <> 0 -> (a * X + b + c + d + e) / X = a + (b + c + d + e) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppX_ppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_pXp_ppppdX a b c d e X : X <> 0 -> (X * a + b + c + d + e) / X = a + (b + c + d + e) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pXp_ppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppX_pppppdX a b c d e f X : X <> 0 -> (a * X + b + c + d + e + f) / X = a + (b + c + d + e + f) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppX_pppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_pXp_pppppdX a b c d e f X : X <> 0 -> (X * a + b + c + d + e + f) / X = a + (b + c + d + e + f) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pXp_pppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppX_ppppppdX a b c d e f g X : X <> 0 -> (a * X + b + c + d + e + f + g) / X = a + (b + c + d + e + f + g) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppX_ppppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_pXp_ppppppdX a b c d e f g X : X <> 0 -> (X * a + b + c + d + e + f + g) / X = a + (b + c + d + e + f + g) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pXp_ppppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppX_pppppppdX a b c d e f g h X : X <> 0 -> (a * X + b + c + d + e + f + g + h) / X = a + (b + c + d + e + f + g + h) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppX_pppppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_pXp_pppppppdX a b c d e f g h X : X <> 0 -> (X * a + b + c + d + e + f + g + h) / X = a + (b + c + d + e + f + g + h) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pXp_pppppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppX_ppppppppdX a b c d e f g h i X : X <> 0 -> (a * X + b + c + d + e + f + g + h + i) / X = a + (b + c + d + e + f + g + h + i) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppX_ppppppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_pXp_ppppppppdX a b c d e f g h i X : X <> 0 -> (X * a + b + c + d + e + f + g + h + i) / X = a + (b + c + d + e + f + g + h + i) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pXp_ppppppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppX_pppppppppdX a b c d e f g h i j X : X <> 0 -> (a * X + b + c + d + e + f + g + h + i + j) / X = a + (b + c + d + e + f + g + h + i + j) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppX_pppppppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_pXp_pppppppppdX a b c d e f g h i j X : X <> 0 -> (X * a + b + c + d + e + f + g + h + i + j) / X = a + (b + c + d + e + f + g + h + i + j) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pXp_pppppppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_pX_dX a b X : X <> 0 -> (a + b * X) / X = b + a / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_pX_dX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_Xp_dX a b X : X <> 0 -> (a + X * b) / X = b + a / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_Xp_dX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_pX_pdX a b c X : X <> 0 -> (a + b * X + c) / X = b + (a + c) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_pX_pdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_Xp_pdX a b c X : X <> 0 -> (a + X * b + c) / X = b + (a + c) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_Xp_pdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_pX_ppdX a b c d X : X <> 0 -> (a + b * X + c + d) / X = b + (a + c + d) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_pX_ppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_Xp_ppdX a b c d X : X <> 0 -> (a + X * b + c + d) / X = b + (a + c + d) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_Xp_ppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_pX_pppdX a b c d e X : X <> 0 -> (a + b * X + c + d + e) / X = b + (a + c + d + e) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_pX_pppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_Xp_pppdX a b c d e X : X <> 0 -> (a + X * b + c + d + e) / X = b + (a + c + d + e) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_Xp_pppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_pX_ppppdX a b c d e f X : X <> 0 -> (a + b * X + c + d + e + f) / X = b + (a + c + d + e + f) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_pX_ppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_Xp_ppppdX a b c d e f X : X <> 0 -> (a + X * b + c + d + e + f) / X = b + (a + c + d + e + f) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_Xp_ppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_pX_pppppdX a b c d e f g X : X <> 0 -> (a + b * X + c + d + e + f + g) / X = b + (a + c + d + e + f + g) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_pX_pppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_Xp_pppppdX a b c d e f g X : X <> 0 -> (a + X * b + c + d + e + f + g) / X = b + (a + c + d + e + f + g) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_Xp_pppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_pX_ppppppdX a b c d e f g h X : X <> 0 -> (a + b * X + c + d + e + f + g + h) / X = b + (a + c + d + e + f + g + h) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_pX_ppppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_Xp_ppppppdX a b c d e f g h X : X <> 0 -> (a + X * b + c + d + e + f + g + h) / X = b + (a + c + d + e + f + g + h) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_Xp_ppppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_pX_pppppppdX a b c d e f g h i X : X <> 0 -> (a + b * X + c + d + e + f + g + h + i) / X = b + (a + c + d + e + f + g + h + i) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_pX_pppppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_Xp_pppppppdX a b c d e f g h i X : X <> 0 -> (a + X * b + c + d + e + f + g + h + i) / X = b + (a + c + d + e + f + g + h + i) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_Xp_pppppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_pX_ppppppppdX a b c d e f g h i j X : X <> 0 -> (a + b * X + c + d + e + f + g + h + i + j) / X = b + (a + c + d + e + f + g + h + i + j) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_pX_ppppppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_Xp_ppppppppdX a b c d e f g h i j X : X <> 0 -> (a + X * b + c + d + e + f + g + h + i + j) / X = b + (a + c + d + e + f + g + h + i + j) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_Xp_ppppppppdX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pX__c_dX a b X : X <> 0 -> (a + (b * X)) / X = b + a / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pX__c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_Xp__c_dX a b X : X <> 0 -> (a + (X * b)) / X = b + a / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_Xp__c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pX_p_c_dX a b c X : X <> 0 -> (a + (b * X + c)) / X = b + (a + c) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pX_p_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_Xp_p_c_dX a b c X : X <> 0 -> (a + (X * b + c)) / X = b + (a + c) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_Xp_p_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pX_pp_c_dX a b c d X : X <> 0 -> (a + (b * X + c + d)) / X = b + (a + c + d) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pX_pp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_Xp_pp_c_dX a b c d X : X <> 0 -> (a + (X * b + c + d)) / X = b + (a + c + d) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_Xp_pp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pX_ppp_c_dX a b c d e X : X <> 0 -> (a + (b * X + c + d + e)) / X = b + (a + c + d + e) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pX_ppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_Xp_ppp_c_dX a b c d e X : X <> 0 -> (a + (X * b + c + d + e)) / X = b + (a + c + d + e) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_Xp_ppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pX_pppp_c_dX a b c d e f X : X <> 0 -> (a + (b * X + c + d + e + f)) / X = b + (a + c + d + e + f) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pX_pppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_Xp_pppp_c_dX a b c d e f X : X <> 0 -> (a + (X * b + c + d + e + f)) / X = b + (a + c + d + e + f) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_Xp_pppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pX_ppppp_c_dX a b c d e f g X : X <> 0 -> (a + (b * X + c + d + e + f + g)) / X = b + (a + c + d + e + f + g) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pX_ppppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_Xp_ppppp_c_dX a b c d e f g X : X <> 0 -> (a + (X * b + c + d + e + f + g)) / X = b + (a + c + d + e + f + g) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_Xp_ppppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pX_pppppp_c_dX a b c d e f g h X : X <> 0 -> (a + (b * X + c + d + e + f + g + h)) / X = b + (a + c + d + e + f + g + h) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pX_pppppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_Xp_pppppp_c_dX a b c d e f g h X : X <> 0 -> (a + (X * b + c + d + e + f + g + h)) / X = b + (a + c + d + e + f + g + h) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_Xp_pppppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pX_ppppppp_c_dX a b c d e f g h i X : X <> 0 -> (a + (b * X + c + d + e + f + g + h + i)) / X = b + (a + c + d + e + f + g + h + i) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pX_ppppppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_Xp_ppppppp_c_dX a b c d e f g h i X : X <> 0 -> (a + (X * b + c + d + e + f + g + h + i)) / X = b + (a + c + d + e + f + g + h + i) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_Xp_ppppppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pX_pppppppp_c_dX a b c d e f g h i j X : X <> 0 -> (a + (b * X + c + d + e + f + g + h + i + j)) / X = b + (a + c + d + e + f + g + h + i + j) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pX_pppppppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_Xp_pppppppp_c_dX a b c d e f g h i j X : X <> 0 -> (a + (X * b + c + d + e + f + g + h + i + j)) / X = b + (a + c + d + e + f + g + h + i + j) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_Xp_pppppppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pX_ppppppppp_c_dX a b c d e f g h i j k X : X <> 0 -> (a + (b * X + c + d + e + f + g + h + i + j + k)) / X = b + (a + c + d + e + f + g + h + i + j + k) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pX_ppppppppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_Xp_ppppppppp_c_dX a b c d e f g h i j k X : X <> 0 -> (a + (X * b + c + d + e + f + g + h + i + j + k)) / X = b + (a + c + d + e + f + g + h + i + j + k) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_Xp_ppppppppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pp_pX__c_dX a b c X : X <> 0 -> (a + (b + c * X)) / X = c + (a + b) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pp_pX__c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pp_Xp__c_dX a b c X : X <> 0 -> (a + (b + X * c)) / X = c + (a + b) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pp_Xp__c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pp_pX_p_c_dX a b c d X : X <> 0 -> (a + (b + c * X + d)) / X = c + (a + b + d) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pp_pX_p_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pp_Xp_p_c_dX a b c d X : X <> 0 -> (a + (b + X * c + d)) / X = c + (a + b + d) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pp_Xp_p_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pp_pX_pp_c_dX a b c d e X : X <> 0 -> (a + (b + c * X + d + e)) / X = c + (a + b + d + e) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pp_pX_pp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pp_Xp_pp_c_dX a b c d e X : X <> 0 -> (a + (b + X * c + d + e)) / X = c + (a + b + d + e) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pp_Xp_pp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pp_pX_ppp_c_dX a b c d e f X : X <> 0 -> (a + (b + c * X + d + e + f)) / X = c + (a + b + d + e + f) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pp_pX_ppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pp_Xp_ppp_c_dX a b c d e f X : X <> 0 -> (a + (b + X * c + d + e + f)) / X = c + (a + b + d + e + f) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pp_Xp_ppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pp_pX_pppp_c_dX a b c d e f g X : X <> 0 -> (a + (b + c * X + d + e + f + g)) / X = c + (a + b + d + e + f + g) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pp_pX_pppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pp_Xp_pppp_c_dX a b c d e f g X : X <> 0 -> (a + (b + X * c + d + e + f + g)) / X = c + (a + b + d + e + f + g) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pp_Xp_pppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pp_pX_ppppp_c_dX a b c d e f g h X : X <> 0 -> (a + (b + c * X + d + e + f + g + h)) / X = c + (a + b + d + e + f + g + h) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pp_pX_ppppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pp_Xp_ppppp_c_dX a b c d e f g h X : X <> 0 -> (a + (b + X * c + d + e + f + g + h)) / X = c + (a + b + d + e + f + g + h) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pp_Xp_ppppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pp_pX_pppppp_c_dX a b c d e f g h i X : X <> 0 -> (a + (b + c * X + d + e + f + g + h + i)) / X = c + (a + b + d + e + f + g + h + i) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pp_pX_pppppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pp_Xp_pppppp_c_dX a b c d e f g h i X : X <> 0 -> (a + (b + X * c + d + e + f + g + h + i)) / X = c + (a + b + d + e + f + g + h + i) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pp_Xp_pppppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pp_pX_ppppppp_c_dX a b c d e f g h i j X : X <> 0 -> (a + (b + c * X + d + e + f + g + h + i + j)) / X = c + (a + b + d + e + f + g + h + i + j) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pp_pX_ppppppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pp_Xp_ppppppp_c_dX a b c d e f g h i j X : X <> 0 -> (a + (b + X * c + d + e + f + g + h + i + j)) / X = c + (a + b + d + e + f + g + h + i + j) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pp_Xp_ppppppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pp_pX_pppppppp_c_dX a b c d e f g h i j k X : X <> 0 -> (a + (b + c * X + d + e + f + g + h + i + j + k)) / X = c + (a + b + d + e + f + g + h + i + j + k) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pp_pX_pppppppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pp_Xp_pppppppp_c_dX a b c d e f g h i j k X : X <> 0 -> (a + (b + X * c + d + e + f + g + h + i + j + k)) / X = c + (a + b + d + e + f + g + h + i + j + k) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pp_Xp_pppppppp_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_p_o_pp_pX__c_p_c_dX a b c d e X : X <> 0 -> (a + (b + (c + d * X) + e)) / X = d + (a + b + c + e) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_p_o_pp_pX__c_p_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_p_o_pp_Xp__c_p_c_dX a b c d e X : X <> 0 -> (a + (b + (c + X * d) + e)) / X = d + (a + b + c + e) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_p_o_pp_Xp__c_p_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_o_pp_pX__c_pdX a b c d e X : X <> 0 -> (a + b + (c + d * X) + e) / X = d + (a + b + c + e) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_o_pp_pX__c_pdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_o_pp_Xp__c_pdX a b c d e X : X <> 0 -> (a + b + (c + X * d) + e) / X = d + (a + b + c + e) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_o_pp_Xp__c_pdX using zutil_arith : zsimplify.
   Lemma simplify_div_pppp_pXp_ppdX a b c d e f X : X <> 0 -> (a + b + c * X * d + e + f) / X = (a + b + e + f + c*d*X) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pppp_pXp_ppdX using zutil_arith : zsimplify.
   Lemma simplify_div_pppp_Xpp_ppdX a b c d e f X : X <> 0 -> (a + b + X * c * d + e + f) / X = (a + b + e + f + c*d*X) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pppp_Xpp_ppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_pXp_ppdX a b c d e X : X <> 0 -> (a + b * X * c + d + e) / X = (a + d + e + b*c*X) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_pXp_ppdX using zutil_arith : zsimplify.
   Lemma simplify_div_ppp_Xpp_ppdX a b c d e X : X <> 0 -> (a + X * b * c + d + e) / X = (a + d + e + b*c*X) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_ppp_Xpp_ppdX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_p_o_pp_pXp__c_p_c_dX a b c d e f X : X <> 0 -> (a + (b + (c + d * X * e) + f)) / X = (a + b + c + f + d*e*X) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_p_o_pp_pXp__c_p_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_p_o_pp_Xpp__c_p_c_dX a b c d e f X : X <> 0 -> (a + (b + (c + X * d * e) + f)) / X = (a + b + c + f + d*e*X) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_p_o_pp_Xpp__c_p_c_dX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pp_pXp__c_pdX a b c d e X : X <> 0 -> (a + (b + c * X * d) + e) / X = (a + b + e + c*d*X) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pp_pXp__c_pdX using zutil_arith : zsimplify.
   Lemma simplify_div_pp_o_pp_Xpp__c_pdX a b c d e X : X <> 0 -> (a + (b + X * c * d) + e) / X = (a + b + e + c*d*X) / X.
   Proof. simplify_div_tac. Qed.
+#[global]
   Hint Rewrite simplify_div_pp_o_pp_Xpp__c_pdX using zutil_arith : zsimplify.
 
 
@@ -463,263 +551,435 @@ for name in names:
 >> *)
   Lemma simplify_mXmmX a b X : a - X - b - X = - 2 * X + a - b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_mXmmX : zsimplify.
   Lemma simplify_mXmpX a b X : a - X - b + X = a - b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_mXmpX : zsimplify.
   Lemma simplify_mXpmX a b X : a - X + b - X = - 2 * X + a + b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_mXpmX : zsimplify.
   Lemma simplify_mXppX a b X : a - X + b + X = a + b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_mXppX : zsimplify.
   Lemma simplify_pXmmX a b X : a + X - b - X = a - b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_pXmmX : zsimplify.
   Lemma simplify_pXmpX a b X : a + X - b + X = 2 * X + a - b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_pXmpX : zsimplify.
   Lemma simplify_pXpmX a b X : a + X + b - X = a + b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_pXpmX : zsimplify.
   Lemma simplify_pXppX a b X : a + X + b + X = 2 * X + a + b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_pXppX : zsimplify.
   Lemma simplify_mXm_Xm a b X : a - X - (X - b) = - 2 * X + a + b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_mXm_Xm : zsimplify.
   Lemma simplify_mXm_Xp a b X : a - X - (X + b) = - 2 * X + a - b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_mXm_Xp : zsimplify.
   Lemma simplify_mXp_Xm a b X : a - X + (X - b) = a - b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_mXp_Xm : zsimplify.
   Lemma simplify_mXp_Xp a b X : a - X + (X + b) = a + b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_mXp_Xp : zsimplify.
   Lemma simplify_pXm_Xm a b X : a + X - (X - b) = a + b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_pXm_Xm : zsimplify.
   Lemma simplify_pXm_Xp a b X : a + X - (X + b) = a - b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_pXm_Xp : zsimplify.
   Lemma simplify_pXp_Xm a b X : a + X + (X - b) = 2 * X + a - b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_pXp_Xm : zsimplify.
   Lemma simplify_pXp_Xp a b X : a + X + (X + b) = 2 * X + a + b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_pXp_Xp : zsimplify.
   Lemma simplify_Xmm_Xm a b X : X - a - (X - b) = - a + b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_Xmm_Xm : zsimplify.
   Lemma simplify_Xmm_Xp a b X : X - a - (X + b) = - a - b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_Xmm_Xp : zsimplify.
   Lemma simplify_Xmp_Xm a b X : X - a + (X - b) = 2 * X - a - b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_Xmp_Xm : zsimplify.
   Lemma simplify_Xmp_Xp a b X : X - a + (X + b) = 2 * X - a + b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_Xmp_Xp : zsimplify.
   Lemma simplify_Xpm_Xm a b X : X + a - (X - b) = a + b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_Xpm_Xm : zsimplify.
   Lemma simplify_Xpm_Xp a b X : X + a - (X + b) = a - b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_Xpm_Xp : zsimplify.
   Lemma simplify_Xpp_Xm a b X : X + a + (X - b) = 2 * X + a - b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_Xpp_Xm : zsimplify.
   Lemma simplify_Xpp_Xp a b X : X + a + (X + b) = 2 * X + a + b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_Xpp_Xp : zsimplify.
   Lemma simplify_mXm_mX a b X : a - X - (b - X) = a - b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_mXm_mX : zsimplify.
   Lemma simplify_mXm_pX a b X : a - X - (b + X) = - 2 * X + a - b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_mXm_pX : zsimplify.
   Lemma simplify_mXp_mX a b X : a - X + (b - X) = - 2 * X + a + b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_mXp_mX : zsimplify.
   Lemma simplify_mXp_pX a b X : a - X + (b + X) = a + b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_mXp_pX : zsimplify.
   Lemma simplify_pXm_mX a b X : a + X - (b - X) = 2 * X + a - b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_pXm_mX : zsimplify.
   Lemma simplify_pXm_pX a b X : a + X - (b + X) = a - b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_pXm_pX : zsimplify.
   Lemma simplify_pXp_mX a b X : a + X + (b - X) = a + b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_pXp_mX : zsimplify.
   Lemma simplify_pXp_pX a b X : a + X + (b + X) = 2 * X + a + b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_pXp_pX : zsimplify.
   Lemma simplify_Xmm_mX a b X : X - a - (b - X) = 2 * X - a - b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_Xmm_mX : zsimplify.
   Lemma simplify_Xmm_pX a b X : X - a - (b + X) = - a - b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_Xmm_pX : zsimplify.
   Lemma simplify_Xmp_mX a b X : X - a + (b - X) = - a + b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_Xmp_mX : zsimplify.
   Lemma simplify_Xmp_pX a b X : X - a + (b + X) = 2 * X - a + b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_Xmp_pX : zsimplify.
   Lemma simplify_Xpm_mX a b X : X + a - (b - X) = 2 * X + a - b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_Xpm_mX : zsimplify.
   Lemma simplify_Xpm_pX a b X : X + a - (b + X) = a - b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_Xpm_pX : zsimplify.
   Lemma simplify_Xpp_mX a b X : X + a + (b - X) = a + b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_Xpp_mX : zsimplify.
   Lemma simplify_Xpp_pX a b X : X + a + (b + X) = 2 * X + a + b.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_Xpp_pX : zsimplify.
   Lemma simplify_m2XpX a X : a - 2 * X + X = - X + a.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_m2XpX : zsimplify.
   Lemma simplify_m2XpXpX a X : a - 2 * X + X + X = a.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_m2XpXpX : zsimplify.
 End Z.
 
 Module Export Hints.
   Export Crypto.Util.ZUtil.Hints.Core.
   Export DivModToQuotRem.Hints.
+#[global]
   Hint Rewrite Z.simplify_div_ppX_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pXp_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppX_pdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pXp_pdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppX_ppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pXp_ppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppX_pppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pXp_pppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppX_ppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pXp_ppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppX_pppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pXp_pppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppX_ppppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pXp_ppppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppX_pppppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pXp_pppppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppX_ppppppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pXp_ppppppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppX_pppppppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pXp_pppppppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_pX_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_Xp_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_pX_pdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_Xp_pdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_pX_ppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_Xp_ppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_pX_pppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_Xp_pppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_pX_ppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_Xp_ppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_pX_pppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_Xp_pppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_pX_ppppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_Xp_ppppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_pX_pppppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_Xp_pppppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_pX_ppppppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_Xp_ppppppppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pX__c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_Xp__c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pX_p_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_Xp_p_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pX_pp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_Xp_pp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pX_ppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_Xp_ppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pX_pppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_Xp_pppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pX_ppppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_Xp_ppppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pX_pppppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_Xp_pppppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pX_ppppppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_Xp_ppppppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pX_pppppppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_Xp_pppppppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pX_ppppppppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_Xp_ppppppppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pp_pX__c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pp_Xp__c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pp_pX_p_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pp_Xp_p_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pp_pX_pp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pp_Xp_pp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pp_pX_ppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pp_Xp_ppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pp_pX_pppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pp_Xp_pppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pp_pX_ppppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pp_Xp_ppppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pp_pX_pppppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pp_Xp_pppppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pp_pX_ppppppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pp_Xp_ppppppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pp_pX_pppppppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pp_Xp_pppppppp_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_p_o_pp_pX__c_p_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_p_o_pp_Xp__c_p_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_o_pp_pX__c_pdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_o_pp_Xp__c_pdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pppp_pXp_ppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pppp_Xpp_ppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_pXp_ppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_ppp_Xpp_ppdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_p_o_pp_pXp__c_p_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_p_o_pp_Xpp__c_p_c_dX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pp_pXp__c_pdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_div_pp_o_pp_Xpp__c_pdX using zutil_arith : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_mXmmX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_mXmpX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_mXpmX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_mXppX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_pXmmX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_pXmpX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_pXpmX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_pXppX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_mXm_Xm : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_mXm_Xp : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_mXp_Xm : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_mXp_Xp : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_pXm_Xm : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_pXm_Xp : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_pXp_Xm : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_pXp_Xp : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_Xmm_Xm : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_Xmm_Xp : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_Xmp_Xm : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_Xmp_Xp : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_Xpm_Xm : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_Xpm_Xp : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_Xpp_Xm : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_Xpp_Xp : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_mXm_mX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_mXm_pX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_mXp_mX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_mXp_pX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_pXm_mX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_pXm_pX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_pXp_mX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_pXp_pX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_Xmm_mX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_Xmm_pX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_Xmp_mX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_Xmp_pX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_Xpm_mX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_Xpm_pX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_Xpp_mX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_Xpp_pX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_m2XpX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_m2XpXpX : zsimplify.
 End Hints.

--- a/src/Util/ZUtil/ZSimplify/Core.v
+++ b/src/Util/ZUtil/ZSimplify/Core.v
@@ -1,17 +1,28 @@
 Require Import Coq.ZArith.ZArith.
 Require Export Crypto.Util.ZUtil.Hints.Core.
 
+#[global]
 Hint Rewrite Z.div_1_r Z.mul_1_r Z.mul_1_l Z.sub_diag Z.mul_0_r Z.mul_0_l Z.add_0_l Z.add_0_r Z.opp_involutive Z.sub_0_r Z_mod_same_full Z.sub_simpl_r Z.sub_simpl_l Z.add_opp_diag_r Z.add_opp_diag_l Zmod_0_l Z.add_simpl_r Z.add_simpl_l Z.opp_0 Zmod_0_r Zmod_mod Z.mul_succ_l Z.mul_succ_r Z.shiftr_0_r Z.shiftr_0_l Z.mod_1_r Zmod_0_l Zmod_0_r Z.shiftl_0_r Z.shiftl_0_l Z.shiftr_0_r Z.shiftr_0_l Z.sub_diag Zdiv_0_r Zdiv_0_l Z.land_0_l Z.land_0_r Z.lor_0_l Z.lor_0_r Z.lnot_0 Z.land_lnot_diag Z.lnot_involutive Z.lxor_lnot_lnot Z.lnot_m1 Z.lxor_m1_l Z.lxor_m1_r Z.add_lnot_diag Z.lor_lnot_diag Z.pow_0_r Z.pow_1_r : zsimplify_fast.
+#[global]
 Hint Rewrite Z.pow_0_l Z.pow_0_l' using assumption : zsimplify_fast.
 
+#[global]
 Hint Rewrite Z.div_1_r Z.mul_1_r Z.mul_1_l Z.sub_diag Z.mul_0_r Z.mul_0_l Z.add_0_l Z.add_0_r Z.opp_involutive Z.sub_0_r Z_mod_same_full Z.sub_simpl_r Z.sub_simpl_l Z.add_opp_diag_r Z.add_opp_diag_l Zmod_0_l Z.add_simpl_r Z.add_simpl_l Z.opp_0 Zmod_0_r Zmod_mod Z.mul_succ_l Z.mul_succ_r Z.shiftr_0_r Z.shiftr_0_l Z.mod_1_r Zmod_0_l Zmod_0_r Z.shiftl_0_r Z.shiftl_0_l Z.shiftr_0_r Z.shiftr_0_l Zplus_minus Z.add_diag Z.abs_0 Z.sgn_0 Nat2Z.inj_0 Z2Nat.inj_0 Zdiv_0_r Zdiv_0_l Z.land_0_l Z.land_0_r Z.lor_0_l Z.lor_0_r Z.lnot_0 Z.land_lnot_diag Z.lnot_involutive Z.lxor_lnot_lnot Z.lnot_m1 Z.lxor_m1_l Z.lxor_m1_r Z.add_lnot_diag Z.lor_lnot_diag Z.pow_0_r Z.pow_1_r : zsimplify.
+#[global]
 Hint Rewrite Z.div_mul Z.div_1_l Z.div_same Z.mod_same Z.div_small Z.mod_small Z.div_add Z.div_add_l Z.mod_add Z.div_0_l Z.mod_mod Z.mod_small Z_mod_zero_opp_full Z.mod_1_l Z.pow_1_l Z.pow_0_l using zutil_arith : zsimplify.
+#[global]
 Hint Rewrite <- Z.opp_eq_mul_m1 Z.one_succ Z.two_succ : zsimplify.
+#[global]
 Hint Rewrite <- Z.div_mod using zutil_arith : zsimplify.
+#[global]
 Hint Rewrite (fun x y => proj2 (Z.eqb_neq x y)) using assumption : zsimplify.
+#[global]
 Hint Rewrite Z.mul_0_l Z.mul_0_r Z.mul_1_l Z.mul_1_r Z.add_0_l Z.add_0_r Z.sub_0_l Z.sub_0_r Zdiv_0_l Zdiv_0_r Zdiv_1_r Zmod_0_l Zmod_0_r Zmod_1_r Z.opp_0 Z.abs_0 Z.sgn_0 Nat2Z.inj_0 Z2Nat.inj_0 Z.land_0_l Z.land_0_r Z.lor_0_l Z.lor_0_r Z.lnot_0 Z.land_lnot_diag Z.lnot_involutive Z.lxor_lnot_lnot Z.lnot_m1 Z.lxor_m1_l Z.lxor_m1_r Z.add_lnot_diag Z.lor_lnot_diag Z.pow_0_r Z.pow_1_r Z.shiftr_0_r Z.shiftr_0_l Z.shiftl_0_r Z.shiftl_0_l Z.sub_diag : zsimplify_const.
+#[global]
 Hint Rewrite Z.pow_0_l Z.pow_0_l' using assumption : zsimplify_const.
 
+#[global]
 Hint Rewrite <- Z.one_succ Z.two_succ : zsimplify_const.
 
+#[global]
 Hint Rewrite Nat2Z.id N2Z.id : zsimplify.

--- a/src/Util/ZUtil/ZSimplify/Simple.v
+++ b/src/Util/ZUtil/ZSimplify/Simple.v
@@ -5,123 +5,177 @@ Local Open Scope Z_scope.
 Module Z.
   Lemma pow_1_l_Zpos a : 1^Zpos a = 1.
   Proof. apply Z.pow_1_l; lia. Qed.
+#[global]
   Hint Rewrite pow_1_l_Zpos : zsimplify_fast zsimplify_const zsimplify.
   Lemma pow_1_l_0 : 1^Z0 = 1. Proof. reflexivity. Qed.
+#[global]
   Hint Rewrite pow_1_l_0 : zsimplify_fast zsimplify_const zsimplify.
   Lemma pow_r_Zneg a b : a^Zneg b = 0. Proof. reflexivity. Qed.
+#[global]
   Hint Rewrite pow_r_Zneg : zsimplify_fast zsimplify_const zsimplify.
   Lemma pow_1_l_Zof_nat a : 1^Z.of_nat a = 1.
   Proof. apply Z.pow_1_l; lia. Qed.
+#[global]
   Hint Rewrite pow_1_l_Zof_nat : zsimplify_fast zsimplify_const zsimplify.
   Lemma pow_0_l_Zpos a : 0^Zpos a = 0.
   Proof. apply Z.pow_0_l; lia. Qed.
+#[global]
   Hint Rewrite pow_0_l_Zpos : zsimplify_fast zsimplify_const zsimplify.
 
   Lemma sub_same_minus (x y : Z) : x - (x - y) = y.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite sub_same_minus : zsimplify.
   Lemma sub_same_plus (x y : Z) : x - (x + y) = -y.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite sub_same_plus : zsimplify.
   Lemma sub_same_minus_plus (x y z : Z) : x - (x - y + z) = y - z.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite sub_same_minus_plus : zsimplify.
   Lemma sub_same_plus_plus (x y z : Z) : x - (x + y + z) = -y - z.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite sub_same_plus_plus : zsimplify.
   Lemma sub_same_minus_minus (x y z : Z) : x - (x - y - z) = y + z.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite sub_same_minus_minus : zsimplify.
   Lemma sub_same_plus_minus (x y z : Z) : x - (x + y - z) = z - y.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite sub_same_plus_minus : zsimplify.
   Lemma sub_same_minus_then_plus (x y w : Z) : x - (x - y) + w = y + w.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite sub_same_minus_then_plus : zsimplify.
   Lemma sub_same_plus_then_plus (x y w : Z) : x - (x + y) + w = w - y.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite sub_same_plus_then_plus : zsimplify.
   Lemma sub_same_minus_plus_then_plus (x y z w : Z) : x - (x - y + z) + w = y - z + w.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite sub_same_minus_plus_then_plus : zsimplify.
   Lemma sub_same_plus_plus_then_plus (x y z w : Z) : x - (x + y + z) + w = w - y - z.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite sub_same_plus_plus_then_plus : zsimplify.
   Lemma sub_same_minus_minus_then_plus (x y z w : Z) : x - (x - y - z) + w = y + z + w.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite sub_same_minus_minus : zsimplify.
   Lemma sub_same_plus_minus_then_plus (x y z w : Z) : x - (x + y - z) + w = z - y + w.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite sub_same_plus_minus_then_plus : zsimplify.
 
   Lemma simplify_twice_sub_sub x y : 2 * x - (x - y) = x + y.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_twice_sub_sub : zsimplify.
 
   Lemma simplify_twice_sub_add x y : 2 * x - (x + y) = x - y.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_twice_sub_add : zsimplify.
 
   Lemma simplify_2XmX X : 2 * X - X = X.
   Proof. lia. Qed.
+#[global]
   Hint Rewrite simplify_2XmX : zsimplify.
 
   Lemma simplify_add_pos x y : Z.pos x + Z.pos y = Z.pos (x + y).
   Proof. reflexivity. Qed.
+#[global]
   Hint Rewrite simplify_add_pos : zsimplify_Z_to_pos.
   Lemma simplify_add_pos10 x0 x1 x2 x3 x4 x5 x6 x7 x8 x9
     : Z.pos x0 + (Z.pos x1 + (Z.pos x2 + (Z.pos x3 + (Z.pos x4 + (Z.pos x5 + (Z.pos x6 + (Z.pos x7 + (Z.pos x8 + Z.pos x9))))))))
       = Z.pos (x0 + (x1 + (x2 + (x3 + (x4 + (x5 + (x6 + (x7 + (x8 + x9))))))))).
   Proof. reflexivity. Qed.
+#[global]
   Hint Rewrite simplify_add_pos10 : zsimplify_Z_to_pos.
   Lemma simplify_mul_pos x y : Z.pos x * Z.pos y = Z.pos (x * y).
   Proof. reflexivity. Qed.
+#[global]
   Hint Rewrite simplify_mul_pos : zsimplify_Z_to_pos.
   Lemma simplify_mul_pos10 x0 x1 x2 x3 x4 x5 x6 x7 x8 x9
     : Z.pos x0 * (Z.pos x1 * (Z.pos x2 * (Z.pos x3 * (Z.pos x4 * (Z.pos x5 * (Z.pos x6 * (Z.pos x7 * (Z.pos x8 * Z.pos x9))))))))
       = Z.pos (x0 * (x1 * (x2 * (x3 * (x4 * (x5 * (x6 * (x7 * (x8 * x9))))))))).
   Proof. reflexivity. Qed.
+#[global]
   Hint Rewrite simplify_mul_pos10 : zsimplify_Z_to_pos.
   Lemma simplify_sub_pos x y : Z.pos x - Z.pos y = Z.pos_sub x y.
   Proof. reflexivity. Qed.
+#[global]
   Hint Rewrite simplify_sub_pos : zsimplify_Z_to_pos.
 
   Lemma two_sub_sub_inner_sub x y z : 2 * x - y - (x - z) = x - y + z.
   Proof. clear; lia. Qed.
+#[global]
   Hint Rewrite two_sub_sub_inner_sub : zsimplify.
 
   Lemma minus_minus_one : - -1 = 1.
   Proof. reflexivity. Qed.
+#[global]
   Hint Rewrite minus_minus_one : zsimplify zsimplify_fast zsimplify_const.
 End Z.
 
 Module Export Hints.
   Export Crypto.Util.ZUtil.Hints.Core.
+#[global]
   Hint Rewrite Z.pow_1_l_Zpos : zsimplify_fast zsimplify_const zsimplify.
+#[global]
   Hint Rewrite Z.pow_1_l_0 : zsimplify_fast zsimplify_const zsimplify.
+#[global]
   Hint Rewrite Z.pow_r_Zneg : zsimplify_fast zsimplify_const zsimplify.
+#[global]
   Hint Rewrite Z.pow_1_l_Zof_nat : zsimplify_fast zsimplify_const zsimplify.
+#[global]
   Hint Rewrite Z.pow_0_l_Zpos : zsimplify_fast zsimplify_const zsimplify.
+#[global]
   Hint Rewrite Z.sub_same_minus : zsimplify.
+#[global]
   Hint Rewrite Z.sub_same_plus : zsimplify.
+#[global]
   Hint Rewrite Z.sub_same_minus_plus : zsimplify.
+#[global]
   Hint Rewrite Z.sub_same_plus_plus : zsimplify.
+#[global]
   Hint Rewrite Z.sub_same_minus_minus : zsimplify.
+#[global]
   Hint Rewrite Z.sub_same_plus_minus : zsimplify.
+#[global]
   Hint Rewrite Z.sub_same_minus_then_plus : zsimplify.
+#[global]
   Hint Rewrite Z.sub_same_plus_then_plus : zsimplify.
+#[global]
   Hint Rewrite Z.sub_same_minus_plus_then_plus : zsimplify.
+#[global]
   Hint Rewrite Z.sub_same_plus_plus_then_plus : zsimplify.
+#[global]
   Hint Rewrite Z.sub_same_minus_minus : zsimplify.
+#[global]
   Hint Rewrite Z.sub_same_plus_minus_then_plus : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_twice_sub_sub : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_twice_sub_add : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_2XmX : zsimplify.
+#[global]
   Hint Rewrite Z.simplify_add_pos : zsimplify_Z_to_pos.
+#[global]
   Hint Rewrite Z.simplify_add_pos10 : zsimplify_Z_to_pos.
+#[global]
   Hint Rewrite Z.simplify_mul_pos : zsimplify_Z_to_pos.
+#[global]
   Hint Rewrite Z.simplify_mul_pos10 : zsimplify_Z_to_pos.
+#[global]
   Hint Rewrite Z.simplify_sub_pos : zsimplify_Z_to_pos.
+#[global]
   Hint Rewrite Z.two_sub_sub_inner_sub : zsimplify.
+#[global]
   Hint Rewrite Z.minus_minus_one : zsimplify zsimplify_fast zsimplify_const.
 End Hints.


### PR DESCRIPTION
This is 100% backwards compatible [w.r.t. Coq 8.16], but is lacking a submodule bump for bbv. The current commit of the latter is still incompatible with coq/coq#16004.