### PR TITLE
rust: Include documentation comments for type alias.

### DIFF
--- a/fiat-rust/src/curve25519_32.rs
+++ b/fiat-rust/src/curve25519_32.rs
@@ -15,13 +15,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
-/* fiat_25519_u1 represents one byte. */
+/** fiat_25519_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_25519_u1 = u8;
-/* fiat_25519_i1 represents one byte. */
+/** fiat_25519_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_25519_i1 = i8;
-/* fiat_25519_u2 represents one byte. */
+/** fiat_25519_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_25519_u2 = u8;
-/* fiat_25519_i2 represents one byte. */
+/** fiat_25519_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_25519_i2 = i8;
 
 /** The type fiat_25519_loose_field_element is a field element with loose bounds. */

--- a/fiat-rust/src/curve25519_32.rs
+++ b/fiat-rust/src/curve25519_32.rs
@@ -15,9 +15,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/* fiat_25519_u1 represents one byte. */
 pub type fiat_25519_u1 = u8;
+/* fiat_25519_i1 represents one byte. */
 pub type fiat_25519_i1 = i8;
+/* fiat_25519_u2 represents one byte. */
 pub type fiat_25519_u2 = u8;
+/* fiat_25519_i2 represents one byte. */
 pub type fiat_25519_i2 = i8;
 
 /** The type fiat_25519_loose_field_element is a field element with loose bounds. */

--- a/fiat-rust/src/curve25519_64.rs
+++ b/fiat-rust/src/curve25519_64.rs
@@ -15,13 +15,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
-/* fiat_25519_u1 represents one byte. */
+/** fiat_25519_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_25519_u1 = u8;
-/* fiat_25519_i1 represents one byte. */
+/** fiat_25519_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_25519_i1 = i8;
-/* fiat_25519_u2 represents one byte. */
+/** fiat_25519_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_25519_u2 = u8;
-/* fiat_25519_i2 represents one byte. */
+/** fiat_25519_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_25519_i2 = i8;
 
 /** The type fiat_25519_loose_field_element is a field element with loose bounds. */

--- a/fiat-rust/src/curve25519_64.rs
+++ b/fiat-rust/src/curve25519_64.rs
@@ -15,9 +15,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/* fiat_25519_u1 represents one byte. */
 pub type fiat_25519_u1 = u8;
+/* fiat_25519_i1 represents one byte. */
 pub type fiat_25519_i1 = i8;
+/* fiat_25519_u2 represents one byte. */
 pub type fiat_25519_u2 = u8;
+/* fiat_25519_i2 represents one byte. */
 pub type fiat_25519_i2 = i8;
 
 /** The type fiat_25519_loose_field_element is a field element with loose bounds. */

--- a/fiat-rust/src/curve25519_scalar_32.rs
+++ b/fiat-rust/src/curve25519_scalar_32.rs
@@ -20,9 +20,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/** fiat_25519_scalar_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_25519_scalar_u1 = u8;
+/** fiat_25519_scalar_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_25519_scalar_i1 = i8;
+/** fiat_25519_scalar_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_25519_scalar_u2 = u8;
+/** fiat_25519_scalar_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_25519_scalar_i2 = i8;
 
 /** The type fiat_25519_scalar_montgomery_domain_field_element is a field element in the Montgomery domain. */

--- a/fiat-rust/src/curve25519_scalar_64.rs
+++ b/fiat-rust/src/curve25519_scalar_64.rs
@@ -20,9 +20,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/** fiat_25519_scalar_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_25519_scalar_u1 = u8;
+/** fiat_25519_scalar_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_25519_scalar_i1 = i8;
+/** fiat_25519_scalar_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_25519_scalar_u2 = u8;
+/** fiat_25519_scalar_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_25519_scalar_i2 = i8;
 
 /** The type fiat_25519_scalar_montgomery_domain_field_element is a field element in the Montgomery domain. */

