### PR TITLE
Make fancy arguments an implicit typeclass

### DIFF
--- a/src/PushButtonSynthesis/BaseConversion.v
+++ b/src/PushButtonSynthesis/BaseConversion.v
@@ -159,6 +159,7 @@ Section __.
   Definition out_bounds : list (ZRange.type.option.interp base.type.Z)
     := List.map (fun u => Some r[0~>u]%zrange) out_upperbounds.
 
+  Local Existing Instance default_translate_to_fancy.
   Local Instance no_select_size : no_select_size_opt := no_select_size_of_no_select machine_wordsize.
   Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values_of_machine_wordsize_with_bytes.
   Local Instance split_multiret_to : split_multiret_to_opt := split_multiret_to_of_should_split_multiret machine_wordsize possible_values_of_machine_wordsize_with_bytes.
@@ -254,7 +255,6 @@ Section __.
   Definition convert_bases
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         None (* fancy *)
          possible_values_with_bytes
          (reified_convert_bases_gen
             @ GallinaReify.Reify (Qnum src_limbwidth) @ GallinaReify.Reify (Z.pos (Qden src_limbwidth))

--- a/src/PushButtonSynthesis/Primitives.v
+++ b/src/PushButtonSynthesis/Primitives.v
@@ -839,6 +839,7 @@ Section __.
     := prefix_with_carry_bytes [machine_wordsize; 2 * machine_wordsize]%Z.
   Let possible_values := possible_values_of_machine_wordsize.
   Let possible_values_with_bytes := possible_values_of_machine_wordsize_with_bytes.
+  Local Existing Instance default_translate_to_fancy.
   Local Instance no_select_size : no_select_size_opt := no_select_size_of_no_select machine_wordsize.
   Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
   Local Instance split_multiret_to : split_multiret_to_opt := split_multiret_to_of_should_split_multiret machine_wordsize possible_values.
@@ -867,7 +868,6 @@ Section __.
   Definition selectznz
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         None (* fancy *)
          possible_values_with_bytes
          reified_selectznz_gen
          (Some r[0~>1], (Some saturated_bounds, (Some saturated_bounds, tt)))%zrange
@@ -883,7 +883,6 @@ Section __.
   Definition mulx (s : Z)
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         None (* fancy *)
          possible_values_with_bytes
          (reified_mulx_gen
             @ GallinaReify.Reify s)
@@ -900,7 +899,6 @@ Section __.
   Definition addcarryx (s : Z)
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         None (* fancy *)
          possible_values_with_bytes
          (reified_addcarryx_gen
             @ GallinaReify.Reify s)
@@ -918,7 +916,6 @@ Section __.
   Definition subborrowx (s : Z)
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         None (* fancy *)
          possible_values_with_bytes
          (reified_subborrowx_gen
             @ GallinaReify.Reify s)
@@ -936,7 +933,6 @@ Section __.
   Definition value_barrier (s : int.type)
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         None (* fancy *)
          possible_values_with_bytes
          reified_value_barrier_gen
          (Some (int.to_zrange s), tt)
@@ -953,7 +949,6 @@ Section __.
   Definition cmovznz (s : Z)
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         None (* fancy *)
          possible_values_with_bytes
          (reified_cmovznz_gen
             @ GallinaReify.Reify s)
@@ -970,7 +965,6 @@ Section __.
   Definition cmovznz_by_mul (s : Z)
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         None (* fancy *)
          possible_values_with_bytes
          (reified_cmovznz_by_mul_gen
             @ GallinaReify.Reify s)
@@ -988,7 +982,6 @@ Section __.
   Definition copy
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         None (* fancy *)
          possible_values
          reified_id_gen
          (Some saturated_bounds, tt)%zrange

--- a/src/PushButtonSynthesis/SaturatedSolinas.v
+++ b/src/PushButtonSynthesis/SaturatedSolinas.v
@@ -115,6 +115,7 @@ Section __.
   Definition boundsn : list (ZRange.type.option.interp base.type.Z)
     := repeat bound n.
 
+  Local Existing Instance default_translate_to_fancy.
   Local Instance no_select_size : no_select_size_opt := no_select_size_of_no_select machine_wordsize.
   Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
   Local Instance split_multiret_to : split_multiret_to_opt := split_multiret_to_of_should_split_multiret machine_wordsize possible_values.
@@ -173,7 +174,6 @@ Section __.
   Definition mul
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_mul_gen
             @ GallinaReify.Reify s @ GallinaReify.Reify c @ GallinaReify.Reify (machine_wordsize:Z) @ GallinaReify.Reify n @ GallinaReify.Reify nreductions)

