### PR TITLE
Bump Go from 1.13 to 1.16

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -29,10 +29,10 @@ jobs:
         #sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7
     - name: GCC Problem Matcher
       uses: ammaraskar/gcc-problem-matcher@0.2.0
-    - name: Set up Go 1.13
+    - name: Set up Go 1.16
       uses: actions/setup-go@v3
       with:
-        go-version: 1.13
+        go-version: 1.16
       id: go
     - name: make only-test-c-files CC=gcc
       run: make only-test-c-files CC=gcc EXTERNAL_DEPENDENCIES=1


### PR DESCRIPTION
For `os.ReadFile` as per https://pkg.go.dev/os#ReadFile to avoid
```
Error: util/embed_test_data.go:79:16: undefined: os.ReadFile
  Error: util/embed_test_data.go:129:16: undefined: os.ReadFile
```
https://github.com/mit-plv/fiat-crypto/actions/runs/3564511625/jobs/5988555886#step:8:110

cc @davidben 