### PR TITLE
Rust: Create newtype structs for typedefs

### DIFF
--- a/fiat-rust/Cargo.toml
+++ b/fiat-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fiat-crypto"
-version = "0.1.21"
+version = "0.2.0"
 authors = ["Fiat Crypto library authors <jgross@mit.edu>"]
 edition = "2018"
 description = "Fiat-crypto generated Rust"

--- a/fiat-rust/src/curve25519_32.rs
+++ b/fiat-rust/src/curve25519_32.rs
@@ -22,11 +22,43 @@ pub type fiat_25519_i2 = i8;
 
 /* The type fiat_25519_loose_field_element is a field element with loose bounds. */
 /* Bounds: [[0x0 ~> 0xc000000], [0x0 ~> 0x6000000], [0x0 ~> 0xc000000], [0x0 ~> 0x6000000], [0x0 ~> 0xc000000], [0x0 ~> 0x6000000], [0x0 ~> 0xc000000], [0x0 ~> 0x6000000], [0x0 ~> 0xc000000], [0x0 ~> 0x6000000]] */
-pub type fiat_25519_loose_field_element = [u32; 10];
+#[derive(Clone, Copy)]
+pub struct fiat_25519_loose_field_element(pub [u32; 10]);
+
+impl std::ops::Index<usize> for fiat_25519_loose_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_25519_loose_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_25519_tight_field_element is a field element with tight bounds. */
 /* Bounds: [[0x0 ~> 0x4000000], [0x0 ~> 0x2000000], [0x0 ~> 0x4000000], [0x0 ~> 0x2000000], [0x0 ~> 0x4000000], [0x0 ~> 0x2000000], [0x0 ~> 0x4000000], [0x0 ~> 0x2000000], [0x0 ~> 0x4000000], [0x0 ~> 0x2000000]] */
-pub type fiat_25519_tight_field_element = [u32; 10];
+#[derive(Clone, Copy)]
+pub struct fiat_25519_tight_field_element(pub [u32; 10]);
+
+impl std::ops::Index<usize> for fiat_25519_tight_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_25519_tight_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_25519_addcarryx_u26 is an addition with carry.

--- a/fiat-rust/src/curve25519_64.rs
+++ b/fiat-rust/src/curve25519_64.rs
@@ -22,11 +22,43 @@ pub type fiat_25519_i2 = i8;
 
 /* The type fiat_25519_loose_field_element is a field element with loose bounds. */
 /* Bounds: [[0x0 ~> 0x18000000000000], [0x0 ~> 0x18000000000000], [0x0 ~> 0x18000000000000], [0x0 ~> 0x18000000000000], [0x0 ~> 0x18000000000000]] */
-pub type fiat_25519_loose_field_element = [u64; 5];
+#[derive(Clone, Copy)]
+pub struct fiat_25519_loose_field_element(pub [u64; 5]);
+
+impl std::ops::Index<usize> for fiat_25519_loose_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_25519_loose_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_25519_tight_field_element is a field element with tight bounds. */
 /* Bounds: [[0x0 ~> 0x8000000000000], [0x0 ~> 0x8000000000000], [0x0 ~> 0x8000000000000], [0x0 ~> 0x8000000000000], [0x0 ~> 0x8000000000000]] */
-pub type fiat_25519_tight_field_element = [u64; 5];
+#[derive(Clone, Copy)]
+pub struct fiat_25519_tight_field_element(pub [u64; 5]);
+
+impl std::ops::Index<usize> for fiat_25519_tight_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_25519_tight_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_25519_addcarryx_u51 is an addition with carry.

--- a/fiat-rust/src/curve25519_scalar_32.rs
+++ b/fiat-rust/src/curve25519_scalar_32.rs
@@ -27,11 +27,43 @@ pub type fiat_25519_scalar_i2 = i8;
 
 /* The type fiat_25519_scalar_montgomery_domain_field_element is a field element in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]] */