--- a/src/PushButtonSynthesis/SmallExamples.v
+++ b/src/PushButtonSynthesis/SmallExamples.v
@@ -27,11 +27,12 @@ Local Instance : assembly_hints_lines_opt := [].
 Local Instance : ignore_unique_asm_names_opt := false.
 Local Instance : only_signed_opt := false.
 Local Instance : no_select_size_opt := None.
+Local Existing Instance default_translate_to_fancy.
 Local Existing Instance default_low_level_rewriter_method.
 
 Time Redirect "log" Compute
      (Pipeline.BoundsPipeline
-        true None [64; 128]
+        true [64; 128]
         ltac:(let r := Reify (fun f g => mulmod (weight 51 1) (2^255) [(1,19)] 5 f g) in
               exact r)
                (Some (repeat (@None _) 5), ((Some (repeat (@None _) 5), tt)))
@@ -39,7 +40,7 @@ Time Redirect "log" Compute
 
 Time Redirect "log" Compute
      (Pipeline.BoundsPipeline
-        true None [64; 128]
+        true [64; 128]
         ltac:(let r := Reify (fun f g => mulmod (weight 51 2) (2^255) [(1,19)] 10 f g) in
               exact r)
                (Some (repeat (@None _) 10), ((Some (repeat (@None _) 10), tt)))
@@ -47,7 +48,7 @@ Time Redirect "log" Compute
 
 Time Redirect "log" Compute
      (Pipeline.BoundsPipeline
-        true None [64; 128]
+        true [64; 128]
         ltac:(let r := Reify (to_associational (weight 51 1) 5) in
               exact r)
                (Some (repeat (@None _) 5), tt)
@@ -55,7 +56,7 @@ Time Redirect "log" Compute
 
 Time Redirect "log" Compute
      (Pipeline.BoundsPipeline
-        true None [64; 128]
+        true [64; 128]
         ltac:(let r := Reify (scmul (weight 51 1) 5) in
               exact r)
                (None, (Some (repeat (@None _) 5), tt))
@@ -63,7 +64,7 @@ Time Redirect "log" Compute
 
 Time Redirect "log" Compute
      (Pipeline.BoundsPipeline
-        true None [64; 128]
+        true [64; 128]
         ltac:(let r := Reify (fun f => carry_mulmod 51 1 (2^255) [(1,19)] 5 (seq 0 5 ++ [0; 1])%list%nat f f) in
               exact r)
                (Some (repeat (@None _) 5), tt)
@@ -85,7 +86,7 @@ Local Instance : emit_primitives_opt := true.
 Time Redirect "log" Compute
   (Pipeline.BoundsPipelineToString
      "fiat_" "fiat_mulx_u64"
-        true true None [64; 128] 64
+        true true [64; 128] 64
         ltac:(let r := Reify (mulx 64) in
               exact r)
                (fun _ _ => [])
@@ -98,7 +99,7 @@ Time Redirect "log" Compute
 Time Redirect "log" Compute
   (Pipeline.BoundsPipelineToString
      "fiat_" "fiat_addcarryx_u64"
-        true true None [1; 64; 128] 64
+        true true [1; 64; 128] 64
         ltac:(let r := Reify (addcarryx 64) in
               exact r)
                (fun _ _ => [])
@@ -111,7 +112,7 @@ Time Redirect "log" Compute
 Time Redirect "log" Compute
   (Pipeline.BoundsPipelineToString
      "fiat_" "fiat_addcarryx_u51"
-        true true None [1; 64; 128] 64
+        true true [1; 64; 128] 64
         ltac:(let r := Reify (addcarryx 51) in
               exact r)
                (fun _ _ => [])
@@ -124,7 +125,7 @@ Time Redirect "log" Compute
 Time Redirect "log" Compute
   (Pipeline.BoundsPipelineToString
      "fiat_" "fiat_subborrowx_u64"
-        true true None [1; 64; 128] 64
+        true true [1; 64; 128] 64
         ltac:(let r := Reify (subborrowx 64) in
               exact r)
                (fun _ _ => [])
@@ -136,7 +137,7 @@ Time Redirect "log" Compute
 Time Redirect "log" Compute
   (Pipeline.BoundsPipelineToString
      "fiat_" "fiat_subborrowx_u51"
-        true true None [1; 64; 128] 64
+        true true [1; 64; 128] 64
         ltac:(let r := Reify (subborrowx 51) in
               exact r)
                (fun _ _ => [])
@@ -149,7 +150,7 @@ Time Redirect "log" Compute
 Time Redirect "log" Compute
   (Pipeline.BoundsPipelineToString
      "fiat_" "fiat_cmovznz64"
-        true true None [1; 64; 128] 64
+        true true [1; 64; 128] 64
         ltac:(let r := Reify (cmovznz 64) in
               exact r)
                (fun _ _ => [])

--- a/src/PushButtonSynthesis/UnsaturatedSolinas.v
+++ b/src/PushButtonSynthesis/UnsaturatedSolinas.v
@@ -179,6 +179,7 @@ Section __.
   Let possible_values := possible_values_of_machine_wordsize.
   Let possible_values_with_bytes := possible_values_of_machine_wordsize_with_bytes.
 
+  Local Existing Instance default_translate_to_fancy.
   Local Instance no_select_size : no_select_size_opt := no_select_size_of_no_select machine_wordsize.
   Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
   Local Instance split_multiret_to : split_multiret_to_opt := split_multiret_to_of_should_split_multiret machine_wordsize possible_values.
@@ -325,7 +326,6 @@ Section __.
   Definition carry_mul
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_carry_mul_gen
             @ GallinaReify.Reify (Qnum limbwidth) @ GallinaReify.Reify (Z.pos (Qden limbwidth)) @ GallinaReify.Reify s @ GallinaReify.Reify c @ GallinaReify.Reify n @ GallinaReify.Reify idxs)
@@ -344,7 +344,6 @@ Section __.
   Definition carry_square
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_carry_square_gen
             @ GallinaReify.Reify (Qnum limbwidth) @ GallinaReify.Reify (Z.pos (Qden limbwidth)) @ GallinaReify.Reify s @ GallinaReify.Reify c @ GallinaReify.Reify n @ GallinaReify.Reify idxs)
@@ -363,7 +362,6 @@ Section __.
   Definition carry_scmul_const (x : Z)
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_carry_scmul_gen
             @ GallinaReify.Reify (Qnum limbwidth) @ GallinaReify.Reify (Z.pos (Qden limbwidth)) @ GallinaReify.Reify s @ GallinaReify.Reify c @ GallinaReify.Reify n @ GallinaReify.Reify idxs @ GallinaReify.Reify x)
@@ -382,7 +380,6 @@ Section __.
   Definition carry
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_carry_gen
             @ GallinaReify.Reify (Qnum limbwidth) @ GallinaReify.Reify (Z.pos (Qden limbwidth)) @ GallinaReify.Reify s @ GallinaReify.Reify c @ GallinaReify.Reify n @ GallinaReify.Reify idxs)
@@ -401,7 +398,6 @@ Section __.
   Definition add
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_add_gen
             @ GallinaReify.Reify (Qnum limbwidth) @ GallinaReify.Reify (Z.pos (Qden limbwidth)) @ GallinaReify.Reify n)
@@ -420,7 +416,6 @@ Section __.
   Definition sub
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_sub_gen
             @ GallinaReify.Reify (Qnum limbwidth) @ GallinaReify.Reify (Z.pos (Qden limbwidth)) @ GallinaReify.Reify n @ GallinaReify.Reify balance)
@@ -439,7 +434,6 @@ Section __.
   Definition opp
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_opp_gen
             @ GallinaReify.Reify (Qnum limbwidth) @ GallinaReify.Reify (Z.pos (Qden limbwidth)) @ GallinaReify.Reify n @ GallinaReify.Reify balance)
@@ -458,7 +452,6 @@ Section __.
   Definition carry_add
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_carry_add_gen
             @ GallinaReify.Reify (Qnum limbwidth) @ GallinaReify.Reify (Z.pos (Qden limbwidth)) @ GallinaReify.Reify s @ GallinaReify.Reify c @ GallinaReify.Reify n @ GallinaReify.Reify idxs)
@@ -477,7 +470,6 @@ Section __.
   Definition carry_sub
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_carry_sub_gen
             @ GallinaReify.Reify (Qnum limbwidth) @ GallinaReify.Reify (Z.pos (Qden limbwidth)) @ GallinaReify.Reify s @ GallinaReify.Reify c @ GallinaReify.Reify n @ GallinaReify.Reify idxs @ GallinaReify.Reify balance)
@@ -496,7 +488,6 @@ Section __.
   Definition carry_opp
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_carry_opp_gen
             @ GallinaReify.Reify (Qnum limbwidth) @ GallinaReify.Reify (Z.pos (Qden limbwidth)) @ GallinaReify.Reify s @ GallinaReify.Reify c @ GallinaReify.Reify n @ GallinaReify.Reify idxs @ GallinaReify.Reify balance)
@@ -515,7 +506,6 @@ Section __.
   Definition relax
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          reified_id_gen
          (Some tight_bounds, tt)
@@ -533,7 +523,6 @@ Section __.
   Definition to_bytes
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         None (* fancy *)
          possible_values_with_bytes
          (reified_to_bytes_gen
             @ GallinaReify.Reify (Qnum limbwidth) @ GallinaReify.Reify (Z.pos (Qden limbwidth)) @ GallinaReify.Reify s @ GallinaReify.Reify n @ GallinaReify.Reify (machine_wordsize:Z) @ GallinaReify.Reify m_enc)
@@ -552,7 +541,6 @@ Section __.
   Definition from_bytes
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         None (* fancy *)
          possible_values_with_bytes
          (reified_from_bytes_gen
             @ GallinaReify.Reify (Qnum limbwidth) @ GallinaReify.Reify (Z.pos (Qden limbwidth)) @ GallinaReify.Reify s @ GallinaReify.Reify n)
@@ -571,7 +559,6 @@ Section __.
   Definition encode
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_encode_gen
             @ GallinaReify.Reify (Qnum limbwidth) @ GallinaReify.Reify (Z.pos (Qden limbwidth)) @ GallinaReify.Reify s @ GallinaReify.Reify c @ GallinaReify.Reify n)
