### PR TITLE
Pipe through carry_sub function

### DIFF
--- a/src/Bedrock/End2End/Poly1305/Field1305.v
+++ b/src/Bedrock/End2End/Poly1305/Field1305.v
@@ -103,6 +103,15 @@ Section Field.
                         functions)
          As fe1305_sub_correct.
   Proof. Time derive_bedrock2_func sub_op. Qed.
+
+  Derive fe1305_carry_sub
+         SuchThat (forall functions,
+                      functions_contain functions fe1305_carry_sub ->
+                      spec_of_BinOp bin_carry_sub
+                        (field_representation:=field_representation n s c)
+                        (functions))
+         As fe1305_carry_sub_correct.
+  Proof. Time derive_bedrock2_func carry_sub_op. Qed.
 End Field.
 
 (* Uncomment below to sanity-check that compilation works *)
@@ -116,6 +125,7 @@ Definition funcs : list (string * func) :=
     fe1305_add;
     fe1305_carry_add;
     fe1305_sub;
+    fe1305_carry_sub;
     fe1305_square;
     fe1305_to_bytes;
     fe1305_from_bytes ].

--- a/src/Bedrock/End2End/RupicolaCrypto/Low.v
+++ b/src/Bedrock/End2End/RupicolaCrypto/Low.v
@@ -1329,6 +1329,7 @@ Instance p_field_params : FieldParameters :=
   add := "fe1305_add";
   carry_add := "fe1305_carry_add";
   sub := "fe1305_sub";
+  carry_sub := "fe1305_carry_sub";
   opp := "fe1305_opp";
   square := "fe1305_square";
   scmula24 := "fe1305_scmul1_dontuse";

--- a/src/Bedrock/End2End/X25519/Field25519.v
+++ b/src/Bedrock/End2End/X25519/Field25519.v
@@ -139,6 +139,15 @@ Section Field.
     As fe25519_sub_correct.
   Proof. Time derive_bedrock2_func sub_op. Qed.
 
+  Derive fe25519_carry_sub
+    SuchThat (forall functions,
+      Interface.map.get functions "fe25519_carry_sub" = Some fe25519_carry_sub ->
+      spec_of_BinOp bin_carry_sub
+        (field_representation:=field_representation n s c)
+        functions)
+    As fe25519_carry_sub_correct.
+  Proof. Time derive_bedrock2_func carry_sub_op. Qed.
+
   Derive fe25519_scmula24
     SuchThat (forall functions,
       Interface.map.get functions "fe25519_scmula24" = Some fe25519_scmula24 ->

--- a/src/Bedrock/Field/Synthesis/New/WordByWordMontgomery.v
+++ b/src/Bedrock/Field/Synthesis/New/WordByWordMontgomery.v
@@ -760,6 +760,7 @@ Definition field_parameters_prefixed
     (prefix ++ "add")
     (prefix ++ "carry_add_dontuse")
     (prefix ++ "sub")
+    (prefix ++ "carry_sub_dontuse")
     (prefix ++ "opp")
     (prefix ++ "square")
     (prefix ++ "scmula24")

--- a/src/Bedrock/Specs/Field.v
+++ b/src/Bedrock/Specs/Field.v
@@ -19,7 +19,7 @@ Class FieldParameters :=
     fe_copy := (@id (F M_pos));
 
     (** function names **)
-    mul : string; add : string; carry_add : string; sub : string; opp : string;
+    mul : string; add : string; carry_add : string; sub : string; carry_sub : string; opp : string;
     square : string; scmula24 : string; inv : string;
     from_bytes : string; to_bytes : string;
     select_znz : string;
@@ -180,6 +180,8 @@ Section FunctionSpecs.
     {| bin_model := F.add; bin_xbounds := tight_bounds; bin_ybounds := tight_bounds; bin_outbounds := tight_bounds |}.
   Instance bin_sub : BinOp sub :=
     {| bin_model := F.sub; bin_xbounds := tight_bounds; bin_ybounds := tight_bounds; bin_outbounds := loose_bounds |}.
+  Instance bin_carry_sub : BinOp carry_sub :=
+    {| bin_model := F.sub; bin_xbounds := tight_bounds; bin_ybounds := tight_bounds; bin_outbounds := tight_bounds |}.
   Instance un_scmula24 : UnOp scmula24 :=
     {| un_model := F.mul a24; un_xbounds := loose_bounds; un_outbounds := tight_bounds |}.
   Instance un_inv : UnOp inv := (* TODO: what are the bounds for inv? *)


### PR DESCRIPTION
Very similar to #1635, but for subtraction. `carry_sub` guarantees `tight_bounds` on the output, which will be necessary for a bedrock2 version of [point doubling](https://github.com/mit-plv/fiat-crypto/blob/5978c17a79ef72758882da9773fe3c90e303d500/src/Curves/Edwards/XYZT/Basic.v#L136).