### PR TITLE
Update for Zig 0.11.0

### DIFF
--- a/fiat-zig/src/curve25519_32.zig
+++ b/fiat-zig/src/curve25519_32.zig
@@ -21,12 +21,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type LooseFieldElement is a field element with loose bounds.

--- a/fiat-zig/src/curve25519_64.zig
+++ b/fiat-zig/src/curve25519_64.zig
@@ -21,12 +21,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type LooseFieldElement is a field element with loose bounds.

--- a/fiat-zig/src/curve25519_scalar_32.zig
+++ b/fiat-zig/src/curve25519_scalar_32.zig
@@ -26,12 +26,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/fiat-zig/src/curve25519_scalar_64.zig
+++ b/fiat-zig/src/curve25519_scalar_64.zig
@@ -26,12 +26,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/fiat-zig/src/curve25519_solinas_64.zig
+++ b/fiat-zig/src/curve25519_solinas_64.zig
@@ -16,12 +16,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 /// The function addcarryxU64 is an addition with carry.

--- a/fiat-zig/src/p224_32.zig
+++ b/fiat-zig/src/p224_32.zig
@@ -26,12 +26,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/fiat-zig/src/p224_64.zig
+++ b/fiat-zig/src/p224_64.zig
@@ -26,12 +26,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/fiat-zig/src/p256_32.zig
+++ b/fiat-zig/src/p256_32.zig
@@ -26,12 +26,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/fiat-zig/src/p256_64.zig
+++ b/fiat-zig/src/p256_64.zig
@@ -26,12 +26,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/fiat-zig/src/p256_scalar_32.zig
+++ b/fiat-zig/src/p256_scalar_32.zig
@@ -26,12 +26,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/fiat-zig/src/p256_scalar_64.zig
+++ b/fiat-zig/src/p256_scalar_64.zig
@@ -26,12 +26,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/fiat-zig/src/p384_32.zig
+++ b/fiat-zig/src/p384_32.zig
@@ -26,12 +26,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/fiat-zig/src/p384_64.zig
+++ b/fiat-zig/src/p384_64.zig
@@ -26,12 +26,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/fiat-zig/src/p384_scalar_32.zig
+++ b/fiat-zig/src/p384_scalar_32.zig
@@ -26,12 +26,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/fiat-zig/src/p384_scalar_64.zig
+++ b/fiat-zig/src/p384_scalar_64.zig
@@ -26,12 +26,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/fiat-zig/src/p434_64.zig
+++ b/fiat-zig/src/p434_64.zig
@@ -26,12 +26,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/fiat-zig/src/p448_solinas_32.zig
+++ b/fiat-zig/src/p448_solinas_32.zig
@@ -21,12 +21,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type LooseFieldElement is a field element with loose bounds.

--- a/fiat-zig/src/p448_solinas_64.zig
+++ b/fiat-zig/src/p448_solinas_64.zig
@@ -21,12 +21,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type LooseFieldElement is a field element with loose bounds.

--- a/fiat-zig/src/p521_32.zig
+++ b/fiat-zig/src/p521_32.zig
@@ -21,12 +21,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type LooseFieldElement is a field element with loose bounds.

--- a/fiat-zig/src/p521_64.zig
+++ b/fiat-zig/src/p521_64.zig
@@ -21,12 +21,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type LooseFieldElement is a field element with loose bounds.

--- a/fiat-zig/src/poly1305_32.zig
+++ b/fiat-zig/src/poly1305_32.zig
@@ -21,12 +21,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type LooseFieldElement is a field element with loose bounds.

--- a/fiat-zig/src/poly1305_64.zig
+++ b/fiat-zig/src/poly1305_64.zig
@@ -21,12 +21,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type LooseFieldElement is a field element with loose bounds.

--- a/fiat-zig/src/secp256k1_dettman_32.zig
+++ b/fiat-zig/src/secp256k1_dettman_32.zig
@@ -21,12 +21,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 /// The function mul multiplies two field elements.

--- a/fiat-zig/src/secp256k1_dettman_64.zig
+++ b/fiat-zig/src/secp256k1_dettman_64.zig
@@ -21,12 +21,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 /// The function mul multiplies two field elements.

--- a/fiat-zig/src/secp256k1_montgomery_32.zig
+++ b/fiat-zig/src/secp256k1_montgomery_32.zig
@@ -26,12 +26,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/fiat-zig/src/secp256k1_montgomery_64.zig
+++ b/fiat-zig/src/secp256k1_montgomery_64.zig
@@ -26,12 +26,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/fiat-zig/src/secp256k1_montgomery_scalar_32.zig
+++ b/fiat-zig/src/secp256k1_montgomery_scalar_32.zig
@@ -26,12 +26,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/fiat-zig/src/secp256k1_montgomery_scalar_64.zig
+++ b/fiat-zig/src/secp256k1_montgomery_scalar_64.zig
@@ -26,12 +26,11 @@ inline fn cast(comptime DestType: type, target: anytype) DestType {
         const dest = @typeInfo(DestType).Int;
         const source = @typeInfo(@TypeOf(target)).Int;
         if (dest.bits < source.bits) {
-            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));
-        } else {
-            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));
+            const T = std.meta.Int(source.signedness, dest.bits);
+            return @bitCast(@as(T, @truncate(target)));
         }
     }
-    return @as(DestType, target);
+    return target;
 }
 
 // The type MontgomeryDomainFieldElement is a field element in the Montgomery domain.

--- a/inversion/zig/inversion.zig
+++ b/inversion/zig/inversion.zig
@@ -46,7 +46,7 @@ fn fieldElement(comptime Field: type) type {
             }
             var v_opp: Field.Limbs = undefined;
             fiat.opp(&v_opp, v);
-            fiat.selectznz(&v, @truncate(u1, f[f.len - 1] >> (@bitSizeOf(Field.Word) - 1)), v, v_opp);
+            fiat.selectznz(&v, @truncate(f[f.len - 1] >> (@bitSizeOf(Field.Word) - 1)), v, v_opp);
 
             const precomp = comptime x: {
                 var precomp: Field.Limbs = undefined;

--- a/src/Stringification/Zig.v
+++ b/src/Stringification/Zig.v
@@ -105,12 +105,11 @@ Module Zig.
          "        const dest = @typeInfo(DestType).Int;";
          "        const source = @typeInfo(@TypeOf(target)).Int;";
          "        if (dest.bits < source.bits) {";
-         "            return @bitCast(DestType, @truncate(std.meta.Int(source.signedness, dest.bits), target));";
-         "        } else {";
-         "            return @bitCast(DestType, @as(std.meta.Int(source.signedness, dest.bits), target));";
+         "            const T = std.meta.Int(source.signedness, dest.bits);";
+         "            return @bitCast(@as(T, @truncate(target)));";
          "        }";
          "    }";
-         "    return @as(DestType, target);";
+         "    return target;";
          "}"]
           ++ (if skip_typedefs
               then []


### PR DESCRIPTION
`@truncate()` and `@bitCast()` now do type inference, so the code can be simplified a bit.

I still really wish there was a way to make the distinction between casts that truncate, and casts that extend the types (and thus are always guaranteed to be safe).