@@ -590,7 +577,6 @@ Section __.
   Definition encode_word
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_encode_gen
             @ GallinaReify.Reify (Qnum limbwidth) @ GallinaReify.Reify (Z.pos (Qden limbwidth)) @ GallinaReify.Reify s @ GallinaReify.Reify c @ GallinaReify.Reify n)
@@ -609,7 +595,6 @@ Section __.
   Definition zero
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_zero_gen
             @ GallinaReify.Reify (Qnum limbwidth) @ GallinaReify.Reify (Z.pos (Qden limbwidth)) @ GallinaReify.Reify s @ GallinaReify.Reify c @ GallinaReify.Reify n)
@@ -628,7 +613,6 @@ Section __.
   Definition one
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_one_gen
             @ GallinaReify.Reify (Qnum limbwidth) @ GallinaReify.Reify (Z.pos (Qden limbwidth)) @ GallinaReify.Reify s @ GallinaReify.Reify c @ GallinaReify.Reify n)
@@ -650,7 +634,6 @@ Section __.
          (Pipeline.PreBoundsPipeline
             true (* subst01 *)
             false (* let_bind_return *)
-            None (* fancy *)
             (reified_eval_gen
                @ GallinaReify.Reify (Qnum limbwidth) @ GallinaReify.Reify (Z.pos (Qden limbwidth)) @ GallinaReify.Reify n)
             (Some loose_bounds, tt)).
