### PR TITLE
fixed annotations on assembly output for assembly-checker

### DIFF
--- a/src/Assembly/Equality.v
+++ b/src/Assembly/Equality.v
@@ -284,7 +284,8 @@ Definition Line_beq (x y : Line) : bool
   := ((x.(indent) =? y.(indent))%string
       && (x.(rawline) =? y.(rawline))%RawLine
       && (x.(pre_comment_whitespace) =? y.(pre_comment_whitespace))%string
-      && option_beq String.eqb x.(comment) y.(comment))%bool.
+      && option_beq String.eqb x.(comment) y.(comment))%bool
+      && (x.(line_number) =? y.(line_number)).
 Global Arguments Line_beq !_ !_ / .
 
 Infix "=?" := Line_beq : Line_scope.

--- a/src/Assembly/Equality.v
+++ b/src/Assembly/Equality.v
@@ -285,7 +285,7 @@ Definition Line_beq (x y : Line) : bool
       && (x.(rawline) =? y.(rawline))%RawLine
       && (x.(pre_comment_whitespace) =? y.(pre_comment_whitespace))%string
       && option_beq String.eqb x.(comment) y.(comment))%bool
-      && (x.(line_number) =? y.(line_number)).
+      && (x.(line_number) =? y.(line_number))%N.
 Global Arguments Line_beq !_ !_ / .
 
 Infix "=?" := Line_beq : Line_scope.

--- a/src/Assembly/Equivalence.v
+++ b/src/Assembly/Equivalence.v
@@ -208,8 +208,9 @@ Definition AnnotatedLines := (Lines * symbolic_state)%type.
 
 Definition show_annotated_Line : Show AnnotatedLine
   := fun '(l, d)
-     => let l := show l in
-        (l ++ match dag.eager.description_lookup d l with
+     => let l_n := show_Line_with_line_number l in
+        let l := show l in
+        (l ++ match dag.eager.description_lookup d l_n with
               | [] => ""
               | new_idxs
                 => String.Tab ++ "; " ++ String.concat ", " (List.map (fun i => "#" ++ show i) new_idxs)

--- a/src/Assembly/Parse.v
+++ b/src/Assembly/Parse.v
@@ -354,7 +354,7 @@ Definition parse_RawLine : ParserAction RawLine
                       parsed_prefix
                end.
 
-Definition parse_Line n : ParserAction Line
+Definition parse_Line (line_num : N) : ParserAction Line
   := fun s
      => let '(indentv, rest_linev) := take_while_drop_while Ascii.is_whitespace s in
         let '(precommentv, commentv)
@@ -367,23 +367,24 @@ Definition parse_Line n : ParserAction Line
         let rawlinev := String.rev rev_rawlinev in
         let trailing_whitespacev := String.rev rev_trailing_whitespacev in
         List.map
-          (fun '(r, rem) => ({| indent := indentv ; rawline := r ; pre_comment_whitespace := trailing_whitespacev ; comment := commentv ; line_number := n |}, rem))
+          (fun '(r, rem) => ({| indent := indentv ; rawline := r ; pre_comment_whitespace := trailing_whitespacev ; comment := commentv ; line_number := line_num |}, rem))
           (parse_RawLine rawlinev).
 
 (* the error is the unparsable lines *)
-Fixpoint parse_Lines' (l : list (string*nat)) : ErrorT (list string) Lines
+Fixpoint parse_Lines' (l : list string) (line_num : N) : ErrorT (list string) Lines
   := match l with
      | [] => Success []
-     | (l, n) :: ls
-       => match finalize (parse_Line n) l, parse_Lines' ls with
-          | None, Error ls => Error (l :: ls)
-          | None, Success _ => Error (l :: nil)
+     | l :: ls
+       => match finalize (parse_Line line_num) l, parse_Lines' ls (line_num + 1) with
+          | None, Error ls => Error (("Line " ++ show line_num ++ ": " ++ l) :: ls)
+          | None, Success _ => Error (("Line " ++ show line_num ++ ": " ++ l) :: nil)
           | Some _, Error ls => Error ls
           | Some l, Success ls => Success (l :: ls)
           end
      end.
 
-Definition parse_Lines (l : list string) := parse_Lines' (List.combine (String.split_newlines l) (seq 1 (length l))).
+Definition parse_Lines (l : list string) : ErrorT (list string) Lines
+  := parse_Lines' (String.split_newlines l) 1.
 
 Notation parse := parse_Lines (only parsing).
 

--- a/src/Assembly/Symbolic.v
+++ b/src/Assembly/Symbolic.v
@@ -3480,7 +3480,7 @@ Definition SymexRawLine {descr:description} (rawline : RawLine) : M unit :=
   end.
 
 Definition SymexLine line :=
-  let descr:description := Build_description (show line) false in
+  let descr:description := Build_description (Parse.show_Line_with_line_number line) false in
   SymexRawLine line.(rawline).
 
 Fixpoint SymexLines (lines : Lines) : M unit

--- a/src/Assembly/Syntax.v
+++ b/src/Assembly/Syntax.v
@@ -112,7 +112,7 @@ Inductive RawLine :=
 | INSTR (instr : NormalInstruction)
 .
 Coercion INSTR : NormalInstruction >-> RawLine.
-Record Line := { indent : string ; rawline :> RawLine ; pre_comment_whitespace : string ; comment : option string }.
+Record Line := { indent : string ; rawline :> RawLine ; pre_comment_whitespace : string ; comment : option string ; line_number : nat}.
 Definition Lines := list Line.
 
 Definition reg_size (r : REG) : N :=

--- a/src/Assembly/Syntax.v
+++ b/src/Assembly/Syntax.v
@@ -112,7 +112,7 @@ Inductive RawLine :=
 | INSTR (instr : NormalInstruction)
 .
 Coercion INSTR : NormalInstruction >-> RawLine.
-Record Line := { indent : string ; rawline :> RawLine ; pre_comment_whitespace : string ; comment : option string ; line_number : nat}.
+Record Line := { indent : string ; rawline :> RawLine ; pre_comment_whitespace : string ; comment : option string ; line_number : N}.
 Definition Lines := list Line.
 
 Definition reg_size (r : REG) : N :=


### PR DESCRIPTION
Fixed the bug that caused the "overwhelmingly long list" mentioned in https://github.com/mit-plv/fiat-crypto/issues/1351.

The issue was caused by the assembly checker not recognizing that identical (separate) lines of assembly code were not in fact the same line.  The annotations from identical lines were all lumped together, resulting in the "overwhelmingly long" annotations.