-pub type fiat_25519_scalar_montgomery_domain_field_element = [u32; 8];
+#[derive(Clone, Copy)]
+pub struct fiat_25519_scalar_montgomery_domain_field_element(pub [u32; 8]);
+
+impl std::ops::Index<usize> for fiat_25519_scalar_montgomery_domain_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_25519_scalar_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_25519_scalar_non_montgomery_domain_field_element is a field element NOT in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]] */
-pub type fiat_25519_scalar_non_montgomery_domain_field_element = [u32; 8];
+#[derive(Clone, Copy)]
+pub struct fiat_25519_scalar_non_montgomery_domain_field_element(pub [u32; 8]);
+
+impl std::ops::Index<usize> for fiat_25519_scalar_non_montgomery_domain_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_25519_scalar_non_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_25519_scalar_addcarryx_u32 is an addition with carry.

--- a/fiat-rust/src/curve25519_scalar_64.rs
+++ b/fiat-rust/src/curve25519_scalar_64.rs
@@ -27,11 +27,43 @@ pub type fiat_25519_scalar_i2 = i8;
 
 /* The type fiat_25519_scalar_montgomery_domain_field_element is a field element in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]] */
-pub type fiat_25519_scalar_montgomery_domain_field_element = [u64; 4];
+#[derive(Clone, Copy)]
+pub struct fiat_25519_scalar_montgomery_domain_field_element(pub [u64; 4]);
+
+impl std::ops::Index<usize> for fiat_25519_scalar_montgomery_domain_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_25519_scalar_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_25519_scalar_non_montgomery_domain_field_element is a field element NOT in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]] */
-pub type fiat_25519_scalar_non_montgomery_domain_field_element = [u64; 4];
+#[derive(Clone, Copy)]
+pub struct fiat_25519_scalar_non_montgomery_domain_field_element(pub [u64; 4]);
+
+impl std::ops::Index<usize> for fiat_25519_scalar_non_montgomery_domain_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_25519_scalar_non_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_25519_scalar_addcarryx_u64 is an addition with carry.

--- a/fiat-rust/src/p224_32.rs
+++ b/fiat-rust/src/p224_32.rs
@@ -27,11 +27,43 @@ pub type fiat_p224_i2 = i8;
 
 /* The type fiat_p224_montgomery_domain_field_element is a field element in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]] */
-pub type fiat_p224_montgomery_domain_field_element = [u32; 7];
+#[derive(Clone, Copy)]
+pub struct fiat_p224_montgomery_domain_field_element(pub [u32; 7]);
+
+impl std::ops::Index<usize> for fiat_p224_montgomery_domain_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p224_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_p224_non_montgomery_domain_field_element is a field element NOT in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]] */
-pub type fiat_p224_non_montgomery_domain_field_element = [u32; 7];
+#[derive(Clone, Copy)]
+pub struct fiat_p224_non_montgomery_domain_field_element(pub [u32; 7]);
+
+impl std::ops::Index<usize> for fiat_p224_non_montgomery_domain_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p224_non_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_p224_addcarryx_u32 is an addition with carry.

--- a/fiat-rust/src/p224_64.rs
+++ b/fiat-rust/src/p224_64.rs
@@ -27,11 +27,43 @@ pub type fiat_p224_i2 = i8;
 
 /* The type fiat_p224_montgomery_domain_field_element is a field element in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]] */
-pub type fiat_p224_montgomery_domain_field_element = [u64; 4];
+#[derive(Clone, Copy)]
+pub struct fiat_p224_montgomery_domain_field_element(pub [u64; 4]);
+
+impl std::ops::Index<usize> for fiat_p224_montgomery_domain_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p224_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_p224_non_montgomery_domain_field_element is a field element NOT in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]] */
-pub type fiat_p224_non_montgomery_domain_field_element = [u64; 4];
+#[derive(Clone, Copy)]
+pub struct fiat_p224_non_montgomery_domain_field_element(pub [u64; 4]);
+
+impl std::ops::Index<usize> for fiat_p224_non_montgomery_domain_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p224_non_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_p224_addcarryx_u64 is an addition with carry.

--- a/fiat-rust/src/p256_32.rs
+++ b/fiat-rust/src/p256_32.rs
@@ -27,11 +27,43 @@ pub type fiat_p256_i2 = i8;
 
 /* The type fiat_p256_montgomery_domain_field_element is a field element in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]] */