@@ -664,7 +647,6 @@ Section __.
          (Pipeline.PreBoundsPipeline
             true (* subst01 *)
             false (* let_bind_return *)
-            None (* fancy *)
             (reified_bytes_eval_gen
                @ GallinaReify.Reify s)
             (Some prime_bytes_bounds, tt)).

--- a/src/PushButtonSynthesis/WordByWordMontgomery.v
+++ b/src/PushButtonSynthesis/WordByWordMontgomery.v
@@ -201,6 +201,7 @@ Section __.
          ; description name := (text_before_type_name ++ name ++ " is a field element NOT in the Montgomery domain.")%string }.
 
 
+  Local Existing Instance default_translate_to_fancy.
   Local Instance no_select_size : no_select_size_opt := no_select_size_of_no_select machine_wordsize.
   Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
   Local Instance split_multiret_to : split_multiret_to_opt := split_multiret_to_of_should_split_multiret machine_wordsize possible_values.
@@ -308,7 +309,6 @@ Section __.
   Definition mul
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_mul_gen
             @ GallinaReify.Reify (machine_wordsize:Z) @ GallinaReify.Reify n @ GallinaReify.Reify m @ GallinaReify.Reify m')
@@ -328,7 +328,6 @@ Section __.
   Definition square
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_square_gen
             @ GallinaReify.Reify (machine_wordsize:Z) @ GallinaReify.Reify n @ GallinaReify.Reify m @ GallinaReify.Reify m')
