### PR TITLE
Only run validate on Coq master / dev

### DIFF
--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -15,9 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - env: { COQ_VERSION: "master"    , COQ_PACKAGE: "coq libcoq-core-ocaml-dev", SKIP_VALIDATE: "", COQCHKEXTRAFLAGS: "-bytecode-compiler yes", PPA: "ppa:jgross-h/coq-master-daily", EXTRA_GH_REPORTIFY: "--warnings" }
+        - env: { COQ_VERSION: "master"    , COQ_PACKAGE: "coq libcoq-core-ocaml-dev", SKIP_VALIDATE: "" , COQCHKEXTRAFLAGS: "-bytecode-compiler yes", PPA: "ppa:jgross-h/coq-master-daily", EXTRA_GH_REPORTIFY: "--warnings" }
           os: 'ubuntu-latest'
-        - env: { COQ_VERSION: "Ubuntu LTS", COQ_PACKAGE: "coq libcoq-ocaml-dev"     , SKIP_VALIDATE: "", COQCHKEXTRAFLAGS: ""                      , PPA: "" }
+        - env: { COQ_VERSION: "Ubuntu LTS", COQ_PACKAGE: "coq libcoq-ocaml-dev"     , SKIP_VALIDATE: "1", COQCHKEXTRAFLAGS: ""                      , PPA: "" }
           os: 'ubuntu-22.04'
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
It seems to be timing out on Ubuntu LTS or something, and we don't really need to see the validate output from multiple versions.  Insofar as we want to stress coqchk, we sort-of only care about stressing the newest version, I think.  Note that validate already only runs on commits to master, not on PRs, so this won't speed up PR CI timing at all.