### PR TITLE
Revert "Bump actions/setup-java from 3.6.0 to 3.7.0"

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         submodules: recursive
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v3.7.0
+      uses: actions/setup-java@v3.6.0
       with:
         java-version: 8
         distribution: 'zulu'


### PR DESCRIPTION
Reverts mit-plv/fiat-crypto#1531

Seems that this version no longer exists