@@ -348,7 +347,6 @@ Section __.
   Definition add
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_add_gen
             @ GallinaReify.Reify (machine_wordsize:Z) @ GallinaReify.Reify n @ GallinaReify.Reify m)
@@ -368,7 +366,6 @@ Section __.
   Definition sub
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_sub_gen
             @ GallinaReify.Reify (machine_wordsize:Z) @ GallinaReify.Reify n @ GallinaReify.Reify m)
@@ -388,7 +385,6 @@ Section __.
   Definition opp
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_opp_gen
             @ GallinaReify.Reify (machine_wordsize:Z) @ GallinaReify.Reify n @ GallinaReify.Reify m)
@@ -408,7 +404,6 @@ Section __.
   Definition from_montgomery
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_from_montgomery_gen
             @ GallinaReify.Reify (machine_wordsize:Z) @ GallinaReify.Reify n @ GallinaReify.Reify m @ GallinaReify.Reify m')
@@ -428,7 +423,6 @@ Section __.
   Definition to_montgomery
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_to_montgomery_gen
             @ GallinaReify.Reify (machine_wordsize:Z) @ GallinaReify.Reify n @ GallinaReify.Reify m @ GallinaReify.Reify m')
@@ -448,7 +442,6 @@ Section __.
   Definition nonzero
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          reified_nonzero_gen
          (Some bounds, tt)
@@ -467,7 +460,6 @@ Section __.
   Definition to_bytes
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         None (* fancy *)
          possible_values_with_bytes
          (reified_to_bytes_gen
             @ GallinaReify.Reify (machine_wordsize:Z) @ GallinaReify.Reify n @ GallinaReify.Reify m)
