### PR TITLE
Reorganize pipeline options to allow for easier additions to them

### DIFF
--- a/src/Bedrock/End2End/Poly1305/Field1305.v
+++ b/src/Bedrock/End2End/Poly1305/Field1305.v
@@ -15,7 +15,9 @@ Section Field.
   Definition s : Z := 2^130.
   Definition c : list (Z * Z) := [(1, 5)]%Z.
 
-  Existing Instances Defaults32.default_parameters
+  Existing Instances
+           Defaults32.machine_wordsize
+           Defaults32.default_parameters
            Defaults32.default_parameters_ok.
   Existing Instances no_select_size split_mul_to split_multiret_to.
   Definition prefix : string := "fe1305_"%string.

--- a/src/Bedrock/End2End/X25519/Field25519.v
+++ b/src/Bedrock/End2End/X25519/Field25519.v
@@ -12,6 +12,8 @@ Require Import Crypto.Bedrock.Specs.Field.
 Import ListNotations.
 
 #[export]
+ Hint Extern 0 BoundsPipeline.machine_wordsize_opt => exact 32%Z : typeclass_instances.
+#[export]
 Existing Instances Naive.word Naive.word32_ok BW32.
 #[export]
 Existing Instances no_select_size split_mul_to split_multiret_to.
@@ -37,7 +39,7 @@ Section Field.
     (error := Syntax.expr.var Defaults.ERROR)
     := tt.
   Instance translation_parameters_ok : Types.ok.
-  Proof. constructor; try exact _; apply prefix_name_gen_unique. Qed.
+  Proof using ext_spec_ok. constructor; try exact _; apply prefix_name_gen_unique. Qed.
 
   (* Define Curve25519 field *)
   Instance field_parameters : FieldParameters.

--- a/src/Bedrock/Field/Synthesis/Examples/X1305_32.v
+++ b/src/Bedrock/Field/Synthesis/Examples/X1305_32.v
@@ -7,7 +7,7 @@ Require Import Crypto.Bedrock.Field.Synthesis.Specialized.UnsaturatedSolinas.
 Local Open Scope Z_scope.
 Import ListNotations.
 
-Local Existing Instances default_parameters default_parameters_ok.
+Local Existing Instances machine_wordsize default_parameters default_parameters_ok.
 Local Definition n := 5%nat.
 Local Definition s := 2^130.
 Local Definition c := [(1, 5)].

--- a/src/Bedrock/Field/Synthesis/Examples/X25519_64.v
+++ b/src/Bedrock/Field/Synthesis/Examples/X25519_64.v
@@ -7,7 +7,7 @@ Require Import Crypto.Bedrock.Field.Synthesis.Specialized.UnsaturatedSolinas.
 Local Open Scope Z_scope.
 Import ListNotations.
 
-Local Existing Instances default_parameters default_parameters_ok.
+Local Existing Instances machine_wordsize default_parameters default_parameters_ok.
 Local Definition n := 10%nat.
 Local Definition s := 2^255.
 Local Definition c := [(1, 19)].

--- a/src/Bedrock/Field/Synthesis/Examples/p224_64.v
+++ b/src/Bedrock/Field/Synthesis/Examples/p224_64.v
@@ -6,7 +6,7 @@ Require Import Crypto.Bedrock.Field.Translation.Parameters.Defaults64.
 Local Open Scope Z_scope.
 
 Local Definition m := 2^224 - 2^96 + 1.
-Local Existing Instances default_parameters default_parameters_ok.
+Local Existing Instances machine_wordsize default_parameters default_parameters_ok.
 Local Definition prefix := "p224_"%string. (* placed before function names *)
 
 #[global]

--- a/src/Bedrock/Field/Synthesis/Examples/p224_64_new.v
+++ b/src/Bedrock/Field/Synthesis/Examples/p224_64_new.v
@@ -26,7 +26,9 @@ Section Field.
   Definition n : nat := 4.
   Definition m : Z := (2^224 - 2^96 + 1)%Z.
 
-  Existing Instances Defaults32.default_parameters
+  Existing Instances
+           Defaults32.machine_wordsize
+           Defaults32.default_parameters
            Defaults32.default_parameters_ok.
   Existing Instances no_select_size split_mul_to split_multiret_to.
   Definition prefix : string := "p224_"%string.
@@ -47,7 +49,7 @@ Section Field.
   Definition from_mont_string := prefix ++ "from_mont".
 
   (* Call fiat-crypto pipeline on all field operations *)
-  Instance p224_ops : @word_by_word_Montgomery_ops from_mont_string to_mont_string _ _ _ _ _ _ _ _ _ _ _ (WordByWordMontgomery.n m machine_wordsize) m.
+  Instance p224_ops : @word_by_word_Montgomery_ops from_mont_string to_mont_string _ _ _ _ _ _ _ _ _ _ _ (WordByWordMontgomery.n m) m.
   Proof using Type. Time constructor; make_computed_op. Defined.
 
 
@@ -65,7 +67,7 @@ Section Field.
         | |- context [spec_of_from_bytes] => eapply from_bytes_func_correct
         | |- context [spec_of_to_bytes] => eapply to_bytes_func_correct
         end.
-      
+
       Ltac derive_bedrock2_func op :=
         begin_derive_bedrock2_func;
         (* this goal fills in the evar, so do it first for [abstract] to be happy *)

--- a/src/Bedrock/Field/Synthesis/Examples/p256_64.v
+++ b/src/Bedrock/Field/Synthesis/Examples/p256_64.v
@@ -5,7 +5,7 @@ Require Import Crypto.Bedrock.Field.Synthesis.Specialized.WordByWordMontgomery.
 Require Import Crypto.Bedrock.Field.Translation.Parameters.Defaults64.
 Local Open Scope Z_scope.
 
-Local Existing Instances default_parameters default_parameters_ok.
+Local Existing Instances machine_wordsize default_parameters default_parameters_ok.
 Local Definition m := 2^256 - 2^224 + 2^192 + 2^96 - 1.
 Local Definition prefix := "p256_"%string. (* placed before function names *)
 

