### PR TITLE
Enable CLI control of equiv checker rewrite passes with `--asm-rewriting-pipeline`, `--asm-rewriting-passes`

### DIFF
--- a/src/Assembly/Equivalence.v
+++ b/src/Assembly/Equivalence.v
@@ -131,23 +131,29 @@ Definition default_assembly_conventions : assembly_conventions_opt
      |}.
 
 Module Export Options.
+  Export Assembly.Symbolic.Options.
   Class equivalence_checker_options_opt :=
     { assembly_conventions_ : assembly_conventions_opt
+    ; symbolic_options_ : symbolic_options_opt
     }.
   Definition default_equivalence_checker_options : equivalence_checker_options_opt
     := {| assembly_conventions_ := default_assembly_conventions
+       ; symbolic_options_ := default_symbolic_options
        |}.
 End Options.
 
 Module Export EquivalenceCheckerHints.
+  Export Assembly.Symbolic.Hints.
   Global Existing Instances
    Build_equivalence_checker_options_opt
    assembly_conventions_
+   symbolic_options_
   .
   #[global]
    Hint Cut [
       ( _ * )
         (assembly_conventions_
+        | symbolic_options_
         ) ( _ * )
         (Build_equivalence_checker_options_opt
         )
@@ -709,7 +715,7 @@ Global Instance show_EquivalenceCheckingError : Show EquivalenceCheckingError
 Definition merge_fresh_symbol {descr:description} : dag.M idx := fun d => merge_node (dag.gensym 64%N d) d.
 Definition merge_literal {descr:description} (l:Z) : dag.M idx := merge_node ((const l, nil)).
 
-Definition SetRegFresh {descr:description} (r : REG) : M idx :=
+Definition SetRegFresh {opts : symbolic_options_computed_opt} {descr:description} (r : REG) : M idx :=
   (idx <- lift_dag merge_fresh_symbol;
   _ <- SetReg r idx;
   Symbolic.ret idx).
@@ -726,7 +732,7 @@ Bind Scope symex_scope with symexM.
 Notation "'slet' x .. y <- X ; B"  := (symex_bind X (fun x => .. (fun y => B%symex) .. )) : symex_scope.
 Notation "A <- X ; B" := (symex_bind X (fun A => B%symex)) : symex_scope.
 (* light alias *)
-Definition App {descr:description} (e : Symbolic.node idx) : symexM idx := fun st => Success (merge (simplify st e) st).
+Definition App {opts : symbolic_options_computed_opt} {descr:description} (e : Symbolic.node idx) : symexM idx := fun st => Success (merge (simplify st e) st).
 Definition RevealConstant (i : idx) : symexM N := fun st =>
   match reveal st 1 i with
   | ExprApp (const n, nil) =>
@@ -803,17 +809,17 @@ Fixpoint build_inputs {descr:description} (types : type_spec) : dag.M (list (idx
      end%dagM.
 
 (* we factor this out so that conversion is not slow when proving things about this *)
-Definition compute_array_address {descr:description} (base : idx) (i : nat)
+Definition compute_array_address {opts : symbolic_options_computed_opt} {descr:description} (base : idx) (i : nat)
   := (offset <- Symbolic.App (zconst 64%N (8 * Z.of_nat i), nil);
       Symbolic.App (add 64%N, [base; offset]))%x86symex.
 
-Definition build_merge_array_addresses {descr:description} (base : idx) (items : list idx) : M (list idx)
+Definition build_merge_array_addresses {opts : symbolic_options_computed_opt} {descr:description} (base : idx) (items : list idx) : M (list idx)
   := mapM (fun '(i, idx) =>
              (addr <- compute_array_address base i;
               (fun s => Success (addr, update_mem_with s (cons (addr,idx)))))
           )%x86symex (List.enumerate items).
 
-Fixpoint build_merge_base_addresses {descr:description} {dereference_scalar:bool} (items : list (idx + list idx)) (reg_available : list REG) : M (list ((REG + idx) + idx))
+Fixpoint build_merge_base_addresses {opts : symbolic_options_computed_opt} {descr:description} {dereference_scalar:bool} (items : list (idx + list idx)) (reg_available : list REG) : M (list ((REG + idx) + idx))
   := match items, reg_available with
      | [], _ | _, [] => Symbolic.ret []
      | inr idxs :: xs, r :: reg_available
@@ -1003,7 +1009,7 @@ Fixpoint symex_T_app_curried {t : API.type} : symex_T t -> type.for_each_lhs_of_
 
 Bind Scope symex_scope with symex_T.
 
-Definition symex_ident {descr:description} {t} (idc : ident t) : symex_T t.
+Definition symex_ident {opts : symbolic_options_computed_opt} {descr:description} {t} (idc : ident t) : symex_T t.
 Proof.
   refine (let symex_mod_zrange idx '(ZRange.Build_zrange l u) :=
             let u := Z.succ u in
@@ -1195,7 +1201,7 @@ Proof.
   all: cbn in *.
 Defined.
 
-Fixpoint symex_expr {descr:description} {t} (e : API.expr (var:=var) t) : symex_T t
+Fixpoint symex_expr {opts : symbolic_options_computed_opt} {descr:description} {t} (e : API.expr (var:=var) t) : symex_T t
   := let _ := @Compilers.ToString.PHOAS.expr.partially_show_expr in
      match e in expr.expr t return symex_T t with
      | expr.Ident _ idc => symex_ident idc
@@ -1218,7 +1224,7 @@ Fixpoint symex_expr {descr:description} {t} (e : API.expr (var:=var) t) : symex_
      end.
 
 (* takes and returns PHOAS-style things *)
-Definition symex_PHOAS_PHOAS {t} (expr : API.Expr t) (input_var_data : type.for_each_lhs_of_arrow _ t) (d : dag)
+Definition symex_PHOAS_PHOAS {opts : symbolic_options_computed_opt} {t} (expr : API.Expr t) (input_var_data : type.for_each_lhs_of_arrow _ t) (d : dag)
   : ErrorT EquivalenceCheckingError (base_var (type.final_codomain t) * dag)
   := let ast : API.expr (type.base (type.final_codomain t))
          := invert_expr.smart_App_curried (expr _) input_var_data in
@@ -1226,6 +1232,7 @@ Definition symex_PHOAS_PHOAS {t} (expr : API.Expr t) (input_var_data : type.for_
 
 (* takes and returns assembly/list style things *)
 Definition symex_PHOAS
+           {opts : symbolic_options_computed_opt}
            {t} (expr : API.Expr t)
            (inputs : list (idx + list idx))
            (d : dag)
@@ -1252,25 +1259,25 @@ Definition init_symbolic_state (d : dag) : symbolic_state
        symbolic_flag_state := Tuple.repeat None 6;
      |}.
 
-Definition compute_stack_base {descr:description} (stack_size : nat) : M idx
+Definition compute_stack_base {opts : symbolic_options_computed_opt} {descr:description} (stack_size : nat) : M idx
   := (rsp_val <- SetRegFresh rsp;
       stack_size <- Symbolic.App (zconst 64 (-8 * Z.of_nat stack_size), []);
       Symbolic.App (add 64%N, [rsp_val; stack_size]))%x86symex.
 
-Definition build_merge_stack_placeholders {descr:description} (stack_size : nat)
+Definition build_merge_stack_placeholders {opts : symbolic_options_computed_opt} {descr:description} (stack_size : nat)
   : M idx
   := (stack_placeholders <- lift_dag (build_inputarray stack_size);
       stack_base <- compute_stack_base stack_size;
       _ <- build_merge_array_addresses stack_base stack_placeholders;
       ret stack_base)%x86symex.
 
-Definition LoadArray {descr:description} (base : idx) (len : nat) : M (list idx)
+Definition LoadArray {opts : symbolic_options_computed_opt} {descr:description} (base : idx) (len : nat) : M (list idx)
   := mapM (fun i =>
              (addr <- compute_array_address base i;
               Remove64 addr)%x86symex)
           (seq 0 len).
 
-Definition LoadOutputs_internal {descr:description} {dereference_scalar:bool} (outputaddrs : list ((REG + idx) + idx)) (output_types : type_spec)
+Definition LoadOutputs_internal {opts : symbolic_options_computed_opt} {descr:description} {dereference_scalar:bool} (outputaddrs : list ((REG + idx) + idx)) (output_types : type_spec)
   : M (list (idx + list idx))
   := (mapM (fun '(ocells, spec) =>
             match ocells, spec with
@@ -1289,7 +1296,7 @@ Definition LoadOutputs_internal {descr:description} {dereference_scalar:bool} (o
                   ret (inr v))
             end) (List.combine outputaddrs output_types))%N%x86symex.
 
-Definition LoadOutputs {descr:description} {dereference_scalar:bool} (outputaddrs : list ((REG + idx) + idx)) (output_types : type_spec)
+Definition LoadOutputs {opts : symbolic_options_computed_opt} {descr:description} {dereference_scalar:bool} (outputaddrs : list ((REG + idx) + idx)) (output_types : type_spec)
   : M (ErrorT EquivalenceCheckingError (list (idx + list idx)))
   := (* In the following line, we match on the result so we can emit Internal_error_output_load_failed in the calling function, rather than passing through the placeholder error from LoadOutputs *)
   fun s => if (List.length outputaddrs =? List.length output_types)%nat
@@ -1307,6 +1314,7 @@ Definition LoadOutputs {descr:description} {dereference_scalar:bool} (outputaddr
              Success (Error (Internal_error_LoadOutputs_length_mismatch outputaddrs output_types), s).
 
 Definition symex_asm_func_M
+           {opts : symbolic_options_computed_opt}
            (dereference_input_scalars:=false)
            {dereference_output_scalars:bool}
            (callee_saved_registers : list REG)
@@ -1344,6 +1352,7 @@ Definition symex_asm_func_M
                     s)))%N%x86symex.
 
 Definition symex_asm_func
+           {opts : symbolic_options_computed_opt}
            {dereference_output_scalars:bool}
            (d : dag) (callee_saved_registers : list REG) (output_types : type_spec) (stack_size : nat)
            (inputs : list (idx + list idx)) (reg_available : list REG) (asm : Lines)
@@ -1374,7 +1383,8 @@ Definition symex_asm_func
              end.
 
 Section check_equivalence.
-  Context {assembly_calling_registers' : assembly_calling_registers_opt}
+  Context {symbolic_opts : symbolic_options_computed_opt}
+          {assembly_calling_registers' : assembly_calling_registers_opt}
           {assembly_stack_size' : assembly_stack_size_opt}
           {assembly_output_first : assembly_output_first_opt}
           {assembly_argument_registers_left_to_right : assembly_argument_registers_left_to_right_opt}

--- a/src/Assembly/WithBedrock/Proofs.v
+++ b/src/Assembly/WithBedrock/Proofs.v
@@ -1450,7 +1450,7 @@ Proof.
   eapply R_subsumed; eassumption.
 Qed.
 
-Lemma build_merge_stack_placeholders_ok_R {descr:description} G s s' frame frame' ms
+Lemma build_merge_stack_placeholders_ok_R {opts : symbolic_options_computed_opt} {descr:description} G s s' frame frame' ms
       (rsp_val : Z) (stack_vals : list Z) base_stack base_stack_word_val
       (H : build_merge_stack_placeholders (List.length stack_vals) s = Success (base_stack, s'))
       (d := s.(dag_state))
@@ -1757,7 +1757,7 @@ Local Ltac handle_eval_eval :=
          end.
 
 Lemma build_merge_base_addresses_ok_R
-      {descr:description} {dereference_scalar:bool}
+      {opts : symbolic_options_computed_opt} {descr:description} {dereference_scalar:bool}
       (idxs : list (idx + list idx))
       (reg_available : list REG)
       (runtime_reg : list Z)
@@ -1961,7 +1961,7 @@ Proof.
     all: eauto with nocore. }
 Qed.
 
-Lemma mapM_GetReg_ok_R_full {descr:description} G regs idxs reg_vals s s' frame ms
+Lemma mapM_GetReg_ok_R_full {opts : symbolic_options_computed_opt} {descr:description} G regs idxs reg_vals s s' frame ms
       (H : mapM GetReg regs s = Success (idxs, s'))
       (d := s.(dag_state))
       (d' := s'.(dag_state))
@@ -1995,7 +1995,7 @@ Proof.
   all: eauto using R_regs_subsumed, R_flags_subsumed, R_mem_subsumed.
 Qed.
 
-Lemma mapM_GetReg_ok_R {descr:description} G regs idxs s s' frame (ms : machine_state)
+Lemma mapM_GetReg_ok_R {opts : symbolic_options_computed_opt} {descr:description} G regs idxs s s' frame (ms : machine_state)
       (H : mapM GetReg regs s = Success (idxs, s'))
       (d := s.(dag_state))
       (d' := s'.(dag_state))
@@ -2031,7 +2031,8 @@ Proof.
   all: try solve [ cbv [R] in HR; destruct s; eapply Forall2_get_reg_of_R_regs; try assumption; try apply HR ].
 Qed.
 
-Lemma SymexLines_ok_R frame G s m asm _tt s'
+Lemma SymexLines_ok_R {opts : symbolic_options_computed_opt}
+      frame G s m asm _tt s'
       (d := s.(dag_state))
       (d' := s'.(dag_state))
       (r := s.(symbolic_reg_state))
@@ -2103,7 +2104,7 @@ Qed.
 Lemma get_asm_reg_bounded s rs : Forall (fun v => (0 <= v < 2 ^ 64)%Z) (get_asm_reg s rs).
 Proof. apply get_reg_bounded_Forall. Qed.
 
-Lemma LoadArray_ok_R {descr:description} frame G s ms s' base base_val base_word_val len idxs
+Lemma LoadArray_ok_R {opts : symbolic_options_computed_opt} {descr:description} frame G s ms s' base base_val base_word_val len idxs
       (H : LoadArray base len s = Success (idxs, s'))
       (d := s.(dag_state))
       (d' := s'.(dag_state))
@@ -2402,7 +2403,7 @@ Proof.
                     | apply SeparationLogic.impl1_r_sep_emp; split; [ | reflexivity ] ].
 Qed.
 
-Lemma LoadOutputs_ok_R {descr:description} {dereference_scalar:bool} frame G s ms s' outputaddrs output_types output_vals idxs
+Lemma LoadOutputs_ok_R {opts : symbolic_options_computed_opt} {descr:description} {dereference_scalar:bool} frame G s ms s' outputaddrs output_types output_vals idxs
       (H : LoadOutputs (dereference_scalar:=dereference_scalar) outputaddrs output_types s = Success (Success idxs, s'))
       (d := s.(dag_state))
       (d' := s'.(dag_state))
@@ -2823,6 +2824,7 @@ Qed.
 Local Ltac debug_run tac := tac ().
 
 Theorem symex_asm_func_M_correct
+        {opts : symbolic_options_computed_opt}
         {output_scalars_are_pointers:bool}
         d frame asm_args_out asm_args_in (G : symbol -> option Z) (s := init_symbolic_state d)
         (s' : symbolic_state) (m : machine_state) (output_types : type_spec) (stack_size : nat) (stack_base : Naive.word 64)
@@ -3267,6 +3269,7 @@ Proof.
 Time Qed. (* Finished transaction in 14.751 secs (14.751u,0.s) *)
 
 Theorem symex_asm_func_correct
+        {opts : symbolic_options_computed_opt}
         {output_scalars_are_pointers:bool}
         frame asm_args_out asm_args_in (G : symbol -> option Z) (d : dag) (output_types : type_spec) (stack_size : nat) (stack_base : Naive.word 64)
         (inputs : list (idx + list idx)) (callee_saved_registers : list REG) (reg_available : list REG) (asm : Lines)
@@ -3301,6 +3304,7 @@ Proof.
 Qed.
 
 Theorem check_equivalence_correct
+        {opts : symbolic_options_computed_opt}
         (output_scalars_are_pointers:=false)
         {assembly_calling_registers' : assembly_calling_registers_opt}
         {assembly_stack_size' : assembly_stack_size_opt}
@@ -3409,6 +3413,7 @@ Proof.
 Qed.
 
 Theorem generate_assembly_of_hinted_expr_correct
+        {opts : symbolic_options_computed_opt}
         (output_scalars_are_pointers:=false)
         {assembly_calling_registers' : assembly_calling_registers_opt}
         {assembly_stack_size' : assembly_stack_size_opt}

--- a/src/Assembly/WithBedrock/SymbolicProofs.v
+++ b/src/Assembly/WithBedrock/SymbolicProofs.v
@@ -408,7 +408,7 @@ Ltac step_Merge :=
 Ltac step_symex2 := first [step_symex1 | step_Merge].
 Ltac step_symex ::= step_symex2.
 
-Lemma App_R {descr:description} s m (HR : R s m) e v (H : eval_node G s e v) :
+Lemma App_R {opts : symbolic_options_computed_opt} {descr:description} s m (HR : R s m) e v (H : eval_node G s e v) :
   forall i s', Symbolic.App e s = Success (i, s') ->
   R s' m /\ s :< s' /\ eval s' i v.
 Proof using Type.
@@ -470,7 +470,7 @@ Ltac step_SetFlag :=
     [eassumption|..|clear H]
   end.
 
-Lemma GetReg_R {descr:description} s m (HR: R s m) r i s'
+Lemma GetReg_R {opts : symbolic_options_computed_opt} {descr:description} s m (HR: R s m) r i s'
   (H : GetReg r s = Success (i, s'))
   : R s' m  /\ s :< s' /\ eval s' i (get_reg m r).
 Proof using Type.
@@ -492,7 +492,7 @@ Ltac step_GetReg :=
     [eassumption|..|clear H]
   end.
 
-Lemma Address_R {descr:description} s m (HR : R s m) (sa:AddressSize) o a s' (H : Symbolic.Address o s = Success (a, s'))
+Lemma Address_R {opts : symbolic_options_computed_opt} {descr:description} s m (HR : R s m) (sa:AddressSize) o a s' (H : Symbolic.Address o s = Success (a, s'))
   : R s' m /\ s :< s' /\ exists v, eval s' a v /\ @DenoteAddress sa m o = v.
 Proof using Type.
   destruct o as [? ? ? ?]; cbv [Address DenoteAddress Syntax.mem_base_reg Syntax.mem_offset Syntax.mem_scale_reg err ret] in *; repeat step_symex.
@@ -707,7 +707,7 @@ Proof using Type.
 Qed.
 
 
-Lemma GetOperand_R {descr:description} s m (HR: R s m) (so:OperationSize) (sa:AddressSize) a i s'
+Lemma GetOperand_R {opts : symbolic_options_computed_opt} {descr:description} s m (HR: R s m) (so:OperationSize) (sa:AddressSize) a i s'
   (H : GetOperand a s = Success (i, s'))
   : R s' m /\ s :< s' /\ exists v, eval s' i v /\ DenoteOperand sa so m a = Some v.
 Proof using Type.
@@ -762,7 +762,7 @@ Ltac step_GetOperand :=
   end.
 
 (* note: do the two SetOperand both truncate inputs or not?... *)
-Lemma R_SetOperand {descr:description} s m (HR : R s m)
+Lemma R_SetOperand {opts : symbolic_options_computed_opt} {descr:description} s m (HR : R s m)
   (sz:OperationSize) (sa:AddressSize) a i _tt s' (H : Symbolic.SetOperand a i s = Success (_tt, s'))
   v (Hv : eval s i v)
   : exists m', SetOperand sa sz m a v = Some m' /\ R s' m' /\ s :< s'.
@@ -1103,7 +1103,7 @@ Proof using Type.
 Qed.
 
 
-Lemma SymexNornalInstruction_R {descr:description} s m (HR : R s m) instr :
+Lemma SymexNornalInstruction_R {opts : symbolic_options_computed_opt} {descr:description} s m (HR : R s m) instr :
   forall _tt s', Symbolic.SymexNormalInstruction instr s = Success (_tt, s') ->
   exists m', Semantics.DenoteNormalInstruction m instr = Some m' /\ R s' m' /\ s :< s'.
 Proof using Type.
@@ -1354,7 +1354,7 @@ Proof using Type.
   all: fail_if_goals_remain ().
 Qed.
 
-Lemma SymexLines_R s m (HR : R s m) asm :
+Lemma SymexLines_R {opts : symbolic_options_computed_opt} s m (HR : R s m) asm :
   forall _tt s', Symbolic.SymexLines asm s = Success (_tt, s') ->
   exists m', Semantics.DenoteLines m asm = Some m' /\ R s' m' /\ s :< s'.
 Proof using Type.

--- a/src/StandaloneDebuggingExamples.v
+++ b/src/StandaloneDebuggingExamples.v
@@ -26,7 +26,8 @@ Module debugging_no_asm.
     cbv [ForExtraction.hint_file_names] in v.
     cbn [map fst snd] in v.
     vm_compute ParseFlagOptions.parse_flag_opts in v.
-    cbv beta iota in v.
+    vm_compute ParseFlagOptions.parse_flag_opts_to_bool_filter in v.
+    cbn [List.app] in v.
     cbn [ForExtraction.with_read_concat_asm_files_cps] in v.
     set (k := ForExtraction.with_read_file "t.asm") in (value of v).
     assert (k = (fun k => k ["SECTION .text"
@@ -125,7 +126,8 @@ Module debugging_typedef_bounds.
     cbv [ForExtraction.hint_file_names] in v.
     cbn [map] in v.
     vm_compute ParseFlagOptions.parse_flag_opts in v.
-    cbv beta iota in v.
+    vm_compute ParseFlagOptions.parse_flag_opts_to_bool_filter in v.
+    cbn [List.app] in v.
     cbn [ForExtraction.with_read_concat_asm_files_cps] in v.
     vm_compute ForExtraction.parse_args in v.
     cbv beta iota zeta in v.


### PR DESCRIPTION
Alternate implementation of the part of #1481 that enables control of which asm passes are enabled.  We go for a much more full-featured approach here, allowing the user to fully customize which rules are run, in what order, and how many times.  On top of #1495, #1496, #1497.

cc @OwenConoly @andres-erbsen 