@@ -487,7 +479,6 @@ Section __.
   Definition from_bytes
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         None (* fancy *)
          possible_values_with_bytes
          (reified_from_bytes_gen
             @ GallinaReify.Reify (machine_wordsize:Z) @ GallinaReify.Reify 1 @ GallinaReify.Reify s @ GallinaReify.Reify n)
@@ -507,7 +498,6 @@ Section __.
   Definition encode
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_encode_gen
             @ GallinaReify.Reify (machine_wordsize:Z) @ GallinaReify.Reify n @ GallinaReify.Reify m @ GallinaReify.Reify m')
@@ -528,7 +518,6 @@ Section __.
   Definition encode_word
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_encode_gen
             @ GallinaReify.Reify (machine_wordsize:Z) @ GallinaReify.Reify n @ GallinaReify.Reify m @ GallinaReify.Reify m')
@@ -548,7 +537,6 @@ Section __.
   Definition zero
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_zero_gen
             @ GallinaReify.Reify (machine_wordsize:Z) @ GallinaReify.Reify n @ GallinaReify.Reify m @ GallinaReify.Reify m')
@@ -568,7 +556,6 @@ Section __.
   Definition one
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_one_gen
             @ GallinaReify.Reify (machine_wordsize:Z) @ GallinaReify.Reify n @ GallinaReify.Reify m @ GallinaReify.Reify m')
@@ -591,7 +578,6 @@ Section __.
          (Pipeline.PreBoundsPipeline
             true (* subst01 *)
             false (* let_bind_return *)
-            None (* fancy *)
             (reified_eval_gen
                @ GallinaReify.Reify (machine_wordsize:Z) @ GallinaReify.Reify n)
             (Some montgomery_domain_bounds, tt)).
@@ -605,7 +591,6 @@ Section __.
          (Pipeline.PreBoundsPipeline
             true (* subst01 *)
             false (* let_bind_return *)
-            None (* fancy *)
             (reified_bytes_eval_gen
                @ GallinaReify.Reify s)
             (Some prime_bytes_bounds, tt)).
@@ -619,7 +604,6 @@ Section __.
          (Pipeline.PreBoundsPipeline
             true (* subst01 *)
             false (* let_bind_return *)
-            None (* fancy *)
             (reified_eval_twos_complement_gen
                @ GallinaReify.Reify (machine_wordsize:Z)
                @ GallinaReify.Reify n)
@@ -641,7 +625,6 @@ Section __.
   Definition msat
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_msat_gen
             @ GallinaReify.Reify (machine_wordsize:Z) @ GallinaReify.Reify sat_limbs @ GallinaReify.Reify m)
