### PR TITLE
Bump rust crate version

### DIFF
--- a/fiat-rust/Cargo.toml
+++ b/fiat-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fiat-crypto"
-version = "0.1.14"
+version = "0.1.16"
 authors = ["Fiat Crypto library authors <jgross@mit.edu>"]
 edition = "2018"
 description = "Fiat-crypto generated Rust"


### PR DESCRIPTION
In light of the failure of https://github.com/mit-plv/fiat-crypto/actions/runs/2938420615/jobs/4692905587 and https://github.com/mit-plv/fiat-crypto/actions/runs/3168539692 we must bump twice