### PR TITLE
Rename Debug options to Flag options

### DIFF
--- a/src/CLI.v
+++ b/src/CLI.v
@@ -16,7 +16,7 @@ Require Import Crypto.Util.Strings.NamingConventions.
 Require Import Crypto.Util.Option.
 Require Import Crypto.Util.OptionList.
 Require Import Crypto.Util.Strings.Show.
-Require Import Crypto.Util.Strings.ParseDebugOptions.
+Require Import Crypto.Util.Strings.ParseFlagOptions.
 Require Import Crypto.Util.DebugMonad.
 Require Crypto.PushButtonSynthesis.SaturatedSolinas.
 Require Crypto.PushButtonSynthesis.UnsaturatedSolinas.
@@ -195,7 +195,7 @@ Module ForExtraction.
     ].
   Definition known_debug_options : list string
     := Eval compute in List.map fst known_debug_options_with_spec.
-  Definition special_debug_options : list (string * debug_option_kind)
+  Definition special_debug_options : list (string * flag_option_kind)
     := [("all", all)
     ].
   (** This string gets parsed as the initial argument to --debug, to be updated by subsequent arguments *)
@@ -708,7 +708,7 @@ Module ForExtraction.
              , doc_prepend_headerv
              , debugv
             ) := data in
-       let debug_to_bool x := bool_of_full_debug_status x false in
+       let flag_to_bool x := bool_of_full_flag_status x false in
        let to_bool ls := (0 <? List.length ls)%nat in
        let to_string_list ls := List.map (@snd _ _) ls in
        let to_N_list ls := List.map (@snd _ _) (List.map (@snd _ _) ls) in
@@ -727,7 +727,7 @@ Module ForExtraction.
        let to_capitalization_convention_opt ls
            := option_map (fun d => {| capitalization_convention_data := d ; only_lower_first_letters := true |})
                          (to_capitalization_data_opt ls) in
-       let '(_, unknown_debug_options, (debug_on_successv, debug_rewritingv)) := parse_debug_opts special_debug_options known_debug_options (default_debug :: List.map snd debugv) in
+       let '(_, unknown_debug_options, (debug_on_successv, debug_rewritingv)) := parse_flag_opts special_debug_options known_debug_options (default_debug :: List.map snd debugv) in
        let res
            := ({|
                   hint_file_names := to_string_list hint_file_namesv
@@ -784,8 +784,8 @@ Module ForExtraction.
                        |}
                   ; before_header_lines := to_string_list doc_prepend_header_rawv
                   ; extra_early_header_lines := to_string_list doc_prepend_headerv
-                  ; debug_rewriting := debug_to_bool debug_rewritingv
-                  ; debug_on_success := debug_to_bool debug_on_successv
+                  ; debug_rewriting := flag_to_bool debug_rewritingv
+                  ; debug_on_success := flag_to_bool debug_on_successv
                |},
                snd (List.hd lang_default langv)) in
        match langv, unknown_debug_options with

--- a/src/StandaloneDebuggingExamples.v
+++ b/src/StandaloneDebuggingExamples.v
@@ -25,7 +25,7 @@ Module debugging_no_asm.
     cbv [ForExtraction.parse_common_optional_options] in v.
     cbv [ForExtraction.hint_file_names] in v.
     cbn [map fst snd] in v.
-    vm_compute ParseDebugOptions.parse_debug_opts in v.
+    vm_compute ParseFlagOptions.parse_flag_opts in v.
     cbv beta iota in v.
     cbn [ForExtraction.with_read_concat_asm_files_cps] in v.
     set (k := ForExtraction.with_read_file "t.asm") in (value of v).
@@ -124,7 +124,7 @@ Module debugging_typedef_bounds.
     cbv [ForExtraction.parse_common_optional_options] in v.
     cbv [ForExtraction.hint_file_names] in v.
     cbn [map] in v.
-    vm_compute ParseDebugOptions.parse_debug_opts in v.
+    vm_compute ParseFlagOptions.parse_flag_opts in v.
     cbv beta iota in v.
     cbn [ForExtraction.with_read_concat_asm_files_cps] in v.
     vm_compute ForExtraction.parse_args in v.

--- a/src/Util/Strings/ParseFlagOptions.v
+++ b/src/Util/Strings/ParseFlagOptions.v
@@ -13,33 +13,33 @@ Local Open Scope string_scope.
 Local Set Boolean Equality Schemes.
 Local Set Decidable Equality Schemes.
 
-Variant debug_status := enabled | disabled.
-Variant full_debug_status := explicit (_ : debug_status) | elided.
-Global Coercion explicit : debug_status >-> full_debug_status.
-Coercion bool_of_debug_status (d : debug_status) : bool
+Variant flag_status := enabled | disabled.
+Variant full_flag_status := explicit (_ : flag_status) | elided.
+Global Coercion explicit : flag_status >-> full_flag_status.
+Coercion bool_of_flag_status (d : flag_status) : bool
   := match d with
      | enabled => true
      | disabled => false
      end.
