### PR TITLE
Adapt to coq/coq#16920

### DIFF
--- a/src/Arithmetic/BarrettReduction/Generalized.v
+++ b/src/Arithmetic/BarrettReduction/Generalized.v
@@ -117,7 +117,7 @@ Section barrett.
       assert (a / b^(k-offset) <= b^(k+offset)) by (autorewrite with pull_Zpow zsimplify in *; assumption).
       subst q r m.
       rewrite (Z.div_mul_diff_exact''' (b^(2*k)) n (a/b^(k-offset))) by auto with lia zero_bounds.
-      rewrite (Z_div_mod_eq (b^(2*k) * _ / n) (b^(k+offset))) by lia.
+      rewrite (Z_div_mod_eq_full (b^(2*k) * _ / n) (b^(k+offset))).
       autorewrite with push_Zmul push_Zopp zsimplify zstrip_div zdiv_to_mod.
       rewrite Z.div_sub_mod_cond, !Z.div_sub_small by auto with zero_bounds zarith.
       eexists (_, _); reflexivity.

--- a/src/Arithmetic/BarrettReduction/HAC.v
+++ b/src/Arithmetic/BarrettReduction/HAC.v
@@ -84,7 +84,7 @@ Section barrett.
       assert (x / b^(k-offset) <= b^(k+offset)) by (autorewrite with pull_Zpow zsimplify in *; assumption).
       subst q1 q2 q3 Q r_mod_3m r_mod_3m_orig r1 r2 R μ.
       rewrite (Z.div_mul_diff_exact' (b^(2*k)) m (x/b^(k-offset))) by auto with lia zero_bounds.
-      rewrite (Z_div_mod_eq (_ * b^(2*k) / m) (b^(k+offset))) by lia.
+      rewrite (Z_div_mod_eq_full (_ * b^(2*k) / m) (b^(k+offset))).
       autorewrite with push_Zmul push_Zopp zsimplify zstrip_div zdiv_to_mod.
       rewrite Z.div_sub_mod_cond, !Z.div_sub_small; auto with zero_bounds zarith.
       eexists (_, _); reflexivity.

--- a/src/Arithmetic/BarrettReduction/Wikipedia.v
+++ b/src/Arithmetic/BarrettReduction/Wikipedia.v
@@ -97,7 +97,7 @@ Section barrett.
       assert (0 <= a * (4 ^ k mod n) / n < 4 ^ k) by (auto with zero_bounds zarith lia).
       subst q r m.
       rewrite (Z.div_mul_diff_exact''' (4^k) n a) by lia.
-      rewrite (Z_div_mod_eq (4^k * _ / n) (4^k)) by lia.
+      rewrite (Z_div_mod_eq_full (4^k * _ / n) (4^k)).
       autorewrite with push_Zmul push_Zopp zsimplify zstrip_div.
       eexists; reflexivity.
     Qed.

--- a/src/Arithmetic/ModularArithmeticTheorems.v
+++ b/src/Arithmetic/ModularArithmeticTheorems.v
@@ -186,8 +186,7 @@ Module F.
     Proof using Type.
       unfold F.to_nat, F.of_nat.
       rewrite F.to_Z_of_Z.
-      assert (Pos.to_nat m <> 0)%nat as HA by (pose proof Pos2Nat.is_pos m; lia).
-      pose proof (mod_Zmod n (Pos.to_nat m) HA) as Hmod.
+      pose proof (Nat2Z.inj_mod n (Pos.to_nat m)) as Hmod.
       rewrite positive_nat_Z in Hmod.
       rewrite <- Hmod.
       rewrite <-Nat2Z.id, Z2Nat.inj_pos; lia.
@@ -209,9 +208,8 @@ Module F.
     Lemma of_nat_mod (n:nat) : F.of_nat m (n mod (Z.to_nat m)) = F.of_nat m n.
     Proof using Type.
       unfold F.of_nat.
-      rewrite (F.of_Z_mod (Z.of_nat n)), ?mod_Zmod, ?Z2Nat.id; [reflexivity|..].
-      { apply Pos2Z.is_nonneg. }
-      { rewrite Z2Nat.inj_pos. apply Pos_to_nat_nonzero. }
+      rewrite (F.of_Z_mod (Z.of_nat n)), ?Nat2Z.inj_mod, ?Z2Nat.id; [reflexivity|..].
+      apply Pos2Z.is_nonneg.
     Qed.
 
     Lemma to_nat_mod (x:F m) (Hm:(0 < m)%Z) : F.to_nat x mod (Z.to_nat m) = F.to_nat x.

--- a/src/Arithmetic/SolinasReduction.v
+++ b/src/Arithmetic/SolinasReduction.v
@@ -1242,18 +1242,14 @@ Module SolinasReduction.
 
         (* not bounded *)
         push.
-        rewrite <-Z_div_mod_eq.
-        auto.
-        rewrite Z.gt_lt_iff.
+        rewrite <-Z_div_mod_eq_full.
         auto.
         push.
         lia.
         push.
 
         push.