-pub type fiat_p256_montgomery_domain_field_element = [u32; 8];
+#[derive(Clone, Copy)]
+pub struct fiat_p256_montgomery_domain_field_element(pub [u32; 8]);
+
+impl std::ops::Index<usize> for fiat_p256_montgomery_domain_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p256_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_p256_non_montgomery_domain_field_element is a field element NOT in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]] */
-pub type fiat_p256_non_montgomery_domain_field_element = [u32; 8];
+#[derive(Clone, Copy)]
+pub struct fiat_p256_non_montgomery_domain_field_element(pub [u32; 8]);
+
+impl std::ops::Index<usize> for fiat_p256_non_montgomery_domain_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p256_non_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_p256_addcarryx_u32 is an addition with carry.

--- a/fiat-rust/src/p256_64.rs
+++ b/fiat-rust/src/p256_64.rs
@@ -27,11 +27,43 @@ pub type fiat_p256_i2 = i8;
 
 /* The type fiat_p256_montgomery_domain_field_element is a field element in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]] */
-pub type fiat_p256_montgomery_domain_field_element = [u64; 4];
+#[derive(Clone, Copy)]
+pub struct fiat_p256_montgomery_domain_field_element(pub [u64; 4]);
+
+impl std::ops::Index<usize> for fiat_p256_montgomery_domain_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p256_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_p256_non_montgomery_domain_field_element is a field element NOT in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]] */
-pub type fiat_p256_non_montgomery_domain_field_element = [u64; 4];
+#[derive(Clone, Copy)]
+pub struct fiat_p256_non_montgomery_domain_field_element(pub [u64; 4]);
+
+impl std::ops::Index<usize> for fiat_p256_non_montgomery_domain_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p256_non_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_p256_addcarryx_u64 is an addition with carry.

--- a/fiat-rust/src/p256_scalar_32.rs
+++ b/fiat-rust/src/p256_scalar_32.rs
@@ -27,11 +27,43 @@ pub type fiat_p256_scalar_i2 = i8;
 
 /* The type fiat_p256_scalar_montgomery_domain_field_element is a field element in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]] */
-pub type fiat_p256_scalar_montgomery_domain_field_element = [u32; 8];
+#[derive(Clone, Copy)]
+pub struct fiat_p256_scalar_montgomery_domain_field_element(pub [u32; 8]);
+
+impl std::ops::Index<usize> for fiat_p256_scalar_montgomery_domain_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p256_scalar_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_p256_scalar_non_montgomery_domain_field_element is a field element NOT in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]] */
-pub type fiat_p256_scalar_non_montgomery_domain_field_element = [u32; 8];
+#[derive(Clone, Copy)]
+pub struct fiat_p256_scalar_non_montgomery_domain_field_element(pub [u32; 8]);
+
+impl std::ops::Index<usize> for fiat_p256_scalar_non_montgomery_domain_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p256_scalar_non_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_p256_scalar_addcarryx_u32 is an addition with carry.

--- a/fiat-rust/src/p256_scalar_64.rs
+++ b/fiat-rust/src/p256_scalar_64.rs
@@ -27,11 +27,43 @@ pub type fiat_p256_scalar_i2 = i8;
 
 /* The type fiat_p256_scalar_montgomery_domain_field_element is a field element in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]] */
-pub type fiat_p256_scalar_montgomery_domain_field_element = [u64; 4];
+#[derive(Clone, Copy)]
+pub struct fiat_p256_scalar_montgomery_domain_field_element(pub [u64; 4]);
+
+impl std::ops::Index<usize> for fiat_p256_scalar_montgomery_domain_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p256_scalar_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_p256_scalar_non_montgomery_domain_field_element is a field element NOT in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]] */
-pub type fiat_p256_scalar_non_montgomery_domain_field_element = [u64; 4];
+#[derive(Clone, Copy)]
+pub struct fiat_p256_scalar_non_montgomery_domain_field_element(pub [u64; 4]);
+
+impl std::ops::Index<usize> for fiat_p256_scalar_non_montgomery_domain_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p256_scalar_non_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_p256_scalar_addcarryx_u64 is an addition with carry.

