### PR TITLE
test-amd64: dependency on binary should not be order-only

### DIFF
--- a/fiat-amd64/gentest.py
+++ b/fiat-amd64/gentest.py
@@ -112,7 +112,7 @@ clean::
 
 .PHONY: {output_name}.only-status
 
-{output_name}.status: | {binary}
+{output_name}.status: {binary}
 
 {output_name}.status {output_name}.only-status: {' '.join(fnames)}
 \t$(SHOW)'TEST AMD64 {description} ...'


### PR DESCRIPTION
This way make test-amd64 will rebuild the status files when the binary changes.