-        rewrite <-Z_div_mod_eq.
-        auto.
-        rewrite Z.gt_lt_iff.
+        rewrite <-Z_div_mod_eq_full.
         auto.
         push.
         lia.

--- a/src/Curves/TableMult/TableMult.v
+++ b/src/Curves/TableMult/TableMult.v
@@ -620,7 +620,7 @@ Section TableMult.
       apply map_ext_in; intros; unfold shift; rewrite map_map.
       apply map_ext_in; intros; rewrite Z.add_comm; trivial.
     Qed.
-      
+
     Lemma multicomb_elts: forall n,
       0 <= n < D -> In (n, n) multicomb.
     Proof.
@@ -639,7 +639,7 @@ Section TableMult.
           * apply Z_div_nonneg_nonneg; lia.
           * apply Z.div_lt_upper_bound; lia.
     Qed.
-    
+
     Theorem multicomb_stateseq: 
       Permutation (stateseq D) multicomb.
     Proof.

--- a/src/Util/NumTheoryUtil.v
+++ b/src/Util/NumTheoryUtil.v
@@ -237,14 +237,14 @@ Proof.
   assert (Z.to_nat x mod 4 = 1)%nat as x_1mod4_nat. {
     replace 1 with (Z.of_nat 1) in * by auto.
     replace (x mod 4) with (Z.of_nat (Z.to_nat x mod 4)) in *
-      by (rewrite mod_Zmod by lia; rewrite Z2Nat.id; auto).
+      by (rewrite Nat2Z.inj_mod; rewrite Z2Nat.id; auto).
     apply Nat2Z.inj in x_1mod4; auto.
   }
   remember (Z.to_nat x / 4)%nat as c eqn:Heqc.
   destruct (divide2_1mod4_nat c (Z.to_nat x) Heqc x_1mod4_nat) as [k k_id].
   replace 2%nat with (Z.to_nat 2) in * by auto.
   apply inj_eq in k_id.
-  rewrite div_Zdiv in k_id by (replace (Z.to_nat 2) with 2%nat by auto; lia).
+  rewrite Nat2Z.inj_div in k_id.
   rewrite Nat2Z.inj_mul in k_id.
   do 2 rewrite Z2Nat.id in k_id by lia.
   rewrite Z.mul_comm in k_id.
@@ -310,5 +310,5 @@ Qed.
 Lemma odd_as_div a : Z.odd a = true -> a = (2*(a/2) + 1)%Z.
 Proof.
   rewrite Zodd_mod, <-Zeq_is_eq_bool; intro H_1; rewrite <-H_1.
-  apply Z_div_mod_eq; reflexivity.
+  apply Z_div_mod_eq_full.
 Qed.

--- a/src/Util/ZUtil/Div.v
+++ b/src/Util/ZUtil/Div.v
@@ -309,7 +309,7 @@ Module Z.
         (Ha : 0 <= a) (Hb : 0 < b) (Hc : 0 <= c)
     : c * a / b = c * (a / b) + (c * (a mod b)) / b.
   Proof.
-    rewrite (Z_div_mod_eq a b) at 1 by lia.
+    rewrite (Z_div_mod_eq_full a b) at 1.
     rewrite Z.mul_add_distr_l.
     replace (c * (b * (a / b))) with ((c * (a / b)) * b) by lia.
     rewrite Z.div_add_l by lia.

--- a/src/Util/ZUtil/Modulo.v
+++ b/src/Util/ZUtil/Modulo.v
@@ -89,9 +89,9 @@ Module Z.
   Qed.
 
   Lemma mod_to_nat x m (Hm:(0 < m)%Z) (Hx:(0 <= x)%Z) : (Z.to_nat x mod Z.to_nat m = Z.to_nat (x mod m))%nat.
-    pose proof Zdiv.mod_Zmod (Z.to_nat x) (Z.to_nat m) as H;
+    pose proof Nat2Z.inj_mod (Z.to_nat x) (Z.to_nat m) as H;
       rewrite !Z2Nat.id in H by lia.
-    rewrite <-H by (change 0%nat with (Z.to_nat 0); rewrite Z2Nat.inj_iff; lia).
+    rewrite <-H.
     rewrite !Nat2Z.id; reflexivity.
   Qed.
 
@@ -140,14 +140,14 @@ Module Z.
   Lemma mul_div_eq : forall a m, m > 0 -> m * (a / m) = (a - a mod m).
   Proof.
     intros a m H.
-    rewrite (Z_div_mod_eq a m) at 2 by auto.
+    rewrite (Z_div_mod_eq_full a m) at 2.
     ring.
   Qed.
 
   Lemma mul_div_eq' : (forall a m, m > 0 -> (a / m) * m = (a - a mod m))%Z.
   Proof.
     intros a m H.
-    rewrite (Z_div_mod_eq a m) at 2 by auto.
+    rewrite (Z_div_mod_eq_full a m) at 2.
     ring.
   Qed.
 


### PR DESCRIPTION
Remove deprecated `Z_div_mod_eq`, `div_Zdiv` and `mod_Zmod` (coq/coq#16920).