--- a/fiat-rust/src/p384_32.rs
+++ b/fiat-rust/src/p384_32.rs
@@ -27,11 +27,43 @@ pub type fiat_p384_i2 = i8;
 
 /* The type fiat_p384_montgomery_domain_field_element is a field element in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]] */
-pub type fiat_p384_montgomery_domain_field_element = [u32; 12];
+#[derive(Clone, Copy)]
+pub struct fiat_p384_montgomery_domain_field_element(pub [u32; 12]);
+
+impl std::ops::Index<usize> for fiat_p384_montgomery_domain_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p384_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_p384_non_montgomery_domain_field_element is a field element NOT in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]] */
-pub type fiat_p384_non_montgomery_domain_field_element = [u32; 12];
+#[derive(Clone, Copy)]
+pub struct fiat_p384_non_montgomery_domain_field_element(pub [u32; 12]);
+
+impl std::ops::Index<usize> for fiat_p384_non_montgomery_domain_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p384_non_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_p384_addcarryx_u32 is an addition with carry.

--- a/fiat-rust/src/p384_64.rs
+++ b/fiat-rust/src/p384_64.rs
@@ -27,11 +27,43 @@ pub type fiat_p384_i2 = i8;
 
 /* The type fiat_p384_montgomery_domain_field_element is a field element in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]] */
-pub type fiat_p384_montgomery_domain_field_element = [u64; 6];
+#[derive(Clone, Copy)]
+pub struct fiat_p384_montgomery_domain_field_element(pub [u64; 6]);
+
+impl std::ops::Index<usize> for fiat_p384_montgomery_domain_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p384_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_p384_non_montgomery_domain_field_element is a field element NOT in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]] */
-pub type fiat_p384_non_montgomery_domain_field_element = [u64; 6];
+#[derive(Clone, Copy)]
+pub struct fiat_p384_non_montgomery_domain_field_element(pub [u64; 6]);
+
+impl std::ops::Index<usize> for fiat_p384_non_montgomery_domain_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p384_non_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_p384_addcarryx_u64 is an addition with carry.

--- a/fiat-rust/src/p384_scalar_32.rs
+++ b/fiat-rust/src/p384_scalar_32.rs
@@ -27,11 +27,43 @@ pub type fiat_p384_scalar_i2 = i8;
 
 /* The type fiat_p384_scalar_montgomery_domain_field_element is a field element in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]] */
-pub type fiat_p384_scalar_montgomery_domain_field_element = [u32; 12];
+#[derive(Clone, Copy)]
+pub struct fiat_p384_scalar_montgomery_domain_field_element(pub [u32; 12]);
+
+impl std::ops::Index<usize> for fiat_p384_scalar_montgomery_domain_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p384_scalar_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_p384_scalar_non_montgomery_domain_field_element is a field element NOT in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]] */
-pub type fiat_p384_scalar_non_montgomery_domain_field_element = [u32; 12];
+#[derive(Clone, Copy)]
+pub struct fiat_p384_scalar_non_montgomery_domain_field_element(pub [u32; 12]);
+
+impl std::ops::Index<usize> for fiat_p384_scalar_non_montgomery_domain_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p384_scalar_non_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_p384_scalar_addcarryx_u32 is an addition with carry.

--- a/fiat-rust/src/p384_scalar_64.rs
+++ b/fiat-rust/src/p384_scalar_64.rs
@@ -27,11 +27,43 @@ pub type fiat_p384_scalar_i2 = i8;
 
 /* The type fiat_p384_scalar_montgomery_domain_field_element is a field element in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]] */
-pub type fiat_p384_scalar_montgomery_domain_field_element = [u64; 6];
+#[derive(Clone, Copy)]
+pub struct fiat_p384_scalar_montgomery_domain_field_element(pub [u64; 6]);
+
+impl std::ops::Index<usize> for fiat_p384_scalar_montgomery_domain_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p384_scalar_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_p384_scalar_non_montgomery_domain_field_element is a field element NOT in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]] */
-pub type fiat_p384_scalar_non_montgomery_domain_field_element = [u64; 6];
+#[derive(Clone, Copy)]
+pub struct fiat_p384_scalar_non_montgomery_domain_field_element(pub [u64; 6]);
+
+impl std::ops::Index<usize> for fiat_p384_scalar_non_montgomery_domain_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p384_scalar_non_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_p384_scalar_addcarryx_u64 is an addition with carry.

