### PR TITLE
Adjust etc/machine.sh to work better on Arch

### DIFF
--- a/etc/machine.sh
+++ b/etc/machine.sh
@@ -18,7 +18,14 @@ online_governors() {
   fi
 }
 
-printf "$(hostname)"
+# hostname is not on arch
+if command -v hostname >/dev/null 2>/dev/null; then
+    printf "$(hostname)"
+elif command -v hostnamectl >/dev/null 2>/dev/null; then
+    printf "$(hostnamectl --static)"
+else
+    printf "unknown_host"
+fi
 printf -
 if ls /sys/devices/system/cpu/cpu[0-9]*/topology/thread_siblings_list >/dev/null 2>/dev/null; then
   grep -q '[^0-9]' /sys/devices/system/cpu/cpu[0-9]*/topology/thread_siblings_list && printf ht || printf noht
@@ -40,5 +47,5 @@ fi
 printf -
 printf "$(printf "%s" "$(online_governors | uniq)" | tr '\n' '_')"
 printf -
-printf "$(gcc -march=native -Q --help=target|grep march | cut -d= -f2 | grep -ow '\S*')"
+printf "$(gcc -march=native -Q --help=target | grep -v 'Known valid arguments' | grep march | cut -d= -f2 | grep -ow '\S*')"
 printf '\n'


### PR DESCRIPTION
Old version prints
```
./etc/machine.sh: line 21: hostname: command not found
-noht-tb-nops-schedutil-haswell
option:
```
because
```
$ gcc -march=native -Q --help=target|grep march
  -march=                               haswell
  Known valid arguments for -march= option:
```
New version prints
```
transparent-rooster-noht-tb-nops-schedutil-haswell
```