### PR TITLE
Qualifying expr.expr and cie coming from Uncurried and EdDSA.sign from Spec

### DIFF
--- a/src/Experiments/SimplyTypedArithmetic.v
+++ b/src/Experiments/SimplyTypedArithmetic.v
@@ -8107,14 +8107,14 @@ Module Straightline.
 
       Fixpoint of_uncurried_scalar {t} (e : uexpr t) : option (scalar t) :=
           match e in Uncurried.expr.expr t return option (scalar t) with
-          | expr.Var t v as e => Some (Var t v)
-          | expr.TT as e => Some TT
-          | expr.Pair A B a b
+          | Uncurried.expr.Var t v as e => Some (Var t v)
+          | Uncurried.expr.TT as e => Some TT
+          | Uncurried.expr.Pair A B a b
             => match of_uncurried_scalar a, of_uncurried_scalar b with
                | Some x, Some y => Some (Pair x y)
                | _, _ => None
                end
-          | expr.AppIdent _ _ idc args
+          | Uncurried.expr.AppIdent _ _ idc args
             => match of_uncurried_scalar args with
                | Some x => of_uncurried_scalar_ident idc x
                | None => None
@@ -8439,10 +8439,10 @@ Module Straightline.
         uinterp e = straightline_interp (@of_uncurried _ dummy_arrow fuel _ e).
       Proof.
         induction fuel; intros; [ pose proof (depth_positive dummy_var e); lia | ].
-        destruct e; cbn [depth of_uncurried expr.interp interp]; intros; invert_ok_expr;
+        destruct e; cbn [depth of_uncurried Uncurried.expr.interp interp]; intros; invert_ok_expr;
           repeat match goal with
                  | |- context [of_uncurried_scalar _ ] => progress rewrite_ok_scalar
-                 | _ => progress (cbn [of_uncurried_step of_uncurried_ident fst snd mk_LetInAppIdent expr.interp interp depth] in * )
+                 | _ => progress (cbn [of_uncurried_step of_uncurried_ident fst snd mk_LetInAppIdent Uncurried.expr.interp interp depth] in * )
                  | _ => progress simpl_inversions
                  | _ => congruence
                  end; [ | | | | ].
@@ -8464,11 +8464,11 @@ Module Straightline.
           { auto. } }
         {
           match goal with H : interp_scalar _ = _ |- _ => rewrite H end.
-          rewrite <-interp_cast_correct.
+    (*      rewrite <-interp_cast_correct.*)
           reflexivity. }
         {
           match goal with H : interp_scalar _ = _ |- _ => rewrite H end.
-          rewrite <-interp_cast2_correct.
+     (*     rewrite <-interp_cast2_correct.*)
           cbn; break_match; reflexivity. }
         { invert_ok_scalar.
           rewrite <-H2.

--- a/src/Primitives/EdDSARepChange.v
+++ b/src/Primitives/EdDSARepChange.v
@@ -237,9 +237,9 @@ Section EdDSA.
     Lemma Z_l_nonzero : Z.pos l <> 0%Z. discriminate. Qed.
 
     Lemma sign_correct (pk sk : word b) {mlen} (msg:word mlen)
-               : sign pk sk msg = EdDSA.sign pk sk msg.
+               : sign pk sk msg = Spec.EdDSA.sign pk sk msg.
     Proof using Agroup Ahomom ERepEnc_correct ErepB_correct H0 Proper_ERepEnc Proper_SRepAdd Proper_SRepERepMul Proper_SRepEnc Proper_SRepMul SRepAdd_correct SRepDecModLShort_correct SRepDecModL_correct SRepERepMul_correct SRepEnc_correct SRepMul_correct splitSecretPrngCurve_correct.
-      cbv [sign EdDSA.sign Let_In].
+      cbv [sign Spec.EdDSA.sign Let_In].
 
       let H := fresh "H" in
       pose proof (splitSecretPrngCurve_correct sk) as H;


### PR DESCRIPTION
Like #1627, this anticipates coq/coq#17888 for fiat-crypto-legacy.

Note that two `rewrite` are now useless in SimplyTypedArithmetic.v` (and actually failing). This is strange, so either I missed some qualification, or there is another change in the Coq PR that makes these `rewrite` useless. I don't know if I should have investigated further to be sure of the answer, or if it is not so important.