-Definition bool_of_full_debug_status (d : full_debug_status) (default : bool) : bool
+Definition bool_of_full_flag_status (d : full_flag_status) (default : bool) : bool
   := match d with
      | elided => default
-     | explicit d => bool_of_debug_status d
+     | explicit d => bool_of_flag_status d
      end.
-Global Instance show_debug_status : Show debug_status
+Global Instance show_flag_status : Show flag_status
   := fun s => match s with
               | enabled => "enabled"
               | disabled => "disabled"
               end.
-Global Instance show_full_debug_status : Show full_debug_status
+Global Instance show_full_flag_status : Show full_flag_status
   := fun s => match s with
               | explicit s => show s
               | elided => "elided"
               end.
-Variant debug_option_kind := all | alias (_ : list string).
-Coercion simple (s : string) : debug_option_kind := alias [s].
+Variant flag_option_kind := all | alias (_ : list string).
+Coercion simple (s : string) : flag_option_kind := alias [s].
 
-Definition preparse_debug_opts (spec : list (string * debug_option_kind)) (args : list string) : list (debug_option_kind * debug_status)
+Definition preparse_flag_opts (spec : list (string * flag_option_kind)) (args : list string) : list (flag_option_kind * flag_status)
   := let spec := List.fold_left (fun acc '(s, k) => StringMap.add s k acc) spec (@StringMap.empty _) in
      let args := List.filter (fun s => negb (s =? "")) (List.map String.trim (List.flat_map (String.split ",") args)) in
      List.map
@@ -53,7 +53,7 @@ Definition preparse_debug_opts (spec : list (string * debug_option_kind)) (args 
            (Option.value (StringMap.find arg spec) (simple arg), status))
        args.
 
-Definition aggregate_debug_opts (args : list (debug_option_kind * debug_status)) : full_debug_status (* all status *) * StringMap.t debug_status
+Definition aggregate_flag_opts (args : list (flag_option_kind * flag_status)) : full_flag_status (* all status *) * StringMap.t flag_status
   := List.fold_left
        (fun '(all_status, acc) '(k, s)
         => match k with
@@ -68,8 +68,8 @@ Definition aggregate_debug_opts (args : list (debug_option_kind * debug_status))
        args
        (elided, @StringMap.empty _).
 
-Fixpoint format_debug_opts (known_options : list string) (status : StringMap.t debug_status) : Tuple.tuple full_debug_status (List.length known_options)
-  := match known_options return Tuple.tuple full_debug_status (List.length known_options) with
+Fixpoint format_flag_opts (known_options : list string) (status : StringMap.t flag_status) : Tuple.tuple full_flag_status (List.length known_options)
+  := match known_options return Tuple.tuple full_flag_status (List.length known_options) with
      | [] => tt
      | opt :: opts
        => Tuple.cons
@@ -77,19 +77,19 @@ Fixpoint format_debug_opts (known_options : list string) (status : StringMap.t d
             | Some s => explicit s
             | None => elided
             end
-            (format_debug_opts opts status)
+            (format_flag_opts opts status)
      end.
 
-Definition post_parse_debug_opts (known_options : list string) (status : full_debug_status (* all status *) * StringMap.t debug_status)
-  : full_debug_status (* all status *) * list (string * debug_status) (* unknown options *) * Tuple.tuple full_debug_status (List.length known_options)
+Definition post_parse_flag_opts (known_options : list string) (status : full_flag_status (* all status *) * StringMap.t flag_status)
+  : full_flag_status (* all status *) * list (string * flag_status) (* unknown options *) * Tuple.tuple full_flag_status (List.length known_options)
   := let '(all_status, status) := status in
      let known_options_set := List.fold_right StringSet.add StringSet.empty known_options in
      let unknown_options := List.filter (fun '(opt, _) => negb (StringSet.mem opt known_options_set)) (StringMap.elements status) in
-     (all_status, unknown_options, format_debug_opts known_options status).
+     (all_status, unknown_options, format_flag_opts known_options status).
 
-Definition parse_debug_opts (spec : list (string * debug_option_kind)) (known_options : list string) (args : list string)
-  : full_debug_status (* all status *) * list (string * debug_status) (* unknown options *) * Tuple.tuple full_debug_status (List.length known_options)
-  := let res := preparse_debug_opts spec args in
-     let res := aggregate_debug_opts res in
-     let res := post_parse_debug_opts known_options res in
+Definition parse_flag_opts (spec : list (string * flag_option_kind)) (known_options : list string) (args : list string)
+  : full_flag_status (* all status *) * list (string * flag_status) (* unknown options *) * Tuple.tuple full_flag_status (List.length known_options)
+  := let res := preparse_flag_opts spec args in
+     let res := aggregate_flag_opts res in
+     let res := post_parse_flag_opts known_options res in
      res.


### PR DESCRIPTION
h/t Andres

This will let us reuse them for rewrite passes without me feeling silly about naming.