--- a/fiat-rust/src/p434_64.rs
+++ b/fiat-rust/src/p434_64.rs
@@ -27,11 +27,43 @@ pub type fiat_p434_i2 = i8;
 
 /* The type fiat_p434_montgomery_domain_field_element is a field element in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]] */
-pub type fiat_p434_montgomery_domain_field_element = [u64; 7];
+#[derive(Clone, Copy)]
+pub struct fiat_p434_montgomery_domain_field_element(pub [u64; 7]);
+
+impl std::ops::Index<usize> for fiat_p434_montgomery_domain_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p434_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_p434_non_montgomery_domain_field_element is a field element NOT in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]] */
-pub type fiat_p434_non_montgomery_domain_field_element = [u64; 7];
+#[derive(Clone, Copy)]
+pub struct fiat_p434_non_montgomery_domain_field_element(pub [u64; 7]);
+
+impl std::ops::Index<usize> for fiat_p434_non_montgomery_domain_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p434_non_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_p434_addcarryx_u64 is an addition with carry.

--- a/fiat-rust/src/p448_solinas_32.rs
+++ b/fiat-rust/src/p448_solinas_32.rs
@@ -22,11 +22,43 @@ pub type fiat_p448_i2 = i8;
 
 /* The type fiat_p448_loose_field_element is a field element with loose bounds. */
 /* Bounds: [[0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000], [0x0 ~> 0x30000000]] */
-pub type fiat_p448_loose_field_element = [u32; 16];
+#[derive(Clone, Copy)]
+pub struct fiat_p448_loose_field_element(pub [u32; 16]);
+
+impl std::ops::Index<usize> for fiat_p448_loose_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p448_loose_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_p448_tight_field_element is a field element with tight bounds. */
 /* Bounds: [[0x0 ~> 0x10000000], [0x0 ~> 0x10000000], [0x0 ~> 0x10000000], [0x0 ~> 0x10000000], [0x0 ~> 0x10000000], [0x0 ~> 0x10000000], [0x0 ~> 0x10000000], [0x0 ~> 0x10000000], [0x0 ~> 0x10000000], [0x0 ~> 0x10000000], [0x0 ~> 0x10000000], [0x0 ~> 0x10000000], [0x0 ~> 0x10000000], [0x0 ~> 0x10000000], [0x0 ~> 0x10000000], [0x0 ~> 0x10000000]] */
-pub type fiat_p448_tight_field_element = [u32; 16];
+#[derive(Clone, Copy)]
+pub struct fiat_p448_tight_field_element(pub [u32; 16]);
+
+impl std::ops::Index<usize> for fiat_p448_tight_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p448_tight_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_p448_addcarryx_u28 is an addition with carry.

--- a/fiat-rust/src/p448_solinas_64.rs
+++ b/fiat-rust/src/p448_solinas_64.rs
@@ -22,11 +22,43 @@ pub type fiat_p448_i2 = i8;
 
 /* The type fiat_p448_loose_field_element is a field element with loose bounds. */
 /* Bounds: [[0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000]] */
-pub type fiat_p448_loose_field_element = [u64; 8];
+#[derive(Clone, Copy)]
+pub struct fiat_p448_loose_field_element(pub [u64; 8]);
+
+impl std::ops::Index<usize> for fiat_p448_loose_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p448_loose_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_p448_tight_field_element is a field element with tight bounds. */
 /* Bounds: [[0x0 ~> 0x100000000000000], [0x0 ~> 0x100000000000000], [0x0 ~> 0x100000000000000], [0x0 ~> 0x100000000000000], [0x0 ~> 0x100000000000000], [0x0 ~> 0x100000000000000], [0x0 ~> 0x100000000000000], [0x0 ~> 0x100000000000000]] */