--- a/fiat-rust/src/curve25519_solinas_64.rs
+++ b/fiat-rust/src/curve25519_solinas_64.rs
@@ -10,13 +10,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
-/* fiat_curve25519_solinas_u1 represents one byte. */
+/** fiat_curve25519_solinas_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_curve25519_solinas_u1 = u8;
-/* fiat_curve25519_solinas_i1 represents one byte. */
+/** fiat_curve25519_solinas_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_curve25519_solinas_i1 = i8;
-/* fiat_curve25519_solinas_u2 represents one byte. */
+/** fiat_curve25519_solinas_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_curve25519_solinas_u2 = u8;
-/* fiat_curve25519_solinas_i2 represents one byte. */
+/** fiat_curve25519_solinas_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_curve25519_solinas_i2 = i8;
 
 

--- a/fiat-rust/src/curve25519_solinas_64.rs
+++ b/fiat-rust/src/curve25519_solinas_64.rs
@@ -10,9 +10,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/* fiat_curve25519_solinas_u1 represents one byte. */
 pub type fiat_curve25519_solinas_u1 = u8;
+/* fiat_curve25519_solinas_i1 represents one byte. */
 pub type fiat_curve25519_solinas_i1 = i8;
+/* fiat_curve25519_solinas_u2 represents one byte. */
 pub type fiat_curve25519_solinas_u2 = u8;
+/* fiat_curve25519_solinas_i2 represents one byte. */
 pub type fiat_curve25519_solinas_i2 = i8;
 
 

--- a/fiat-rust/src/p224_32.rs
+++ b/fiat-rust/src/p224_32.rs
@@ -20,9 +20,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/** fiat_p224_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p224_u1 = u8;
+/** fiat_p224_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p224_i1 = i8;
+/** fiat_p224_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p224_u2 = u8;
+/** fiat_p224_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p224_i2 = i8;
 
 /** The type fiat_p224_montgomery_domain_field_element is a field element in the Montgomery domain. */

--- a/fiat-rust/src/p224_64.rs
+++ b/fiat-rust/src/p224_64.rs
@@ -20,9 +20,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/** fiat_p224_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p224_u1 = u8;
+/** fiat_p224_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p224_i1 = i8;
+/** fiat_p224_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p224_u2 = u8;
+/** fiat_p224_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p224_i2 = i8;
 
 /** The type fiat_p224_montgomery_domain_field_element is a field element in the Montgomery domain. */

--- a/fiat-rust/src/p256_32.rs
+++ b/fiat-rust/src/p256_32.rs
@@ -20,9 +20,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/** fiat_p256_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p256_u1 = u8;
+/** fiat_p256_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p256_i1 = i8;
+/** fiat_p256_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p256_u2 = u8;
+/** fiat_p256_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p256_i2 = i8;
 
 /** The type fiat_p256_montgomery_domain_field_element is a field element in the Montgomery domain. */

--- a/fiat-rust/src/p256_64.rs
+++ b/fiat-rust/src/p256_64.rs
@@ -20,9 +20,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/** fiat_p256_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p256_u1 = u8;
+/** fiat_p256_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p256_i1 = i8;
+/** fiat_p256_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p256_u2 = u8;
+/** fiat_p256_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p256_i2 = i8;
 
 /** The type fiat_p256_montgomery_domain_field_element is a field element in the Montgomery domain. */

--- a/fiat-rust/src/p256_scalar_32.rs
+++ b/fiat-rust/src/p256_scalar_32.rs
@@ -20,9 +20,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/** fiat_p256_scalar_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p256_scalar_u1 = u8;
+/** fiat_p256_scalar_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p256_scalar_i1 = i8;
+/** fiat_p256_scalar_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p256_scalar_u2 = u8;
+/** fiat_p256_scalar_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p256_scalar_i2 = i8;
 
 /** The type fiat_p256_scalar_montgomery_domain_field_element is a field element in the Montgomery domain. */