--- a/src/Bedrock/Field/Synthesis/Generic/WordByWordMontgomery.v
+++ b/src/Bedrock/Field/Synthesis/Generic/WordByWordMontgomery.v
@@ -98,22 +98,23 @@ Section __.
    `{parameters_sentinel : @parameters width BW word mem locals env ext_spec varname_gen error}
           {inname_gen outname_gen : nat -> string}
           (m : Z).
+  Local Hint Extern 0 machine_wordsize_opt => exact width : typeclass_instances.
   Local Notation is_correct := (is_correct (parameters_sentinel:=parameters_sentinel) (inname_gen:=inname_gen) (outname_gen:=outname_gen)).
   Local Notation bit_range := {|ZRange.lower := 0; ZRange.upper := 1|}.
-  Local Notation n := (WordByWordMontgomery.n m width).
+  Local Notation n := (WordByWordMontgomery.n m).
   Local Notation n_bytes := (WordByWordMontgomery.n_bytes m).
   Local Notation bounds :=
-    (WordByWordMontgomery.bounds m width).
+    (WordByWordMontgomery.bounds m).
   Local Notation montgomery_domain_bounds :=
-    (WordByWordMontgomery.montgomery_domain_bounds m width).
+    (WordByWordMontgomery.montgomery_domain_bounds m).
   Local Notation non_montgomery_domain_bounds :=
-    (WordByWordMontgomery.non_montgomery_domain_bounds m width).
+    (WordByWordMontgomery.non_montgomery_domain_bounds m).
   Local Notation prime_bounds :=
-    (WordByWordMontgomery.prime_bounds m width).
+    (WordByWordMontgomery.prime_bounds m).
   Local Notation prime_bytes_bounds :=
     (WordByWordMontgomery.prime_bytes_bounds m).
   Local Notation saturated_bounds :=
-    (Primitives.saturated_bounds n width).
+    (Primitives.saturated_bounds n).
   Local Notation eval :=
     (@WordByWordMontgomery.WordByWordMontgomery.eval width n).
 
@@ -162,85 +163,83 @@ Section __.
               t inbounds insizes outsizes inlengths outlengths)
     with (pipeline_out:=out)
          (check_args_ok:=
-            check_args m machine_wordsize [] (ErrorT.Success tt)
+            check_args m [] (ErrorT.Success tt)
             = ErrorT.Success tt).
 
   Definition mul
     : operation (type_listZ -> type_listZ -> type_listZ).
   Proof.
-    make_operation (WordByWordMontgomery.mul m width).
+    make_operation (WordByWordMontgomery.mul m).
     prove_operation_correctness.
   Defined.
 
   Definition square
     : operation (type_listZ -> type_listZ).
   Proof.
-    make_operation (WordByWordMontgomery.square m width).
+    make_operation (WordByWordMontgomery.square m).
     prove_operation_correctness.
   Defined.
 
   Definition add
     : operation (type_listZ -> type_listZ -> type_listZ).
   Proof.
-    make_operation (WordByWordMontgomery.add m width).
+    make_operation (WordByWordMontgomery.add m).
     prove_operation_correctness.
   Defined.
 
   Definition sub
     : operation (type_listZ -> type_listZ -> type_listZ).
   Proof.
-    make_operation (WordByWordMontgomery.sub m width).
+    make_operation (WordByWordMontgomery.sub m).
     prove_operation_correctness.
   Defined.
 
   Definition opp
     : operation (type_listZ -> type_listZ).
   Proof.
-    make_operation (WordByWordMontgomery.opp m width).
+    make_operation (WordByWordMontgomery.opp m).
     prove_operation_correctness.
   Defined.
 
   Definition to_montgomery
     : operation (type_listZ -> type_listZ).
   Proof.
-    make_operation (WordByWordMontgomery.to_montgomery m width).
+    make_operation (WordByWordMontgomery.to_montgomery m).
     prove_operation_correctness.
   Defined.
 
   Definition from_montgomery
     : operation (type_listZ -> type_listZ).
   Proof.
-    make_operation (WordByWordMontgomery.from_montgomery m width).
+    make_operation (WordByWordMontgomery.from_montgomery m).
     prove_operation_correctness.
   Defined.
 
   Definition nonzero
     : operation (type_listZ -> type_Z).
   Proof.
-    make_operation (WordByWordMontgomery.nonzero m width).
+    make_operation (WordByWordMontgomery.nonzero m).
     prove_operation_correctness.
   Defined.
 
   Definition selectznz
     : operation (type_Z -> type_listZ -> type_listZ -> type_listZ).
   Proof.
-    make_operation (WordByWordMontgomery.selectznz m width).
+    make_operation (WordByWordMontgomery.selectznz m).
     prove_operation_correctness.
-    Unshelve.
-    { apply width. }
   Defined.
 
   Definition to_bytes
     : operation (type_listZ -> type_listZ).
   Proof.
-    make_operation (WordByWordMontgomery.to_bytes m width).
+    make_operation (WordByWordMontgomery.to_bytes m).
     prove_operation_correctness.
   Defined.
 
   Definition from_bytes
     : operation (type_listZ -> type_listZ).
   Proof.
-    make_operation (WordByWordMontgomery.from_bytes m width).
+    make_operation (WordByWordMontgomery.from_bytes m).
     prove_operation_correctness.
   Defined.
 
@@ -493,9 +492,10 @@ Section __.
     Lemma relax_to_max_bounds x :
       list_Z_bounded_by bounds x ->
       list_Z_bounded_by (@max_bounds width n) x.
-    Proof.
+    Proof using Type.
       apply relax_list_Z_bounded_by. cbn.
       cbv [bounds Primitives.saturated_bounds Primitives.word_bound max_bounds list_Z_tighter_than].
+      vm_compute machine_wordsize in *.
       induction n; [ reflexivity | ].
       cbn [repeat FoldBool.fold_andb_map ZRange.lower ZRange.upper max_range].
       apply Bool.andb_true_iff. split; [ | solve [ auto ] ].
@@ -513,7 +513,7 @@ Section __.
     Lemma relax_prime_bounds x :
       list_Z_bounded_by prime_bounds x ->
       list_Z_bounded_by bounds x.
-    Proof.
+    Proof using ok.
       cbv [prime_bounds prime_upperbound_list].
       intros; eapply relax_to_bounded_upperbounds;
         eauto; [ | solve [apply MaxBounds.partition_bounded_by] ].
@@ -523,7 +523,7 @@ Section __.
     Lemma relax_to_byte_bounds x :
       list_Z_bounded_by prime_bytes_bounds x ->
       list_Z_bounded_by (byte_bounds n_bytes) x.
-    Proof.
+    Proof using Type.
       cbv [prime_bytes_bounds prime_bytes_upperbound_list].
       intros; eapply relax_to_bounded_upperbounds;
         eauto using ByteBounds.partition_bounded_by; [ ].
@@ -531,21 +531,21 @@ Section __.
     Qed.
 
     Lemma length_bounds : length bounds = n.
-    Proof. apply repeat_length. Qed.
+    Proof using Type. apply repeat_length. Qed.
 
     Lemma bounded_by_bounds_length x :
       list_Z_bounded_by bounds x -> length x = n.
-    Proof.
+    Proof using Type.
       intros. pose proof length_list_Z_bounded_by _ _ ltac:(eassumption).
       rewrite <-length_bounds. cbn - [bounds]. congruence.
     Qed.
 
     Lemma length_saturated_bounds : length saturated_bounds = n.
-    Proof. apply repeat_length. Qed.
+    Proof using Type. apply repeat_length. Qed.
 
     Lemma bounded_by_saturated_bounds_length x :
       list_Z_bounded_by saturated_bounds x -> length x = n.
-    Proof.
+    Proof using Type.
       cbv [max_bounds].
       intros. pose proof length_list_Z_bounded_by _ _ ltac:(eassumption).
       rewrite Primitives.length_saturated_bounds in *. lia.
@@ -553,7 +553,7 @@ Section __.
 
     Lemma bounded_by_prime_bounds_length x :
       list_Z_bounded_by prime_bounds x -> length x = n.
-    Proof.
+    Proof using Type.
       intros. pose proof length_list_Z_bounded_by _ _ ltac:(eassumption).
       cbv [prime_bounds prime_upperbound_list] in *.
       rewrite map_length, length_partition in *. lia.
@@ -561,7 +561,7 @@ Section __.
 
     Lemma bounded_by_prime_bytes_bounds_length x :
       list_Z_bounded_by prime_bytes_bounds x -> length x = n_bytes.
-    Proof.
+    Proof using Type.
       intros. pose proof length_list_Z_bounded_by _ _ ltac:(eassumption).
       cbv [prime_bytes_bounds prime_bytes_upperbound_list] in *.
       rewrite map_length, length_partition in *. lia.
@@ -569,23 +569,23 @@ Section __.
 
     Lemma bounded_by_byte_bounds_length x :
       list_Z_bounded_by (byte_bounds n_bytes) x -> length x = n_bytes.
-    Proof. eapply byte_bounds_range_iff. Qed.
+    Proof using Type. eapply byte_bounds_range_iff. Qed.
 
     Lemma valid_bounded_by_prime_bounds x :
-      (check_args m width [] (ErrorT.Success tt)
+      (check_args m [] (ErrorT.Success tt)
        = ErrorT.Success tt) ->
       WordByWordMontgomery.valid width n m x ->
       list_Z_bounded_by prime_bounds x.
-    Proof.
+    Proof using Type.
       intros; unshelve eapply bounded_by_prime_bounds_of_valid; eauto.
     Qed.
 
     Lemma valid_bounded_by_prime_bytes_bounds x :
-      (check_args m width [] (ErrorT.Success tt)
+      (check_args m [] (ErrorT.Success tt)
        = ErrorT.Success tt) ->
       WordByWordMontgomery.valid 8 n_bytes m x ->
       list_Z_bounded_by prime_bytes_bounds x.
-    Proof.
+    Proof using Type.
       intros; eapply bounded_by_prime_bytes_bounds_of_bytes_valid; eauto.
     Qed.
 
@@ -725,74 +725,74 @@ Section __.
       | setup_lists_reserved; solve_lists_reserved out_ptrs ].
 
     Context (check_args_ok :
-               check_args m width [] (ErrorT.Success tt)
+               check_args m [] (ErrorT.Success tt)
                = ErrorT.Success tt).
 
     Lemma mul_correct name :
       is_correct
-        (WordByWordMontgomery.mul m width)
+        (WordByWordMontgomery.mul m)
         mul (spec_of_mul name).
-    Proof. setup; prove_is_correct Rout. Qed.
+    Proof using check_args_ok inname_gen_unique inname_gen_varname_gen_ok ok outname_gen_inname_gen_ok outname_gen_unique outname_gen_varname_gen_ok. setup; prove_is_correct Rout. Qed.
 
     Lemma square_correct name :
       is_correct
-        (WordByWordMontgomery.square m width)
+        (WordByWordMontgomery.square m)
         square (spec_of_square name).
-    Proof. setup. prove_is_correct Rout. Qed.
+    Proof using check_args_ok inname_gen_unique inname_gen_varname_gen_ok ok outname_gen_inname_gen_ok outname_gen_unique outname_gen_varname_gen_ok. setup. prove_is_correct Rout. Qed.
 
     Lemma add_correct name :
       is_correct
-        (WordByWordMontgomery.add m width)
+        (WordByWordMontgomery.add m)
         add (spec_of_add name).
-    Proof. setup; prove_is_correct Rout. Qed.
+    Proof using check_args_ok inname_gen_unique inname_gen_varname_gen_ok ok outname_gen_inname_gen_ok outname_gen_unique outname_gen_varname_gen_ok. setup; prove_is_correct Rout. Qed.
 
     Lemma sub_correct name :
       is_correct
-        (WordByWordMontgomery.sub m width)
+        (WordByWordMontgomery.sub m)
         sub (spec_of_sub name).
-    Proof. setup; prove_is_correct Rout. Qed.
+    Proof using check_args_ok inname_gen_unique inname_gen_varname_gen_ok ok outname_gen_inname_gen_ok outname_gen_unique outname_gen_varname_gen_ok. setup; prove_is_correct Rout. Qed.
 
     Lemma opp_correct name :
       is_correct
-        (WordByWordMontgomery.opp m width)
+        (WordByWordMontgomery.opp m)
         opp (spec_of_opp name).
-    Proof. setup; prove_is_correct Rout. Qed.
+    Proof using check_args_ok inname_gen_unique inname_gen_varname_gen_ok ok outname_gen_inname_gen_ok outname_gen_unique outname_gen_varname_gen_ok. setup; prove_is_correct Rout. Qed.
 
     Lemma to_montgomery_correct name :
       is_correct
-        (WordByWordMontgomery.to_montgomery m width)
+        (WordByWordMontgomery.to_montgomery m)
         to_montgomery (spec_of_to_montgomery name).
-    Proof. setup; prove_is_correct Rout. Qed.
+    Proof using check_args_ok inname_gen_unique inname_gen_varname_gen_ok ok outname_gen_inname_gen_ok outname_gen_unique outname_gen_varname_gen_ok. setup; prove_is_correct Rout. Qed.
 
     Lemma from_montgomery_correct name :
       is_correct
-        (WordByWordMontgomery.from_montgomery m width)
+        (WordByWordMontgomery.from_montgomery m)
         from_montgomery (spec_of_from_montgomery name).
-    Proof. setup; prove_is_correct Rout. Qed.
+    Proof using check_args_ok inname_gen_unique inname_gen_varname_gen_ok ok outname_gen_inname_gen_ok outname_gen_unique outname_gen_varname_gen_ok. setup; prove_is_correct Rout. Qed.
 
     Lemma nonzero_correct name :
       is_correct
-        (WordByWordMontgomery.nonzero m width)
+        (WordByWordMontgomery.nonzero m)
         nonzero (spec_of_nonzero name).
-    Proof. setup; prove_is_correct Rout. Qed.
+    Proof using check_args_ok inname_gen_unique inname_gen_varname_gen_ok ok outname_gen_inname_gen_ok outname_gen_unique outname_gen_varname_gen_ok. setup; prove_is_correct Rout. Qed.
 
     Lemma selectznz_correct name :
       is_correct
-        (WordByWordMontgomery.selectznz m width)
+        (WordByWordMontgomery.selectznz m)
         selectznz (spec_of_selectznz name).
-    Proof. setup; prove_is_correct Rout. Qed.
+    Proof using check_args_ok inname_gen_unique inname_gen_varname_gen_ok ok outname_gen_inname_gen_ok outname_gen_unique outname_gen_varname_gen_ok. setup; prove_is_correct Rout. Qed.
 
     Lemma to_bytes_correct name :
       is_correct
-        (WordByWordMontgomery.to_bytes m width)
+        (WordByWordMontgomery.to_bytes m)
         to_bytes (spec_of_to_bytes name).
-    Proof. setup; prove_is_correct Rout. Qed.
+    Proof using check_args_ok inname_gen_unique inname_gen_varname_gen_ok ok outname_gen_inname_gen_ok outname_gen_unique outname_gen_varname_gen_ok. setup; prove_is_correct Rout. Qed.
 
     Lemma from_bytes_correct name :
       is_correct
-        (WordByWordMontgomery.from_bytes m width)
+        (WordByWordMontgomery.from_bytes m)
         from_bytes (spec_of_from_bytes name).
-    Proof. setup; prove_is_correct Rout. Qed.
+    Proof using check_args_ok inname_gen_unique inname_gen_varname_gen_ok ok outname_gen_inname_gen_ok outname_gen_unique outname_gen_varname_gen_ok. setup; prove_is_correct Rout. Qed.
   End Proofs.
 End __.
 #[global]

--- a/src/Bedrock/Field/Synthesis/Specialized/UnsaturatedSolinas.v
+++ b/src/Bedrock/Field/Synthesis/Specialized/UnsaturatedSolinas.v
@@ -99,59 +99,59 @@ Class names_of_operations :=
     name_of_carry_scmul_const : Z -> string }.
 
 Record unsaturated_solinas_reified_ops
-  {width BW word mem locals env ext_spec varname_gen error}
+  {width : BoundsPipeline.machine_wordsize_opt} {BW word mem locals env ext_spec varname_gen error}
   {parameters_sentinel : @Types.parameters width BW word mem locals env ext_spec varname_gen error}
   {names : names_of_operations} {n s c} :=
-  { 
+  {
     reified_carry_mul :
       reified_op name_of_carry_mul
                  (Generic.UnsaturatedSolinas.carry_mul n s c)
                  (PushButtonSynthesis.UnsaturatedSolinas.carry_mul
-                    n s c width);
+                    n s c);
     reified_carry_square :
       reified_op name_of_carry_square
                  (Generic.UnsaturatedSolinas.carry_square n s c)
                  (PushButtonSynthesis.UnsaturatedSolinas.carry_square
-                    n s c width);
+                    n s c);
     reified_carry :
       reified_op name_of_carry
                  (Generic.UnsaturatedSolinas.carry n s c)
                  (PushButtonSynthesis.UnsaturatedSolinas.carry
-                    n s c width);
+                    n s c);
     reified_add :
       reified_op name_of_add
                  (Generic.UnsaturatedSolinas.add n s c)
                  (PushButtonSynthesis.UnsaturatedSolinas.add
-                    n s c width);
+                    n s c);
     reified_sub :
       reified_op name_of_sub
                  (Generic.UnsaturatedSolinas.sub n s c)
                  (PushButtonSynthesis.UnsaturatedSolinas.sub
-                    n s c width);
+                    n s c);
     reified_opp :
       reified_op name_of_opp
                  (Generic.UnsaturatedSolinas.opp n s c)
                  (PushButtonSynthesis.UnsaturatedSolinas.opp
-                    n s c width);
+                    n s c);
     reified_selectznz :
       reified_op name_of_selectznz
                  (Generic.UnsaturatedSolinas.selectznz n s c)
                  (PushButtonSynthesis.UnsaturatedSolinas.selectznz
-                    n width);
+                    n);
     reified_to_bytes :
       reified_op name_of_to_bytes
                  (Generic.UnsaturatedSolinas.to_bytes n s c)
                  (PushButtonSynthesis.UnsaturatedSolinas.to_bytes
-                    n s c width);
+                    n s c);
     reified_from_bytes :
       reified_op name_of_from_bytes
                  (Generic.UnsaturatedSolinas.from_bytes n s c)
                  (PushButtonSynthesis.UnsaturatedSolinas.from_bytes
-                    n s c width) }.
+                    n s c) }.
 Arguments unsaturated_solinas_reified_ops {_ _ _ _ _ _ _ _ _ _ _ } n s c.
 
 Record unsaturated_solinas_reified_scmul
-  {width BW word mem locals env ext_spec varname_gen error}
+  {width : BoundsPipeline.machine_wordsize_opt} { BW word mem locals env ext_spec varname_gen error}
   {parameters_sentinel : @Types.parameters width BW word mem locals env ext_spec varname_gen error}
   {names : names_of_operations} {n s c} {x : Z} :=
   { scmul_params : Types.parameters;
@@ -161,7 +161,7 @@ Record unsaturated_solinas_reified_scmul
                  (Generic.UnsaturatedSolinas.carry_scmul_const
                     n s c x)
                  (PushButtonSynthesis.UnsaturatedSolinas.carry_scmul_const
-                    n s c width x) }.
+                    n s c x) }.
 Arguments unsaturated_solinas_reified_scmul {_ _ _ _ _ _ _ _ _ _ _} n s c x.
 
 (*** Helpers ***)
@@ -394,7 +394,7 @@ Ltac prove_correctness ops n s c :=
   let p := lazymatch type of ops with unsaturated_solinas_reified_ops(parameters_sentinel:=?p) _ _ _ => p end in
   let width := lazymatch type of ops with unsaturated_solinas_reified_ops(width:=?width) _ _ _ => width end in
   assert (UnsaturatedSolinas.check_args
-            n s c width necessary_requests (ErrorT.Success tt) =
+            n s c necessary_requests (ErrorT.Success tt) =
           ErrorT.Success tt) by abstract (native_compute; reflexivity);
   lazymatch goal with
     | |- bedrock2_unsaturated_solinas_correctness => econstructor end;
@@ -406,7 +406,7 @@ Ltac prove_correctness_scmul ops n s c :=
   let p := lazymatch type of ops with unsaturated_solinas_reified_scmul(parameters_sentinel:=?p) _ _ _ _ => p end in
   let width := lazymatch type of ops with unsaturated_solinas_reified_scmul(width:=?width) _ _ _ _ => width end in
   assert (UnsaturatedSolinas.check_args
-            n s c width necessary_requests (ErrorT.Success tt) =
+            n s c necessary_requests (ErrorT.Success tt) =
           ErrorT.Success tt) by abstract (native_compute; reflexivity);
   lazymatch goal with
   | |- bedrock2_unsaturated_solinas_scmul_correctness =>

--- a/src/Bedrock/Field/Synthesis/Specialized/WordByWordMontgomery.v
+++ b/src/Bedrock/Field/Synthesis/Specialized/WordByWordMontgomery.v
@@ -96,53 +96,53 @@ Class names_of_operations :=
     name_of_from_bytes : string }.
 
 Record wbwmontgomery_reified_ops
-  {width BW word mem locals env ext_spec varname_gen error}
+  {width : BoundsPipeline.machine_wordsize_opt} {BW word mem locals env ext_spec varname_gen error}
   {parameters_sentinel : @Types.parameters width BW word mem locals env ext_spec varname_gen error}
        {names : names_of_operations} {m} :=
   { reified_mul :
       reified_op name_of_mul
                  (Generic.WordByWordMontgomery.mul m)
-                 (PushButtonSynthesis.WordByWordMontgomery.mul m width);
+                 (PushButtonSynthesis.WordByWordMontgomery.mul m);
     reified_square :
       reified_op name_of_square
                  (Generic.WordByWordMontgomery.square m)
-                 (PushButtonSynthesis.WordByWordMontgomery.square m width);
+                 (PushButtonSynthesis.WordByWordMontgomery.square m);
     reified_add :
       reified_op name_of_add
                  (Generic.WordByWordMontgomery.add m)
-                 (PushButtonSynthesis.WordByWordMontgomery.add m width);
+                 (PushButtonSynthesis.WordByWordMontgomery.add m);
     reified_sub :
       reified_op name_of_sub
                  (Generic.WordByWordMontgomery.sub m)
-                 (PushButtonSynthesis.WordByWordMontgomery.sub m width);
+                 (PushButtonSynthesis.WordByWordMontgomery.sub m);
     reified_opp :
       reified_op name_of_opp
                  (Generic.WordByWordMontgomery.opp m)
-                 (PushButtonSynthesis.WordByWordMontgomery.opp m width);
+                 (PushButtonSynthesis.WordByWordMontgomery.opp m);
     reified_to_montgomery :
       reified_op name_of_to_montgomery
                  (Generic.WordByWordMontgomery.to_montgomery m)
-                 (PushButtonSynthesis.WordByWordMontgomery.to_montgomery m width);
+                 (PushButtonSynthesis.WordByWordMontgomery.to_montgomery m);
     reified_from_montgomery :
       reified_op name_of_from_montgomery
                  (Generic.WordByWordMontgomery.from_montgomery m)
-                 (PushButtonSynthesis.WordByWordMontgomery.from_montgomery m width);
+                 (PushButtonSynthesis.WordByWordMontgomery.from_montgomery m);
     reified_nonzero :
       reified_op name_of_nonzero
                  (Generic.WordByWordMontgomery.nonzero m)
-                 (PushButtonSynthesis.WordByWordMontgomery.nonzero m width);
+                 (PushButtonSynthesis.WordByWordMontgomery.nonzero m);
     reified_selectznz :
       reified_op name_of_selectznz
                  (Generic.WordByWordMontgomery.selectznz m)
-                 (PushButtonSynthesis.WordByWordMontgomery.selectznz m width);
+                 (PushButtonSynthesis.WordByWordMontgomery.selectznz m);
     reified_to_bytes :
       reified_op name_of_to_bytes
                  (Generic.WordByWordMontgomery.to_bytes m)
-                 (PushButtonSynthesis.WordByWordMontgomery.to_bytes m width);
+                 (PushButtonSynthesis.WordByWordMontgomery.to_bytes m);
     reified_from_bytes :
       reified_op name_of_from_bytes
                  (Generic.WordByWordMontgomery.from_bytes m)
-                 (PushButtonSynthesis.WordByWordMontgomery.from_bytes m width) }.
+                 (PushButtonSynthesis.WordByWordMontgomery.from_bytes m) }.
 Arguments wbwmontgomery_reified_ops {_ _ _ _ _ _ _ _ _ _ _} m.
 
 (*** Helpers ***)
@@ -383,7 +383,7 @@ Ltac change_with_computed_func ops :=
 Ltac prove_correctness ops m :=
   let width := lazymatch type of ops with wbwmontgomery_reified_ops(width:=?width) _ => width end in
   assert (WordByWordMontgomery.check_args
-            m width [] (ErrorT.Success tt) =
+            m [] (ErrorT.Success tt) =
           ErrorT.Success tt) by abstract (native_compute; reflexivity);
   lazymatch goal with
     | |- bedrock2_wbwmontgomery_correctness => econstructor end;

--- a/src/Bedrock/Field/Translation/Parameters/Defaults32.v
+++ b/src/Bedrock/Field/Translation/Parameters/Defaults32.v
@@ -21,7 +21,7 @@ Local Open Scope string_scope.
 a 32-bit word size. *)
 
 Section Defaults_32.
-  Definition machine_wordsize := 32.
+  Instance machine_wordsize : machine_wordsize_opt := 32.
 
   (* Define how to split mul/multi-return functions *)
   Definition possible_values

--- a/src/Bedrock/Field/Translation/Parameters/Defaults64.v
+++ b/src/Bedrock/Field/Translation/Parameters/Defaults64.v
@@ -21,7 +21,7 @@ Local Open Scope string_scope.
 a 64-bit word size. *)
 
 Section Defaults_64.
-  Definition machine_wordsize := 64.
+  Instance machine_wordsize : machine_wordsize_opt := 64.
 
   (* Define how to split mul/multi-return functions *)
   Definition possible_values

--- a/src/CLI.v
+++ b/src/CLI.v
@@ -471,6 +471,8 @@ Module ForExtraction.
     {
       (** Is the code static / private *)
       static :> static_opt
+      (** Dummy alias; the lower levels have a separate variable for this, but we don't (backwards compat? TODO: explain better) *)
+      ; all_static :> all_static_opt := static
       (** Is the internal code static / private *)
       ; internal_static :> internal_static_opt
       (** Is the code inlined *)
@@ -957,7 +959,7 @@ Module ForExtraction.
 
           Synthesize
           := fun _ opts '(n, s, c, tight_bounds_multiplier, requests) comment_header prefix
-             => UnsaturatedSolinas.Synthesize n s c machine_wordsize comment_header prefix requests;
+             => UnsaturatedSolinas.Synthesize n s c comment_header prefix requests;
         }.
 
     Definition PipelineMain
@@ -999,7 +1001,7 @@ Module ForExtraction.
 
           Synthesize
           := fun _ opts '(m, requests) comment_header prefix
-             => WordByWordMontgomery.Synthesize m machine_wordsize comment_header prefix requests
+             => WordByWordMontgomery.Synthesize m comment_header prefix requests
         }.
 
     Definition PipelineMain
@@ -1034,7 +1036,7 @@ Module ForExtraction.
 
           Synthesize
           := fun _ opts '(s, c, requests) comment_header prefix
-             => SaturatedSolinas.Synthesize s c machine_wordsize comment_header prefix requests
+             => SaturatedSolinas.Synthesize s c comment_header prefix requests
         }.
 
     Definition PipelineMain
@@ -1102,7 +1104,7 @@ Module ForExtraction.
 
           Synthesize
           := fun _ opts '(src_n, s, c, src_limbwidth, dst_limbwidth, inbounds_multiplier, outbounds_multiplier, inbounds, outbounds, requests) comment_header prefix
-             => BaseConversion.Synthesize s c src_n src_limbwidth dst_limbwidth machine_wordsize inbounds_multiplier outbounds_multiplier inbounds outbounds comment_header prefix requests
+             => BaseConversion.Synthesize s c src_n src_limbwidth dst_limbwidth inbounds_multiplier outbounds_multiplier inbounds outbounds comment_header prefix requests
         }.
 
     Definition PipelineMain

--- a/src/PushButtonSynthesis/BarrettReduction.v
+++ b/src/PushButtonSynthesis/BarrettReduction.v
@@ -42,13 +42,10 @@ Local Set Keyed Unification. (* needed for making [autorewrite] fast, c.f. COQBU
 Local Opaque reified_barrett_red_gen. (* needed for making [autorewrite] not take a very long time *)
 
 Section rbarrett_red.
-  Context {output_language_api : ToString.OutputLanguageAPI}
-          {static : static_opt}
-          {internal_static : internal_static_opt}
-          {inline : inline_opt}
-          {inline_internal : inline_internal_opt}
-          (M : Z)
-          (machine_wordsize : machine_wordsize_opt).
+  Context {Pipeline_Options : Pipeline.BaseOptions}
+          {Pipeline_ExtendedOptions : Pipeline.ExtendedOptions}
+          {extra_opts : ExtraOptions}
+          (M : Z).
 
   Let value_range := r[0 ~> (2^machine_wordsize - 1)%Z]%zrange.
   Let flag_range := r[0 ~> 1]%zrange.
@@ -61,35 +58,22 @@ Section rbarrett_red.
     := [1; machine_wordsize / 2; machine_wordsize; 2 * machine_wordsize]%Z.
   Let possible_values := possible_values_of_machine_wordsize.
 
-  Local Existing Instance default_language_naming_conventions.
-  Local Existing Instance default_documentation_options.
-  Local Existing Instance default_output_options.
-  Local Existing Instance AbstractInterpretation.default_Options.
-  Local Instance widen_carry : widen_carry_opt := false.
-  Local Instance widen_bytes : widen_bytes_opt := true.
-  Local Instance only_signed : only_signed_opt := false.
-  Local Instance no_select_size : no_select_size_opt := None.
-  Local Instance split_mul_to : split_mul_to_opt := None.
-  Local Instance split_multiret_to : split_multiret_to_opt := None.
-  Local Instance unfold_value_barrier : unfold_value_barrier_opt := true.
-  Local Instance assembly_hints_lines : assembly_hints_lines_opt := [].
-  Local Instance ignore_unique_asm_names : ignore_unique_asm_names_opt := false.
-  Local Instance low_level_rewriter_method : low_level_rewriter_method_opt := default_low_level_rewriter_method.
+  Local Existing Instance Primitives.DerivedRewriteConfiguration_opts.
 
-  Let fancy_args
-    := (Some {| Pipeline.invert_low log2wordsize := invert_low log2wordsize consts_list;
-                Pipeline.invert_high log2wordsize := invert_high log2wordsize consts_list;
-                Pipeline.value_range := value_range;
-                Pipeline.flag_range := flag_range |}).
+  Local Instance fancy_args : translate_to_fancy_opt
+    := (Some {| BoundsPipeline.invert_low log2wordsize := invert_low log2wordsize consts_list;
+                BoundsPipeline.invert_high log2wordsize := invert_high log2wordsize consts_list;
+                BoundsPipeline.value_range := value_range;
+                BoundsPipeline.flag_range := flag_range |}).
 
   Lemma fancy_args_good
     : match fancy_args with
-      | Some {| Pipeline.invert_low := il ; Pipeline.invert_high := ih |}
+      | Some {| BoundsPipeline.invert_low := il ; BoundsPipeline.invert_high := ih |}
         => (forall s v v' : Z, il s v = Some v' -> v = Z.land v' (2^(s/2)-1))
            /\ (forall s v v' : Z, ih s v = Some v' -> v = Z.shiftr v' (s/2))
       | None => True
       end.
-  Proof.
+  Proof using consts_list value_range.
     cbv [fancy_args invert_low invert_high constant_to_scalar constant_to_scalar_single consts_list fold_right];
       split; intros; break_innermost_match_hyps; Z.ltb_to_lt; subst; congruence.
   Qed.
@@ -98,10 +82,10 @@ Section rbarrett_red.
   Lemma mut_correct :
     0 < machine_wordsize ->
     Partition.partition (uweight machine_wordsize) (1 + 1) (muLow + 2 ^ machine_wordsize) = [muLow; 1].
-  Proof.
+  Proof using mu.
     intros; cbn. subst muLow.
     assert (0 < 2^machine_wordsize) by ZeroBounds.Z.zero_bounds.
-    pose proof (Z.mod_pos_bound mu (2^machine_wordsize) ltac:(lia)).
+    pose proof (Z.mod_pos_bound mu (2^machine_wordsize) ltac:(eassumption)).
     rewrite !uweight_S, weight_0; auto using uwprops with lia.
     autorewrite with zsimplify.
     Modulo.push_Zmod. autorewrite with zsimplify. Modulo.pull_Zmod.
@@ -113,7 +97,7 @@ Section rbarrett_red.
     0 < machine_wordsize ->
     2^(machine_wordsize - 1) < M < 2^machine_wordsize ->
     Partition.partition (uweight machine_wordsize) 1 M = [M].
-  Proof.
+  Proof using Type.
     intros; cbn. assert (0 < 2^(machine_wordsize-1)) by ZeroBounds.Z.zero_bounds.
     rewrite !uweight_S, weight_0; auto using uwprops with lia.
     autorewrite with zsimplify. RewriteModSmall.Z.rewrite_mod_small.
@@ -164,7 +148,6 @@ Section rbarrett_red.
   Definition barrett_red
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         fancy_args (* fancy *)
          possible_values
          (reified_barrett_red_gen
             @ GallinaReify.Reify M
@@ -180,7 +163,7 @@ Section rbarrett_red.
     : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
-          machine_wordsize prefix "barrett_red" barrett_red
+          prefix "barrett_red" barrett_red
           (fun _ _ _ => @nil string).
 
   Local Ltac solve_barrett_red_preconditions :=
@@ -203,7 +186,8 @@ Section rbarrett_red.
   Proof using M curve_good.
     cbv [barrett_red_correct]; intros.
     assert (1 < machine_wordsize) by apply use_curve_good.
-    pose proof (Z.mod_pos_bound mu (2^machine_wordsize) ltac:(lia)).
+    assert (0 < 2^machine_wordsize) by ZeroBounds.Z.zero_bounds.
+    pose proof (Z.mod_pos_bound mu (2^machine_wordsize) ltac:(eassumption)).
     rewrite <-Fancy.fancy_reduce_correct with (mu := muLow + 2^machine_wordsize) (width:=machine_wordsize) (sz:=1%nat) (mut:=[muLow;1]) (Mt:=[M]) by solve_barrett_red_preconditions.
     remember Fancy.fancy_reduce eqn:?. (* to prevent [reflexivity] from taking forever *)
     prove_correctness' ltac:(fun _ => idtac) use_curve_good.

--- a/src/PushButtonSynthesis/SmallExamples.v
+++ b/src/PushButtonSynthesis/SmallExamples.v
@@ -20,18 +20,17 @@ Import Compilers.API.
 
 Import Associational Positional.
 
-Local Instance : split_mul_to_opt := None.
-Local Instance : split_multiret_to_opt := None.
-Local Instance : unfold_value_barrier_opt := true.
-Local Instance : assembly_hints_lines_opt := [].
-Local Instance : ignore_unique_asm_names_opt := false.
-Local Instance : only_signed_opt := false.
-Local Instance : no_select_size_opt := None.
-Local Existing Instance default_low_level_rewriter_method.
+Local Existing Instance ToString.C.OutputCAPI.
+Local Instance machine_wordsize : machine_wordsize_opt := 64.
+Local Existing Instance Pipeline.default_BaseOptions.
+Local Existing Instance Pipeline.default_DerivedOptions.
+Local Existing Instance Pipeline.default_ExtendedOptions.
+(* sanity check for lack of evars *)
+Goal True. pose Pipeline.BoundsPipeline as check_evar_free. Abort.
 
 Time Redirect "log" Compute
      (Pipeline.BoundsPipeline
-        true None [64; 128]
+        true [64; 128]
         ltac:(let r := Reify (fun f g => mulmod (weight 51 1) (2^255) [(1,19)] 5 f g) in
               exact r)
                (Some (repeat (@None _) 5), ((Some (repeat (@None _) 5), tt)))
@@ -39,7 +38,7 @@ Time Redirect "log" Compute
 
 Time Redirect "log" Compute
      (Pipeline.BoundsPipeline
-        true None [64; 128]
+        true [64; 128]
         ltac:(let r := Reify (fun f g => mulmod (weight 51 2) (2^255) [(1,19)] 10 f g) in
               exact r)
                (Some (repeat (@None _) 10), ((Some (repeat (@None _) 10), tt)))
@@ -47,7 +46,7 @@ Time Redirect "log" Compute
 
 Time Redirect "log" Compute
      (Pipeline.BoundsPipeline
-        true None [64; 128]
+        true [64; 128]
         ltac:(let r := Reify (to_associational (weight 51 1) 5) in
               exact r)
                (Some (repeat (@None _) 5), tt)
@@ -55,7 +54,7 @@ Time Redirect "log" Compute
 
 Time Redirect "log" Compute
      (Pipeline.BoundsPipeline
-        true None [64; 128]
+        true [64; 128]
         ltac:(let r := Reify (scmul (weight 51 1) 5) in
               exact r)
                (None, (Some (repeat (@None _) 5), tt))
@@ -63,29 +62,19 @@ Time Redirect "log" Compute
 
 Time Redirect "log" Compute
      (Pipeline.BoundsPipeline
-        true None [64; 128]
+        true [64; 128]
         ltac:(let r := Reify (fun f => carry_mulmod 51 1 (2^255) [(1,19)] 5 (seq 0 5 ++ [0; 1])%list%nat f f) in
               exact r)
                (Some (repeat (@None _) 5), tt)
                ZRange.type.base.option.None).
 
-Local Existing Instance ToString.C.OutputCAPI.
-Local Existing Instance default_language_naming_conventions.
-Local Existing Instance default_documentation_options.
-Local Existing Instance default_output_options.
-Local Existing Instance AbstractInterpretation.default_Options.
-Local Instance : package_name_opt := None.
-Local Instance : class_name_opt := None.
-Local Instance : static_opt := true.
-Local Instance : internal_static_opt := true.
-Local Instance : inline_opt := true.
-Local Instance : inline_internal_opt := true.
-Local Instance : emit_primitives_opt := true.
+(* sanity check for lack of evars *)
+Goal True. pose Pipeline.BoundsPipelineToString as check_evar_free. Abort.
 
 Time Redirect "log" Compute
   (Pipeline.BoundsPipelineToString
      "fiat_" "fiat_mulx_u64"
-        true true None [64; 128] 64
+        true [64; 128]
         ltac:(let r := Reify (mulx 64) in
               exact r)
                (fun _ _ => [])
@@ -98,7 +87,7 @@ Time Redirect "log" Compute
 Time Redirect "log" Compute
   (Pipeline.BoundsPipelineToString
      "fiat_" "fiat_addcarryx_u64"
-        true true None [1; 64; 128] 64
+        true [1; 64; 128]
         ltac:(let r := Reify (addcarryx 64) in
               exact r)
                (fun _ _ => [])
@@ -111,7 +100,7 @@ Time Redirect "log" Compute
 Time Redirect "log" Compute
   (Pipeline.BoundsPipelineToString
      "fiat_" "fiat_addcarryx_u51"
-        true true None [1; 64; 128] 64
+        true [1; 64; 128]
         ltac:(let r := Reify (addcarryx 51) in
               exact r)
                (fun _ _ => [])
@@ -124,7 +113,7 @@ Time Redirect "log" Compute
 Time Redirect "log" Compute
   (Pipeline.BoundsPipelineToString
      "fiat_" "fiat_subborrowx_u64"
-        true true None [1; 64; 128] 64
+        true [1; 64; 128]
         ltac:(let r := Reify (subborrowx 64) in
               exact r)
                (fun _ _ => [])
@@ -136,7 +125,7 @@ Time Redirect "log" Compute
 Time Redirect "log" Compute
   (Pipeline.BoundsPipelineToString
      "fiat_" "fiat_subborrowx_u51"
-        true true None [1; 64; 128] 64
+        true [1; 64; 128]
         ltac:(let r := Reify (subborrowx 51) in
               exact r)
                (fun _ _ => [])
@@ -149,7 +138,7 @@ Time Redirect "log" Compute
 Time Redirect "log" Compute
   (Pipeline.BoundsPipelineToString
      "fiat_" "fiat_cmovznz64"
-        true true None [1; 64; 128] 64
+        true [1; 64; 128]
         ltac:(let r := Reify (cmovznz 64) in
               exact r)
                (fun _ _ => [])

--- a/src/StandaloneDebuggingExamples.v
+++ b/src/StandaloneDebuggingExamples.v
@@ -79,11 +79,11 @@ Module debugging_no_asm.
     set (k' := (_ =? _)%string) in (value of k) at 1; vm_compute in k'; subst k'; cbv beta iota in k.
     cbn [fold_right map List.app] in k.
     cbv [UnsaturatedSolinas.extra_special_synthesis UnsaturatedSolinas.scarry_mul] in k.
-    set (cm := UnsaturatedSolinas.carry_mul _ _ _ _) in (value of k).
+    set (cm := UnsaturatedSolinas.carry_mul _ _ _) in (value of k).
     vm_compute in cm.
     set (cmv := (fun var => Language.Compilers.expr.Abs _)) in (value of cm).
     subst cm; cbv beta iota in k.
-    set (cml := Language.Compilers.ToString.ToFunctionLines _ _ _ _ _ _ _ _ _ _ _ _ _ _) in (value of k).
+    set (cml := Language.Compilers.ToString.ToFunctionLines _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) in (value of k).
     vm_compute in cml.
     set (cmlv := _ :: _) in (value of cml) at 1.
     subst cml.
@@ -92,6 +92,9 @@ Module debugging_no_asm.
     cbn [ErrorT.bind] in k.
     vm_compute String.append in k.
     subst k.
+    cbv [Primitives.assembly_hints_lines] in v.
+    set (k := Parse.parse_validated _) in (value of v).
+    vm_compute in k; subst k; cbv beta iota in v.
     cbn [ErrorT.bind] in v.
     set (k := Primitives.split_to_assembly_functions _ _) in (value of v).
     clear -k.
@@ -160,7 +163,7 @@ Module debugging_typedef_bounds.
     cbv [UnsaturatedSolinas.known_functions] in k'.
     cbn [map] in k'.
     repeat (set (k'' := (_ =? _)%string) in (value of k') at 1; vm_compute in k''; subst k''; cbv beta iota zeta in k').
-    set (k'' := UnsaturatedSolinas.sadd _ _ _ _ _) in (value of k').
+    set (k'' := UnsaturatedSolinas.sadd _ _ _ _) in (value of k').
     clear -k''; rename k'' into v.
     cbn -[UnsaturatedSolinas.sadd] in v.
     cbv [ForExtraction.low_level_rewriter_method] in v.
@@ -169,9 +172,11 @@ Module debugging_typedef_bounds.
     vm_compute UnsaturatedSolinas.add in v.
     cbv beta iota zeta in v.
     cbv [Language.Compilers.ToString.ToFunctionLines] in v.
-    cbv [C.Compilers.ToString.C.OutputCAPI] in v.
+    cbv [C.Compilers.ToString.C.OutputCAPI BoundsPipeline.Pipeline.output_language_api] in v.
     cbv [C.Compilers.ToString.C.ToFunctionLines] in v.
-    vm_compute IR.Compilers.ToString.IR.OfPHOAS.ExprOfPHOAS in v.
+    set (k := IR.Compilers.ToString.IR.OfPHOAS.ExprOfPHOAS _ _ _ _ _ _) in (value of v).
+    vm_compute in k.
+    subst k.
     cbv beta iota zeta in v.
     set (k := Language.Compilers.ToString.OfPHOAS.input_bounds_to_string _ _) in (value of v).
     cbv [Language.Compilers.ToString.OfPHOAS.input_bounds_to_string] in k; clear -k.


### PR DESCRIPTION
I decided to add some debugging ability to rewriting (in particular some options to let fiat-crypto print out the AST before/after each rewrite pass), and decided in passing to reorganize the options to the pipeline to allow for less invasive future additions.  I'm concerned this might be making things worse, though.

The most invasive change here is making `machine_wordsize` a typeclass argument rather than an explicit parameter.  While this makes some things a bit nicer, it seems to make a lot of the bedrock stuff more painful, so may not be worth it.
Thoughts on this (especially the bedrock files) @andres-erbsen @jadephilipoom?