-pub type fiat_p448_tight_field_element = [u64; 8];
+#[derive(Clone, Copy)]
+pub struct fiat_p448_tight_field_element(pub [u64; 8]);
+
+impl std::ops::Index<usize> for fiat_p448_tight_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p448_tight_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_p448_addcarryx_u56 is an addition with carry.

--- a/fiat-rust/src/p521_32.rs
+++ b/fiat-rust/src/p521_32.rs
@@ -22,11 +22,43 @@ pub type fiat_p521_i2 = i8;
 
 /* The type fiat_p521_loose_field_element is a field element with loose bounds. */
 /* Bounds: [[0x0 ~> 0x30000000], [0x0 ~> 0x18000000], [0x0 ~> 0x30000000], [0x0 ~> 0x18000000], [0x0 ~> 0x30000000], [0x0 ~> 0x18000000], [0x0 ~> 0x18000000], [0x0 ~> 0x30000000], [0x0 ~> 0x18000000], [0x0 ~> 0x30000000], [0x0 ~> 0x18000000], [0x0 ~> 0x30000000], [0x0 ~> 0x18000000], [0x0 ~> 0x18000000], [0x0 ~> 0x30000000], [0x0 ~> 0x18000000], [0x0 ~> 0x30000000], [0x0 ~> 0x18000000], [0x0 ~> 0x18000000]] */
-pub type fiat_p521_loose_field_element = [u32; 19];
+#[derive(Clone, Copy)]
+pub struct fiat_p521_loose_field_element(pub [u32; 19]);
+
+impl std::ops::Index<usize> for fiat_p521_loose_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p521_loose_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_p521_tight_field_element is a field element with tight bounds. */
 /* Bounds: [[0x0 ~> 0x10000000], [0x0 ~> 0x8000000], [0x0 ~> 0x10000000], [0x0 ~> 0x8000000], [0x0 ~> 0x10000000], [0x0 ~> 0x8000000], [0x0 ~> 0x8000000], [0x0 ~> 0x10000000], [0x0 ~> 0x8000000], [0x0 ~> 0x10000000], [0x0 ~> 0x8000000], [0x0 ~> 0x10000000], [0x0 ~> 0x8000000], [0x0 ~> 0x8000000], [0x0 ~> 0x10000000], [0x0 ~> 0x8000000], [0x0 ~> 0x10000000], [0x0 ~> 0x8000000], [0x0 ~> 0x8000000]] */
-pub type fiat_p521_tight_field_element = [u32; 19];
+#[derive(Clone, Copy)]
+pub struct fiat_p521_tight_field_element(pub [u32; 19]);
+
+impl std::ops::Index<usize> for fiat_p521_tight_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p521_tight_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_p521_addcarryx_u28 is an addition with carry.

--- a/fiat-rust/src/p521_64.rs
+++ b/fiat-rust/src/p521_64.rs
@@ -22,11 +22,43 @@ pub type fiat_p521_i2 = i8;
 
 /* The type fiat_p521_loose_field_element is a field element with loose bounds. */
 /* Bounds: [[0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0x600000000000000]] */
-pub type fiat_p521_loose_field_element = [u64; 9];
+#[derive(Clone, Copy)]
+pub struct fiat_p521_loose_field_element(pub [u64; 9]);
+
+impl std::ops::Index<usize> for fiat_p521_loose_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p521_loose_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_p521_tight_field_element is a field element with tight bounds. */
 /* Bounds: [[0x0 ~> 0x400000000000000], [0x0 ~> 0x400000000000000], [0x0 ~> 0x400000000000000], [0x0 ~> 0x400000000000000], [0x0 ~> 0x400000000000000], [0x0 ~> 0x400000000000000], [0x0 ~> 0x400000000000000], [0x0 ~> 0x400000000000000], [0x0 ~> 0x200000000000000]] */
-pub type fiat_p521_tight_field_element = [u64; 9];
+#[derive(Clone, Copy)]
+pub struct fiat_p521_tight_field_element(pub [u64; 9]);
+
+impl std::ops::Index<usize> for fiat_p521_tight_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_p521_tight_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_p521_addcarryx_u58 is an addition with carry.