--- a/fiat-rust/src/p256_scalar_64.rs
+++ b/fiat-rust/src/p256_scalar_64.rs
@@ -20,9 +20,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/** fiat_p256_scalar_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p256_scalar_u1 = u8;
+/** fiat_p256_scalar_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p256_scalar_i1 = i8;
+/** fiat_p256_scalar_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p256_scalar_u2 = u8;
+/** fiat_p256_scalar_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p256_scalar_i2 = i8;
 
 /** The type fiat_p256_scalar_montgomery_domain_field_element is a field element in the Montgomery domain. */

--- a/fiat-rust/src/p384_32.rs
+++ b/fiat-rust/src/p384_32.rs
@@ -20,9 +20,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/** fiat_p384_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p384_u1 = u8;
+/** fiat_p384_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p384_i1 = i8;
+/** fiat_p384_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p384_u2 = u8;
+/** fiat_p384_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p384_i2 = i8;
 
 /** The type fiat_p384_montgomery_domain_field_element is a field element in the Montgomery domain. */

--- a/fiat-rust/src/p384_64.rs
+++ b/fiat-rust/src/p384_64.rs
@@ -20,9 +20,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/** fiat_p384_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p384_u1 = u8;
+/** fiat_p384_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p384_i1 = i8;
+/** fiat_p384_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p384_u2 = u8;
+/** fiat_p384_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p384_i2 = i8;
 
 /** The type fiat_p384_montgomery_domain_field_element is a field element in the Montgomery domain. */

--- a/fiat-rust/src/p384_scalar_32.rs
+++ b/fiat-rust/src/p384_scalar_32.rs
@@ -20,9 +20,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/** fiat_p384_scalar_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p384_scalar_u1 = u8;
+/** fiat_p384_scalar_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p384_scalar_i1 = i8;
+/** fiat_p384_scalar_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p384_scalar_u2 = u8;
+/** fiat_p384_scalar_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p384_scalar_i2 = i8;
 
 /** The type fiat_p384_scalar_montgomery_domain_field_element is a field element in the Montgomery domain. */

--- a/fiat-rust/src/p384_scalar_64.rs
+++ b/fiat-rust/src/p384_scalar_64.rs
@@ -20,9 +20,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/** fiat_p384_scalar_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p384_scalar_u1 = u8;
+/** fiat_p384_scalar_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p384_scalar_i1 = i8;
+/** fiat_p384_scalar_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p384_scalar_u2 = u8;
+/** fiat_p384_scalar_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p384_scalar_i2 = i8;
 
 /** The type fiat_p384_scalar_montgomery_domain_field_element is a field element in the Montgomery domain. */

--- a/fiat-rust/src/p434_64.rs
+++ b/fiat-rust/src/p434_64.rs
@@ -20,9 +20,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/** fiat_p434_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p434_u1 = u8;
+/** fiat_p434_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p434_i1 = i8;
+/** fiat_p434_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p434_u2 = u8;
+/** fiat_p434_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p434_i2 = i8;
 
 /** The type fiat_p434_montgomery_domain_field_element is a field element in the Montgomery domain. */

--- a/fiat-rust/src/p448_solinas_32.rs
+++ b/fiat-rust/src/p448_solinas_32.rs
@@ -15,13 +15,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
-/* fiat_p448_u1 represents one byte. */
+/** fiat_p448_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p448_u1 = u8;
-/* fiat_p448_i1 represents one byte. */
+/** fiat_p448_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p448_i1 = i8;
-/* fiat_p448_u2 represents one byte. */
+/** fiat_p448_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p448_u2 = u8;
-/* fiat_p448_i2 represents one byte. */
+/** fiat_p448_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p448_i2 = i8;
 
 /** The type fiat_p448_loose_field_element is a field element with loose bounds. */

--- a/fiat-rust/src/p448_solinas_32.rs
+++ b/fiat-rust/src/p448_solinas_32.rs
@@ -15,9 +15,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/* fiat_p448_u1 represents one byte. */
 pub type fiat_p448_u1 = u8;
+/* fiat_p448_i1 represents one byte. */
 pub type fiat_p448_i1 = i8;
