### PR TITLE
Add `--debug` flag and debug info for rewriting

### DIFF
--- a/src/CLI.v
+++ b/src/CLI.v
@@ -198,7 +198,7 @@ Module ForExtraction.
     := [("all", all)
     ].
   (** This string gets parsed as the initial argument to --debug, to be updated by subsequent arguments *)
-  Definition default_debug : string := "rewriting".
+  Definition default_debug : string := "".
 
   Definition CollectErrors
              {machine_wordsize : machine_wordsize_opt}

--- a/src/CLI.v
+++ b/src/CLI.v
@@ -198,7 +198,7 @@ Module ForExtraction.
     := [("all", all)
     ].
   (** This string gets parsed as the initial argument to --debug, to be updated by subsequent arguments *)
-  Definition default_debug : string := "".
+  Definition default_debug : string := "rewriting".
 
   Definition CollectErrors
              {machine_wordsize : machine_wordsize_opt}

--- a/src/PushButtonSynthesis/BarrettReduction.v
+++ b/src/PushButtonSynthesis/BarrettReduction.v
@@ -157,7 +157,7 @@ Section rbarrett_red.
          bound.
 
   Definition sbarrett_red (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "barrett_red" barrett_red

--- a/src/PushButtonSynthesis/BaseConversion.v
+++ b/src/PushButtonSynthesis/BaseConversion.v
@@ -240,7 +240,7 @@ Section __.
          (Some out_bounds).
 
   Definition sconvert_bases (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "convert_bases" convert_bases
@@ -304,7 +304,7 @@ Section __.
     (** Note: If you change the name or type signature of this
           function, you will need to update the code in CLI.v *)
     Definition Synthesize (comment_header : list string) (function_name_prefix : string) (requests : list string)
-      : list (synthesis_output_kind * string * Pipeline.ErrorT (list string))
+      : list (synthesis_output_kind * string * Pipeline.M (list string))
       := Primitives.Synthesize
            machine_wordsize valid_names known_functions (fun _ => nil) all_typedefs!
            check_args

--- a/src/PushButtonSynthesis/FancyMontgomeryReduction.v
+++ b/src/PushButtonSynthesis/FancyMontgomeryReduction.v
@@ -142,7 +142,7 @@ Section rmontred.
          bound.
 
   Definition smontred (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "montred" montred

--- a/src/PushButtonSynthesis/SaturatedSolinas.v
+++ b/src/PushButtonSynthesis/SaturatedSolinas.v
@@ -160,7 +160,7 @@ Section __.
          (Some boundsn, None (* Should be: Some r[0~>0]%zrange, but bounds analysis is not good enough *) ).
 
   Definition smul (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "mul" mul
@@ -198,7 +198,7 @@ Section __.
     (** Note: If you change the name or type signature of this
           function, you will need to update the code in CLI.v *)
     Definition Synthesize (comment_header : list string) (function_name_prefix : string) (requests : list string)
-      : list (synthesis_output_kind * string * Pipeline.ErrorT (list string))
+      : list (synthesis_output_kind * string * Pipeline.M (list string))
       := Primitives.Synthesize
            machine_wordsize valid_names known_functions (fun _ => nil) all_typedefs!
            check_args

--- a/src/PushButtonSynthesis/UnsaturatedSolinas.v
+++ b/src/PushButtonSynthesis/UnsaturatedSolinas.v
@@ -345,7 +345,7 @@ Section __.
          (Some tight_bounds).
 
   Definition scarry_mul (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "carry_mul" carry_mul
@@ -363,7 +363,7 @@ Section __.
          (Some tight_bounds).
 
   Definition scarry_square (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "carry_square" carry_square
@@ -381,7 +381,7 @@ Section __.
          (Some tight_bounds).
 
   Definition scarry_scmul_const (prefix : string) (x : Z)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix ("carry_scmul_" ++ Decimal.Z.to_string x)%string (carry_scmul_const x)
@@ -399,7 +399,7 @@ Section __.
          (Some tight_bounds).
 
   Definition scarry (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "carry" carry
@@ -417,7 +417,7 @@ Section __.
          (Some loose_bounds).
 
   Definition sadd (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "add" add
@@ -435,7 +435,7 @@ Section __.
          (Some loose_bounds).
 
   Definition ssub (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "sub" sub
@@ -453,7 +453,7 @@ Section __.
          (Some loose_bounds).
 
   Definition sopp (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "opp" opp
@@ -471,7 +471,7 @@ Section __.
          (Some tight_bounds).
 
   Definition scarry_add (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "carry_add" carry_add
@@ -489,7 +489,7 @@ Section __.
          (Some tight_bounds).
 
   Definition scarry_sub (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "carry_sub" carry_sub
@@ -507,7 +507,7 @@ Section __.
          (Some tight_bounds).
 
   Definition scarry_opp (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "carry_opp" carry_opp
@@ -524,7 +524,7 @@ Section __.
          (Some loose_bounds).
 
   Definition srelax (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "relax" relax
@@ -542,7 +542,7 @@ Section __.
          (Some prime_bytes_bounds).
 
   Definition sto_bytes (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "to_bytes" to_bytes
@@ -560,7 +560,7 @@ Section __.
          (Some tight_bounds).
 
   Definition sfrom_bytes (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "from_bytes" from_bytes
@@ -578,7 +578,7 @@ Section __.
          (Some tight_bounds).
 
   Definition sencode (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "encode" encode
@@ -596,7 +596,7 @@ Section __.
          (Some tight_bounds).
 
   Definition sencode_word (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "encode_word" encode_word
@@ -614,7 +614,7 @@ Section __.
          (Some tight_bounds).
 
   Definition szero (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "zero" zero
@@ -632,7 +632,7 @@ Section __.
          (Some tight_bounds).
 
   Definition sone (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "one" one
@@ -668,12 +668,12 @@ Section __.
 
   Definition selectznz : Pipeline.ErrorT _ := Primitives.selectznz n machine_wordsize.
   Definition sselectznz (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Primitives.sselectznz n machine_wordsize prefix.
 
   Definition copy : Pipeline.ErrorT _ := Primitives.copy n machine_wordsize.
   Definition scopy (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Primitives.scopy n machine_wordsize prefix.
 
   Local Ltac solve_extra_bounds_side_conditions :=
@@ -893,7 +893,7 @@ Section __.
   Lemma copy_correct res
         (Hres : copy = Success res)
     : copy_correct saturated_bounds (Interp res).
-  Proof using curve_good. Primitives.prove_correctness use_curve_good. Qed.
+  Proof using curve_good. apply Primitives.copy_correct; assumption. Qed.
 
   Lemma Wf_copy res (Hres : copy = Success res) : Wf res.
   Proof using Type. revert Hres; cbv [copy]; apply Wf_copy. Qed.
@@ -968,7 +968,7 @@ Section __.
       := Eval compute in String.concat ", " (List.map (@fst _ _) known_functions) ++ ", or 'carry_scmul' followed by a decimal literal".
 
     Definition extra_special_synthesis (function_name_prefix : string) (name : string)
-      : list (option { t : _ & string * Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult t) }%type)
+      : list (option { t : _ & string * Pipeline.M (Pipeline.ExtendedSynthesisResult t) }%type)
       := [if prefix "carry_scmul" name
           then let sc := substring (String.length "carry_scmul") (String.length name) name in
                (scZ <- Decimal.Z.of_string sc;
@@ -980,7 +980,7 @@ Section __.
     (** Note: If you change the name or type signature of this
           function, you will need to update the code in CLI.v *)
     Definition Synthesize (comment_header : list string) (function_name_prefix : string) (requests : list string)
-      : list (synthesis_output_kind * string * Pipeline.ErrorT (list string))
+      : list (synthesis_output_kind * string * Pipeline.M (list string))
       := Primitives.Synthesize
            machine_wordsize valid_names known_functions (extra_special_synthesis function_name_prefix) all_typedefs!
            check_args

--- a/src/PushButtonSynthesis/WordByWordMontgomery.v
+++ b/src/PushButtonSynthesis/WordByWordMontgomery.v
@@ -288,7 +288,7 @@ Section __.
          (Some montgomery_domain_bounds).
 
   Definition smul (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "mul" mul
@@ -307,7 +307,7 @@ Section __.
          (Some montgomery_domain_bounds).
 
   Definition ssquare (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "square" square
@@ -326,7 +326,7 @@ Section __.
          (Some montgomery_domain_bounds).
 
   Definition sadd (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "add" add
@@ -345,7 +345,7 @@ Section __.
          (Some montgomery_domain_bounds).
 
   Definition ssub (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "sub" sub
@@ -364,7 +364,7 @@ Section __.
          (Some montgomery_domain_bounds).
 
   Definition sopp (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "opp" opp
@@ -383,7 +383,7 @@ Section __.
          (Some non_montgomery_domain_bounds).
 
   Definition sfrom_montgomery (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "from_montgomery" from_montgomery
@@ -402,7 +402,7 @@ Section __.
          (Some montgomery_domain_bounds).
 
   Definition sto_montgomery (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "to_montgomery" to_montgomery
@@ -420,7 +420,7 @@ Section __.
          (Some r[0~>r-1]%zrange).
 
   Definition snonzero (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "nonzero" nonzero
@@ -439,7 +439,7 @@ Section __.
          (Some prime_bytes_bounds).
 
   Definition sto_bytes (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "to_bytes" to_bytes
@@ -458,7 +458,7 @@ Section __.
          (Some prime_bounds).
 
   Definition sfrom_bytes (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "from_bytes" from_bytes
@@ -477,7 +477,7 @@ Section __.
          (Some montgomery_domain_bounds).
 
   Definition sencode (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "encode" encode
@@ -497,7 +497,7 @@ Section __.
          (Some saturated_bounds).
 
   Definition sencode_word (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "encode_word" encode_word
@@ -516,7 +516,7 @@ Section __.
          (Some montgomery_domain_bounds).
 
   Definition szero (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "zero" zero
@@ -535,7 +535,7 @@ Section __.
          (Some montgomery_domain_bounds).
 
   Definition sone (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "set_one" one (* to avoid conflict with boringSSL *)
@@ -586,12 +586,12 @@ Section __.
 
   Definition selectznz : Pipeline.ErrorT _ := Primitives.selectznz n machine_wordsize.
   Definition sselectznz (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Primitives.sselectznz n machine_wordsize prefix.
 
   Definition copy : Pipeline.ErrorT _ := Primitives.copy n machine_wordsize.
   Definition scopy (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Primitives.scopy n machine_wordsize prefix.
 
   Definition msat
@@ -604,7 +604,7 @@ Section __.
          (Some larger_bounds).
 
  Definition smsat (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "msat" msat
@@ -623,7 +623,7 @@ Section __.
          (Some bounds).
 
   Definition sdivstep_precomp (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "divstep_precomp" divstep_precomp
@@ -642,7 +642,7 @@ Section __.
          (divstep_output).
 
   Definition sdivstep (prefix : string)
-    : string * (Pipeline.ErrorT (Pipeline.ExtendedSynthesisResult _))
+    : string * (Pipeline.M (Pipeline.ExtendedSynthesisResult _))
     := Eval cbv beta in
         FromPipelineToString!
           machine_wordsize prefix "divstep" divstep
@@ -1078,7 +1078,7 @@ Section __.
     (** Note: If you change the name or type signature of this
           function, you will need to update the code in CLI.v *)
     Definition Synthesize (comment_header : list string) (function_name_prefix : string) (requests : list string)
-      : list (synthesis_output_kind * string * Pipeline.ErrorT (list string))
+      : list (synthesis_output_kind * string * Pipeline.M (list string))
       := Primitives.Synthesize
            machine_wordsize valid_names known_functions (fun _ => nil) all_typedefs!
            check_args

--- a/src/Rewriter/PerfTesting/Core.v
+++ b/src/Rewriter/PerfTesting/Core.v
@@ -121,7 +121,7 @@ Module Import UnsaturatedSolinas.
 
     Definition PipelineArithOf : Expr _
       := let E := E2 in
-         let E := Pipeline.RewriteAndEliminateDeadAndInline (RewriteRules.RewriteArith 0 opts) true (*with_dead_code_elimination*) false (*with_subst01*) true (* let_bind_return *) E in
+         let E := DebugMonad.Debug.eval_result (Pipeline.RewriteAndEliminateDeadAndInline "RewriteArith_0" (RewriteRules.RewriteArith 0 opts) true (*with_dead_code_elimination*) false (*with_subst01*) true (* let_bind_return *) E) in
          E.
 
     Definition PipelineFlatArithOf : GeneralizeVar.Flat.expr _
@@ -328,7 +328,7 @@ Module Import WordByWordMontgomery.
 
     Definition PipelineArithOf : Expr _
       := let E := E2 in
-         let E := Pipeline.RewriteAndEliminateDeadAndInline (RewriteRules.RewriteArith 0 opts) true (*with_dead_code_elimination*) false (*with_subst01*) true (* let_bind_return *) E in
+         let E := DebugMonad.Debug.eval_result (Pipeline.RewriteAndEliminateDeadAndInline "RewriteArith_0" (RewriteRules.RewriteArith 0 opts) true (*with_dead_code_elimination*) false (*with_subst01*) true (* let_bind_return *) E) in
          E.
 
     Definition PipelineFlatArithOf : GeneralizeVar.Flat.expr _

--- a/src/SlowPrimeSynthesisExamples.v
+++ b/src/SlowPrimeSynthesisExamples.v
@@ -16,6 +16,7 @@ Require Crypto.Stringification.C.
 Require Crypto.Stringification.Go.
 Require Crypto.Stringification.Java.
 Require Import Crypto.BoundsPipeline.
+Require Import Crypto.Util.DebugMonad.
 Require Import Crypto.Util.ZUtil.ModInv.
 
 Require Import Crypto.Util.Notations.
@@ -71,17 +72,24 @@ Module debugging_go_bits_add.
       pose (WordByWordMontgomery.smul (s - Associational.eval c) machine_wordsize "p256_") as v.
       vm_compute Z.sub in v.
       cbv [WordByWordMontgomery.smul] in v.
-      set (k := WordByWordMontgomery.mul _ _) in (value of v).
+      set (k := Pipeline.BoundsPipelineWithDebug _ _ _ _ _) in (value of v).
       vm_compute in v.
-      clear v; cbv [WordByWordMontgomery.mul] in k.
-      cbv beta delta [Pipeline.BoundsPipeline] in k.
-      cbv [Rewriter.Util.LetIn.Let_In] in k.
+      clear v.
+      cbv beta delta [Pipeline.BoundsPipelineWithDebug] in k.
+      rename k into k'; pose (DebugMonad.Debug.eval_result k') as k; subst k'.
+      cbv [Rewriter.Util.LetIn.Let_In DebugMonad.Debug.eval_result DebugMonad.Debug.sequence Pipeline.debug_after_rewrite DebugMonad.Debug.ret] in k.
+      vm_compute Pipeline.debug_rewriting in k.
+      unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
       set (v := CheckedPartialEvaluateWithBounds _ _ _ _ _ _ _) in (value of k).
       vm_compute in v.
       repeat match goal with
              | [ H := @inl ?A ?B ?v |- _ ] => let H' := fresh "E" in pose v as H'; change (@inl A B H') in (value of H); subst H; rename H' into H; cbv beta iota in *
              | [ H := @inr ?A ?B ?v |- _ ] => let H' := fresh "E" in pose v as H'; change (@inr A B H') in (value of H); subst H; rename H' into H; cbv beta iota in *
              end.
+      unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
+      unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
+      set (v' := DebugMonad.Debug.bind _) in (value of k) at 1.
+      vm_compute in v'; subst v'; cbn [snd] in k.
       set (v' := CheckedPartialEvaluateWithBounds _ _ _ _ _ _ _) in (value of k).
       vm_compute in v'.
       clear -k.
@@ -95,6 +103,7 @@ Module debugging_go_bits_add.
       vm_compute Pipeline.split_multiret_to in k.
       vm_compute Pipeline.translate_to_fancy in k.
       cbv beta iota in k.
+      unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
       set (v := CheckedPartialEvaluateWithBounds _ _ _ _ _ _ _) in (value of k).
       vm_compute in v.
       clear -k.
@@ -104,8 +113,14 @@ Module debugging_go_bits_add.
              end.
       vm_compute Pipeline.relax_adc_sbb_return_carry_to_bitwidth in k.
       cbv beta iota in k.
-      set (v' := Pipeline.RewriteAndEliminateDeadAndInline _ _ _ _ _) in (value of k).
+      unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
+      set (v' := DebugMonad.Debug.bind _) in (value of k) at 1.
+      vm_compute in v'; subst v'; cbn [snd] in k.
+      unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
+      set (v' := Pipeline.RewriteAndEliminateDeadAndInline _ _ _ _ _ _) in (value of k).
       vm_compute in v'; clear -k.
+      unfold DebugMonad.Debug.bind in (value of k) at 1; subst v'; cbn [snd] in k.
+      cbv [Pipeline.wrap_debug_rewrite] in k.
       set (v := RelaxBitwidthAdcSbb.Compilers.RewriteRules.RewriteRelaxBitwidthAdcSbb _ _ _) in (value of k).
       Notation uint64 := r[0~>18446744073709551615]%zrange.
       Import IdentifiersBasicGENERATED.Compilers.
@@ -363,8 +378,11 @@ Module debugging_typedefs.
     Import IR.Compilers.ToString.
     Redirect "log"
              Compute match (sadd n s c machine_wordsize "1271") return (string * Pipeline.ErrorT _) with
-                     | (name, ErrorT.Success {| Pipeline.lines := v |}) => (name, ErrorT.Success (String.concat String.NewLine v))
-                     | v => _
+                     | (name, v)
+                       => match Debug.eval_result v with
+                          | ErrorT.Success {| Pipeline.lines := v |} => (name, ErrorT.Success (String.concat String.NewLine v))
+                          | _ => _
+                          end
                      end.
     Redirect "log"
              Compute Synthesize n s c machine_wordsize [] "curve" ["add"].
@@ -372,11 +390,15 @@ Module debugging_typedefs.
     Goal True.
       pose (sadd n s c machine_wordsize "1271") as v.
       cbv [sadd] in v.
-      vm_compute add in v.
+      vm_compute Pipeline.BoundsPipelineWithDebug in v.
       cbv beta iota zeta in v.
+      unfold Debug.bind in (value of v) at 1.
+      cbn [fst snd] in v.
       cbv [Language.Compilers.ToString.ToFunctionLines] in v.
       cbv [C.OutputCAPI] in v.
       cbv [ToFunctionLines] in v.
+      set (dbg := tree.smart_app _ _) in (value of v) at 1.
+      vm_compute in dbg; subst dbg.
       vm_compute IR.OfPHOAS.ExprOfPHOAS in v.
       cbv beta iota zeta in v.
       (*vm_compute in v.*)
@@ -417,13 +439,17 @@ Module debugging_21271_from_bytes.
     Goal True.
       pose (sfrom_bytes n s c machine_wordsize "1271") as v.
       cbv [sfrom_bytes] in v.
-      set (k := from_bytes _ _ _ _) in (value of v).
+      set (k := Pipeline.BoundsPipelineWithDebug _ _ _ _ _) in (value of v).
       clear v.
       cbv [from_bytes] in k.
-      cbv [Pipeline.BoundsPipeline] in k.
+      cbv [Pipeline.BoundsPipelineWithDebug] in k.
       set (k' := Pipeline.PreBoundsPipeline _ _ _ _) in (value of k).
       vm_compute in k'.
-      cbv [Rewriter.Util.LetIn.Let_In] in k.
+      cbv beta delta [Pipeline.BoundsPipelineWithDebug] in k.
+      let k' := fresh in rename k into k'; pose (DebugMonad.Debug.eval_result k') as k; subst k'.
+      cbv [Rewriter.Util.LetIn.Let_In DebugMonad.Debug.eval_result DebugMonad.Debug.sequence Pipeline.debug_after_rewrite DebugMonad.Debug.ret] in k.
+      vm_compute Pipeline.debug_rewriting in k.
+      unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
       set (k'' := CheckedPartialEvaluateWithBounds _ _ _ _ _ _ _) in (value of k).
       vm_compute in k''.
       lazymatch (eval cbv [k''] in k'') with
@@ -431,6 +457,9 @@ Module debugging_21271_from_bytes.
       end.
       cbv beta iota zeta in k.
       clear k''.
+      unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
+      unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
+      unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
       set (e := GeneralizeVar.FromFlat _) in (value of k).
       vm_compute in e.
       set (k'' := CheckedPartialEvaluateWithBounds _ _ _ _ _ _ _) in (value of k).
@@ -1230,12 +1259,16 @@ Module debugging_p256_mul_bedrock2.
       pose (smul m machine_wordsize "p256") as v.
       Import IdentifiersBasicGENERATED.Compilers.
       cbv [smul] in v.
-      set (k := mul _ _) in (value of v).
+      set (k := Pipeline.BoundsPipelineWithDebug _ _ _ _ _) in (value of v).
       vm_compute in v.
       clear v.
       cbv [mul] in k.
-      cbv -[Pipeline.BoundsPipeline WordByWordMontgomeryReificationCache.WordByWordMontgomery.reified_mul_gen] in k.
-      cbv [Pipeline.BoundsPipeline Pipeline.PreBoundsPipeline Rewriter.Util.LetIn.Let_In] in k.
+      cbv -[Pipeline.BoundsPipelineWithDebug WordByWordMontgomeryReificationCache.WordByWordMontgomery.reified_mul_gen] in k.
+      cbv [Pipeline.BoundsPipelineWithDebug Pipeline.PreBoundsPipeline Rewriter.Util.LetIn.Let_In] in k.
+      let k' := fresh in rename k into k'; pose (DebugMonad.Debug.eval_result k') as k; subst k'.
+      cbv [Rewriter.Util.LetIn.Let_In DebugMonad.Debug.eval_result DebugMonad.Debug.sequence Pipeline.debug_after_rewrite DebugMonad.Debug.ret] in k.
+      vm_compute Pipeline.debug_rewriting in k.
+      unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
       set (k' := CheckedPartialEvaluateWithBounds _ _ _ _ _ _ _) in (value of k).
       vm_compute in k'.
       subst k'; cbv beta iota zeta in k.
@@ -1300,11 +1333,11 @@ Module debugging_25519_to_bytes_bedrock2.
     Goal True.
       pose (sto_bytes n s c machine_wordsize "curve25519") as v.
       cbv [sto_bytes] in v.
-      set (k := to_bytes _ _ _ _) in (value of v).
+      set (k := Pipeline.BoundsPipelineWithDebug _ _ _ _ _) in (value of v).
       clear v.
       (*
       cbv [to_bytes] in k.
-      cbv [Pipeline.BoundsPipeline Pipeline.PreBoundsPipeline] in k.
+      cbv [Pipeline.BoundsPipelineWithDebug Pipeline.PreBoundsPipeline] in k.
       set (k' := Arith.Compilers.RewriteRules.RewriteArith _ _ _) in (value of k).
       vm_compute in k'.
       cbv [Rewriter.Util.LetIn.Let_In] in k.
@@ -1313,7 +1346,7 @@ Module debugging_25519_to_bytes_bedrock2.
       set (uint64 := r[0 ~> 18446744073709551615]%zrange) in (value of k'').
       subst k''.
       cbv beta iota zeta in k.
-      set (k'' := Pipeline.RewriteAndEliminateDeadAndInline _ _ _ _ _) in (value of k).
+      set (k'' := Pipeline.RewriteAndEliminateDeadAndInline _ _ _ _ _ _) in (value of k).
       vm_compute in k''.
       Compute Z.log2 9223372036854775808.
       clear -k''.
@@ -1683,7 +1716,7 @@ Module debugging_25519_to_bytes_bedrock2.
       cbv [widen_bytes_opt_instance_0] in k.
       cbv [widen_carry] in k.
       cbv [widen_carry_opt_instance_0] in k.
-      cbv [Pipeline.BoundsPipeline Pipeline.PreBoundsPipeline] in k.
+      cbv [Pipeline.BoundsPipelineWithDebug Pipeline.PreBoundsPipeline] in k.
       cbv [Rewriter.Util.LetIn.Let_In] in k.
       set (k' := GeneralizeVar.FromFlat _) in (value of k); vm_compute in k'; subst k'.
       cbv [CheckedPartialEvaluateWithBounds] in k.
@@ -1752,10 +1785,14 @@ Module debugging_25519_to_bytes_java.
     Goal True.
       pose (sto_bytes n s c machine_wordsize "curve25519") as v.
       cbv [sto_bytes] in v.
-      set (k := to_bytes _ _ _ _) in (value of v).
+      set (k := Pipeline.BoundsPipelineWithDebug _ _ _ _ _) in (value of v).
       vm_compute in k.
       subst k.
       cbv beta iota zeta in v.
+      let k' := fresh in rename v into k'; pose (DebugMonad.Debug.eval_result (snd k')) as v; subst k'.
+      cbv [Rewriter.Util.LetIn.Let_In DebugMonad.Debug.eval_result DebugMonad.Debug.sequence Pipeline.debug_after_rewrite DebugMonad.Debug.ret] in v.
+      vm_compute Pipeline.debug_rewriting in v.
+      unfold DebugMonad.Debug.bind in (value of v) at 1; cbn [snd] in v.
       set (k := Language.Compilers.ToString.ToFunctionLines _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) in (value of v).
       clear v.
       cbv [Language.Compilers.ToString.ToFunctionLines] in k.
@@ -1839,7 +1876,7 @@ Module debugging_25519_to_bytes_java.
       cbv [widen_bytes_opt_instance_0] in k.
       cbv [widen_carry] in k.
       cbv [widen_carry_opt_instance_0] in k.
-      cbv [Pipeline.BoundsPipeline Pipeline.PreBoundsPipeline] in k.
+      cbv [Pipeline.BoundsPipelineWithDebug Pipeline.PreBoundsPipeline] in k.
       cbv [Rewriter.Util.LetIn.Let_In] in k.
       set (k' := GeneralizeVar.FromFlat _) in (value of k); vm_compute in k'; subst k'.
       cbv [CheckedPartialEvaluateWithBounds] in k.
@@ -1903,15 +1940,22 @@ Module debugging_p256_uint1.
     Goal True.
       pose (smul m machine_wordsize "p256") as v.
       cbv [smul] in v.
-      set (k := WordByWordMontgomery.mul m machine_wordsize) in (value of v).
+      set (k := Pipeline.BoundsPipelineWithDebug _ _ _ _ _) in (value of v).
       cbv [WordByWordMontgomery.mul] in k.
       cbv [Primitives.possible_values_of_machine_wordsize] in k.
       cbv [widen_carry] in k.
       cbv [widen_carry_opt_instance_0] in k.
-      cbv [Pipeline.BoundsPipeline Pipeline.PreBoundsPipeline] in k.
+      cbv [Pipeline.BoundsPipelineWithDebug Pipeline.PreBoundsPipeline] in k.
       cbv [Rewriter.Util.LetIn.Let_In] in k.
       clear v.
-      set (k' := GeneralizeVar.FromFlat _) in (value of k); vm_compute in k'; subst k'.
+      let k' := fresh in rename k into k'; pose (DebugMonad.Debug.eval_result k') as k; subst k'.
+      cbv [Rewriter.Util.LetIn.Let_In DebugMonad.Debug.eval_result DebugMonad.Debug.sequence Pipeline.debug_after_rewrite DebugMonad.Debug.ret] in k.
+      vm_compute Pipeline.debug_rewriting in k.
+      unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
+      match (eval cbv delta [k] in k) with
+      | context[CheckedPartialEvaluateWithBounds _ _ _ _ ?e _ _]
+        => set (k' := e) in (value of k)
+      end; vm_compute in k'; subst k'.
       cbv [CheckedPartialEvaluateWithBounds] in k.
       cbv [Rewriter.Util.LetIn.Let_In] in k.
       set (k' := GeneralizeVar.FromFlat (GeneralizeVar.ToFlat _)) in (value of k).
@@ -1927,6 +1971,9 @@ Module debugging_p256_uint1.
       cbv [split_mul_to] in k.
       cbv [should_split_mul] in k.
       cbv [should_split_mul_opt_instance_0] in k.
+      unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
+      unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
+      unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
       set (k' := ZRange.type.base.option.is_tighter_than _ _) in (value of k).
       vm_compute in k'; subst k'.
       cbv beta iota in k.
@@ -1964,7 +2011,7 @@ Module debugging_go_build0.
     Goal True.
       pose (scarry_mul n s c machine_wordsize "p448_") as v.
       cbv [scarry_mul] in v.
-      set (k := carry_mul n s c machine_wordsize) in (value of v).
+      set (k := Pipeline.BoundsPipelineWithDebug _ _ _ _ _) in (value of v).
       vm_compute in k.
       subst k.
       cbv beta iota in v.
@@ -2036,7 +2083,7 @@ Module debugging_go_build0.
       cbv [Primitives.possible_values_of_machine_wordsize] in k.
       cbv [widen_carry] in k.
       cbv [widen_carry_opt_instance_0] in k.
-      cbv [Pipeline.BoundsPipeline Pipeline.PreBoundsPipeline] in k.
+      cbv [Pipeline.BoundsPipelineWithDebug Pipeline.PreBoundsPipeline] in k.
       set (k' := GeneralizeVar.ToFlat _) in (value of k).
       vm_compute in k'; subst k'.
       cbv [Rewriter.Util.LetIn.Let_In] in k.
@@ -2076,12 +2123,12 @@ Module debugging_go_build.
     Goal True.
       pose (sadd m machine_wordsize "p256") as v.
       cbv [sadd] in v.
-      set (k := WordByWordMontgomery.add m machine_wordsize) in (value of v).
+      set (k := Pipeline.BoundsPipelineWithDebug _ _ _ _ _) in (value of v).
       cbv [WordByWordMontgomery.add] in k.
       cbv [Primitives.possible_values_of_machine_wordsize] in k.
       cbv [widen_carry] in k.
       cbv [widen_carry_opt_instance_0] in k.
-      cbv [Pipeline.BoundsPipeline Pipeline.PreBoundsPipeline] in k.
+      cbv [Pipeline.BoundsPipelineWithDebug Pipeline.PreBoundsPipeline] in k.
       set (k' := GeneralizeVar.ToFlat _) in (value of k).
       vm_compute in k'; subst k'.
       cbv [Rewriter.Util.LetIn.Let_In] in k.
@@ -3793,12 +3840,16 @@ Module debugging_remove_mul_split2.
       pose (smul m machine_wordsize "") as v; clear -v.
       cbv in m; subst m machine_wordsize.
       cbv [smul] in v.
-      set (k := mul _ _) in (value of v).
+      set (k := Pipeline.BoundsPipelineWithDebug _ _ _ _ _) in (value of v).
       clear v.
       cbv [mul] in k.
       Import WordByWordMontgomeryReificationCache.
-      cbv -[Pipeline.BoundsPipeline reified_mul_gen] in k.
-      cbv [Pipeline.BoundsPipeline Pipeline.PreBoundsPipeline LetIn.Let_In] in k.
+      cbv -[Pipeline.BoundsPipelineWithDebug reified_mul_gen] in k.
+      cbv [Pipeline.BoundsPipelineWithDebug Pipeline.PreBoundsPipeline LetIn.Let_In] in k.
+      let k' := fresh in rename k into k'; pose (DebugMonad.Debug.eval_result k') as k; subst k'.
+      cbv [Rewriter.Util.LetIn.Let_In DebugMonad.Debug.eval_result DebugMonad.Debug.sequence Pipeline.debug_after_rewrite DebugMonad.Debug.ret] in k.
+      vm_compute Pipeline.debug_rewriting in k.
+      unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
       set (v := CheckedPartialEvaluateWithBounds _ _ _ _ _ _ _) in (value of k).
       Notation INL := (inl _).
       vm_compute in v.
@@ -3807,7 +3858,9 @@ Module debugging_remove_mul_split2.
       | @inl ?A ?B ?x => pose (id x) as v'; change v with (@inl A B v') in (value of k); clear v
       end.
       cbv beta iota in k.
-      set (v := Pipeline.RewriteAndEliminateDeadAndInline _ _ _ _ _) in (value of k) at 1.
+      unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
+      unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
+      set (v := Pipeline.RewriteAndEliminateDeadAndInline _ _ _ _ _ _) in (value of k) at 1.
       vm_compute in v; clear v';
       lazymatch (eval cbv [v] in v) with
       | ?x => pose (id x) as v'; change v with v' in (value of k); clear v
@@ -3921,7 +3974,7 @@ Module debugging_rewriting.
   Goal True.
     pose foo as X; cbv [foo] in X.
     clear -X.
-    cbv [Pipeline.BoundsPipeline Pipeline.PreBoundsPipeline LetIn.Let_In] in X.
+    cbv [Pipeline.BoundsPipelineWithDebug Pipeline.PreBoundsPipeline LetIn.Let_In] in X.
     set (Y := (PartialEvaluateWithListInfoFromBounds _ _)) in (value of X).
     vm_compute in Y.
     subst Y; set (Y := (Rewriter.Compilers.PartialEvaluate _)) in (value of X).

--- a/src/SlowPrimeSynthesisExamples.v
+++ b/src/SlowPrimeSynthesisExamples.v
@@ -397,8 +397,8 @@ Module debugging_typedefs.
       cbv [Language.Compilers.ToString.ToFunctionLines] in v.
       cbv [C.OutputCAPI] in v.
       cbv [ToFunctionLines] in v.
-      set (dbg := tree.smart_app _ _) in (value of v) at 1.
-      vm_compute in dbg; subst dbg.
+      try (set (dbg := tree.smart_app _ _) in (value of v) at 1;
+           vm_compute in dbg; subst dbg).
       vm_compute IR.OfPHOAS.ExprOfPHOAS in v.
       cbv beta iota zeta in v.
       (*vm_compute in v.*)
@@ -1265,7 +1265,7 @@ Module debugging_p256_mul_bedrock2.
       cbv [mul] in k.
       cbv -[Pipeline.BoundsPipelineWithDebug WordByWordMontgomeryReificationCache.WordByWordMontgomery.reified_mul_gen] in k.
       cbv [Pipeline.BoundsPipelineWithDebug Pipeline.PreBoundsPipeline Rewriter.Util.LetIn.Let_In] in k.
-      let k' := fresh in rename k into k'; pose (DebugMonad.Debug.eval_result k') as k; subst k'.
+      let k' := fresh in rename k into k'; epose (DebugMonad.Debug.eval_result k') as k; subst k'.
       cbv [Rewriter.Util.LetIn.Let_In DebugMonad.Debug.eval_result DebugMonad.Debug.sequence Pipeline.debug_after_rewrite DebugMonad.Debug.ret] in k.
       vm_compute Pipeline.debug_rewriting in k.
       unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
@@ -3846,7 +3846,7 @@ Module debugging_remove_mul_split2.
       Import WordByWordMontgomeryReificationCache.
       cbv -[Pipeline.BoundsPipelineWithDebug reified_mul_gen] in k.
       cbv [Pipeline.BoundsPipelineWithDebug Pipeline.PreBoundsPipeline LetIn.Let_In] in k.
-      let k' := fresh in rename k into k'; pose (DebugMonad.Debug.eval_result k') as k; subst k'.
+      let k' := fresh in rename k into k'; epose (DebugMonad.Debug.eval_result k') as k; subst k'.
       cbv [Rewriter.Util.LetIn.Let_In DebugMonad.Debug.eval_result DebugMonad.Debug.sequence Pipeline.debug_after_rewrite DebugMonad.Debug.ret] in k.
       vm_compute Pipeline.debug_rewriting in k.
       unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.

--- a/src/StandaloneDebuggingExamples.v
+++ b/src/StandaloneDebuggingExamples.v
@@ -15,7 +15,7 @@ Module debugging_no_asm.
     pose main as v.
     cbv beta iota zeta delta [main main_gen] in v.
     set (k := map _ sys_argv) in (value of v).
-    assert (k = ["./src/ExtractionOCaml/unsaturated_solinas"; "25519"; "64"; "5"; "2^255-19"; "carry_mul"; "--no-primitives"; "--hints-file"; "t.asm"]) by admit.
+    assert (k = ["./src/ExtractionOCaml/unsaturated_solinas"; "25519"; "64"; "5"; "2^255-19"; "carry_mul"; "--no-primitives"; "--debug"; "-all"; "--hints-file"; "t.asm"]) by admit.
     clearbody k; subst k.
     cbv beta iota zeta delta [ForExtraction.UnsaturatedSolinas.PipelineMain ForExtraction.Parameterized.PipelineMain] in v.
     vm_compute Arg.parse_argv in v.
@@ -112,7 +112,7 @@ Module debugging_typedef_bounds.
     pose main as v.
     cbv beta iota zeta delta [main main_gen] in v.
     set (k := map _ sys_argv) in (value of v).
-    assert (k = ["./src/ExtractionOCaml/unsaturated_solinas"; "curve25519"; "64"; "5"; "2^255-19"; "add"; "--no-primitives"]) by admit.
+    assert (k = ["./src/ExtractionOCaml/unsaturated_solinas"; "curve25519"; "64"; "5"; "2^255-19"; "add"; "--no-primitives"; "--debug"; "-all"]) by admit.
     clearbody k; subst k.
     cbv beta iota zeta delta [ForExtraction.UnsaturatedSolinas.PipelineMain ForExtraction.Parameterized.PipelineMain] in v.
     vm_compute Arg.parse_argv in v.

--- a/src/StandaloneDebuggingExamples.v
+++ b/src/StandaloneDebuggingExamples.v
@@ -25,6 +25,8 @@ Module debugging_no_asm.
     cbv [ForExtraction.parse_common_optional_options] in v.
     cbv [ForExtraction.hint_file_names] in v.
     cbn [map fst snd] in v.
+    vm_compute ParseDebugOptions.parse_debug_opts in v.
+    cbv beta iota in v.
     cbn [ForExtraction.with_read_concat_asm_files_cps] in v.
     set (k := ForExtraction.with_read_file "t.asm") in (value of v).
     assert (k = (fun k => k ["SECTION .text"
@@ -79,10 +81,14 @@ Module debugging_no_asm.
     set (k' := (_ =? _)%string) in (value of k) at 1; vm_compute in k'; subst k'; cbv beta iota in k.
     cbn [fold_right map List.app] in k.
     cbv [UnsaturatedSolinas.extra_special_synthesis UnsaturatedSolinas.scarry_mul] in k.
-    set (cm := UnsaturatedSolinas.carry_mul _ _ _ _) in (value of k).
+    set (cm := BoundsPipeline.Pipeline.BoundsPipelineWithDebug _ _ _ _ _) in (value of k).
     vm_compute in cm.
     set (cmv := (fun var => Language.Compilers.expr.Abs _)) in (value of cm).
     subst cm; cbv beta iota in k.
+    let k' := fresh in rename k into k'; pose (List.map DebugMonad.Debug.eval_result (List.map snd k')) as k; subst k'.
+    cbv [DebugMonad.Debug.eval_result] in k; cbn [List.map snd] in k.
+    unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
+    unfold DebugMonad.Debug.bind in (value of k) at 1; cbn [snd] in k.
     set (cml := Language.Compilers.ToString.ToFunctionLines _ _ _ _ _ _ _ _ _ _ _ _ _ _) in (value of k).
     vm_compute in cml.
     set (cmlv := _ :: _) in (value of cml) at 1.
@@ -118,6 +124,8 @@ Module debugging_typedef_bounds.
     cbv [ForExtraction.parse_common_optional_options] in v.
     cbv [ForExtraction.hint_file_names] in v.
     cbn [map] in v.
+    vm_compute ParseDebugOptions.parse_debug_opts in v.
+    cbv beta iota in v.
     cbn [ForExtraction.with_read_concat_asm_files_cps] in v.
     vm_compute ForExtraction.parse_args in v.
     cbv beta iota zeta in v.
@@ -166,8 +174,11 @@ Module debugging_typedef_bounds.
     cbv [ForExtraction.low_level_rewriter_method] in v.
     cbn -[UnsaturatedSolinas.sadd] in v.
     cbv [UnsaturatedSolinas.sadd] in v.
-    vm_compute UnsaturatedSolinas.add in v.
+    vm_compute BoundsPipeline.Pipeline.BoundsPipelineWithDebug in v.
     cbv beta iota zeta in v.
+    let k' := fresh in rename v into k'; pose (DebugMonad.Debug.eval_result (snd k')) as v; subst k'.
+    cbv [DebugMonad.Debug.eval_result] in v; cbn [List.map snd] in v.
+    unfold DebugMonad.Debug.bind in (value of v) at 1; cbn [snd] in v.
     cbv [Language.Compilers.ToString.ToFunctionLines] in v.
     cbv [C.Compilers.ToString.C.OutputCAPI] in v.
     cbv [C.Compilers.ToString.C.ToFunctionLines] in v.

--- a/src/StandaloneOCamlMain.v
+++ b/src/StandaloneOCamlMain.v
@@ -16,6 +16,16 @@ Global Unset Extraction Optimize.
 (** Work around COQBUG(https://github.com/coq/coq/issues/4875) / COQBUG(https://github.com/coq/coq/issues/7954) / COQBUG(https://github.com/coq/coq/issues/7954) / https://discuss.ocaml.org/t/why-wont-ocaml-specialize-weak-type-variables-in-dead-code/7776 *)
 Extraction Inline Show.ShowLevel_of_Show.
 
+(** Performance hacks *)
+Extraction Inline DebugMonad.Debug.debug'.
+Extraction Inline DebugMonad.Debug.bind.
+Extraction Inline DebugMonad.Debug.sequence.
+Extraction Inline DebugMonad.Debug.map.
+Extraction Inline DebugMonad.Debug.ret.
+Extraction Inline DebugMonad.Debug.eval_result.
+Extraction Inline BoundsPipeline.Pipeline.debug_after_rewrite.
+Extraction Inline BoundsPipeline.Pipeline.wrap_debug_rewrite.
+
 Inductive int : Set := int_O | int_S (x : int).
 
 (** We pull a hack to get coqchk to not report these as axioms; for

--- a/src/StandaloneOCamlMain.v
+++ b/src/StandaloneOCamlMain.v
@@ -16,16 +16,6 @@ Global Unset Extraction Optimize.
 (** Work around COQBUG(https://github.com/coq/coq/issues/4875) / COQBUG(https://github.com/coq/coq/issues/7954) / COQBUG(https://github.com/coq/coq/issues/7954) / https://discuss.ocaml.org/t/why-wont-ocaml-specialize-weak-type-variables-in-dead-code/7776 *)
 Extraction Inline Show.ShowLevel_of_Show.
 
-(** Performance hacks *)
-Extraction Inline DebugMonad.Debug.debug'.
-Extraction Inline DebugMonad.Debug.bind.
-Extraction Inline DebugMonad.Debug.sequence.
-Extraction Inline DebugMonad.Debug.map.
-Extraction Inline DebugMonad.Debug.ret.
-Extraction Inline DebugMonad.Debug.eval_result.
-Extraction Inline BoundsPipeline.Pipeline.debug_after_rewrite.
-Extraction Inline BoundsPipeline.Pipeline.wrap_debug_rewrite.
-
 Inductive int : Set := int_O | int_S (x : int).
 
 (** We pull a hack to get coqchk to not report these as axioms; for

--- a/src/Util/DebugMonad.v
+++ b/src/Util/DebugMonad.v
@@ -41,13 +41,16 @@ Module Debug.
   Notation debug v := (debug' (fun 'tt => v)).
   Local Notation eta x := (fst x, snd x).
   Definition bind {dbg A B} (x : DebugM A) (k : A -> DebugM B) : @DebugM dbg B
-    := let '(dbg1, a) := eta x in
-       let '(dbg2, b) := eta (k a) in
+    := let x := x in
+       let '(dbg1, a) := eta x in
+       let ka := k a in
+       let '(dbg2, b) := eta ka in
        (tree.smart_app dbg1 dbg2, b).
   Definition sequence {dbg A} (x : DebugM unit) (k : DebugM A) : @DebugM dbg A
     := bind x (fun 'tt => k).
   Definition map {dbg A B} (f : A -> B) (x : DebugM A) : @DebugM dbg B
-    := let '(dbg, a) := eta x in
+    := let x := x in
+       let '(dbg, a) := eta x in
        (dbg, f a).
   Definition ret {dbg A} (a : A) : @DebugM dbg A
     := (tree.empty, a).

--- a/src/Util/DebugMonad.v
+++ b/src/Util/DebugMonad.v
@@ -30,30 +30,30 @@ Module tree. (* for efficient debugging at various depths *)
   End tree.
   Global Arguments empty {_}.
 End tree.
-Definition DebugM {dbg} (T : Type) : Type := (tree.t (unit -> list dbg)) * T.
+Definition DebugM {dbg : Type} (T : Type) : Type := unit * T.
 Global Arguments DebugM {_} _, _ _.
 Declare Scope debugM_scope.
 Delimit Scope debugM_scope with debugM.
 Bind Scope debugM_scope with DebugM.
 Module Debug.
-  Definition debug' {dbg} : (unit -> list dbg) -> DebugM unit
-    := fun msg => (tree.singleton msg, tt).
+  Definition debug' {dbg} : (unit -> list dbg) -> @DebugM dbg unit
+    := fun msg => (tt, tt).
   Notation debug v := (debug' (fun 'tt => v)).
   Local Notation eta x := (fst x, snd x).
-  Definition bind {dbg A B} (x : DebugM A) (k : A -> DebugM B) : @DebugM dbg B
+  Definition bind {dbg A B} (x : DebugM dbg A) (k : A -> DebugM dbg B) : @DebugM dbg B
     := let x := x in
        let '(dbg1, a) := eta x in
        let ka := k a in
        let '(dbg2, b) := eta ka in
-       (tree.smart_app dbg1 dbg2, b).
+       (tt, b).
   Definition sequence {dbg A} (x : DebugM unit) (k : DebugM A) : @DebugM dbg A
     := bind x (fun 'tt => k).
-  Definition map {dbg A B} (f : A -> B) (x : DebugM A) : @DebugM dbg B
+  Definition map {dbg A B} (f : A -> B) (x : DebugM dbg A) : @DebugM dbg B
     := let x := x in
        let '(dbg, a) := eta x in
        (dbg, f a).
   Definition ret {dbg A} (a : A) : @DebugM dbg A
-    := (tree.empty, a).
+    := (tt, a).
   Definition eval_result {dbg A} : @DebugM dbg A -> A
     := @snd _ _.
   Definition copy_debug_info {dbg A} (x : DebugM A) : @DebugM dbg unit
@@ -61,7 +61,7 @@ Module Debug.
   Definition with_debug_info {dbg A B} (x : DebugM A) (y : DebugM B) : @DebugM dbg B
     := sequence (copy_debug_info x) y.
   Definition get_debug_info {dbg A} (v : DebugM dbg A) : list (unit -> list dbg)
-    := tree.to_list (fst v).
+    := nil.
 
   Lemma eval_result_bind dbg A B x k
     : eval_result (@bind dbg A B x k) = let y := eval_result x in eval_result (k y).

--- a/src/Util/DebugMonad.v
+++ b/src/Util/DebugMonad.v
@@ -1,0 +1,69 @@
+Require Import Coq.Strings.String.
+Require Import Coq.Lists.List.
+Require Import Crypto.Util.Notations.
+Require Export Crypto.Util.GlobalSettings.
+Require Export Crypto.Util.FixCoqMistakes.
+Import ListNotations.
+
+Local Set Boolean Equality Schemes.
+Local Set Decidable Equality Schemes.
+Local Set Implicit Arguments.
+Module tree. (* for efficient debugging at various depths *)
+  Section tree.
+    Context (T : Type).
+    Inductive t := empty | singleton (_ : T) | app (_ _ : t).
+    (* deduplicates empties *)
+    Definition smart_app (x y : t)
+      := match x, y with
+         | empty, _ => y
+         | _, empty => x
+         | _, _ => app x y
+         end.
+    Definition fold {A} (f : T -> A -> A)  :=
+      fix fold (v : t) (init : A) : A
+        := match v with
+           | empty => init
+           | singleton v => f v init
+           | app l r => fold l (fold r init)
+           end.
+    Definition to_list (v : t) : list T := fold (@cons _) v nil.
+  End tree.
+  Global Arguments empty {_}.
+End tree.
+Definition DebugM {dbg} (T : Type) : Type := (tree.t (unit -> list dbg)) * T.
+Global Arguments DebugM {_} _, _ _.
+Declare Scope debugM_scope.
+Delimit Scope debugM_scope with debugM.
+Bind Scope debugM_scope with DebugM.
+Module Debug.
+  Definition debug' {dbg} : (unit -> list dbg) -> DebugM unit
+    := fun msg => (tree.singleton msg, tt).
+  Notation debug v := (debug' (fun 'tt => v)).
+  Local Notation eta x := (fst x, snd x).
+  Definition bind {dbg A B} (x : DebugM A) (k : A -> DebugM B) : @DebugM dbg B
+    := let '(dbg1, a) := eta x in
+       let '(dbg2, b) := eta (k a) in
+       (tree.smart_app dbg1 dbg2, b).
+  Definition sequence {dbg A} (x : DebugM unit) (k : DebugM A) : @DebugM dbg A
+    := bind x (fun 'tt => k).
+  Definition map {dbg A B} (f : A -> B) (x : DebugM A) : @DebugM dbg B
+    := let '(dbg, a) := eta x in
+       (dbg, f a).
+  Definition ret {dbg A} (a : A) : @DebugM dbg A
+    := (tree.empty, a).
+  Definition eval_result {dbg A} : @DebugM dbg A -> A
+    := @snd _ _.
+  Definition copy_debug_info {dbg A} (x : DebugM A) : @DebugM dbg unit
+    := bind x (fun _ => ret tt).
+  Definition with_debug_info {dbg A B} (x : DebugM A) (y : DebugM B) : @DebugM dbg B
+    := sequence (copy_debug_info x) y.
+  Definition get_debug_info {dbg A} (v : DebugM dbg A) : list (unit -> list dbg)
+    := tree.to_list (fst v).
+
+  Lemma eval_result_bind dbg A B x k
+    : eval_result (@bind dbg A B x k) = let y := eval_result x in eval_result (k y).
+  Proof. reflexivity. Qed.
+End Debug.
+
+Notation "x <- y ; f" := (Debug.bind y (fun x => f%debugM)) : debugM_scope.
+Notation "f ;; g" := (Debug.sequence f g) : debugM_scope.

--- a/src/Util/DebugMonad.v
+++ b/src/Util/DebugMonad.v
@@ -30,30 +30,30 @@ Module tree. (* for efficient debugging at various depths *)
   End tree.
   Global Arguments empty {_}.
 End tree.
-Definition DebugM {dbg : Type} (T : Type) : Type := unit * T.
+Definition DebugM {dbg} (T : Type) : Type := (tree.t (unit -> list dbg)) * T.
 Global Arguments DebugM {_} _, _ _.
 Declare Scope debugM_scope.
 Delimit Scope debugM_scope with debugM.
 Bind Scope debugM_scope with DebugM.
 Module Debug.
-  Definition debug' {dbg} : (unit -> list dbg) -> @DebugM dbg unit
-    := fun msg => (tt, tt).
+  Definition debug' {dbg} : (unit -> list dbg) -> DebugM unit
+    := fun msg => (tree.singleton msg, tt).
   Notation debug v := (debug' (fun 'tt => v)).
   Local Notation eta x := (fst x, snd x).
-  Definition bind {dbg A B} (x : DebugM dbg A) (k : A -> DebugM dbg B) : @DebugM dbg B
+  Definition bind {dbg A B} (x : DebugM A) (k : A -> DebugM B) : @DebugM dbg B
     := let x := x in
        let '(dbg1, a) := eta x in
        let ka := k a in
        let '(dbg2, b) := eta ka in
-       (tt, b).
+       (tree.smart_app dbg1 dbg2, b).
   Definition sequence {dbg A} (x : DebugM unit) (k : DebugM A) : @DebugM dbg A
     := bind x (fun 'tt => k).
-  Definition map {dbg A B} (f : A -> B) (x : DebugM dbg A) : @DebugM dbg B
+  Definition map {dbg A B} (f : A -> B) (x : DebugM A) : @DebugM dbg B
     := let x := x in
        let '(dbg, a) := eta x in
        (dbg, f a).
   Definition ret {dbg A} (a : A) : @DebugM dbg A
-    := (tt, a).
+    := (tree.empty, a).
   Definition eval_result {dbg A} : @DebugM dbg A -> A
     := @snd _ _.
   Definition copy_debug_info {dbg A} (x : DebugM A) : @DebugM dbg unit
@@ -61,7 +61,7 @@ Module Debug.
   Definition with_debug_info {dbg A B} (x : DebugM A) (y : DebugM B) : @DebugM dbg B
     := sequence (copy_debug_info x) y.
   Definition get_debug_info {dbg A} (v : DebugM dbg A) : list (unit -> list dbg)
-    := nil.
+    := tree.to_list (fst v).
 
   Lemma eval_result_bind dbg A B x k
     : eval_result (@bind dbg A B x k) = let y := eval_result x in eval_result (k y).

--- a/src/Util/FSets/FMapString.v
+++ b/src/Util/FSets/FMapString.v
@@ -1,0 +1,8 @@
+Require Import Coq.Strings.String.
+Require Import Coq.FSets.FMapFullAVL.
+Require Import Coq.FSets.FMapInterface.
+Require Import Coq.Structures.OrderedTypeEx.
+Require Export Crypto.Util.FixCoqMistakes.
+(* TODO: use tries instead? *)
+
+Module StringMap <: S := FMapFullAVL.Make String_as_OT.

--- a/src/Util/MSets/MSetString.v
+++ b/src/Util/MSets/MSetString.v
@@ -1,0 +1,10 @@
+Require Import Coq.Strings.String.
+Require Import Coq.MSets.MSetAVL.
+Require Import Coq.MSets.MSetFacts.
+Require Import Coq.MSets.MSetInterface.
+Require Import Coq.Structures.OrdersEx.
+Require Export Crypto.Util.FixCoqMistakes.
+(* TODO: use tries instead? *)
+
+Module StringSet <: S := MSetAVL.Make String_as_OT.
+Module StringSetFacts := Facts StringSet.

--- a/src/Util/Strings/ParseDebugOptions.v
+++ b/src/Util/Strings/ParseDebugOptions.v
@@ -1,0 +1,95 @@
+Require Import Coq.Strings.String.
+Require Import Coq.Lists.List.
+Require Import Crypto.Util.Strings.String.
+Require Import Crypto.Util.Strings.Show.
+Require Crypto.Util.Tuple.
+Require Import Crypto.Util.Option.
+Require Import Crypto.Util.FSets.FMapString.
+Require Import Crypto.Util.MSets.MSetString.
+Import ListNotations.
+Local Open Scope list_scope.
+Local Open Scope string_scope.
+
+Local Set Boolean Equality Schemes.
+Local Set Decidable Equality Schemes.
+
+Variant debug_status := enabled | disabled.
+Variant full_debug_status := explicit (_ : debug_status) | elided.
+Global Coercion explicit : debug_status >-> full_debug_status.
+Coercion bool_of_debug_status (d : debug_status) : bool
+  := match d with
+     | enabled => true
+     | disabled => false
+     end.
+Definition bool_of_full_debug_status (d : full_debug_status) (default : bool) : bool
+  := match d with
+     | elided => default
+     | explicit d => bool_of_debug_status d
+     end.
+Global Instance show_debug_status : Show debug_status
+  := fun s => match s with
+              | enabled => "enabled"
+              | disabled => "disabled"
+              end.
+Global Instance show_full_debug_status : Show full_debug_status
+  := fun s => match s with
+              | explicit s => show s
+              | elided => "elided"
+              end.
+Variant debug_option_kind := all | alias (_ : list string).
+Coercion simple (s : string) : debug_option_kind := alias [s].
+
+Definition preparse_debug_opts (spec : list (string * debug_option_kind)) (args : list string) : list (debug_option_kind * debug_status)
+  := let spec := List.fold_left (fun acc '(s, k) => StringMap.add s k acc) spec (@StringMap.empty _) in
+     let args := List.filter (fun s => negb (s =? "")) (List.map String.trim (List.flat_map (String.split ",") args)) in
+     List.map
+       (fun arg
+        => let '(prefix, shortened_arg) := (substring 0 1 arg, substring 1 (String.length arg) arg) in
+           let '(status, arg) := if (prefix =? "-")%string
+                                 then (disabled, shortened_arg)
+                                 else if (prefix =? "+")%string
+                                      then (enabled, shortened_arg)
+                                      else (enabled, arg) in
+           (Option.value (StringMap.find arg spec) (simple arg), status))
+       args.
+
+Definition aggregate_debug_opts (args : list (debug_option_kind * debug_status)) : full_debug_status (* all status *) * StringMap.t debug_status
+  := List.fold_left
+       (fun '(all_status, acc) '(k, s)
+        => match k with
+           | all => (explicit s, StringMap.map (fun _ => s) acc)
+           | alias ls
+             => (all_status,
+                  List.fold_left
+                    (fun acc arg => StringMap.add arg s acc)
+                    ls
+                    acc)
+           end)
+       args
+       (elided, @StringMap.empty _).
+
+Fixpoint format_debug_opts (known_options : list string) (status : StringMap.t debug_status) : Tuple.tuple full_debug_status (List.length known_options)
+  := match known_options return Tuple.tuple full_debug_status (List.length known_options) with
+     | [] => tt
+     | opt :: opts
+       => Tuple.cons
+            match StringMap.find opt status with
+            | Some s => explicit s
+            | None => elided
+            end
+            (format_debug_opts opts status)
+     end.
+
+Definition post_parse_debug_opts (known_options : list string) (status : full_debug_status (* all status *) * StringMap.t debug_status)
+  : full_debug_status (* all status *) * list (string * debug_status) (* unknown options *) * Tuple.tuple full_debug_status (List.length known_options)
+  := let '(all_status, status) := status in
+     let known_options_set := List.fold_right StringSet.add StringSet.empty known_options in
+     let unknown_options := List.filter (fun '(opt, _) => negb (StringSet.mem opt known_options_set)) (StringMap.elements status) in
+     (all_status, unknown_options, format_debug_opts known_options status).
+
+Definition parse_debug_opts (spec : list (string * debug_option_kind)) (known_options : list string) (args : list string)
+  : full_debug_status (* all status *) * list (string * debug_status) (* unknown options *) * Tuple.tuple full_debug_status (List.length known_options)
+  := let res := preparse_debug_opts spec args in
+     let res := aggregate_debug_opts res in
+     let res := post_parse_debug_opts known_options res in
+     res.


### PR DESCRIPTION
Passing `--debug rewriting` will now print out info on the rewriting passes when synthesis fails; passing `--debug rewriting,on-success` will also print out the information even if synthesis succeeds.

This will hopefully help with debugging https://github.com/mit-plv/fiat-crypto/pull/1358#discussion_r990919165

Thoughts @andres-erbsen on whether or not we want to see all the intermediate debug info about rewriting passes on every synthesis failure?  (That is, should we be passing `--debug " -rewriting"` to disable the debug info, or should we have to pass `--debug rewriting` to enable it?)

Timing info coming soon