--- a/fiat-rust/src/poly1305_32.rs
+++ b/fiat-rust/src/poly1305_32.rs
@@ -22,11 +22,43 @@ pub type fiat_poly1305_i2 = i8;
 
 /* The type fiat_poly1305_loose_field_element is a field element with loose bounds. */
 /* Bounds: [[0x0 ~> 0xc000000], [0x0 ~> 0xc000000], [0x0 ~> 0xc000000], [0x0 ~> 0xc000000], [0x0 ~> 0xc000000]] */
-pub type fiat_poly1305_loose_field_element = [u32; 5];
+#[derive(Clone, Copy)]
+pub struct fiat_poly1305_loose_field_element(pub [u32; 5]);
+
+impl std::ops::Index<usize> for fiat_poly1305_loose_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_poly1305_loose_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_poly1305_tight_field_element is a field element with tight bounds. */
 /* Bounds: [[0x0 ~> 0x4000000], [0x0 ~> 0x4000000], [0x0 ~> 0x4000000], [0x0 ~> 0x4000000], [0x0 ~> 0x4000000]] */
-pub type fiat_poly1305_tight_field_element = [u32; 5];
+#[derive(Clone, Copy)]
+pub struct fiat_poly1305_tight_field_element(pub [u32; 5]);
+
+impl std::ops::Index<usize> for fiat_poly1305_tight_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_poly1305_tight_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_poly1305_addcarryx_u26 is an addition with carry.

--- a/fiat-rust/src/poly1305_64.rs
+++ b/fiat-rust/src/poly1305_64.rs
@@ -22,11 +22,43 @@ pub type fiat_poly1305_i2 = i8;
 
 /* The type fiat_poly1305_loose_field_element is a field element with loose bounds. */
 /* Bounds: [[0x0 ~> 0x300000000000], [0x0 ~> 0x180000000000], [0x0 ~> 0x180000000000]] */
-pub type fiat_poly1305_loose_field_element = [u64; 3];
+#[derive(Clone, Copy)]
+pub struct fiat_poly1305_loose_field_element(pub [u64; 3]);
+
+impl std::ops::Index<usize> for fiat_poly1305_loose_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_poly1305_loose_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_poly1305_tight_field_element is a field element with tight bounds. */
 /* Bounds: [[0x0 ~> 0x100000000000], [0x0 ~> 0x80000000000], [0x0 ~> 0x80000000000]] */
-pub type fiat_poly1305_tight_field_element = [u64; 3];
+#[derive(Clone, Copy)]
+pub struct fiat_poly1305_tight_field_element(pub [u64; 3]);
+
+impl std::ops::Index<usize> for fiat_poly1305_tight_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_poly1305_tight_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_poly1305_addcarryx_u44 is an addition with carry.

--- a/fiat-rust/src/secp256k1_montgomery_32.rs
+++ b/fiat-rust/src/secp256k1_montgomery_32.rs
@@ -27,11 +27,43 @@ pub type fiat_secp256k1_montgomery_i2 = i8;
 
 /* The type fiat_secp256k1_montgomery_montgomery_domain_field_element is a field element in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]] */
-pub type fiat_secp256k1_montgomery_montgomery_domain_field_element = [u32; 8];
+#[derive(Clone, Copy)]
+pub struct fiat_secp256k1_montgomery_montgomery_domain_field_element(pub [u32; 8]);
+
+impl std::ops::Index<usize> for fiat_secp256k1_montgomery_montgomery_domain_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_secp256k1_montgomery_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_secp256k1_montgomery_non_montgomery_domain_field_element is a field element NOT in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]] */
-pub type fiat_secp256k1_montgomery_non_montgomery_domain_field_element = [u32; 8];
+#[derive(Clone, Copy)]
+pub struct fiat_secp256k1_montgomery_non_montgomery_domain_field_element(pub [u32; 8]);
+
+impl std::ops::Index<usize> for fiat_secp256k1_montgomery_non_montgomery_domain_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_secp256k1_montgomery_non_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_secp256k1_montgomery_addcarryx_u32 is an addition with carry.

