### PR TITLE
Reorganize pipeline options to allow for easier additions to them

### DIFF
--- a/src/Bedrock/End2End/Poly1305/Field1305.v
+++ b/src/Bedrock/End2End/Poly1305/Field1305.v
@@ -17,7 +17,6 @@ Section Field.
 
   Existing Instances Defaults32.default_parameters
            Defaults32.default_parameters_ok.
-  Existing Instances no_select_size split_mul_to split_multiret_to.
   Definition prefix : string := "fe1305_"%string.
 
   (* Define Poly1305 field *)

--- a/src/Bedrock/End2End/X25519/Field25519.v
+++ b/src/Bedrock/End2End/X25519/Field25519.v
@@ -14,8 +14,6 @@ Import ListNotations.
 #[export]
 Existing Instances Naive.word Naive.word32_ok BW32.
 #[export]
-Existing Instances no_select_size split_mul_to split_multiret_to.
-#[export]
 Existing Instances SortedListWord.map SortedListWord.ok.
 
 (* Parameters for Curve25519 field (32-bit machine). *)

--- a/src/Bedrock/Field/Synthesis/Examples/p224_64_new.v
+++ b/src/Bedrock/Field/Synthesis/Examples/p224_64_new.v
@@ -28,7 +28,6 @@ Section Field.
 
   Existing Instances Defaults32.default_parameters
            Defaults32.default_parameters_ok.
-  Existing Instances no_select_size split_mul_to split_multiret_to.
   Definition prefix : string := "p224_"%string.
 
   (* Define p224 field *)

--- a/src/Bedrock/Field/Synthesis/Generic/UnsaturatedSolinas.v
+++ b/src/Bedrock/Field/Synthesis/Generic/UnsaturatedSolinas.v
@@ -74,7 +74,7 @@ Ltac apply_correctness_in H :=
   | context [UnsaturatedSolinas.opp] =>
     eapply UnsaturatedSolinas.opp_correct in H
   | context [UnsaturatedSolinas.selectznz] =>
-    eapply Primitives.selectznz_correct in H
+    eapply UnsaturatedSolinas.selectznz_correct in H
   | context [UnsaturatedSolinas.to_bytes] =>
     eapply UnsaturatedSolinas.to_bytes_correct in H
   | context [UnsaturatedSolinas.from_bytes] =>
@@ -208,8 +208,6 @@ Section __.
   Proof.
     make_operation (UnsaturatedSolinas.selectznz n width).
     prove_operation_correctness.
-    Unshelve.
-    { apply width. }
   Defined.
 
   Definition to_bytes

--- a/src/Bedrock/Field/Synthesis/Generic/WordByWordMontgomery.v
+++ b/src/Bedrock/Field/Synthesis/Generic/WordByWordMontgomery.v
@@ -79,7 +79,7 @@ Ltac apply_correctness_in H :=
   | context [WordByWordMontgomery.nonzero] =>
     eapply WordByWordMontgomery.nonzero_correct in H
   | context [WordByWordMontgomery.selectznz] =>
-    eapply Primitives.selectznz_correct in H
+    eapply WordByWordMontgomery.selectznz_correct in H
   | context [WordByWordMontgomery.to_bytes] =>
     eapply WordByWordMontgomery.to_bytes_correct in H
   | context [WordByWordMontgomery.from_bytes] =>
@@ -226,8 +226,6 @@ Section __.
   Proof.
     make_operation (WordByWordMontgomery.selectznz m width).
     prove_operation_correctness.
-    Unshelve.
-    { apply width. }
   Defined.
 
   Definition to_bytes

--- a/src/Bedrock/Field/Synthesis/New/UnsaturatedSolinas.v
+++ b/src/Bedrock/Field/Synthesis/New/UnsaturatedSolinas.v
@@ -633,7 +633,6 @@ Section Tests.
   Definition c := [(1, 19)]%Z.
 
   Existing Instances Defaults64.default_parameters default_parameters_ok.
-  Existing Instances no_select_size split_mul_to split_multiret_to.
   Definition prefix : string := "fe25519_"%string.
 
   Instance field_parameters : FieldParameters.

--- a/src/Bedrock/Field/Synthesis/New/WordByWordMontgomery.v
+++ b/src/Bedrock/Field/Synthesis/New/WordByWordMontgomery.v
@@ -770,7 +770,6 @@ Require Import bedrock2.ProgramLogic.
   Definition prefix : string := "p224_"%string.
 
   Existing Instances Defaults64.default_parameters default_parameters_ok.
-  Existing Instances no_select_size split_mul_to split_multiret_to.
   Definition n := Eval vm_compute in (WordByWordMontgomery.n m machine_wordsize).
 
   Instance field_parameters : FieldParameters.

--- a/src/Bedrock/Field/Translation/Parameters/Defaults.v
+++ b/src/Bedrock/Field/Translation/Parameters/Defaults.v
@@ -5,9 +5,11 @@ Require Import coqutil.Word.Interface.
 Require Import bedrock2.Syntax.
 Require Import Crypto.Bedrock.Field.Common.Types.
 Require Import Crypto.BoundsPipeline.
+Require Import Crypto.PushButtonSynthesis.Primitives.
 Require Import Crypto.UnsaturatedSolinasHeuristics.
 Require Crypto.Util.Strings.Decimal.
 Require Import Crypto.Util.Strings.String.
