### PR TITLE
Rust: Reference newtype operators from `core` instead of `std`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,8 @@ jobs:
       run: (cd fiat-rust; cargo build --verbose)
     - name: cargo test
       run: (cd fiat-rust; cargo test --verbose)
+    - name: cargo test (no_std)
+      run: (cd fiat-rust; cargo test --no-default-features --verbose)
     - name: curve25519-dalek test
       run: etc/ci/test-fiat-rust-curve25519-dalek.sh
     - name: crate-crypto/Ed448-Goldilocks test

--- a/fiat-rust/Cargo.toml
+++ b/fiat-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fiat-crypto"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Fiat Crypto library authors <jgross@mit.edu>"]
 edition = "2018"
 description = "Fiat-crypto generated Rust"

--- a/fiat-rust/src/curve25519_32.rs
+++ b/fiat-rust/src/curve25519_32.rs
@@ -25,7 +25,7 @@ pub type fiat_25519_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_25519_loose_field_element(pub [u32; 10]);
 
-impl std::ops::Index<usize> for fiat_25519_loose_field_element {
+impl core::ops::Index<usize> for fiat_25519_loose_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -33,7 +33,7 @@ impl std::ops::Index<usize> for fiat_25519_loose_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_25519_loose_field_element {
+impl core::ops::IndexMut<usize> for fiat_25519_loose_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -45,7 +45,7 @@ impl std::ops::IndexMut<usize> for fiat_25519_loose_field_element {
 #[derive(Clone, Copy)]
 pub struct fiat_25519_tight_field_element(pub [u32; 10]);
 
-impl std::ops::Index<usize> for fiat_25519_tight_field_element {
+impl core::ops::Index<usize> for fiat_25519_tight_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -53,7 +53,7 @@ impl std::ops::Index<usize> for fiat_25519_tight_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_25519_tight_field_element {
+impl core::ops::IndexMut<usize> for fiat_25519_tight_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/curve25519_64.rs
+++ b/fiat-rust/src/curve25519_64.rs
@@ -25,7 +25,7 @@ pub type fiat_25519_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_25519_loose_field_element(pub [u64; 5]);
 
-impl std::ops::Index<usize> for fiat_25519_loose_field_element {
+impl core::ops::Index<usize> for fiat_25519_loose_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -33,7 +33,7 @@ impl std::ops::Index<usize> for fiat_25519_loose_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_25519_loose_field_element {
+impl core::ops::IndexMut<usize> for fiat_25519_loose_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -45,7 +45,7 @@ impl std::ops::IndexMut<usize> for fiat_25519_loose_field_element {
 #[derive(Clone, Copy)]
 pub struct fiat_25519_tight_field_element(pub [u64; 5]);
 
-impl std::ops::Index<usize> for fiat_25519_tight_field_element {
+impl core::ops::Index<usize> for fiat_25519_tight_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -53,7 +53,7 @@ impl std::ops::Index<usize> for fiat_25519_tight_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_25519_tight_field_element {
+impl core::ops::IndexMut<usize> for fiat_25519_tight_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/curve25519_scalar_32.rs
+++ b/fiat-rust/src/curve25519_scalar_32.rs
@@ -30,7 +30,7 @@ pub type fiat_25519_scalar_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_25519_scalar_montgomery_domain_field_element(pub [u32; 8]);
 
-impl std::ops::Index<usize> for fiat_25519_scalar_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_25519_scalar_montgomery_domain_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -38,7 +38,7 @@ impl std::ops::Index<usize> for fiat_25519_scalar_montgomery_domain_field_elemen
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_25519_scalar_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_25519_scalar_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -50,7 +50,7 @@ impl std::ops::IndexMut<usize> for fiat_25519_scalar_montgomery_domain_field_ele
 #[derive(Clone, Copy)]
 pub struct fiat_25519_scalar_non_montgomery_domain_field_element(pub [u32; 8]);
 
-impl std::ops::Index<usize> for fiat_25519_scalar_non_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_25519_scalar_non_montgomery_domain_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -58,7 +58,7 @@ impl std::ops::Index<usize> for fiat_25519_scalar_non_montgomery_domain_field_el
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_25519_scalar_non_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_25519_scalar_non_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/curve25519_scalar_64.rs
+++ b/fiat-rust/src/curve25519_scalar_64.rs
@@ -30,7 +30,7 @@ pub type fiat_25519_scalar_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_25519_scalar_montgomery_domain_field_element(pub [u64; 4]);
 
-impl std::ops::Index<usize> for fiat_25519_scalar_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_25519_scalar_montgomery_domain_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -38,7 +38,7 @@ impl std::ops::Index<usize> for fiat_25519_scalar_montgomery_domain_field_elemen
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_25519_scalar_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_25519_scalar_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -50,7 +50,7 @@ impl std::ops::IndexMut<usize> for fiat_25519_scalar_montgomery_domain_field_ele
 #[derive(Clone, Copy)]
 pub struct fiat_25519_scalar_non_montgomery_domain_field_element(pub [u64; 4]);
 
-impl std::ops::Index<usize> for fiat_25519_scalar_non_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_25519_scalar_non_montgomery_domain_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -58,7 +58,7 @@ impl std::ops::Index<usize> for fiat_25519_scalar_non_montgomery_domain_field_el
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_25519_scalar_non_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_25519_scalar_non_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/p224_32.rs
+++ b/fiat-rust/src/p224_32.rs
@@ -30,7 +30,7 @@ pub type fiat_p224_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_p224_montgomery_domain_field_element(pub [u32; 7]);
 
-impl std::ops::Index<usize> for fiat_p224_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p224_montgomery_domain_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -38,7 +38,7 @@ impl std::ops::Index<usize> for fiat_p224_montgomery_domain_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p224_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p224_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -50,7 +50,7 @@ impl std::ops::IndexMut<usize> for fiat_p224_montgomery_domain_field_element {
 #[derive(Clone, Copy)]
 pub struct fiat_p224_non_montgomery_domain_field_element(pub [u32; 7]);
 
-impl std::ops::Index<usize> for fiat_p224_non_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p224_non_montgomery_domain_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -58,7 +58,7 @@ impl std::ops::Index<usize> for fiat_p224_non_montgomery_domain_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p224_non_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p224_non_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/p224_64.rs
+++ b/fiat-rust/src/p224_64.rs
@@ -30,7 +30,7 @@ pub type fiat_p224_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_p224_montgomery_domain_field_element(pub [u64; 4]);
 
-impl std::ops::Index<usize> for fiat_p224_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p224_montgomery_domain_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -38,7 +38,7 @@ impl std::ops::Index<usize> for fiat_p224_montgomery_domain_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p224_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p224_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -50,7 +50,7 @@ impl std::ops::IndexMut<usize> for fiat_p224_montgomery_domain_field_element {
 #[derive(Clone, Copy)]
 pub struct fiat_p224_non_montgomery_domain_field_element(pub [u64; 4]);
 
-impl std::ops::Index<usize> for fiat_p224_non_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p224_non_montgomery_domain_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -58,7 +58,7 @@ impl std::ops::Index<usize> for fiat_p224_non_montgomery_domain_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p224_non_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p224_non_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/p256_32.rs
+++ b/fiat-rust/src/p256_32.rs
@@ -30,7 +30,7 @@ pub type fiat_p256_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_p256_montgomery_domain_field_element(pub [u32; 8]);
 
-impl std::ops::Index<usize> for fiat_p256_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p256_montgomery_domain_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -38,7 +38,7 @@ impl std::ops::Index<usize> for fiat_p256_montgomery_domain_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p256_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p256_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -50,7 +50,7 @@ impl std::ops::IndexMut<usize> for fiat_p256_montgomery_domain_field_element {
 #[derive(Clone, Copy)]
 pub struct fiat_p256_non_montgomery_domain_field_element(pub [u32; 8]);
 
-impl std::ops::Index<usize> for fiat_p256_non_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p256_non_montgomery_domain_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -58,7 +58,7 @@ impl std::ops::Index<usize> for fiat_p256_non_montgomery_domain_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p256_non_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p256_non_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/p256_64.rs
+++ b/fiat-rust/src/p256_64.rs
@@ -30,7 +30,7 @@ pub type fiat_p256_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_p256_montgomery_domain_field_element(pub [u64; 4]);
 
-impl std::ops::Index<usize> for fiat_p256_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p256_montgomery_domain_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -38,7 +38,7 @@ impl std::ops::Index<usize> for fiat_p256_montgomery_domain_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p256_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p256_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -50,7 +50,7 @@ impl std::ops::IndexMut<usize> for fiat_p256_montgomery_domain_field_element {
 #[derive(Clone, Copy)]
 pub struct fiat_p256_non_montgomery_domain_field_element(pub [u64; 4]);
 
-impl std::ops::Index<usize> for fiat_p256_non_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p256_non_montgomery_domain_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -58,7 +58,7 @@ impl std::ops::Index<usize> for fiat_p256_non_montgomery_domain_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p256_non_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p256_non_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/p256_scalar_32.rs
+++ b/fiat-rust/src/p256_scalar_32.rs
@@ -30,7 +30,7 @@ pub type fiat_p256_scalar_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_p256_scalar_montgomery_domain_field_element(pub [u32; 8]);
 
-impl std::ops::Index<usize> for fiat_p256_scalar_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p256_scalar_montgomery_domain_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -38,7 +38,7 @@ impl std::ops::Index<usize> for fiat_p256_scalar_montgomery_domain_field_element
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p256_scalar_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p256_scalar_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -50,7 +50,7 @@ impl std::ops::IndexMut<usize> for fiat_p256_scalar_montgomery_domain_field_elem
 #[derive(Clone, Copy)]
 pub struct fiat_p256_scalar_non_montgomery_domain_field_element(pub [u32; 8]);
 
-impl std::ops::Index<usize> for fiat_p256_scalar_non_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p256_scalar_non_montgomery_domain_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -58,7 +58,7 @@ impl std::ops::Index<usize> for fiat_p256_scalar_non_montgomery_domain_field_ele
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p256_scalar_non_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p256_scalar_non_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/p256_scalar_64.rs
+++ b/fiat-rust/src/p256_scalar_64.rs
@@ -30,7 +30,7 @@ pub type fiat_p256_scalar_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_p256_scalar_montgomery_domain_field_element(pub [u64; 4]);
 
-impl std::ops::Index<usize> for fiat_p256_scalar_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p256_scalar_montgomery_domain_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -38,7 +38,7 @@ impl std::ops::Index<usize> for fiat_p256_scalar_montgomery_domain_field_element
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p256_scalar_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p256_scalar_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -50,7 +50,7 @@ impl std::ops::IndexMut<usize> for fiat_p256_scalar_montgomery_domain_field_elem
 #[derive(Clone, Copy)]
 pub struct fiat_p256_scalar_non_montgomery_domain_field_element(pub [u64; 4]);
 
-impl std::ops::Index<usize> for fiat_p256_scalar_non_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p256_scalar_non_montgomery_domain_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -58,7 +58,7 @@ impl std::ops::Index<usize> for fiat_p256_scalar_non_montgomery_domain_field_ele
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p256_scalar_non_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p256_scalar_non_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/p384_32.rs
+++ b/fiat-rust/src/p384_32.rs
@@ -30,7 +30,7 @@ pub type fiat_p384_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_p384_montgomery_domain_field_element(pub [u32; 12]);
 
-impl std::ops::Index<usize> for fiat_p384_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p384_montgomery_domain_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -38,7 +38,7 @@ impl std::ops::Index<usize> for fiat_p384_montgomery_domain_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p384_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p384_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -50,7 +50,7 @@ impl std::ops::IndexMut<usize> for fiat_p384_montgomery_domain_field_element {
 #[derive(Clone, Copy)]
 pub struct fiat_p384_non_montgomery_domain_field_element(pub [u32; 12]);
 
-impl std::ops::Index<usize> for fiat_p384_non_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p384_non_montgomery_domain_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -58,7 +58,7 @@ impl std::ops::Index<usize> for fiat_p384_non_montgomery_domain_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p384_non_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p384_non_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/p384_64.rs
+++ b/fiat-rust/src/p384_64.rs
@@ -30,7 +30,7 @@ pub type fiat_p384_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_p384_montgomery_domain_field_element(pub [u64; 6]);
 
-impl std::ops::Index<usize> for fiat_p384_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p384_montgomery_domain_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -38,7 +38,7 @@ impl std::ops::Index<usize> for fiat_p384_montgomery_domain_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p384_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p384_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -50,7 +50,7 @@ impl std::ops::IndexMut<usize> for fiat_p384_montgomery_domain_field_element {
 #[derive(Clone, Copy)]
 pub struct fiat_p384_non_montgomery_domain_field_element(pub [u64; 6]);
 
-impl std::ops::Index<usize> for fiat_p384_non_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p384_non_montgomery_domain_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -58,7 +58,7 @@ impl std::ops::Index<usize> for fiat_p384_non_montgomery_domain_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p384_non_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p384_non_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/p384_scalar_32.rs
+++ b/fiat-rust/src/p384_scalar_32.rs
@@ -30,7 +30,7 @@ pub type fiat_p384_scalar_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_p384_scalar_montgomery_domain_field_element(pub [u32; 12]);
 
-impl std::ops::Index<usize> for fiat_p384_scalar_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p384_scalar_montgomery_domain_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -38,7 +38,7 @@ impl std::ops::Index<usize> for fiat_p384_scalar_montgomery_domain_field_element
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p384_scalar_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p384_scalar_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -50,7 +50,7 @@ impl std::ops::IndexMut<usize> for fiat_p384_scalar_montgomery_domain_field_elem
 #[derive(Clone, Copy)]
 pub struct fiat_p384_scalar_non_montgomery_domain_field_element(pub [u32; 12]);
 
-impl std::ops::Index<usize> for fiat_p384_scalar_non_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p384_scalar_non_montgomery_domain_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -58,7 +58,7 @@ impl std::ops::Index<usize> for fiat_p384_scalar_non_montgomery_domain_field_ele
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p384_scalar_non_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p384_scalar_non_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/p384_scalar_64.rs
+++ b/fiat-rust/src/p384_scalar_64.rs
@@ -30,7 +30,7 @@ pub type fiat_p384_scalar_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_p384_scalar_montgomery_domain_field_element(pub [u64; 6]);
 
-impl std::ops::Index<usize> for fiat_p384_scalar_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p384_scalar_montgomery_domain_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -38,7 +38,7 @@ impl std::ops::Index<usize> for fiat_p384_scalar_montgomery_domain_field_element
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p384_scalar_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p384_scalar_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -50,7 +50,7 @@ impl std::ops::IndexMut<usize> for fiat_p384_scalar_montgomery_domain_field_elem
 #[derive(Clone, Copy)]
 pub struct fiat_p384_scalar_non_montgomery_domain_field_element(pub [u64; 6]);
 
-impl std::ops::Index<usize> for fiat_p384_scalar_non_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p384_scalar_non_montgomery_domain_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -58,7 +58,7 @@ impl std::ops::Index<usize> for fiat_p384_scalar_non_montgomery_domain_field_ele
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p384_scalar_non_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p384_scalar_non_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/p434_64.rs
+++ b/fiat-rust/src/p434_64.rs
@@ -30,7 +30,7 @@ pub type fiat_p434_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_p434_montgomery_domain_field_element(pub [u64; 7]);
 
-impl std::ops::Index<usize> for fiat_p434_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p434_montgomery_domain_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -38,7 +38,7 @@ impl std::ops::Index<usize> for fiat_p434_montgomery_domain_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p434_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p434_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -50,7 +50,7 @@ impl std::ops::IndexMut<usize> for fiat_p434_montgomery_domain_field_element {
 #[derive(Clone, Copy)]
 pub struct fiat_p434_non_montgomery_domain_field_element(pub [u64; 7]);
 
-impl std::ops::Index<usize> for fiat_p434_non_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_p434_non_montgomery_domain_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -58,7 +58,7 @@ impl std::ops::Index<usize> for fiat_p434_non_montgomery_domain_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p434_non_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_p434_non_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/p448_solinas_32.rs
+++ b/fiat-rust/src/p448_solinas_32.rs
@@ -25,7 +25,7 @@ pub type fiat_p448_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_p448_loose_field_element(pub [u32; 16]);
 
-impl std::ops::Index<usize> for fiat_p448_loose_field_element {
+impl core::ops::Index<usize> for fiat_p448_loose_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -33,7 +33,7 @@ impl std::ops::Index<usize> for fiat_p448_loose_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p448_loose_field_element {
+impl core::ops::IndexMut<usize> for fiat_p448_loose_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -45,7 +45,7 @@ impl std::ops::IndexMut<usize> for fiat_p448_loose_field_element {
 #[derive(Clone, Copy)]
 pub struct fiat_p448_tight_field_element(pub [u32; 16]);
 
-impl std::ops::Index<usize> for fiat_p448_tight_field_element {
+impl core::ops::Index<usize> for fiat_p448_tight_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -53,7 +53,7 @@ impl std::ops::Index<usize> for fiat_p448_tight_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p448_tight_field_element {
+impl core::ops::IndexMut<usize> for fiat_p448_tight_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/p448_solinas_64.rs
+++ b/fiat-rust/src/p448_solinas_64.rs
@@ -25,7 +25,7 @@ pub type fiat_p448_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_p448_loose_field_element(pub [u64; 8]);
 
-impl std::ops::Index<usize> for fiat_p448_loose_field_element {
+impl core::ops::Index<usize> for fiat_p448_loose_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -33,7 +33,7 @@ impl std::ops::Index<usize> for fiat_p448_loose_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p448_loose_field_element {
+impl core::ops::IndexMut<usize> for fiat_p448_loose_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -45,7 +45,7 @@ impl std::ops::IndexMut<usize> for fiat_p448_loose_field_element {
 #[derive(Clone, Copy)]
 pub struct fiat_p448_tight_field_element(pub [u64; 8]);
 
-impl std::ops::Index<usize> for fiat_p448_tight_field_element {
+impl core::ops::Index<usize> for fiat_p448_tight_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -53,7 +53,7 @@ impl std::ops::Index<usize> for fiat_p448_tight_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p448_tight_field_element {
+impl core::ops::IndexMut<usize> for fiat_p448_tight_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/p521_32.rs
+++ b/fiat-rust/src/p521_32.rs
@@ -25,7 +25,7 @@ pub type fiat_p521_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_p521_loose_field_element(pub [u32; 19]);
 
-impl std::ops::Index<usize> for fiat_p521_loose_field_element {
+impl core::ops::Index<usize> for fiat_p521_loose_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -33,7 +33,7 @@ impl std::ops::Index<usize> for fiat_p521_loose_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p521_loose_field_element {
+impl core::ops::IndexMut<usize> for fiat_p521_loose_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -45,7 +45,7 @@ impl std::ops::IndexMut<usize> for fiat_p521_loose_field_element {
 #[derive(Clone, Copy)]
 pub struct fiat_p521_tight_field_element(pub [u32; 19]);
 
-impl std::ops::Index<usize> for fiat_p521_tight_field_element {
+impl core::ops::Index<usize> for fiat_p521_tight_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -53,7 +53,7 @@ impl std::ops::Index<usize> for fiat_p521_tight_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p521_tight_field_element {
+impl core::ops::IndexMut<usize> for fiat_p521_tight_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/p521_64.rs
+++ b/fiat-rust/src/p521_64.rs
@@ -25,7 +25,7 @@ pub type fiat_p521_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_p521_loose_field_element(pub [u64; 9]);
 
-impl std::ops::Index<usize> for fiat_p521_loose_field_element {
+impl core::ops::Index<usize> for fiat_p521_loose_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -33,7 +33,7 @@ impl std::ops::Index<usize> for fiat_p521_loose_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p521_loose_field_element {
+impl core::ops::IndexMut<usize> for fiat_p521_loose_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -45,7 +45,7 @@ impl std::ops::IndexMut<usize> for fiat_p521_loose_field_element {
 #[derive(Clone, Copy)]
 pub struct fiat_p521_tight_field_element(pub [u64; 9]);
 
-impl std::ops::Index<usize> for fiat_p521_tight_field_element {
+impl core::ops::Index<usize> for fiat_p521_tight_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -53,7 +53,7 @@ impl std::ops::Index<usize> for fiat_p521_tight_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_p521_tight_field_element {
+impl core::ops::IndexMut<usize> for fiat_p521_tight_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/poly1305_32.rs
+++ b/fiat-rust/src/poly1305_32.rs
@@ -25,7 +25,7 @@ pub type fiat_poly1305_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_poly1305_loose_field_element(pub [u32; 5]);
 
-impl std::ops::Index<usize> for fiat_poly1305_loose_field_element {
+impl core::ops::Index<usize> for fiat_poly1305_loose_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -33,7 +33,7 @@ impl std::ops::Index<usize> for fiat_poly1305_loose_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_poly1305_loose_field_element {
+impl core::ops::IndexMut<usize> for fiat_poly1305_loose_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -45,7 +45,7 @@ impl std::ops::IndexMut<usize> for fiat_poly1305_loose_field_element {
 #[derive(Clone, Copy)]
 pub struct fiat_poly1305_tight_field_element(pub [u32; 5]);
 
-impl std::ops::Index<usize> for fiat_poly1305_tight_field_element {
+impl core::ops::Index<usize> for fiat_poly1305_tight_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -53,7 +53,7 @@ impl std::ops::Index<usize> for fiat_poly1305_tight_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_poly1305_tight_field_element {
+impl core::ops::IndexMut<usize> for fiat_poly1305_tight_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/poly1305_64.rs
+++ b/fiat-rust/src/poly1305_64.rs
@@ -25,7 +25,7 @@ pub type fiat_poly1305_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_poly1305_loose_field_element(pub [u64; 3]);
 
-impl std::ops::Index<usize> for fiat_poly1305_loose_field_element {
+impl core::ops::Index<usize> for fiat_poly1305_loose_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -33,7 +33,7 @@ impl std::ops::Index<usize> for fiat_poly1305_loose_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_poly1305_loose_field_element {
+impl core::ops::IndexMut<usize> for fiat_poly1305_loose_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -45,7 +45,7 @@ impl std::ops::IndexMut<usize> for fiat_poly1305_loose_field_element {
 #[derive(Clone, Copy)]
 pub struct fiat_poly1305_tight_field_element(pub [u64; 3]);
 
-impl std::ops::Index<usize> for fiat_poly1305_tight_field_element {
+impl core::ops::Index<usize> for fiat_poly1305_tight_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -53,7 +53,7 @@ impl std::ops::Index<usize> for fiat_poly1305_tight_field_element {
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_poly1305_tight_field_element {
+impl core::ops::IndexMut<usize> for fiat_poly1305_tight_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/secp256k1_montgomery_32.rs
+++ b/fiat-rust/src/secp256k1_montgomery_32.rs
@@ -30,7 +30,7 @@ pub type fiat_secp256k1_montgomery_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_secp256k1_montgomery_montgomery_domain_field_element(pub [u32; 8]);
 
-impl std::ops::Index<usize> for fiat_secp256k1_montgomery_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_secp256k1_montgomery_montgomery_domain_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -38,7 +38,7 @@ impl std::ops::Index<usize> for fiat_secp256k1_montgomery_montgomery_domain_fiel
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_secp256k1_montgomery_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_secp256k1_montgomery_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -50,7 +50,7 @@ impl std::ops::IndexMut<usize> for fiat_secp256k1_montgomery_montgomery_domain_f
 #[derive(Clone, Copy)]
 pub struct fiat_secp256k1_montgomery_non_montgomery_domain_field_element(pub [u32; 8]);
 
-impl std::ops::Index<usize> for fiat_secp256k1_montgomery_non_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_secp256k1_montgomery_non_montgomery_domain_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -58,7 +58,7 @@ impl std::ops::Index<usize> for fiat_secp256k1_montgomery_non_montgomery_domain_
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_secp256k1_montgomery_non_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_secp256k1_montgomery_non_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/secp256k1_montgomery_64.rs
+++ b/fiat-rust/src/secp256k1_montgomery_64.rs
@@ -30,7 +30,7 @@ pub type fiat_secp256k1_montgomery_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_secp256k1_montgomery_montgomery_domain_field_element(pub [u64; 4]);
 
-impl std::ops::Index<usize> for fiat_secp256k1_montgomery_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_secp256k1_montgomery_montgomery_domain_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -38,7 +38,7 @@ impl std::ops::Index<usize> for fiat_secp256k1_montgomery_montgomery_domain_fiel
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_secp256k1_montgomery_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_secp256k1_montgomery_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -50,7 +50,7 @@ impl std::ops::IndexMut<usize> for fiat_secp256k1_montgomery_montgomery_domain_f
 #[derive(Clone, Copy)]
 pub struct fiat_secp256k1_montgomery_non_montgomery_domain_field_element(pub [u64; 4]);
 
-impl std::ops::Index<usize> for fiat_secp256k1_montgomery_non_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_secp256k1_montgomery_non_montgomery_domain_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -58,7 +58,7 @@ impl std::ops::Index<usize> for fiat_secp256k1_montgomery_non_montgomery_domain_
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_secp256k1_montgomery_non_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_secp256k1_montgomery_non_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/secp256k1_montgomery_scalar_32.rs
+++ b/fiat-rust/src/secp256k1_montgomery_scalar_32.rs
@@ -30,7 +30,7 @@ pub type fiat_secp256k1_montgomery_scalar_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element(pub [u32; 8]);
 
-impl std::ops::Index<usize> for fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -38,7 +38,7 @@ impl std::ops::Index<usize> for fiat_secp256k1_montgomery_scalar_montgomery_doma
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -50,7 +50,7 @@ impl std::ops::IndexMut<usize> for fiat_secp256k1_montgomery_scalar_montgomery_d
 #[derive(Clone, Copy)]
 pub struct fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element(pub [u32; 8]);
 
-impl std::ops::Index<usize> for fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element {
     type Output = u32;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -58,7 +58,7 @@ impl std::ops::Index<usize> for fiat_secp256k1_montgomery_scalar_non_montgomery_
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/fiat-rust/src/secp256k1_montgomery_scalar_64.rs
+++ b/fiat-rust/src/secp256k1_montgomery_scalar_64.rs
@@ -30,7 +30,7 @@ pub type fiat_secp256k1_montgomery_scalar_i2 = i8;
 #[derive(Clone, Copy)]
 pub struct fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element(pub [u64; 4]);
 
-impl std::ops::Index<usize> for fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -38,7 +38,7 @@ impl std::ops::Index<usize> for fiat_secp256k1_montgomery_scalar_montgomery_doma
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
@@ -50,7 +50,7 @@ impl std::ops::IndexMut<usize> for fiat_secp256k1_montgomery_scalar_montgomery_d
 #[derive(Clone, Copy)]
 pub struct fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element(pub [u64; 4]);
 
-impl std::ops::Index<usize> for fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element {
+impl core::ops::Index<usize> for fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element {
     type Output = u64;
     #[inline]
     fn index(&self, index: usize) -> &Self::Output {
@@ -58,7 +58,7 @@ impl std::ops::Index<usize> for fiat_secp256k1_montgomery_scalar_non_montgomery_
     }
 }
 
-impl std::ops::IndexMut<usize> for fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element {
+impl core::ops::IndexMut<usize> for fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]

--- a/src/Stringification/Rust.v
+++ b/src/Stringification/Rust.v
@@ -56,14 +56,14 @@ Module Rust.
                 | Some None (* unknown array length *) => visibility ++ "type " ++ name ++ " = *mut " ++ ty_string ++ ";"
                 | Some (Some len) => "#[derive(Clone, Copy)]" ++ String.NewLine
                   ++ visibility ++ "struct " ++ name ++ "(pub [" ++ ty_string ++ "; " ++ Decimal.Z.to_string (Z.of_nat len) ++ "]);" ++ String.NewLine ++ String.NewLine
-                  ++ "impl std::ops::Index<usize> for " ++ name ++ " {" ++ String.NewLine
+                  ++ "impl core::ops::Index<usize> for " ++ name ++ " {" ++ String.NewLine
                   ++ "    type Output = " ++ ty_string ++ ";" ++ String.NewLine
                   ++ "    #[inline]" ++ String.NewLine
                   ++ "    fn index(&self, index: usize) -> &Self::Output {" ++ String.NewLine
                   ++ "        &self.0[index]" ++ String.NewLine
                   ++ "    }" ++ String.NewLine
                   ++ "}" ++ String.NewLine ++ String.NewLine
-                  ++ "impl std::ops::IndexMut<usize> for " ++ name ++ " {" ++ String.NewLine
+                  ++ "impl core::ops::IndexMut<usize> for " ++ name ++ " {" ++ String.NewLine
                   ++ "    #[inline]" ++ String.NewLine
                   ++ "    fn index_mut(&mut self, index: usize) -> &mut Self::Output {" ++ String.NewLine
                   ++ "        &mut self.0[index]" ++ String.NewLine


### PR DESCRIPTION
closes #1645 

I have also added a Actions test to prevent this from happening in the future.