### PR TITLE
More selective correctness proof tactics for PushButtonSynthesis

### DIFF
--- a/.github/workflows/coq-windows.yml
+++ b/.github/workflows/coq-windows.yml
@@ -97,13 +97,17 @@ jobs:
       run: |
         %CYGWIN_ROOT%\bin\bash.exe -l -c 'cd "%cd%"; opam exec -- etc/ci/github-actions-make.sh -j${NJOBS} standalone-ocaml'
       shell: cmd
-    - name: all-except-generated
+    - name: coq
       run: |
         %CYGWIN_ROOT%\bin\bash.exe -l -c 'cd "%cd%"; opam exec -- etc/ci/github-actions-make.sh -j1 coq'
       shell: cmd
-    - name: all
+    - name: all-except-generated
       run: |
-        %CYGWIN_ROOT%\bin\bash.exe -l -c 'cd "%cd%"; opam exec -- etc/ci/github-actions-make.sh -j${NJOBS} all'
+        %CYGWIN_ROOT%\bin\bash.exe -l -c 'cd "%cd%"; opam exec -- etc/ci/github-actions-make.sh -j1 all-except-generated'
+      shell: cmd
+    - name: c-files
+      run: |
+        %CYGWIN_ROOT%\bin\bash.exe -l -c 'cd "%cd%"; opam exec -- etc/ci/github-actions-make.sh -j${NJOBS} c-files'
       shell: cmd
     - name: only-test-amd64-files
       run: |

--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -1338,10 +1338,12 @@ Module PipelineTactics.
         clear H1 H2 Hres
       | .. ];
       solve_side_conditions_of_BoundsPipeline_correct
-    | match goal with
-      | [ |- Wf _ ]
-        => repeat apply expr.Wf_APP; try typeclasses eauto with nocore wf_extra wf_gen_cache; try typeclasses eauto with nocore wf wf_gen_cache
-      end ].
+    | lazymatch goal with |- Wf _ => idtac end;
+      repeat match goal with
+             | [ |- Wf (expr.APP _ _) ] => apply expr.Wf_APP
+             end;
+      try typeclasses eauto with nocore wf_extra wf_gen_cache;
+      try typeclasses eauto with nocore wf wf_gen_cache ].
 
   Ltac prove_pipeline_wf _ :=
     lazymatch goal with

--- a/src/PushButtonSynthesis/FancyMontgomeryReduction.v
+++ b/src/PushButtonSynthesis/FancyMontgomeryReduction.v
@@ -92,7 +92,7 @@ Section rmontred.
            /\ (forall s v v' : Z, ih s v = Some v' -> v = Z.shiftr v' (s/2))
       | None => True
       end.
-  Proof.
+  Proof using consts_list value_range.
     cbv [fancy_args invert_low invert_high constant_to_scalar constant_to_scalar_single consts_list fold_right];
       split; intros; break_innermost_match_hyps; Z.ltb_to_lt; subst; congruence.
   Qed.
@@ -178,7 +178,7 @@ Section rmontred.
            | progress Z.rewrite_mod_small ].
 
   Local Strategy -100 [montred]. (* needed for making Qed not take forever *)