+Import ListNotations.
 
 (* Declares default parameters for the bedrock2 backend that apply to all
    machine word sizes. Do NOT import this file unless you're prepared to have a
@@ -16,30 +18,29 @@ Require Import Crypto.Util.Strings.String.
 (* use in-memory lists; local ones are only used internally *)
 Global Existing Instances Types.rep.Z Types.rep.listZ_mem.
 
-(* Reification/bounds pipeline options *)
-Global Existing Instance default_low_level_rewriter_method.
-(* Output options involving typedefs, carry bounds, etc, which are generally not relevant to bedrock2 *)
-Global Existing Instance default_output_options.
-(* Abstract interpretation options; currently only involving (>>) uint1 bounds, which is not relevant to bedrock2 *)
-Global Instance : AbstractInterpretation.Options
-  := let _ := AbstractInterpretation.default_Options in
-     {| AbstractInterpretation.shiftr_avoid_uint1 := false (* we need to not avoid uint1 to pass bounds analysis tightness, for some reason? *) |}.
-(* Split multiplications into two outputs, not just one huge word *)
-Global Instance should_split_mul : should_split_mul_opt := true.
-(* For functions that return multiple values, split into two LetIns (this is
+Global Instance pipeline_opts : PipelineOptions :=
+  let _ := default_PipelineOptions in
+  {| (* Abstract interpretation options; currently only involving (>>) uint1 bounds, which is not relevant to bedrock2 *)
+    absint_opts :=
+    {| AbstractInterpretation.shiftr_avoid_uint1 := false (* we need to not avoid uint1 to pass bounds analysis tightness, for some reason? *) |}
+  (* Split multiplications into two outputs, not just one huge word *)
+  ; should_split_mul := true
+  (* For functions that return multiple values, split into two LetIns (this is
      because bedrock2 does not support multiple-sets, so they would have to be
      split anyway) *)
-Global Instance should_split_multiret : should_split_multiret_opt := true.
-(* Make all words full-size, even if they could be smaller *)
-Global Instance widen_carry : widen_carry_opt := true.
-Global Instance widen_bytes : widen_bytes_opt := true.
-(* Unsigned integers *)
-Global Instance only_signed : only_signed_opt := false.
-(* Rewrite selects into expressions that don't require cmov *)
-Global Instance no_select : no_select_opt := true.
+  ; should_split_multiret := true
+  (* Make all words full-size, even if they could be smaller *)
+  ; widen_carry := true
+  ; widen_bytes := true
+  (* Unsigned integers *)
+  ; only_signed := false
+  (* Rewrite selects into expressions that don't require cmov *)
+  ; no_select := true
+  (* We don't handle value_barrier in bedrock2 *)
+  ; unfold_value_barrier := true
+  |}.
+
 Global Instance tight_upperbound_fraction : tight_upperbound_fraction_opt := default_tight_upperbound_fraction.
-(* We don't handle value_barrier in bedrock2 *)
-Global Instance unfold_value_barrier : unfold_value_barrier_opt := true.
 
 (* bedrock2 backend parameters *)
 Global Existing Instances Types.rep.Z Types.rep.listZ_mem.

--- a/src/Bedrock/Field/Translation/Parameters/Defaults32.v
+++ b/src/Bedrock/Field/Translation/Parameters/Defaults32.v
@@ -23,15 +23,6 @@ a 32-bit word size. *)
 Section Defaults_32.
   Definition machine_wordsize := 32.
 
-  (* Define how to split mul/multi-return functions *)
-  Definition possible_values
-    := prefix_with_carry [machine_wordsize; 2 * machine_wordsize]%Z.
-  Instance no_select_size : no_select_size_opt :=
-    no_select_size_of_no_select machine_wordsize.
-  Instance split_mul_to : split_mul_to_opt :=
-    split_mul_to_of_should_split_mul machine_wordsize possible_values.
-  Instance split_multiret_to : split_multiret_to_opt :=
-    split_multiret_to_of_should_split_multiret machine_wordsize possible_values.
   Let wordsize_bytes := Eval vm_compute in (machine_wordsize / 8)%Z.
   Instance default_parameters : Types.parameters
     (word := BasicC32Semantics.word)

--- a/src/Bedrock/Field/Translation/Parameters/Defaults64.v
+++ b/src/Bedrock/Field/Translation/Parameters/Defaults64.v
@@ -23,15 +23,6 @@ a 64-bit word size. *)
 Section Defaults_64.
   Definition machine_wordsize := 64.
 
-  (* Define how to split mul/multi-return functions *)
-  Definition possible_values
-    := prefix_with_carry [machine_wordsize; 2 * machine_wordsize]%Z.
-  Instance no_select_size : no_select_size_opt :=
-    no_select_size_of_no_select machine_wordsize.
-  Instance split_mul_to : split_mul_to_opt :=
-    split_mul_to_of_should_split_mul machine_wordsize possible_values.
-  Instance split_multiret_to : split_multiret_to_opt :=
-    split_multiret_to_of_should_split_multiret machine_wordsize possible_values.
   Let wordsize_bytes := Eval vm_compute in (machine_wordsize / 8)%Z.
   Instance default_parameters : Types.parameters
     (word := BasicC64Semantics.word)

--- a/src/Bedrock/Field/Translation/Parameters/FE310.v
+++ b/src/Bedrock/Field/Translation/Parameters/FE310.v
@@ -25,15 +25,6 @@ a 32-bit word size. *)
 Section Defaults_32.
   Definition machine_wordsize := 32.
 
-  (* Define how to split mul/multi-return functions *)
-  Definition possible_values
-    := prefix_with_carry [machine_wordsize; 2 * machine_wordsize]%Z.
-  Instance no_select_size : no_select_size_opt :=
-    no_select_size_of_no_select machine_wordsize.
-  Instance split_mul_to : split_mul_to_opt :=
-    split_mul_to_of_should_split_mul machine_wordsize possible_values.
-  Instance split_multiret_to : split_multiret_to_opt :=
-    split_multiret_to_of_should_split_multiret machine_wordsize possible_values.
   Let wordsize_bytes := Eval vm_compute in (machine_wordsize / 8)%Z.
 
   Instance default_parameters : Types.parameters

--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -302,6 +302,63 @@ Definition typedef_info_of_typedef {relax_zrange : relax_zrange_opt} {t bounds} 
 
 Module Pipeline.
   Import GeneralizeVar.
+
+  Class BoundsPipelineOptions :=
+    { AbstractInterpretation_opts : AbstractInterpretation.Options
+    ; low_level_rewriter_method : low_level_rewriter_method_opt
+    ; only_signed : only_signed_opt
+    ; no_select_size : no_select_size_opt
+    ; split_mul_to : split_mul_to_opt
+    ; split_multiret_to : split_multiret_to_opt
+    ; unfold_value_barrier : unfold_value_barrier_opt
+    ; relax_adc_sbb_return_carry_to_bitwidth : relax_adc_sbb_return_carry_to_bitwidth_opt
+    ; translate_to_fancy : translate_to_fancy_opt
+    ; with_dead_code_elimination : bool := true
+    ; with_let_bind_return : bool := true
+    (** convert adc/sbb which generates no carry to add/sub iff we're not fancy *)
+    ; adc_no_carry_to_add := match translate_to_fancy with Some _ => false | None => true end
+    }.
+  Definition default_BoundsPipelineOptions : BoundsPipelineOptions :=
+    {| AbstractInterpretation_opts := AbstractInterpretation.default_Options
+    ; low_level_rewriter_method := default_low_level_rewriter_method
+    ; only_signed := false
+    ; no_select_size := None
+    ; split_mul_to := None
+    ; split_multiret_to := None
+    ; unfold_value_barrier := true
+    ; relax_adc_sbb_return_carry_to_bitwidth := []
+    ; translate_to_fancy := default_translate_to_fancy
+    |}.
+
+  Global Existing Instances
+         Build_BoundsPipelineOptions
+         AbstractInterpretation_opts
+         low_level_rewriter_method
+         only_signed
+         no_select_size
+         split_mul_to
+         split_multiret_to
+         unfold_value_barrier
+         relax_adc_sbb_return_carry_to_bitwidth
+         translate_to_fancy
+  .
+  #[global]
+   Hint Cut [
+      ( _ * )
+        (AbstractInterpretation_opts
+        | low_level_rewriter_method
+        | only_signed
+        | no_select_size
+        | split_mul_to
+        | split_multiret_to
+        | unfold_value_barrier
+        | relax_adc_sbb_return_carry_to_bitwidth
+        | translate_to_fancy
+        ) ( _ * )
+        (Build_BoundsPipelineOptions
+        )
+    ] : typeclass_instances.
+
   Inductive ErrorMessage :=
   | Computed_bounds_are_not_tight_enough
       {t} (computed_bounds expected_bounds : ZRange.type.base.option.interp (type.final_codomain t))
@@ -598,22 +655,10 @@ Module Pipeline.
        List.fold_right (fun f v => f v) E (List.repeat (RewriteRules.RewriteAddAssocLeft opts) n).
 
   Definition BoundsPipeline
-             {opts : AbstractInterpretation.Options}
-             {low_level_rewriter_method : low_level_rewriter_method_opt}
-             {only_signed : only_signed_opt}
-             {no_select_size : no_select_size_opt}
-             {split_mul_to : split_mul_to_opt}
-             {split_multiret_to : split_multiret_to_opt}
-             {unfold_value_barrier : unfold_value_barrier_opt}
-             {relax_adc_sbb_return_carry_to_bitwidth : relax_adc_sbb_return_carry_to_bitwidth_opt}
-             {translate_to_fancy : translate_to_fancy_opt}
-             (with_dead_code_elimination : bool := true)
+             {opts : BoundsPipelineOptions}
              (with_subst01 : bool)
-             (with_let_bind_return : bool := true)
              (possible_values : list Z)
              (relax_zrange := relax_zrange_gen only_signed possible_values)
-             ((** convert adc/sbb which generates no carry to add/sub iff we're not fancy *)
-               adc_no_carry_to_add := match translate_to_fancy with Some _ => false | None => true end)
              {t}
              (E : Expr t)
              arg_bounds
@@ -693,7 +738,7 @@ Module Pipeline.
       end.
 
   Definition BoundsPipelineToExtendedResult
-             {opts : AbstractInterpretation.Options}
+             {opts : BoundsPipelineOptions}
              {output_language_api : ToString.OutputLanguageAPI}
              {language_naming_conventions : language_naming_conventions_opt}
              {documentation_options : documentation_options_opt}
@@ -701,16 +746,8 @@ Module Pipeline.
              {internal_static : internal_static_opt}
              {static : static_opt}
              {all_static : static_opt}
-             {low_level_rewriter_method : low_level_rewriter_method_opt}
-             {only_signed : only_signed_opt}
-             {no_select_size : no_select_size_opt}
-             {split_mul_to : split_mul_to_opt}
-             {split_multiret_to : split_multiret_to_opt}
-             {unfold_value_barrier : unfold_value_barrier_opt}
-             {translate_to_fancy : translate_to_fancy_opt}
              (type_prefix : string)
              (name : string)
-             (with_dead_code_elimination : bool := true)
              (with_subst01 : bool)
              (inline : bool)
              (possible_values : list Z)
@@ -726,7 +763,6 @@ Module Pipeline.
              (out_typedefs : ToString.OfPHOAS.base_var_typedef_data (type.final_codomain t))
     : ErrorT (ExtendedSynthesisResult t)
     := dlet_nd E := BoundsPipeline
-                      (*with_dead_code_elimination*)
                       with_subst01
                       possible_values
                       E arg_bounds out_bounds in
@@ -742,7 +778,7 @@ Module Pipeline.
        end.
 
   Definition BoundsPipelineToStrings
-             {opts : AbstractInterpretation.Options}
+             {opts : BoundsPipelineOptions}
              {output_language_api : ToString.OutputLanguageAPI}
              {language_naming_conventions : language_naming_conventions_opt}
              {documentation_options : documentation_options_opt}
@@ -750,16 +786,8 @@ Module Pipeline.
              {internal_static : internal_static_opt}
              {static : static_opt}
              {all_static : static_opt}
-             {low_level_rewriter_method : low_level_rewriter_method_opt}
-             {only_signed : only_signed_opt}
-             {no_select_size : no_select_size_opt}
-             {split_mul_to : split_mul_to_opt}
-             {split_multiret_to : split_multiret_to_opt}
-             {unfold_value_barrier : unfold_value_barrier_opt}
-             {translate_to_fancy : translate_to_fancy_opt}
              (type_prefix : string)
              (name : string)
-             (with_dead_code_elimination : bool := true)
              (with_subst01 : bool)
              (inline : bool)
              (possible_values : list Z)
@@ -777,7 +805,6 @@ Module Pipeline.
     := let E := BoundsPipelineToExtendedResult
                   (static:=static) (all_static:=all_static)
                   type_prefix name
-                  (*with_dead_code_elimination*)
                   with_subst01
                   inline
                   possible_values
@@ -789,23 +816,15 @@ Module Pipeline.
        end.
 
   Definition BoundsPipelineToString
-             {opts : AbstractInterpretation.Options}
+             {opts : BoundsPipelineOptions}
              {output_language_api : ToString.OutputLanguageAPI}
              {language_naming_conventions : language_naming_conventions_opt}
              {documentation_options : documentation_options_opt}
              {output_options : output_options_opt}
              {internal_static : internal_static_opt}
              {static : static_opt}
-             {low_level_rewriter_method : low_level_rewriter_method_opt}
-             {only_signed : only_signed_opt}
-             {no_select_size : no_select_size_opt}
-             {split_mul_to : split_mul_to_opt}
-             {split_multiret_to : split_multiret_to_opt}
-             {unfold_value_barrier : unfold_value_barrier_opt}
-             {translate_to_fancy : translate_to_fancy_opt}
              (type_prefix : string)
              (name : string)
-             (with_dead_code_elimination : bool := true)
              (with_subst01 : bool)
              (inline : bool)
              (possible_values : list Z)
@@ -820,7 +839,6 @@ Module Pipeline.
     : ErrorT (string * ToString.ident_infos)
     := let E := BoundsPipelineToStrings
                   type_prefix name
-                  (*with_dead_code_elimination*)
                   with_subst01
                   inline
                   possible_values
@@ -862,16 +880,16 @@ Module Pipeline.
     end.
 
   Notation type_of_pipeline result
-    := ((fun a b c d e f g h i j possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c d e f g h i j possible_values t E arg_bounds out_bounds = result') => t) _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ result eq_refl)
+    := ((fun a b possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b possible_values t E arg_bounds out_bounds = result') => t) _ _ _ _ _ _ _ result eq_refl)
          (only parsing).
   Notation arg_bounds_of_pipeline result
-    := ((fun a b c d e f g h i j possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c d e f g h i j possible_values t E arg_bounds out_bounds = result') => arg_bounds) _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ result eq_refl)
+    := ((fun a b possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b possible_values t E arg_bounds out_bounds = result') => arg_bounds) _ _ _ _ _ _ _ result eq_refl)
          (only parsing).
   Notation out_bounds_of_pipeline result
-    := ((fun a b c d e f g h i j possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c d e f g h i j possible_values t E arg_bounds out_bounds = result') => out_bounds) _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ result eq_refl)
+    := ((fun a b possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b possible_values t E arg_bounds out_bounds = result') => out_bounds) _ _ _ _ _ _ _ result eq_refl)
          (only parsing).
   Notation possible_values_of_pipeline result
-    := ((fun a b c d e f g h i j possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b c d e f g h i j possible_values t E arg_bounds out_bounds = result') => possible_values) _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ result eq_refl)
+    := ((fun a b possible_values t E arg_bounds out_bounds result' (H : @Pipeline.BoundsPipeline a b possible_values t E arg_bounds out_bounds = result') => possible_values) _ _ _ _ _ _ _ result eq_refl)
          (only parsing).
   Notation arg_typedefs_via_tc_of_pipeline result
     := (match type_of_pipeline result, arg_bounds_of_pipeline result return _ with
@@ -1176,7 +1194,7 @@ Module Pipeline.
     rewrite (correct_of_final_iff_correct_of_initial Hinterp) by assumption.
     pose proof Hwf as Hwf'. (* keep an extra copy so it's not cleared *)
     cbv [translate_to_fancy_opt_correct] in *.
-    cbv beta delta [BoundsPipeline PreBoundsPipeline Let_In] in Hrv.
+    cbv beta iota delta [BoundsPipeline PreBoundsPipeline Let_In Pipeline.translate_to_fancy] in Hrv.
     fwd Hrv Hwf Hinterp; [ repeat fwd_side_condition_step .. | subst ].
     solve [ eauto using conj with nocore ].
   Qed.

--- a/src/BoundsPipeline.v
+++ b/src/BoundsPipeline.v
@@ -1159,17 +1159,8 @@ Module Pipeline.
           | progress destruct_head'_and ].
 
   Lemma BoundsPipeline_correct
-             {opts : AbstractInterpretation.Options}
-             {low_level_rewriter_method : low_level_rewriter_method_opt}
-             {only_signed : only_signed_opt}
-             {no_select_size : no_select_size_opt}
-             {split_mul_to : split_mul_to_opt}
-             {split_multiret_to : split_multiret_to_opt}
-             {unfold_value_barrier : unfold_value_barrier_opt}
-             {relax_adc_sbb_return_carry_to_bitwidth : relax_adc_sbb_return_carry_to_bitwidth_opt}
-             {translate_to_fancy : translate_to_fancy_opt}
+             {opts : BoundsPipelineOptions}
              {translate_to_fancy_correct : translate_to_fancy_opt_correct}
-             (with_dead_code_elimination : bool := true)
              (with_subst01 : bool)
              (possible_values : list Z)
              {t}
@@ -1178,7 +1169,7 @@ Module Pipeline.
              out_bounds
              {type_good : type_goodT t}
              rv
-             (Hrv : BoundsPipeline (*with_dead_code_elimination*) with_subst01 possible_values e arg_bounds out_bounds = Success rv)
+             (Hrv : BoundsPipeline with_subst01 possible_values e arg_bounds out_bounds = Success rv)
              (Hwf : Wf e)
     : (forall arg1 arg2
               (Harg12 : type.and_for_each_lhs_of_arrow (@type.eqv) arg1 arg2)
@@ -1194,7 +1185,7 @@ Module Pipeline.
     rewrite (correct_of_final_iff_correct_of_initial Hinterp) by assumption.
     pose proof Hwf as Hwf'. (* keep an extra copy so it's not cleared *)
     cbv [translate_to_fancy_opt_correct] in *.
-    cbv beta iota delta [BoundsPipeline PreBoundsPipeline Let_In Pipeline.translate_to_fancy] in Hrv.
+    cbv beta iota delta [BoundsPipeline PreBoundsPipeline Let_In] in Hrv.
     fwd Hrv Hwf Hinterp; [ repeat fwd_side_condition_step .. | subst ].
     solve [ eauto using conj with nocore ].
   Qed.
@@ -1213,17 +1204,8 @@ Module Pipeline.
        /\ Wf rv.
 
   Lemma BoundsPipeline_correct_trans
-        {opts : AbstractInterpretation.Options}
-        {low_level_rewriter_method : low_level_rewriter_method_opt}
-        {only_signed : only_signed_opt}
-        {no_select_size : no_select_size_opt}
-        {split_mul_to : split_mul_to_opt}
-        {split_multiret_to : split_multiret_to_opt}
-        {unfold_value_barrier : unfold_value_barrier_opt}
-        {relax_adc_sbb_return_carry_to_bitwidth : relax_adc_sbb_return_carry_to_bitwidth_opt}
-        {translate_to_fancy : translate_to_fancy_opt}
+        {opts : BoundsPipelineOptions}
         {translate_to_fancy_correct : translate_to_fancy_opt_correct}
-        (with_dead_code_elimination : bool := true)
         (with_subst01 : bool)
         (possible_values : list Z)
         {t}

--- a/src/Fancy/Barrett256.v
+++ b/src/Fancy/Barrett256.v
@@ -21,6 +21,12 @@ Module Barrett256.
   Definition M := Eval lazy in (2^256-2^224+2^192+2^96-1).
   Definition machine_wordsize := 256.
 
+  Local Instance : Primitives.Options.PipelineOptions
+    := let _ := Primitives.Options.default_PipelineOptions in
+       {| Primitives.Options.widen_carry := false
+       ; Primitives.Options.widen_bytes := true
+       ; Primitives.Options.unfold_value_barrier := true |}.
+
   Derive barrett_red256
          SuchThat (barrett_red M machine_wordsize = ErrorT.Success barrett_red256)
          As barrett_red256_eq.

--- a/src/Fancy/Montgomery256.v
+++ b/src/Fancy/Montgomery256.v
@@ -24,6 +24,12 @@ Module Montgomery256.
   Definition R' := 115792089183396302114378112356516095823261736990586219612555396166510339686400.
   Definition machine_wordsize := 256.
 
+  Local Instance : Primitives.Options.PipelineOptions
+    := let _ := Primitives.Options.default_PipelineOptions in
+       {| Primitives.Options.widen_carry := false
+       ; Primitives.Options.widen_bytes := true
+       ; Primitives.Options.unfold_value_barrier := true |}.
+
   Derive montred256
          SuchThat (montred N R N' machine_wordsize = ErrorT.Success montred256)
          As montred256_eq.

--- a/src/PushButtonSynthesis/BarrettReduction.v
+++ b/src/PushButtonSynthesis/BarrettReduction.v
@@ -43,10 +43,9 @@ Local Opaque reified_barrett_red_gen. (* needed for making [autorewrite] not tak
 
 Section rbarrett_red.
   Context {output_language_api : ToString.OutputLanguageAPI}
-          {static : static_opt}
-          {internal_static : internal_static_opt}
-          {inline : inline_opt}
-          {inline_internal : inline_internal_opt}
+          {pipeline_opts : PipelineOptions}
+          {pipeline_to_string_opts : PipelineToStringOptions}
+          {synthesis_opts : SynthesisOptions}
           (M : Z)
           (machine_wordsize : machine_wordsize_opt).
 
@@ -59,22 +58,11 @@ Section rbarrett_red.
 
   Definition possible_values_of_machine_wordsize
     := [1; machine_wordsize / 2; machine_wordsize; 2 * machine_wordsize]%Z.
-  Let possible_values := possible_values_of_machine_wordsize.
+  Local Notation possible_values := possible_values_of_machine_wordsize.
 
-  Local Existing Instance default_language_naming_conventions.
-  Local Existing Instance default_documentation_options.
-  Local Existing Instance default_output_options.
-  Local Existing Instance AbstractInterpretation.default_Options.
-  Local Instance widen_carry : widen_carry_opt := false.
-  Local Instance widen_bytes : widen_bytes_opt := true.
-  Local Instance only_signed : only_signed_opt := false.
-  Local Instance no_select_size : no_select_size_opt := None.
-  Local Instance split_mul_to : split_mul_to_opt := None.
-  Local Instance split_multiret_to : split_multiret_to_opt := None.
-  Local Instance unfold_value_barrier : unfold_value_barrier_opt := true.
-  Local Instance assembly_hints_lines : assembly_hints_lines_opt := [].
-  Local Instance ignore_unique_asm_names : ignore_unique_asm_names_opt := false.
-  Local Instance low_level_rewriter_method : low_level_rewriter_method_opt := default_low_level_rewriter_method.
+  Local Instance no_select_size : no_select_size_opt := no_select_size_of_no_select machine_wordsize.
+  Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
+  Local Instance split_multiret_to : split_multiret_to_opt := split_multiret_to_of_should_split_multiret machine_wordsize possible_values.
 
   Local Instance fancy_args : translate_to_fancy_opt
     := (Some {| BoundsPipeline.invert_low log2wordsize := invert_low log2wordsize consts_list;

--- a/src/PushButtonSynthesis/BaseConversion.v
+++ b/src/PushButtonSynthesis/BaseConversion.v
@@ -78,30 +78,9 @@ Definition default_bounds : bounds := use_prime.
 
 Section __.
   Context {output_language_api : ToString.OutputLanguageAPI}
-          {language_naming_conventions : language_naming_conventions_opt}
-          {documentation_options : documentation_options_opt}
-          {output_options : output_options_opt}
-          {opts : AbstractInterpretation.Options}
-          {package_namev : package_name_opt}
-          {class_namev : class_name_opt}
-          {static : static_opt}
-          {internal_static : internal_static_opt}
-          {inline : inline_opt}
-          {inline_internal : inline_internal_opt}
-          {low_level_rewriter_method : low_level_rewriter_method_opt}
-          {only_signed : only_signed_opt}
-          {no_select : no_select_opt}
-          {use_mul_for_cmovznz : use_mul_for_cmovznz_opt}
-          {emit_primitives : emit_primitives_opt}
-          {should_split_mul : should_split_mul_opt}
-          {should_split_multiret : should_split_multiret_opt}
-          {unfold_value_barrier : unfold_value_barrier_opt}
-          {assembly_hints_lines : assembly_hints_lines_opt}
-          {ignore_unique_asm_names : ignore_unique_asm_names_opt}
-          {widen_carry : widen_carry_opt}
-          {widen_bytes : widen_bytes_opt}
-          {assembly_conventions : assembly_conventions_opt}
-          {error_on_unused_assembly_functions : error_on_unused_assembly_functions_opt}
+          {pipeline_opts : PipelineOptions}
+          {pipeline_to_string_opts : PipelineToStringOptions}
+          {synthesis_opts : SynthesisOptions}
           (s : Z) (c : list (Z * Z))
           (src_n : nat)
           (src_limbwidth : Q)
@@ -148,12 +127,8 @@ Section __.
           | use_bitwidth => encode (dst_weight dst_n - 1)
           end).
 
-  (* We include [0], so that even after bounds relaxation, we can
-       notice where the constant 0s are, and remove them. *)
-  Definition possible_values_of_machine_wordsize_with_bytes
-    := prefix_with_carry_bytes [machine_wordsize; 2 * machine_wordsize]%Z.
+  Local Notation possible_values_with_bytes := (possible_values_of_machine_wordsize_with_bytes machine_wordsize).
 
-  Let possible_values_with_bytes := possible_values_of_machine_wordsize_with_bytes.
   Definition in_bounds : list (ZRange.type.option.interp base.type.Z)
     := List.map (fun u => Some r[0~>u]%zrange) in_upperbounds.
   Definition out_bounds : list (ZRange.type.option.interp base.type.Z)
@@ -161,8 +136,8 @@ Section __.
 
   Local Existing Instance default_translate_to_fancy.
   Local Instance no_select_size : no_select_size_opt := no_select_size_of_no_select machine_wordsize.
-  Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values_of_machine_wordsize_with_bytes.
-  Local Instance split_multiret_to : split_multiret_to_opt := split_multiret_to_of_should_split_multiret machine_wordsize possible_values_of_machine_wordsize_with_bytes.
+  Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values_with_bytes.
+  Local Instance split_multiret_to : split_multiret_to_opt := split_multiret_to_of_should_split_multiret machine_wordsize possible_values_with_bytes.
 
   (** Note: If you change the name or type signature of this
         function, you will need to update the code in CLI.v *)

--- a/src/PushButtonSynthesis/FancyMontgomeryReduction.v
+++ b/src/PushButtonSynthesis/FancyMontgomeryReduction.v
@@ -45,10 +45,9 @@ Local Opaque reified_montred_gen. (* needed for making [autorewrite] not take a 
 
 Section rmontred.
   Context {output_language_api : ToString.OutputLanguageAPI}
-          {static : static_opt}
-          {internal_static : internal_static_opt}
-          {inline : inline_opt}
-          {inline_internal : inline_internal_opt}
+          {pipeline_opts : PipelineOptions}
+          {pipeline_to_string_opts : PipelineToStringOptions}
+          {synthesis_opts : SynthesisOptions}
           (N R N' : Z) (n : nat)
           (machine_wordsize : machine_wordsize_opt).
 
@@ -62,22 +61,11 @@ Section rmontred.
     := [1; machine_wordsize / 2; machine_wordsize; 2 * machine_wordsize]%Z.
   Local Arguments possible_values_of_machine_wordsize / .
 
-  Let possible_values := possible_values_of_machine_wordsize.
+  Local Notation possible_values := possible_values_of_machine_wordsize.
 
-  Local Existing Instance default_language_naming_conventions.
-  Local Existing Instance default_documentation_options.
-  Local Existing Instance default_output_options.
-  Local Existing Instance AbstractInterpretation.default_Options.
-  Local Instance widen_carry : widen_carry_opt := false.
-  Local Instance widen_bytes : widen_bytes_opt := true.
-  Local Instance only_signed : only_signed_opt := false.
-  Local Instance no_select_size : no_select_size_opt := None.
-  Local Instance split_mul_to : split_mul_to_opt := None.
-  Local Instance split_multiret_to : split_multiret_to_opt := None.
-  Local Instance unfold_value_barrier : unfold_value_barrier_opt := true.
-  Local Instance assembly_hints_lines : assembly_hints_lines_opt := [].
-  Local Instance ignore_unique_asm_names : ignore_unique_asm_names_opt := false.
-  Local Instance low_level_rewriter_method : low_level_rewriter_method_opt := default_low_level_rewriter_method.
+  Local Instance no_select_size : no_select_size_opt := no_select_size_of_no_select machine_wordsize.
+  Local Instance split_mul_to : split_mul_to_opt := split_mul_to_of_should_split_mul machine_wordsize possible_values.
+  Local Instance split_multiret_to : split_multiret_to_opt := split_multiret_to_of_should_split_multiret machine_wordsize possible_values.
 
   Local Instance fancy_args : translate_to_fancy_opt
     := (Some {| BoundsPipeline.invert_low log2wordsize := invert_low log2wordsize consts_list;

--- a/src/PushButtonSynthesis/Primitives.v
+++ b/src/PushButtonSynthesis/Primitives.v
@@ -799,34 +799,142 @@ Notation "'docstring_with_summary_from_lemma!' summary correctness"
   := (CorrectnessStringification.docstring_with_summary_from_lemma summary correctness) (only parsing, at level 10, summary at next level, correctness at next level).
 (** Used to sigma up the output of stringified pipelines *)
 Notation wrap_s v := (fun s => existT (fun t => prod string (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult t))) _ (v s)) (only parsing).
+
+(** We stick this in a module to work around COQBUG(https://github.com/coq/coq/issues/16677) *)
+Module Export Options.
+  (** The options which are passed from higher levels for synthesizing
+      individual pipeline operations as an AST *)
+  Class PipelineOptions :=
+    { absint_opts : AbstractInterpretation.Options
+    ; widen_carry : widen_carry_opt
+    ; widen_bytes : widen_bytes_opt
+    ; unfold_value_barrier : unfold_value_barrier_opt
+    ; should_split_multiret : should_split_multiret_opt
+    ; should_split_mul : should_split_mul_opt
+    ; output_options : output_options_opt
+    ; only_signed : only_signed_opt
+    ; no_select : no_select_opt
+    ; low_level_rewriter_method : low_level_rewriter_method_opt
+    }.
+  Definition default_PipelineOptions : PipelineOptions
+    := let _ := Pipeline.default_BoundsPipelineOptions in
+       {| widen_carry := false
+       ; widen_bytes := false
+       ; should_split_multiret := false
+       ; should_split_mul := false
+       ; no_select := false
+       ; output_options := default_output_options |}.
+  (** The additional options which are passed from higher levels for
+      stringifying synthesized operations.  We do not include
+      [OutputLanguageAPI] for lack of a good default. *)
+  Class PipelineToStringOptions :=
+    { static : static_opt
+    ; language_naming_conventions : language_naming_conventions_opt
+    ; internal_static : internal_static_opt
+    ; inline_internal : inline_internal_opt
+    ; inline : inline_opt
+    ; documentation_options : documentation_options_opt }.
+  Definition default_PipelineToStringOptions : PipelineToStringOptions :=
+    {| static := false
+    ; language_naming_conventions := default_language_naming_conventions
+    ; internal_static := false
+    ; inline_internal := false
+    ; inline := false
+    ; documentation_options := default_documentation_options |}.
+  (** The additional options used for invoking [Synthesize], the entire
+      field pipeline *)
+  Class SynthesisOptions :=
+    { use_mul_for_cmovznz : use_mul_for_cmovznz_opt
+    ; package_namev : package_name_opt
+    ; ignore_unique_asm_names : ignore_unique_asm_names_opt
+    ; error_on_unused_assembly_functions : error_on_unused_assembly_functions_opt
+    ; emit_primitives : emit_primitives_opt
+    ; class_namev : class_name_opt
+    ; assembly_hints_lines : assembly_hints_lines_opt
+    ; assembly_conventions : assembly_conventions_opt }.
+  Definition default_SynthesisOptions : SynthesisOptions :=
+    {| use_mul_for_cmovznz := false
+    ; package_namev := None
+    ; ignore_unique_asm_names := true
+    ; error_on_unused_assembly_functions := true
+    ; emit_primitives := true
+    ; class_namev := None
+    ; assembly_hints_lines := []
+    ; assembly_conventions := default_assembly_conventions |}.
+End Options.
+Module Import PipelineHints.
+  Global Existing Instances
+         Build_PipelineOptions
+         Build_PipelineToStringOptions
+         Build_SynthesisOptions
+         absint_opts
+         widen_carry
+         widen_bytes
+         unfold_value_barrier
+         should_split_multiret
+         should_split_mul
+         output_options
+         only_signed
+         no_select
+         low_level_rewriter_method
+         static
+         language_naming_conventions
+         internal_static
+         inline_internal
+         inline
+         documentation_options
+         use_mul_for_cmovznz
+         package_namev
+         ignore_unique_asm_names
+         error_on_unused_assembly_functions
+         emit_primitives
+         class_namev
+         assembly_hints_lines
+         assembly_conventions
+  .
+  #[global]
+   Hint Cut [
+      ( _ * )
+        (absint_opts
+        | widen_carry
+        | widen_bytes
+        | unfold_value_barrier
+        | should_split_multiret
+        | should_split_mul
+        | output_options
+        | only_signed
+        | no_select
+        | low_level_rewriter_method
+        | static
+        | language_naming_conventions
+        | internal_static
+        | inline_internal
+        | inline
+        | documentation_options
+        | use_mul_for_cmovznz
+        | package_namev
+        | ignore_unique_asm_names
+        | error_on_unused_assembly_functions
+        | emit_primitives
+        | class_namev
+        | assembly_hints_lines
+        | assembly_conventions
+        ) ( _ * )
+        (Build_PipelineOptions
+        | Build_PipelineToStringOptions
+        | Build_SynthesisOptions
+        )
+    ] : typeclass_instances.
+End PipelineHints.
+
 Section __.
   Context {output_language_api : ToString.OutputLanguageAPI}
-          {language_naming_conventions : language_naming_conventions_opt}
-          {documentation_options : documentation_options_opt}
-          {output_options : output_options_opt}
-          {absint_opts : AbstractInterpretation.Options}
-          {package_namev : package_name_opt}
-          {class_namev : class_name_opt}
-          {static : static_opt}
-          {internal_static : internal_static_opt}
-          {inline : inline_opt}
-          {inline_internal : inline_internal_opt}
-          {low_level_rewriter_method : low_level_rewriter_method_opt}
-          {only_signed : only_signed_opt}
-          {no_select : no_select_opt}
-          {use_mul_for_cmovznz : use_mul_for_cmovznz_opt}
-          {emit_primitives : emit_primitives_opt}
-          {should_split_mul : should_split_mul_opt}
-          {should_split_multiret : should_split_multiret_opt}
-          {unfold_value_barrier : unfold_value_barrier_opt}
-          {assembly_hints_lines : assembly_hints_lines_opt}
-          {widen_carry : widen_carry_opt}
-          {widen_bytes : widen_bytes_opt}
-          {assembly_conventions : assembly_conventions_opt}
-          {error_on_unused_assembly_functions : error_on_unused_assembly_functions_opt}
-          {ignore_unique_asm_names : ignore_unique_asm_names_opt}
+          {pipeline_opts : PipelineOptions}
+          {pipeline_to_string_opts : PipelineToStringOptions}
+          {synthesis_opts : SynthesisOptions}
           (n : nat)
           (machine_wordsize : machine_wordsize_opt).
+
   Definition word_bound : ZRange.type.interp base.type.Z
     := r[0 ~> 2^machine_wordsize-1]%zrange.
   Definition saturated_bounds : list (ZRange.type.option.interp base.type.Z)
@@ -1341,7 +1449,8 @@ Notation "'all_typedefs!'" :=
    end) (only parsing).
 
 Module Export Hints.
-#[global]
+  Export PipelineHints.
+  #[global]
   Hint Opaque
        mulx
        addcarryx
@@ -1352,7 +1461,7 @@ Module Export Hints.
        selectznz
        copy
   : wf_op_cache.
-#[global]
+  #[global]
   Hint Immediate
        Wf_mulx
        Wf_addcarryx

--- a/src/PushButtonSynthesis/SaturatedSolinas.v
+++ b/src/PushButtonSynthesis/SaturatedSolinas.v
@@ -60,35 +60,16 @@ Local Opaque expr.Interp.
 
 Section __.
   Context {output_language_api : ToString.OutputLanguageAPI}
-          {language_naming_conventions : language_naming_conventions_opt}
-          {documentation_options : documentation_options_opt}
-          {output_options : output_options_opt}
-          {opts : AbstractInterpretation.Options}
-          {package_namev : package_name_opt}
-          {class_namev : class_name_opt}
-          {static : static_opt}
-          {internal_static : internal_static_opt}
-          {inline : inline_opt}
-          {inline_internal : inline_internal_opt}
-          {low_level_rewriter_method : low_level_rewriter_method_opt}
-          {only_signed : only_signed_opt}
-          {no_select : no_select_opt}
-          {use_mul_for_cmovznz : use_mul_for_cmovznz_opt}
-          {emit_primitives : emit_primitives_opt}
-          {should_split_mul : should_split_mul_opt}
-          {should_split_multiret : should_split_multiret_opt}
-          {unfold_value_barrier : unfold_value_barrier_opt}
-          {assembly_hints_lines : assembly_hints_lines_opt}
-          {ignore_unique_asm_names : ignore_unique_asm_names_opt}
-          {widen_carry : widen_carry_opt}
-          (widen_bytes : widen_bytes_opt := true) (* true, because we don't allow byte-sized things anyway, so we should not expect carries to be widened to byte-size when emitting C code *)
-          {assembly_conventions : assembly_conventions_opt}
-          {error_on_unused_assembly_functions : error_on_unused_assembly_functions_opt}
+          {pipeline_opts : PipelineOptions}
+          {pipeline_to_string_opts : PipelineToStringOptions}
+          {synthesis_opts : SynthesisOptions}
           (s : Z)
           (c : list (Z * Z))
           (machine_wordsize : machine_wordsize_opt).
 
-  Local Existing Instance widen_bytes.
+  Local Instance override_pipeline_opts : PipelineOptions
+    := {| widen_bytes := true (* true, because we don't allow byte-sized things anyway, so we should not expect carries to be widened to byte-size when emitting C code *)
+       |}.
 
   (* We include [0], so that even after bounds relaxation, we can
        notice where the constant 0s are, and remove them. *)
@@ -110,10 +91,8 @@ Section __.
     if Z.of_nat n - i <=? 1
     then n
     else Z.to_nat (Qceiling (Z.of_nat n / (Z.of_nat n - i - 1))).
-  Let possible_values := possible_values_of_machine_wordsize.
-  Definition bound := Some r[0 ~> (2^machine_wordsize - 1)]%zrange.
-  Definition boundsn : list (ZRange.type.option.interp base.type.Z)
-    := repeat bound n.
+  Local Notation possible_values := possible_values_of_machine_wordsize.
+  Local Notation boundsn := (saturated_bounds n machine_wordsize).
 
   Local Existing Instance default_translate_to_fancy.
   Local Instance no_select_size : no_select_size_opt := no_select_size_of_no_select machine_wordsize.

--- a/src/PushButtonSynthesis/SmallExamples.v
+++ b/src/PushButtonSynthesis/SmallExamples.v
@@ -20,15 +20,7 @@ Import Compilers.API.
 
 Import Associational Positional.
 
-Local Instance : split_mul_to_opt := None.
-Local Instance : split_multiret_to_opt := None.
-Local Instance : unfold_value_barrier_opt := true.
-Local Instance : assembly_hints_lines_opt := [].
-Local Instance : ignore_unique_asm_names_opt := false.
-Local Instance : only_signed_opt := false.
-Local Instance : no_select_size_opt := None.
-Local Existing Instance default_translate_to_fancy.
-Local Existing Instance default_low_level_rewriter_method.
+Local Existing Instance Pipeline.default_BoundsPipelineOptions.
 
 Time Redirect "log" Compute
      (Pipeline.BoundsPipeline

--- a/src/PushButtonSynthesis/WordByWordMontgomery.v
+++ b/src/PushButtonSynthesis/WordByWordMontgomery.v
@@ -101,30 +101,9 @@ Local Opaque
 
 Section __.
   Context {output_language_api : ToString.OutputLanguageAPI}
-          {language_naming_conventions : language_naming_conventions_opt}
-          {documentation_options : documentation_options_opt}
-          {output_options : output_options_opt}
-          {opts : AbstractInterpretation.Options}
-          {package_namev : package_name_opt}
-          {class_namev : class_name_opt}
-          {static : static_opt}
-          {internal_static : internal_static_opt}
-          {inline : inline_opt}
-          {inline_internal : inline_internal_opt}
-          {low_level_rewriter_method : low_level_rewriter_method_opt}
-          {only_signed : only_signed_opt}
-          {no_select : no_select_opt}
-          {use_mul_for_cmovznz : use_mul_for_cmovznz_opt}
-          {emit_primitives : emit_primitives_opt}
-          {should_split_mul : should_split_mul_opt}
-          {should_split_multiret : should_split_multiret_opt}
-          {unfold_value_barrier : unfold_value_barrier_opt}
-          {assembly_hints_lines : assembly_hints_lines_opt}
-          {ignore_unique_asm_names : ignore_unique_asm_names_opt}
-          {widen_carry : widen_carry_opt}
-          {widen_bytes : widen_bytes_opt}
-          {assembly_conventions : assembly_conventions_opt}
-          {error_on_unused_assembly_functions : error_on_unused_assembly_functions_opt}
+          {pipeline_opts : PipelineOptions}
+          {pipeline_to_string_opts : PipelineToStringOptions}
+          {synthesis_opts : SynthesisOptions}
           (m : Z)
           (machine_wordsize : machine_wordsize_opt).
 
@@ -175,16 +154,9 @@ Section __.
      Some (repeat (Some r[0 ~> 2^machine_wordsize-1]) n),
      Some (repeat (Some r[0 ~> 2^machine_wordsize-1]) n))%zrange.
 
-  (* We include [0], so that even after bounds relaxation, we can
-       notice where the constant 0s are, and remove them. *)
-  Definition possible_values_of_machine_wordsize
-    := prefix_with_carry [machine_wordsize; 2 * machine_wordsize]%Z.
+  Local Notation possible_values := (possible_values_of_machine_wordsize machine_wordsize).
+  Local Notation possible_values_with_bytes := (possible_values_of_machine_wordsize_with_bytes machine_wordsize).
 
-  Definition possible_values_of_machine_wordsize_with_bytes
-    := prefix_with_carry_bytes [machine_wordsize; 2 * machine_wordsize]%Z.
-
-  Let possible_values := possible_values_of_machine_wordsize.
-  Let possible_values_with_bytes := possible_values_of_machine_wordsize_with_bytes.
   Definition bounds : list (ZRange.type.option.interp base.type.Z)
     := saturated_bounds (*List.map (fun u => Some r[0~>u]%zrange) upperbounds*).
   Definition larger_bounds : list (ZRange.type.option.interp base.type.Z)

--- a/src/Rewriter/PerfTesting/Core.v
+++ b/src/Rewriter/PerfTesting/Core.v
@@ -44,27 +44,9 @@ Import
   Rewriter.All.Compilers.
 
 Local Existing Instance Stringification.C.Compilers.ToString.C.OutputCAPI.
-Local Existing Instance default_language_naming_conventions.
-Local Existing Instance default_documentation_options.
-Local Existing Instance default_output_options.
-Local Existing Instance AbstractInterpretation.default_Options.
-Local Instance : package_name_opt := None.
-Local Instance : class_name_opt := None.
-Local Instance : static_opt := true.
-Local Instance : internal_static_opt := true.
-Local Instance : inline_opt := true.
-Local Instance : inline_internal_opt := true.
-Local Instance : use_mul_for_cmovznz_opt := false.
-Local Instance : emit_primitives_opt := true.
-Local Instance : only_signed_opt := false.
-Local Instance : no_select_opt := false.
-Local Instance : should_split_mul_opt := false.
-Local Instance : should_split_multiret_opt := false.
-Local Instance : unfold_value_barrier_opt := true.
-Local Instance : assembly_hints_lines_opt := [].
-Local Instance : ignore_unique_asm_names_opt := false.
-Local Instance : widen_bytes_opt := false.
-Local Instance : widen_carry_opt := false.
+Local Existing Instance Primitives.Options.default_PipelineOptions.
+Local Existing Instance Primitives.Options.default_PipelineToStringOptions.
+Local Existing Instance Primitives.Options.default_SynthesisOptions.
 Local Instance : tight_upperbound_fraction_opt := default_tight_upperbound_fraction.
 
 Import API.

--- a/src/SlowPrimeSynthesisExamples.v
+++ b/src/SlowPrimeSynthesisExamples.v
@@ -37,37 +37,31 @@ Local Coercion QArith_base.inject_Z : Z >-> Q.
 Local Coercion Z.pos : positive >-> Z.
 
 Local Existing Instance default_translate_to_fancy.
-Local Existing Instance default_low_level_rewriter_method.
-Local Existing Instance AbstractInterpretation.default_Options.
+Local Existing Instances
+      Primitives.Options.default_PipelineOptions
+      Primitives.Options.default_PipelineToStringOptions
+      Primitives.Options.default_SynthesisOptions
+| 100.
 Local Instance : unfold_value_barrier_opt := true.
-Local Instance : assembly_hints_lines_opt := [].
-Local Instance : ignore_unique_asm_names_opt := false.
 Local Instance : tight_upperbound_fraction_opt := default_tight_upperbound_fraction.
-Local Existing Instance default_language_naming_conventions.
-Local Existing Instance default_documentation_options.
-Local Instance : package_name_opt := None.
-Local Instance : class_name_opt := None.
 
 Module debugging_go_bits_add.
   Import Stringification.Go.
   Section __.
     Local Existing Instance Go.OutputGoAPI.
-    Local Instance : relax_adc_sbb_return_carry_to_bitwidth_opt := [32; 64].
-    Local Instance : skip_typedefs_opt := true.
-    Local Instance : language_specific_cast_adjustment_opt := true.
-    Local Existing Instance Build_output_options_opt.
-    Local Instance static : static_opt := false.
-    Local Instance : internal_static_opt := false.
-    Local Instance : inline_opt := false.
-    Local Instance : inline_internal_opt := false.
-    Local Instance : emit_primitives_opt := true.
-    Local Instance : use_mul_for_cmovznz_opt := true.
-    Local Instance : widen_carry_opt := true.
-    Local Instance : widen_bytes_opt := true.
-    Local Instance : only_signed_opt := false.
-    Local Instance : no_select_opt := false.
-    Local Instance : should_split_mul_opt := true. (* only for x64 *)
-    Local Instance : should_split_multiret_opt := false.
+    Local Instance : Primitives.Options.PipelineOptions :=
+      {| Primitives.Options.output_options :=
+        {| relax_adc_sbb_return_carry_to_bitwidth_ := [32; 64]
+        ; skip_typedefs_ := true
+        ; language_specific_cast_adjustment_ := true
+        |}
+      ; Primitives.Options.widen_carry := true
+      ; Primitives.Options.widen_bytes := true
+      ; Primitives.Options.only_signed := false
+      ; Primitives.Options.no_select := false
+      ; Primitives.Options.should_split_mul := true (* only for x64 *)
+      ; Primitives.Options.should_split_multiret := false
+      |}.
 
     Context (s := 2^127)
             (c :=  [(1,1)])
@@ -175,7 +169,7 @@ Module debugging_go_bits_add.
          | context T[let a := ?v in @?f a]  => do_set a v f
          | context T[dlet a := ?v in @?f a] => do_set a v f
          end; cbv beta iota in * ).
-      vm_compute WordByWordMontgomery.possible_values_of_machine_wordsize in relax_zrange.
+      vm_compute Primitives.possible_values_of_machine_wordsize in relax_zrange.
       cbv [only_signed_opt_instance_0] in relax_zrange.
       cbv [Pipeline.opts_of_method] in E1; subst E0.
       cbv [default_low_level_rewriter_method] in E1.
@@ -320,7 +314,7 @@ Module debugging_go_bits_add.
 
       clear v; rename v' into v.
       cbv [WordByWordMontgomery.add] in k.
-      cbv [possible_values_of_machine_wordsize] in k.
+      cbv [Primitives.possible_values_of_machine_wordsize] in k.
       cbv [widen_carry] in k.
       cbv [widen_carry_opt_instance_0] in k.
       cbv [Pipeline.BoundsPipeline Pipeline.PreBoundsPipeline] in k.
@@ -1683,8 +1677,8 @@ Module debugging_25519_to_bytes_bedrock2.
       cbv -[Language.Compilers.ToString.ToFunctionLines] in v.
       clear v.
       cbv [to_bytes] in k.
-      cbv [possible_values_of_machine_wordsize] in k.
-      cbv [possible_values_of_machine_wordsize_with_bytes] in k.
+      cbv [Primitives.possible_values_of_machine_wordsize] in k.
+      cbv [Primitives.possible_values_of_machine_wordsize_with_bytes] in k.
       cbv [widen_bytes] in k.
       cbv [widen_bytes_opt_instance_0] in k.
       cbv [widen_carry] in k.
@@ -1839,8 +1833,8 @@ Module debugging_25519_to_bytes_java.
       cbv -[Language.Compilers.ToString.ToFunctionLines] in v.
       clear v.
       cbv [to_bytes] in k.
-      cbv [possible_values_of_machine_wordsize] in k.
-      cbv [possible_values_of_machine_wordsize_with_bytes] in k.
+      cbv [Primitives.possible_values_of_machine_wordsize] in k.
+      cbv [Primitives.possible_values_of_machine_wordsize_with_bytes] in k.
       cbv [widen_bytes] in k.
       cbv [widen_bytes_opt_instance_0] in k.
       cbv [widen_carry] in k.
@@ -1911,7 +1905,7 @@ Module debugging_p256_uint1.
       cbv [smul] in v.
       set (k := WordByWordMontgomery.mul m machine_wordsize) in (value of v).
       cbv [WordByWordMontgomery.mul] in k.
-      cbv [possible_values_of_machine_wordsize] in k.
+      cbv [Primitives.possible_values_of_machine_wordsize] in k.
       cbv [widen_carry] in k.
       cbv [widen_carry_opt_instance_0] in k.
       cbv [Pipeline.BoundsPipeline Pipeline.PreBoundsPipeline] in k.
@@ -2039,7 +2033,7 @@ Module debugging_go_build0.
 
       clear v; rename v' into v.
       cbv [WordByWordMontgomery.add] in k.
-      cbv [possible_values_of_machine_wordsize] in k.
+      cbv [Primitives.possible_values_of_machine_wordsize] in k.
       cbv [widen_carry] in k.
       cbv [widen_carry_opt_instance_0] in k.
       cbv [Pipeline.BoundsPipeline Pipeline.PreBoundsPipeline] in k.
@@ -2084,7 +2078,7 @@ Module debugging_go_build.
       cbv [sadd] in v.
       set (k := WordByWordMontgomery.add m machine_wordsize) in (value of v).
       cbv [WordByWordMontgomery.add] in k.
-      cbv [possible_values_of_machine_wordsize] in k.
+      cbv [Primitives.possible_values_of_machine_wordsize] in k.
       cbv [widen_carry] in k.
       cbv [widen_carry_opt_instance_0] in k.
       cbv [Pipeline.BoundsPipeline Pipeline.PreBoundsPipeline] in k.

--- a/src/SlowPrimeSynthesisExamples.v
+++ b/src/SlowPrimeSynthesisExamples.v
@@ -95,10 +95,11 @@ Module debugging_go_bits_add.
              | [ H := @inl ?A ?B ?v |- _ ] => let H' := fresh "E" in pose v as H'; change (@inl A B H') in (value of H); subst H; rename H' into H; cbv beta iota in *
              | [ H := @inr ?A ?B ?v |- _ ] => let H' := fresh "E" in pose v as H'; change (@inr A B H') in (value of H); subst H; rename H' into H; cbv beta iota in *
              end.
-      vm_compute WordByWordMontgomery.no_select_size in k.
-      vm_compute WordByWordMontgomery.split_mul_to in k.
-      vm_compute WordByWordMontgomery.split_multiret_to in k.
-      vm_compute WordByWordMontgomery.split_multiret_to in k.
+      vm_compute Pipeline.no_select_size in k.
+      vm_compute Pipeline.split_mul_to in k.
+      vm_compute Pipeline.split_multiret_to in k.
+      vm_compute Pipeline.split_multiret_to in k.
+      vm_compute Pipeline.translate_to_fancy in k.
       cbv beta iota in k.
       set (v := CheckedPartialEvaluateWithBounds _ _ _ _ _ _ _) in (value of k).
       vm_compute in v.
@@ -107,7 +108,7 @@ Module debugging_go_bits_add.
              | [ H := @inl ?A ?B ?v |- _ ] => let H' := fresh "E" in pose v as H'; change (@inl A B H') in (value of H); subst H; rename H' into H; cbv beta iota in *
              | [ H := @inr ?A ?B ?v |- _ ] => let H' := fresh "E" in pose v as H'; change (@inr A B H') in (value of H); subst H; rename H' into H; cbv beta iota in *
              end.
-      vm_compute relax_adc_sbb_return_carry_to_bitwidth_ in k.
+      vm_compute Pipeline.relax_adc_sbb_return_carry_to_bitwidth in k.
       cbv beta iota in k.
       set (v' := Pipeline.RewriteAndEliminateDeadAndInline _ _ _ _ _) in (value of k).
       vm_compute in v'; clear -k.

--- a/src/StandaloneDebuggingExamples.v
+++ b/src/StandaloneDebuggingExamples.v
@@ -66,7 +66,7 @@ Module debugging_no_asm.
     cbv [Primitives.parse_asm_hints] in v.
     cbv [Primitives.Synthesize] in v.
     cbv beta delta [Primitives.parse_asm_hints Primitives.parse_asm_files_lines] in v.
-    vm_compute ForExtraction.assembly_hints_lines in v.
+    vm_compute Primitives.Options.assembly_hints_lines in v.
     cbv beta iota in v.
     vm_compute Parse.parse_validated in v.
     cbv beta iota in v.
@@ -145,7 +145,7 @@ Module debugging_typedef_bounds.
     cbv [Primitives.parse_asm_hints] in v.
     cbv [Primitives.Synthesize] in v.
     cbv [Primitives.parse_asm_hints] in v.
-    vm_compute ForExtraction.assembly_hints_lines in v.
+    vm_compute Primitives.Options.assembly_hints_lines in v.
     cbv beta iota in v.
     cbv beta iota delta [Primitives.Synthesize] in v.
     set (k := ForExtraction.CollectErrors _) in (value of v).


### PR DESCRIPTION
Alternative to #1440
Closes #1440

I decided to add some debugging ability to rewriting (in particular some options to let fiat-crypto print out the AST before/after each rewrite pass), and decided in passing to reorganize the options to the pipeline to allow for less invasive future additions.  #1440 was too heavy, so I decided to instead base the records on how we use the options (BoundsPipeline to AST, BoundsPipeline to strings, field Pipeline to AST, field pipeline to strings, (the field synthesis does a bit more computation on top of the bounds pipeline, because it knows which operation is being synthesized, whether it's for the fancy machine, etc), or the full field synthesis pipeline (which also does things like assembly equivalence checking)).

Timing check coming soon