--- a/fiat-rust/src/secp256k1_montgomery_64.rs
+++ b/fiat-rust/src/secp256k1_montgomery_64.rs
@@ -27,11 +27,43 @@ pub type fiat_secp256k1_montgomery_i2 = i8;
 
 /* The type fiat_secp256k1_montgomery_montgomery_domain_field_element is a field element in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]] */
-pub type fiat_secp256k1_montgomery_montgomery_domain_field_element = [u64; 4];
+#[derive(Clone, Copy)]
+pub struct fiat_secp256k1_montgomery_montgomery_domain_field_element(pub [u64; 4]);
+
+impl std::ops::Index<usize> for fiat_secp256k1_montgomery_montgomery_domain_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_secp256k1_montgomery_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_secp256k1_montgomery_non_montgomery_domain_field_element is a field element NOT in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]] */
-pub type fiat_secp256k1_montgomery_non_montgomery_domain_field_element = [u64; 4];
+#[derive(Clone, Copy)]
+pub struct fiat_secp256k1_montgomery_non_montgomery_domain_field_element(pub [u64; 4]);
+
+impl std::ops::Index<usize> for fiat_secp256k1_montgomery_non_montgomery_domain_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_secp256k1_montgomery_non_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_secp256k1_montgomery_addcarryx_u64 is an addition with carry.

--- a/fiat-rust/src/secp256k1_montgomery_scalar_32.rs
+++ b/fiat-rust/src/secp256k1_montgomery_scalar_32.rs
@@ -27,11 +27,43 @@ pub type fiat_secp256k1_montgomery_scalar_i2 = i8;
 
 /* The type fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element is a field element in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]] */
-pub type fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element = [u32; 8];
+#[derive(Clone, Copy)]
+pub struct fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element(pub [u32; 8]);
+
+impl std::ops::Index<usize> for fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element is a field element NOT in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]] */
-pub type fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element = [u32; 8];
+#[derive(Clone, Copy)]
+pub struct fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element(pub [u32; 8]);
+
+impl std::ops::Index<usize> for fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element {
+    type Output = u32;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_secp256k1_montgomery_scalar_addcarryx_u32 is an addition with carry.

--- a/fiat-rust/src/secp256k1_montgomery_scalar_64.rs
+++ b/fiat-rust/src/secp256k1_montgomery_scalar_64.rs
@@ -27,11 +27,43 @@ pub type fiat_secp256k1_montgomery_scalar_i2 = i8;
 
 /* The type fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element is a field element in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]] */
-pub type fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element = [u64; 4];
+#[derive(Clone, Copy)]
+pub struct fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element(pub [u64; 4]);
+
+impl std::ops::Index<usize> for fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 /* The type fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element is a field element NOT in the Montgomery domain. */
 /* Bounds: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]] */
-pub type fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element = [u64; 4];
+#[derive(Clone, Copy)]
+pub struct fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element(pub [u64; 4]);
+
+impl std::ops::Index<usize> for fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element {
+    type Output = u64;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl std::ops::IndexMut<usize> for fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
 
 
 /// The function fiat_secp256k1_montgomery_scalar_addcarryx_u64 is an addition with carry.


### PR DESCRIPTION
This PR fixes #1620 by replacing type aliases for arrays with newtypes. As the types for Montgomery/non-Montgomery or tight/loose field elements are now distinct, this will prevent misuse by consumers. Since this is a breaking change, I bumped the crate version to 0.2.0.

I couldn't figure out how to make the suggested changes to stringification of `IR.List_nth` expressions, so I solved that part of the problem in Rust instead. Bare arrays, without typedefs, are still used in function arguments. Thus, any `IR.List_nth` operation would either need to be lowered to `({v}[{n}])` or `({v}.0[{n}])`, depending on the type of the operation's argument. I couldn't figure out how to access type information starting from these IR nodes, so I instead implemented `Index` and `IndexMut` on the new Rust structs, in order to forward indexing operations to the wrapped arrays.

FYI, I test-ran the Rust CI scripts locally, and I noted that in the curve25519-dalek and Ed448-Goldilocks tests, Cargo is ignoring the patched dependencies because of version number mismatches. (path = "../fiat-rust" has version 0.2.0, while the two tested crates depend on 0.1, so Cargo still uses the original crate from `crates.io`)