-  Local Strategy -100 [montred' reified_montred_gen]. (* needed for making prove_correctness not take forever *)
+  Local Strategy -100 [montred']. (* needed for making prove_correctness not take forever *)
   Lemma montred_correct res (Hres : montred = Success res)
     : montred_correct N R R' (API.Interp res).
   Proof using n curve_good.

--- a/src/PushButtonSynthesis/Primitives.v
+++ b/src/PushButtonSynthesis/Primitives.v
@@ -256,9 +256,10 @@ Ltac prove_correctness' should_not_clear use_curve_good :=
   intros;
   try split; PipelineTactics.use_compilers_correctness Hres;
   [ pose_proof_length_list_Z_bounded_by;
-    repeat first [ reflexivity
+    repeat first [ match goal with |- ?x = ?x => reflexivity end
                  | progress autorewrite with interp_extra interp_gen_cache
                  | progress autorewrite with push_eval
+                 | reflexivity
                  | erewrite select_eq
                  | progress autounfold with push_eval
                  | progress autorewrite with distr_length in *

--- a/src/PushButtonSynthesis/UnsaturatedSolinas.v
+++ b/src/PushButtonSynthesis/UnsaturatedSolinas.v
@@ -62,21 +62,26 @@ Local Set Keyed Unification. (* needed for making [autorewrite] fast, c.f. COQBU
 
 (* needed for making [autorewrite] not take a very long time *)
 Local Opaque
+      reified_carry_mul_gen
       reified_carry_square_gen
       reified_carry_scmul_gen
       reified_carry_gen
-      reified_encode_gen
       reified_add_gen
       reified_sub_gen
       reified_opp_gen
+      reified_carry_add_gen
+      reified_carry_sub_gen
+      reified_carry_opp_gen
       reified_id_gen
-      reified_zero_gen
-      reified_one_gen
-      reified_prime_gen
-      reified_eval_gen
-      reified_bytes_eval_gen
       reified_to_bytes_gen
       reified_from_bytes_gen
+      reified_encode_gen
+      reified_encode_gen
+      reified_zero_gen
+      reified_one_gen
+      reified_eval_gen
+      reified_bytes_eval_gen
+      reified_prime_gen
       expr.Interp.
 
 Section __.

--- a/src/PushButtonSynthesis/WordByWordMontgomery.v
+++ b/src/PushButtonSynthesis/WordByWordMontgomery.v
@@ -79,18 +79,24 @@ Local Set Keyed Unification. (* needed for making [autorewrite] fast, c.f. COQBU
 (* needed for making [autorewrite] not take a very long time *)
 Local Opaque
       reified_mul_gen
+      reified_square_gen
       reified_add_gen
       reified_sub_gen
       reified_opp_gen
-      reified_to_bytes_gen
-      reified_from_bytes_gen
-      reified_nonzero_gen
-      reified_square_gen
-      reified_encode_gen
       reified_from_montgomery_gen
       reified_to_montgomery_gen
+      reified_to_bytes_gen
+      reified_from_bytes_gen
+      reified_encode_gen
       reified_zero_gen
       reified_one_gen
+      reified_eval_gen
+      reified_bytes_eval_gen
+      reified_eval_twos_complement_gen
+      reified_msat_gen
+      reified_encode_gen
+      reified_divstep_gen
+      reified_nonzero_gen
       expr.Interp.
 
 Section __.
@@ -1036,7 +1042,7 @@ Section __.
   Lemma selectznz_correct res
         (Hres : selectznz = Success res)
     : selectznz_correct saturated_bounds (Interp res).
-  Proof using curve_good. Primitives.prove_correctness use_curve_good. Qed.
+  Proof using curve_good. apply Primitives.selectznz_correct, Hres. Qed.
 
   Lemma Wf_selectznz res (Hres : selectznz = Success res) : Wf res.
   Proof using Type. revert Hres; cbv [selectznz]; apply Wf_selectznz. Qed.


### PR DESCRIPTION
When we move to using more caching, we need to be more careful to not unfold the reified definitions.

<details><summary>Timing Diff</summary>
<p>

```
    After |   Peak Mem | File Name                                                   |    Before |   Peak Mem ||    Change || Change (mem) | % Change | % Change (mem)
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
33m54.38s | 5261256 ko | Total Time / Peak Mem                                       | 33m55.10s | 5262224 ko || -0m00.72s ||      -968 ko |   -0.03% |         -0.01%
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 1m52.12s | 1586420 ko | Bedrock/End2End/X25519/Field25519.vo                        |  1m50.74s | 1585876 ko || +0m01.37s ||       544 ko |   +1.24% |         +0.03%
 1m48.88s | 2118900 ko | Fancy/Barrett256.vo                                         |  1m47.16s | 2118952 ko || +0m01.71s ||       -52 ko |   +1.60% |         -0.00%
 0m46.93s | 1676076 ko | Fancy/Montgomery256.vo                                      |  0m48.17s | 1676264 ko || -0m01.24s ||      -188 ko |   -2.57% |         -0.01%
 0m22.97s | 1144628 ko | PushButtonSynthesis/WordByWordMontgomery.vo                 |  0m24.51s | 1136684 ko || -0m01.54s ||      7944 ko |   -6.28% |         +0.69%
 0m04.02s | 1017036 ko | PushButtonSynthesis/FancyMontgomeryReduction.vo             |  0m05.35s | 1017096 ko || -0m01.33s ||       -60 ko |  -24.85% |         -0.00%
10m13.48s | 5261256 ko | Bedrock/End2End/X25519/GarageDoor.vo                        | 10m13.30s | 5262224 ko || +0m00.18s ||      -968 ko |   +0.02% |         -0.01%
 5m24.70s | 2720388 ko | Bedrock/Field/Synthesis/Examples/p224_64_new.vo             |  5m25.11s | 2720524 ko || -0m00.41s ||      -136 ko |   -0.12% |         -0.00%
 1m55.79s | 1429896 ko | Bedrock/Field/Synthesis/Examples/X25519_64.vo               |  1m55.92s | 1429604 ko || -0m00.13s ||       292 ko |   -0.11% |         +0.02%
 1m26.83s | 1937084 ko | SlowPrimeSynthesisExamples.vo                               |  1m27.34s | 1937084 ko || -0m00.51s ||         0 ko |   -0.58% |         +0.00%
 1m05.03s | 1692052 ko | Bedrock/Field/Synthesis/Examples/p256_64.vo                 |  1m04.79s | 1692024 ko || +0m00.23s ||        28 ko |   +0.37% |         +0.00%
 1m05.02s | 1728964 ko | Bedrock/Field/Synthesis/Examples/p224_64.vo                 |  1m05.14s | 1729128 ko || -0m00.12s ||      -164 ko |   -0.18% |         -0.00%
 0m33.77s | 1487048 ko | Bedrock/Field/Synthesis/Generic/UnsaturatedSolinas.vo       |  0m33.79s | 1487040 ko || -0m00.01s ||         8 ko |   -0.05% |         +0.00%
 0m32.67s | 1235884 ko | Bedrock/End2End/X25519/MontgomeryLadder.vo                  |  0m32.65s | 1235824 ko || +0m00.02s ||        60 ko |   +0.06% |         +0.00%
 0m32.45s | 1415008 ko | Bedrock/Field/Synthesis/Generic/WordByWordMontgomery.vo     |  0m32.03s | 1414872 ko || +0m00.42s ||       136 ko |   +1.31% |         +0.00%
 0m31.28s | 1179316 ko | PushButtonSynthesis/UnsaturatedSolinas.vo                   |  0m30.37s | 1154156 ko || +0m00.91s ||     25160 ko |   +2.99% |         +2.17%
 0m25.81s | 1186976 ko | Bedrock/Field/Synthesis/Examples/LadderStep.vo              |  0m26.24s | 1186988 ko || -0m00.42s ||       -12 ko |   -1.63% |         -0.00%
 0m22.76s | 1330440 ko | Bedrock/End2End/RupicolaCrypto/Low.vo                       |  0m22.77s | 1330372 ko || -0m00.00s ||        68 ko |   -0.04% |         +0.00%
 0m20.96s | 1129620 ko | Bedrock/Field/Synthesis/Examples/X1305_32.vo                |  0m20.98s | 1129644 ko || -0m00.01s ||       -24 ko |   -0.09% |         -0.00%
 0m20.68s | 1241696 ko | StandaloneDebuggingExamples.vo                              |  0m20.65s | 1241764 ko || +0m00.03s ||       -68 ko |   +0.14% |         -0.00%
 0m19.14s | 1168264 ko | Bedrock/End2End/RupicolaCrypto/Derive.vo                    |  0m18.98s | 1168176 ko || +0m00.16s ||        88 ko |   +0.84% |         +0.00%
 0m18.60s | 1098660 ko | Bedrock/Field/Translation/Proofs/Func.vo                    |  0m18.82s | 1098736 ko || -0m00.21s ||       -76 ko |   -1.16% |         -0.00%
```
</details>