### PR TITLE
Make the dag available in ASM equiv rewrite passes

### DIFF
--- a/src/Assembly/EquivalenceProofs.v
+++ b/src/Assembly/EquivalenceProofs.v
@@ -305,12 +305,14 @@ Lemma App_correct {opts : symbolic_options_computed_opt} {descr:description} n d
   : eval G d' (ExprRef i) v /\ gensym_dag_ok G d' /\ (forall e n, eval G d e n -> eval G d' e n).
 Proof using Type.
   cbv [App] in *. inversion_ErrorT.
-  do 2
   match goal with
   | H : context [simplify ?d ?n] |- _ =>
-      unique pose proof (eval_simplify _ d n _ ltac:(eassumption))
+      unique pose proof (fun G => eval_simplify G d n)
+  end.
+  specialize_under_binders_by eassumption.
+  match goal with
   | H : context [merge ?e ?d] |- _ =>
-      case (eval_merge _ e _ d ltac:(eassumption) ltac:(eassumption)) as (?&?&?)
+      edestruct (fun G n => eval_merge G e n d) as (?&?&?); try eassumption
   end.
   inversion_prod; subst; eauto 9.
 Qed.
@@ -1573,8 +1575,8 @@ Proof.
   (* need to do this early to deal with conversion slowness *)
   repeat match goal with
          | [ H : context[simplify ?s ?n] |- _ ]
-           => unshelve epose proof (@eval_simplify _ _ s n _ _); shelve_unifiable;
-              [ solve [ repeat first [ eassumption | exactly_once econstructor ] ] | ];
+           => unshelve epose proof (@eval_simplify _ _ s n _ _ _); shelve_unifiable;
+              [ solve [ repeat first [ eassumption | exactly_once econstructor ] ] .. | ];
               generalize dependent (simplify s n); intros
          | [ H : context[merge ?e ?d] |- _ ]
            => pose proof (@eval_merge _ _ e _ d ltac:(eassumption) ltac:(eassumption));
@@ -1728,8 +1730,8 @@ Proof.
   (* need to do this early to deal with conversion slowness *)
   repeat match goal with
          | [ H : context[simplify ?s ?n] |- _ ]
-           => unshelve epose proof (@eval_simplify _ _ s n _ _); shelve_unifiable;
-              [ solve [ repeat first [ eassumption | exactly_once econstructor ] ] | ];
+           => unshelve epose proof (@eval_simplify _ _ s n _ _ _); shelve_unifiable;
+              [ solve [ repeat first [ eassumption | exactly_once econstructor ] ] .. | ];
               generalize dependent (simplify s n); intros
          | [ H : context[merge ?e ?d] |- _ ]
            => pose proof (@eval_merge _ _ e _ d ltac:(eassumption) ltac:(eassumption));
@@ -1906,8 +1908,8 @@ Proof.
   (* need to do this early to deal with conversion slowness *)
   repeat first [ match goal with
                  | [ H : context[simplify ?s ?n] |- _ ]
-                   => unshelve epose proof (@eval_simplify _ _ s n _ _); shelve_unifiable;
-                      [ solve [ repeat first [ eassumption | solve [ eauto ] | exactly_once econstructor ] ] | ];
+                   => unshelve epose proof (@eval_simplify _ _ s n _ _ _); shelve_unifiable;
+                      [ solve [ repeat first [ eassumption | solve [ eauto ] | exactly_once econstructor ] ] .. | ];
                       generalize dependent (simplify s n); intros
                  | [ H : context[merge ?e ?d] |- _ ]
                    => pose proof (@eval_merge _ _ e _ d ltac:(eassumption) ltac:(eassumption));
@@ -2078,8 +2080,8 @@ Proof.
                       | [ H : (tt, (?y, ?z)) = (tt, (?y', ?z')) |- _ ]
                         => is_var y; is_var z; is_var y'; is_var z'; inversion H; clear H
                       | [ H : context[simplify ?s ?n] |- _ ]
-                        => unshelve epose proof (@eval_simplify _ _ s n _ _); shelve_unifiable;
-                           [ solve [ repeat first [ eassumption | solve [ eauto ] | exactly_once econstructor ] ] | ];
+                        => unshelve epose proof (@eval_simplify _ _ s n _ _ _); shelve_unifiable;
+                           [ solve [ repeat first [ eassumption | solve [ eauto ] | exactly_once econstructor ] ] .. | ];
                            generalize dependent (simplify s n); intros
                       | [ H : context[merge ?e ?d] |- _ ]
                         => pose proof (@eval_merge _ _ e _ d ltac:(eassumption) ltac:(eassumption));

--- a/src/Util/Tactics/DestructHead.v
+++ b/src/Util/Tactics/DestructHead.v
@@ -10,10 +10,12 @@ Ltac destruct_head_matcher T HT :=
 Ltac destruct_head T := destruct_all_matches ltac:(destruct_head_matcher T).
 Ltac destruct_one_head T := destruct_one_match ltac:(destruct_head_matcher T).
 Ltac destruct_head' T := destruct_all_matches' ltac:(destruct_head_matcher T).
+Ltac destruct_one_head' T := destruct_one_match' ltac:(destruct_head_matcher T).
 
 Ltac inversion_head T := inversion_all_matches ltac:(destruct_head_matcher T).
 Ltac inversion_one_head T := inversion_one_match ltac:(destruct_head_matcher T).
 Ltac inversion_head' T := inversion_all_matches' ltac:(destruct_head_matcher T).
+Ltac inversion_one_head' T := inversion_one_match' ltac:(destruct_head_matcher T).
 
 
 Ltac head_hnf_matcher T HT :=
@@ -23,10 +25,12 @@ Ltac head_hnf_matcher T HT :=
 Ltac destruct_head_hnf T := destruct_all_matches ltac:(head_hnf_matcher T).
 Ltac destruct_one_head_hnf T := destruct_one_match ltac:(head_hnf_matcher T).
 Ltac destruct_head_hnf' T := destruct_all_matches' ltac:(head_hnf_matcher T).
+Ltac destruct_one_head_hnf' T := destruct_one_match' ltac:(head_hnf_matcher T).
 
 Ltac inversion_head_hnf T := inversion_all_matches ltac:(head_hnf_matcher T).
 Ltac inversion_one_head_hnf T := inversion_one_match ltac:(head_hnf_matcher T).
 Ltac inversion_head_hnf' T := inversion_all_matches' ltac:(head_hnf_matcher T).
+Ltac inversion_one_head_hnf' T := inversion_one_match' ltac:(head_hnf_matcher T).
 
 (** Faster versions for some common connectives *)
 Ltac destruct_one_head'_ex := match goal with H : ex _ |- _ => destruct H end.

--- a/src/Util/Tactics/DestructHyps.v
+++ b/src/Util/Tactics/DestructHyps.v
@@ -34,10 +34,12 @@ Ltac destruct_all_matches matcher :=
   destruct_all_matches_then matcher ltac:( simpl in * ).
 Ltac destruct_one_match matcher := destruct_one_match_then matcher ltac:( simpl in * ).
 Ltac destruct_all_matches' matcher := destruct_all_matches_then matcher idtac.
+Ltac destruct_one_match' matcher := destruct_one_match_then matcher idtac.
 
 Ltac inversion_all_matches matcher := inversion_all_matches_then matcher ltac:( simpl in * ).
 Ltac inversion_one_match matcher := inversion_one_match_then matcher ltac:( simpl in * ).
 Ltac inversion_all_matches' matcher := inversion_all_matches_then matcher idtac.
+Ltac inversion_one_match' matcher := inversion_one_match_then matcher idtac.
 
 (* matches anything whose type has a [T] in it *)
 Ltac destruct_type_matcher T HT :=


### PR DESCRIPTION
We don't currently use it, but this will allow us to augment `bound_expr` to make use of bounds in the dag and write passes that use this augmented bounds information.

In theory, this may also allow us to do lazy revealing of expressions rather than needing to reveal them deeply up-front.

This is split off so that it is possible to add more rewrite passes without conflicting too much with changes to how bounds are handled.

On top of #1504 

Timing info coming soon

cc @OwenConoly 