### PR TITLE
Use 66520 for stack size limit for MacOS compat

### DIFF
--- a/etc/ensure_stack_limit.sh
+++ b/etc/ensure_stack_limit.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-recstacksize=65536
+recstacksize=66520
 if command -v ulimit >/dev/null 2>/dev/null; then
     hardstacksize="$(ulimit -H -s || true)"
     (


### PR DESCRIPTION
Apparently 66520 is the absolute limit on Mac, cf https://github.com/mit-plv/fiat-crypto/issues/1565#issuecomment-1499054965