+/* fiat_p448_u2 represents one byte. */
 pub type fiat_p448_u2 = u8;
+/* fiat_p448_i2 represents one byte. */
 pub type fiat_p448_i2 = i8;
 
 /** The type fiat_p448_loose_field_element is a field element with loose bounds. */

--- a/fiat-rust/src/p448_solinas_64.rs
+++ b/fiat-rust/src/p448_solinas_64.rs
@@ -15,13 +15,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
-/* fiat_p448_u1 represents one byte. */
+/** fiat_p448_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p448_u1 = u8;
-/* fiat_p448_i1 represents one byte. */
+/** fiat_p448_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p448_i1 = i8;
-/* fiat_p448_u2 represents one byte. */
+/** fiat_p448_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p448_u2 = u8;
-/* fiat_p448_i2 represents one byte. */
+/** fiat_p448_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p448_i2 = i8;
 
 /** The type fiat_p448_loose_field_element is a field element with loose bounds. */

--- a/fiat-rust/src/p448_solinas_64.rs
+++ b/fiat-rust/src/p448_solinas_64.rs
@@ -15,9 +15,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/* fiat_p448_u1 represents one byte. */
 pub type fiat_p448_u1 = u8;
+/* fiat_p448_i1 represents one byte. */
 pub type fiat_p448_i1 = i8;
+/* fiat_p448_u2 represents one byte. */
 pub type fiat_p448_u2 = u8;
+/* fiat_p448_i2 represents one byte. */
 pub type fiat_p448_i2 = i8;
 
 /** The type fiat_p448_loose_field_element is a field element with loose bounds. */

--- a/fiat-rust/src/p521_32.rs
+++ b/fiat-rust/src/p521_32.rs
@@ -15,13 +15,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
-/* fiat_p521_u1 represents one byte. */
+/** fiat_p521_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p521_u1 = u8;
-/* fiat_p521_i1 represents one byte. */
+/** fiat_p521_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p521_i1 = i8;
-/* fiat_p521_u2 represents one byte. */
+/** fiat_p521_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p521_u2 = u8;
-/* fiat_p521_i2 represents one byte. */
+/** fiat_p521_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p521_i2 = i8;
 
 /** The type fiat_p521_loose_field_element is a field element with loose bounds. */

--- a/fiat-rust/src/p521_32.rs
+++ b/fiat-rust/src/p521_32.rs
@@ -15,9 +15,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/* fiat_p521_u1 represents one byte. */
 pub type fiat_p521_u1 = u8;
+/* fiat_p521_i1 represents one byte. */
 pub type fiat_p521_i1 = i8;
+/* fiat_p521_u2 represents one byte. */
 pub type fiat_p521_u2 = u8;
+/* fiat_p521_i2 represents one byte. */
 pub type fiat_p521_i2 = i8;
 
 /** The type fiat_p521_loose_field_element is a field element with loose bounds. */

--- a/fiat-rust/src/p521_64.rs
+++ b/fiat-rust/src/p521_64.rs
@@ -15,13 +15,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
-/* fiat_p521_u1 represents one byte. */
+/** fiat_p521_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p521_u1 = u8;
-/* fiat_p521_i1 represents one byte. */
+/** fiat_p521_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_p521_i1 = i8;
-/* fiat_p521_u2 represents one byte. */
+/** fiat_p521_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p521_u2 = u8;
-/* fiat_p521_i2 represents one byte. */
+/** fiat_p521_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_p521_i2 = i8;
 
 /** The type fiat_p521_loose_field_element is a field element with loose bounds. */

--- a/fiat-rust/src/p521_64.rs
+++ b/fiat-rust/src/p521_64.rs
@@ -15,9 +15,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/* fiat_p521_u1 represents one byte. */
 pub type fiat_p521_u1 = u8;
+/* fiat_p521_i1 represents one byte. */
 pub type fiat_p521_i1 = i8;
+/* fiat_p521_u2 represents one byte. */
 pub type fiat_p521_u2 = u8;
