### PR TITLE
Stop relying on `replace by` automatic `assumption`-based solving

### DIFF
--- a/src/Fancy/Prod.v
+++ b/src/Fancy/Prod.v
@@ -114,7 +114,7 @@ Ltac step_rhs :=
   match goal with
   | H: ?x = spec ?i ?args _
     |- context [spec ?i ?args ?cc] =>
-    replace (spec i args cc) with x by idtac
+    replace (spec i args cc) with x by first [assumption | symmetry;assumption]
   end;
   match goal with
   | H : ?y = (?x mod ?m)%Z |- context [(?x mod ?m)%Z] =>


### PR DESCRIPTION
Before coq/coq#17964 `replace foo with bar by tac` actually means `replace foo with bar by first [assumption | symmetry; assumption | tac]`.