### PR TITLE
Note OCaml 4.08 minimal version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This repository requires [Coq](https://coq.inria.fr/) [8.15](https://github.com/
 Note that if you install Coq from Ubuntu aptitude packages, you need `libcoq-ocaml-dev` in addition to `coq`.
 Note that in some cases (such as installing Coq via homebrew on Mac), you may also need to install `ocaml-findlib` (for `ocamlfind`).
 If you want to build the bedrock2 code, you need [Coq 8.15](https://github.com/coq/coq/releases/tag/V8.15.0) or later (otherwise this code will be skipped automatically; you can skip this code on newer versions of Coq by passing `SKIP_BEDROCK2=1` to `make`).
+The extracted OCaml code for the standalone binaries requires [OCaml](https://ocaml.org/) [4.08](https://ocaml.org/p/ocaml/4.08.0) or later.
 We suggest downloading [the latest version of Coq](https://github.com/coq/coq/wiki#coq-installation).
 Generation of JSON code via the Makefile also requires `jq`.
 


### PR DESCRIPTION
Since d9f123fd330dab3fab551d69cd144a15dd0a77c5 (#1292) we've been using `Int.t` to work around a lack of coq/coq#11987.  The `Int` module was added in OCaml 4.08.

Dropping support for older OCaml is not such a big loss, as Coq 8.16 will require OCaml >= 4.09, (8.15 allows >= 4.05), Debian stable has 4.11, and Ubuntu LTS has 4.13 (even the old Ubuntu LTS has 4.08).