+/* fiat_p521_i2 represents one byte. */
 pub type fiat_p521_i2 = i8;
 
 /** The type fiat_p521_loose_field_element is a field element with loose bounds. */

--- a/fiat-rust/src/poly1305_32.rs
+++ b/fiat-rust/src/poly1305_32.rs
@@ -15,9 +15,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/* fiat_poly1305_u1 represents one byte. */
 pub type fiat_poly1305_u1 = u8;
+/* fiat_poly1305_i1 represents one byte. */
 pub type fiat_poly1305_i1 = i8;
+/* fiat_poly1305_u2 represents one byte. */
 pub type fiat_poly1305_u2 = u8;
+/* fiat_poly1305_i2 represents one byte. */
 pub type fiat_poly1305_i2 = i8;
 
 /** The type fiat_poly1305_loose_field_element is a field element with loose bounds. */

--- a/fiat-rust/src/poly1305_32.rs
+++ b/fiat-rust/src/poly1305_32.rs
@@ -15,13 +15,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
-/* fiat_poly1305_u1 represents one byte. */
+/** fiat_poly1305_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_poly1305_u1 = u8;
-/* fiat_poly1305_i1 represents one byte. */
+/** fiat_poly1305_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_poly1305_i1 = i8;
-/* fiat_poly1305_u2 represents one byte. */
+/** fiat_poly1305_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_poly1305_u2 = u8;
-/* fiat_poly1305_i2 represents one byte. */
+/** fiat_poly1305_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_poly1305_i2 = i8;
 
 /** The type fiat_poly1305_loose_field_element is a field element with loose bounds. */

--- a/fiat-rust/src/poly1305_64.rs
+++ b/fiat-rust/src/poly1305_64.rs
@@ -15,9 +15,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/* fiat_poly1305_u1 represents one byte. */
 pub type fiat_poly1305_u1 = u8;
+/* fiat_poly1305_i1 represents one byte. */
 pub type fiat_poly1305_i1 = i8;
+/* fiat_poly1305_u2 represents one byte. */
 pub type fiat_poly1305_u2 = u8;
+/* fiat_poly1305_i2 represents one byte. */
 pub type fiat_poly1305_i2 = i8;
 
 /** The type fiat_poly1305_loose_field_element is a field element with loose bounds. */

--- a/fiat-rust/src/poly1305_64.rs
+++ b/fiat-rust/src/poly1305_64.rs
@@ -15,13 +15,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
-/* fiat_poly1305_u1 represents one byte. */
+/** fiat_poly1305_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_poly1305_u1 = u8;
-/* fiat_poly1305_i1 represents one byte. */
+/** fiat_poly1305_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_poly1305_i1 = i8;
-/* fiat_poly1305_u2 represents one byte. */
+/** fiat_poly1305_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_poly1305_u2 = u8;
-/* fiat_poly1305_i2 represents one byte. */
+/** fiat_poly1305_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_poly1305_i2 = i8;
 
 /** The type fiat_poly1305_loose_field_element is a field element with loose bounds. */

--- a/fiat-rust/src/secp256k1_montgomery_32.rs
+++ b/fiat-rust/src/secp256k1_montgomery_32.rs
@@ -20,9 +20,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/** fiat_secp256k1_montgomery_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_secp256k1_montgomery_u1 = u8;
+/** fiat_secp256k1_montgomery_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_secp256k1_montgomery_i1 = i8;
+/** fiat_secp256k1_montgomery_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_secp256k1_montgomery_u2 = u8;
+/** fiat_secp256k1_montgomery_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_secp256k1_montgomery_i2 = i8;
 
 /** The type fiat_secp256k1_montgomery_montgomery_domain_field_element is a field element in the Montgomery domain. */