@@ -661,7 +644,6 @@ Section __.
   Definition divstep_precomp
     := Pipeline.BoundsPipeline
          true (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_encode_gen
             @ GallinaReify.Reify (machine_wordsize:Z) @ GallinaReify.Reify n @ GallinaReify.Reify m @ GallinaReify.Reify m' @ GallinaReify.Reify divstep_precompmod)
@@ -681,7 +663,6 @@ Section __.
   Definition divstep
     := Pipeline.BoundsPipeline
          false (* subst01 *)
-         None (* fancy *)
          possible_values
          (reified_divstep_gen
             @ GallinaReify.Reify (machine_wordsize:Z) @ GallinaReify.Reify sat_limbs @ GallinaReify.Reify n @ GallinaReify.Reify m)

--- a/src/SlowPrimeSynthesisExamples.v
+++ b/src/SlowPrimeSynthesisExamples.v
@@ -36,6 +36,7 @@ Local Coercion Z.of_nat : nat >-> Z.
 Local Coercion QArith_base.inject_Z : Z >-> Q.
 Local Coercion Z.pos : positive >-> Z.
 
+Local Existing Instance default_translate_to_fancy.
 Local Existing Instance default_low_level_rewriter_method.
 Local Existing Instance AbstractInterpretation.default_Options.
 Local Instance : unfold_value_barrier_opt := true.
@@ -425,7 +426,7 @@ Module debugging_21271_from_bytes.
       clear v.
       cbv [from_bytes] in k.
       cbv [Pipeline.BoundsPipeline] in k.
-      set (k' := Pipeline.PreBoundsPipeline _ _ _ _ _) in (value of k).
+      set (k' := Pipeline.PreBoundsPipeline _ _ _ _) in (value of k).
       vm_compute in k'.
       cbv [Rewriter.Util.LetIn.Let_In] in k.
       set (k'' := CheckedPartialEvaluateWithBounds _ _ _ _ _ _ _) in (value of k).
@@ -533,7 +534,6 @@ Module debugging_sat_solinas_25519.
             "fiat" "mul"
             false (* subst01 *)
             false (* inline *)
-            None (* fancy *)
             possible_values
             machine_wordsize
             ltac:(let n := (eval cbv in n) (* needs to be reduced to reify correctly *) in
@@ -752,7 +752,6 @@ Module debugging_sat_solinas_25519_expanded_straightforward.
             "fiat" "mul"
             false (* subst01 *)
             false (* inline *)
-            None (* fancy *)
             possible_values
             machine_wordsize
             ltac:(let n := (eval cbv in n) (* needs to be reduced to reify correctly *) in
@@ -974,7 +973,6 @@ Module debugging_sat_solinas_25519_expanded.
             "fiat" "mul"
             false (* subst01 *)
             false (* inline *)
-            None (* fancy *)
             possible_values
             machine_wordsize
             ltac:(let n := (eval cbv in n) (* needs to be reduced to reify correctly *) in
@@ -3068,7 +3066,6 @@ Module debugging_remove_mul_split_to_C_uint1_carry.
       "mul"
       false (* subst01 *)
       false (* inline *)
-      None (* fancy *)
       possible_values
       machine_wordsize
       ltac:(let r := Reify ((fun f g => dlet _ := ident.comment ("foo", f, g) in carry_mulmod limbwidth_num limbwidth_den s c n idxs f g)) in
@@ -3376,7 +3373,6 @@ Module debugging_remove_mul_split.
     Redirect "log" Compute
       Pipeline.BoundsPipeline
       false (* subst01 *)
-      None (* fancy *)
       possible_values
       ltac:(let r := Reify ((carry_mulmod limbwidth_num limbwidth_den s c n idxs)) in
             exact r)
@@ -3788,7 +3784,6 @@ Module debugging_remove_mul_split2.
       false (* subst01 *)
       false (* inline *)
       None
-      None (* fancy *)
       possible_values
       foo
       (fun _ _ => []) (* comment *)
@@ -3871,7 +3866,7 @@ Module debugging_rewriting.
 
     Redirect "log" Compute
       (Pipeline.BoundsPipeline
-         true None [64; 128]
+         true [64; 128]
          ltac:(let r := Reify (fun f g
                                => (  (addmod limbwidth_num limbwidth_den n f g)
                               )) in
@@ -3881,7 +3876,7 @@ Module debugging_rewriting.
 
     Redirect "log" Compute
       (Pipeline.BoundsPipeline
-         true None [64; 128]
+         true [64; 128]
          ltac:(let r := Reify (fun f g
                                => (  (add (weight limbwidth_num limbwidth_den) n f g)
                               )) in
@@ -3891,7 +3886,7 @@ Module debugging_rewriting.
 
     Redirect "log" Compute
       (Pipeline.BoundsPipeline
-         true None [64; 128]
+         true [64; 128]
          ltac:(let r := Reify (fun f g
                                => let a_a := to_associational (weight limbwidth_num limbwidth_den) n f in
                                   let b_a := to_associational (weight limbwidth_num limbwidth_den) n g in from_associational (weight limbwidth_num limbwidth_den) n (a_a ++ b_a)
@@ -3902,7 +3897,7 @@ Module debugging_rewriting.
 
     Redirect "log" Compute
       (Pipeline.BoundsPipeline
-         true None [64; 128]
+         true [64; 128]
          ltac:(let r := Reify (fun f (g : list Z)
                                => let a_a := to_associational (weight limbwidth_num limbwidth_den) n f in
                                   a_a) in
@@ -3912,7 +3907,7 @@ Module debugging_rewriting.
 
     Redirect "log" Compute
       (Pipeline.BoundsPipeline
-         true None [64; 128]
+         true [64; 128]
          ltac:(let r := Reify (fun (f g : list Z)
                                => let a_a := combine (map (weight limbwidth_num limbwidth_den) (seq 0 n)) f in
                                   a_a) in
@@ -3921,7 +3916,7 @@ Module debugging_rewriting.
                 ZRange.type.base.option.None).
 
     Definition foo := (Pipeline.BoundsPipeline
-                         true None [64; 128]
+                         true [64; 128]
                          ltac:(let r := Reify (combine [1; 2] [1; 2]) in
                                exact r)
                                 tt
@@ -3981,7 +3976,7 @@ Section debugging_p448.
   Redirect "log" Print squaremod.
   Time Redirect "log" Compute
      (Pipeline.BoundsPipeline
-        true None [64; 128]
+        true [64; 128]
         ltac:(let r := Reify (fun f
                               => (  (squaremod (weight limbwidth_num limbwidth_den) s c n f)
                                     )) in
@@ -3995,7 +3990,6 @@ Section debugging_p448.
        "mul"
        false (* subst01 *)
        false (* inline *)
-       None (* fancy *)
        possible_values machine_wordsize
        ltac:(let r := Reify ((carry_mulmod limbwidth_num limbwidth_den s c n [3; 7; 4; 0; 5; 1; 6; 2; 7; 3; 4; 0]%nat)) in
              exact r)
@@ -4009,7 +4003,6 @@ Section debugging_p448.
   Time Redirect "log" Compute
        Pipeline.BoundsPipeline
        false (* subst01 *)
-       None (* fancy *)
        possible_values
        ltac:(let r := Reify ((carry_mulmod limbwidth_num limbwidth_den s c n [3; 7; 4; 0; 5; 1; 6; 2; 7; 3; 4; 0]%nat)) in
              exact r)
@@ -4018,7 +4011,7 @@ Section debugging_p448.
 
   Time Redirect "log" Compute
      (Pipeline.BoundsPipeline
-        true None [64; 128]
+        true [64; 128]
         ltac:(let r := Reify ((carry_mulmod limbwidth_num limbwidth_den s c n [3; 7; 4; 0; 5; 1; 6; 2; 7; 3; 4; 0]%nat)) in
               exact r)
                (Some (repeat (@None _) n), (Some (repeat (@None _) n), tt))
@@ -4026,7 +4019,7 @@ Section debugging_p448.
 
   Time Redirect "log" Compute
      (Pipeline.BoundsPipeline
-        true None [64; 128]
+        true [64; 128]
         ltac:(let r := Reify ((carry_mulmod limbwidth_num limbwidth_den s c n []%nat)) in
               exact r)
                (Some (repeat (@None _) n), (Some (repeat (@None _) n), tt))
@@ -4034,7 +4027,7 @@ Section debugging_p448.
 
   Time Redirect "log" Compute
      (Pipeline.BoundsPipeline
-        true None [64; 128]
+        true [64; 128]
         ltac:(let r := Reify (fun f g
                               => (  (mulmod (weight limbwidth_num limbwidth_den) s c n f g)
                                     )) in
@@ -4044,7 +4037,7 @@ Section debugging_p448.
 
   Time Redirect "log" Compute
      (Pipeline.BoundsPipeline
-        true None [64; 128]
+        true [64; 128]
         ltac:(let r := Reify (fun a b
                               => (let weight := weight limbwidth_num limbwidth_den in
                                   let a_a := to_associational weight n a in


### PR DESCRIPTION
They were explicit because they predated the implicit typeclass way of passing options.  Since the fancy argument does not change within a single file, there's no reason to make it easy to set and clog up the pipeline invocations.