--- a/fiat-rust/src/secp256k1_montgomery_64.rs
+++ b/fiat-rust/src/secp256k1_montgomery_64.rs
@@ -20,9 +20,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/** fiat_secp256k1_montgomery_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_secp256k1_montgomery_u1 = u8;
+/** fiat_secp256k1_montgomery_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_secp256k1_montgomery_i1 = i8;
+/** fiat_secp256k1_montgomery_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_secp256k1_montgomery_u2 = u8;
+/** fiat_secp256k1_montgomery_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_secp256k1_montgomery_i2 = i8;
 
 /** The type fiat_secp256k1_montgomery_montgomery_domain_field_element is a field element in the Montgomery domain. */

--- a/fiat-rust/src/secp256k1_montgomery_scalar_32.rs
+++ b/fiat-rust/src/secp256k1_montgomery_scalar_32.rs
@@ -20,9 +20,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/** fiat_secp256k1_montgomery_scalar_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_secp256k1_montgomery_scalar_u1 = u8;
+/** fiat_secp256k1_montgomery_scalar_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_secp256k1_montgomery_scalar_i1 = i8;
+/** fiat_secp256k1_montgomery_scalar_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_secp256k1_montgomery_scalar_u2 = u8;
+/** fiat_secp256k1_montgomery_scalar_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_secp256k1_montgomery_scalar_i2 = i8;
 
 /** The type fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element is a field element in the Montgomery domain. */

--- a/fiat-rust/src/secp256k1_montgomery_scalar_64.rs
+++ b/fiat-rust/src/secp256k1_montgomery_scalar_64.rs
@@ -20,9 +20,13 @@
 #![allow(unused_parens)]
 #![allow(non_camel_case_types)]
 
+/** fiat_secp256k1_montgomery_scalar_u1 represents values of 1 bits, stored in one byte. */
 pub type fiat_secp256k1_montgomery_scalar_u1 = u8;
+/** fiat_secp256k1_montgomery_scalar_i1 represents values of 1 bits, stored in one byte. */
 pub type fiat_secp256k1_montgomery_scalar_i1 = i8;
+/** fiat_secp256k1_montgomery_scalar_u2 represents values of 2 bits, stored in one byte. */
 pub type fiat_secp256k1_montgomery_scalar_u2 = u8;
+/** fiat_secp256k1_montgomery_scalar_i2 represents values of 2 bits, stored in one byte. */
 pub type fiat_secp256k1_montgomery_scalar_i2 = i8;
 
 /** The type fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element is a field element in the Montgomery domain. */

--- a/src/Stringification/Rust.v
+++ b/src/Stringification/Rust.v
@@ -90,9 +90,12 @@ Module Rust.
         ""]%string
            ++ (List.flat_map
                  (fun bw
-                  => (if IntSet.mem (int.of_bitwidth false bw) bitwidths_used || IntSet.mem (int.of_bitwidth true bw) bitwidths_used
-                      then [type_prefix ++ int_type_to_string internal_private prefix (int.of_bitwidth false bw) ++ " = u8;"; (* C: typedef unsigned char prefix_uint1 *)
-                           type_prefix ++ int_type_to_string internal_private prefix (int.of_bitwidth true bw) ++ " = i8;" ]%string (* C: typedef signed char prefix_int1 *)
+                  => let type_suffix (b : bool) := (int.of_bitwidth b bw) in
+                     let typedef_name (b : bool) := int_type_to_string internal_private prefix (type_suffix b) in
+                     let type_comment (name : string) := String.concat String.NewLine (comment_block [( name ++ " represents values of " ++ show bw ++ " bits, stored in one byte.")%string]) in
+                     (if IntSet.mem (type_suffix false) bitwidths_used || IntSet.mem (type_suffix true) bitwidths_used
+                      then [type_comment (typedef_name false) ++ String.NewLine ++ type_prefix ++ (typedef_name false) ++ " = u8;"; (* C: typedef unsigned char prefix_uint1 *)
+                            type_comment (typedef_name true ) ++ String.NewLine ++ type_prefix ++ (typedef_name true)  ++ " = i8;"]%string (* C: typedef signed char prefix_int1 *)
                       else []))
                  [1; 2])
            ++ (if skip_typedefs


### PR DESCRIPTION
Includes doc comments for auxiliary type alias, which are created for one-byte variables.