### PR TITLE
rust: Replaces return an empty tuple by nothing (void).

### DIFF
--- a/fiat-rust/src/curve25519_32.rs
+++ b/fiat-rust/src/curve25519_32.rs
@@ -75,7 +75,7 @@ impl core::ops::IndexMut<usize> for fiat_25519_tight_field_element {
 ///   out1: [0x0 ~> 0x3ffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_25519_addcarryx_u26(out1: &mut u32, out2: &mut fiat_25519_u1, arg1: fiat_25519_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_25519_addcarryx_u26(out1: &mut u32, out2: &mut fiat_25519_u1, arg1: fiat_25519_u1, arg2: u32, arg3: u32) {
   let x1: u32 = (((arg1 as u32) + arg2) + arg3);
   let x2: u32 = (x1 & 0x3ffffff);
   let x3: fiat_25519_u1 = ((x1 >> 26) as fiat_25519_u1);
@@ -97,7 +97,7 @@ pub fn fiat_25519_addcarryx_u26(out1: &mut u32, out2: &mut fiat_25519_u1, arg1: 
 ///   out1: [0x0 ~> 0x3ffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_25519_subborrowx_u26(out1: &mut u32, out2: &mut fiat_25519_u1, arg1: fiat_25519_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_25519_subborrowx_u26(out1: &mut u32, out2: &mut fiat_25519_u1, arg1: fiat_25519_u1, arg2: u32, arg3: u32) {
   let x1: i32 = ((((((arg2 as i64) - (arg1 as i64)) as i32) as i64) - (arg3 as i64)) as i32);
   let x2: fiat_25519_i1 = ((x1 >> 26) as fiat_25519_i1);
   let x3: u32 = (((x1 as i64) & (0x3ffffff as i64)) as u32);
@@ -119,7 +119,7 @@ pub fn fiat_25519_subborrowx_u26(out1: &mut u32, out2: &mut fiat_25519_u1, arg1:
 ///   out1: [0x0 ~> 0x1ffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_25519_addcarryx_u25(out1: &mut u32, out2: &mut fiat_25519_u1, arg1: fiat_25519_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_25519_addcarryx_u25(out1: &mut u32, out2: &mut fiat_25519_u1, arg1: fiat_25519_u1, arg2: u32, arg3: u32) {
   let x1: u32 = (((arg1 as u32) + arg2) + arg3);
   let x2: u32 = (x1 & 0x1ffffff);
   let x3: fiat_25519_u1 = ((x1 >> 25) as fiat_25519_u1);
@@ -141,7 +141,7 @@ pub fn fiat_25519_addcarryx_u25(out1: &mut u32, out2: &mut fiat_25519_u1, arg1: 
 ///   out1: [0x0 ~> 0x1ffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_25519_subborrowx_u25(out1: &mut u32, out2: &mut fiat_25519_u1, arg1: fiat_25519_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_25519_subborrowx_u25(out1: &mut u32, out2: &mut fiat_25519_u1, arg1: fiat_25519_u1, arg2: u32, arg3: u32) {
   let x1: i32 = ((((((arg2 as i64) - (arg1 as i64)) as i32) as i64) - (arg3 as i64)) as i32);
   let x2: fiat_25519_i1 = ((x1 >> 25) as fiat_25519_i1);
   let x3: u32 = (((x1 as i64) & (0x1ffffff as i64)) as u32);
@@ -161,7 +161,7 @@ pub fn fiat_25519_subborrowx_u25(out1: &mut u32, out2: &mut fiat_25519_u1, arg1:
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_25519_cmovznz_u32(out1: &mut u32, arg1: fiat_25519_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_25519_cmovznz_u32(out1: &mut u32, arg1: fiat_25519_u1, arg2: u32, arg3: u32) {
   let x1: fiat_25519_u1 = (!(!arg1));
   let x2: u32 = ((((((0x0 as fiat_25519_i2) - (x1 as fiat_25519_i2)) as fiat_25519_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
@@ -174,7 +174,7 @@ pub fn fiat_25519_cmovznz_u32(out1: &mut u32, arg1: fiat_25519_u1, arg2: u32, ar
 ///   eval out1 mod m = (eval arg1 * eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_25519_carry_mul(out1: &mut fiat_25519_tight_field_element, arg1: &fiat_25519_loose_field_element, arg2: &fiat_25519_loose_field_element) -> () {
+pub fn fiat_25519_carry_mul(out1: &mut fiat_25519_tight_field_element, arg1: &fiat_25519_loose_field_element, arg2: &fiat_25519_loose_field_element) {
   let x1: u64 = (((arg1[9]) as u64) * (((arg2[9]) * 0x26) as u64));
   let x2: u64 = (((arg1[9]) as u64) * (((arg2[8]) * 0x13) as u64));
   let x3: u64 = (((arg1[9]) as u64) * (((arg2[7]) * 0x26) as u64));
@@ -340,7 +340,7 @@ pub fn fiat_25519_carry_mul(out1: &mut fiat_25519_tight_field_element, arg1: &fi
 ///   eval out1 mod m = (eval arg1 * eval arg1) mod m
 ///
 #[inline]
-pub fn fiat_25519_carry_square(out1: &mut fiat_25519_tight_field_element, arg1: &fiat_25519_loose_field_element) -> () {
+pub fn fiat_25519_carry_square(out1: &mut fiat_25519_tight_field_element, arg1: &fiat_25519_loose_field_element) {
   let x1: u32 = ((arg1[9]) * 0x13);
   let x2: u32 = (x1 * 0x2);
   let x3: u32 = ((arg1[9]) * 0x2);
@@ -479,7 +479,7 @@ pub fn fiat_25519_carry_square(out1: &mut fiat_25519_tight_field_element, arg1: 
 ///   eval out1 mod m = eval arg1 mod m
 ///
 #[inline]
-pub fn fiat_25519_carry(out1: &mut fiat_25519_tight_field_element, arg1: &fiat_25519_loose_field_element) -> () {
+pub fn fiat_25519_carry(out1: &mut fiat_25519_tight_field_element, arg1: &fiat_25519_loose_field_element) {
   let x1: u32 = (arg1[0]);
   let x2: u32 = ((x1 >> 26) + (arg1[1]));
   let x3: u32 = ((x2 >> 25) + (arg1[2]));
@@ -520,7 +520,7 @@ pub fn fiat_25519_carry(out1: &mut fiat_25519_tight_field_element, arg1: &fiat_2
 ///   eval out1 mod m = (eval arg1 + eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_25519_add(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_25519_tight_field_element, arg2: &fiat_25519_tight_field_element) -> () {
+pub fn fiat_25519_add(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_25519_tight_field_element, arg2: &fiat_25519_tight_field_element) {
   let x1: u32 = ((arg1[0]) + (arg2[0]));
   let x2: u32 = ((arg1[1]) + (arg2[1]));
   let x3: u32 = ((arg1[2]) + (arg2[2]));
@@ -549,7 +549,7 @@ pub fn fiat_25519_add(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_255
 ///   eval out1 mod m = (eval arg1 - eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_25519_sub(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_25519_tight_field_element, arg2: &fiat_25519_tight_field_element) -> () {
+pub fn fiat_25519_sub(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_25519_tight_field_element, arg2: &fiat_25519_tight_field_element) {
   let x1: u32 = ((0x7ffffda + (arg1[0])) - (arg2[0]));
   let x2: u32 = ((0x3fffffe + (arg1[1])) - (arg2[1]));
   let x3: u32 = ((0x7fffffe + (arg1[2])) - (arg2[2]));
@@ -578,7 +578,7 @@ pub fn fiat_25519_sub(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_255
 ///   eval out1 mod m = -eval arg1 mod m
 ///
 #[inline]
-pub fn fiat_25519_opp(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_25519_tight_field_element) -> () {
+pub fn fiat_25519_opp(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_25519_tight_field_element) {
   let x1: u32 = (0x7ffffda - (arg1[0]));
   let x2: u32 = (0x3fffffe - (arg1[1]));
   let x3: u32 = (0x7fffffe - (arg1[2]));
@@ -613,7 +613,7 @@ pub fn fiat_25519_opp(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_255
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_25519_selectznz(out1: &mut [u32; 10], arg1: fiat_25519_u1, arg2: &[u32; 10], arg3: &[u32; 10]) -> () {
+pub fn fiat_25519_selectznz(out1: &mut [u32; 10], arg1: fiat_25519_u1, arg2: &[u32; 10], arg3: &[u32; 10]) {
   let mut x1: u32 = 0;
   fiat_25519_cmovznz_u32(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u32 = 0;
@@ -654,7 +654,7 @@ pub fn fiat_25519_selectznz(out1: &mut [u32; 10], arg1: fiat_25519_u1, arg2: &[u
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x7f]]
 #[inline]
-pub fn fiat_25519_to_bytes(out1: &mut [u8; 32], arg1: &fiat_25519_tight_field_element) -> () {
+pub fn fiat_25519_to_bytes(out1: &mut [u8; 32], arg1: &fiat_25519_tight_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_25519_u1 = 0;
   fiat_25519_subborrowx_u26(&mut x1, &mut x2, 0x0, (arg1[0]), 0x3ffffed);
@@ -835,7 +835,7 @@ pub fn fiat_25519_to_bytes(out1: &mut [u8; 32], arg1: &fiat_25519_tight_field_el
 /// Input Bounds:
 ///   arg1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x7f]]
 #[inline]
-pub fn fiat_25519_from_bytes(out1: &mut fiat_25519_tight_field_element, arg1: &[u8; 32]) -> () {
+pub fn fiat_25519_from_bytes(out1: &mut fiat_25519_tight_field_element, arg1: &[u8; 32]) {
   let x1: u32 = (((arg1[31]) as u32) << 18);
   let x2: u32 = (((arg1[30]) as u32) << 10);
   let x3: u32 = (((arg1[29]) as u32) << 2);
@@ -932,7 +932,7 @@ pub fn fiat_25519_from_bytes(out1: &mut fiat_25519_tight_field_element, arg1: &[
 ///   out1 = arg1
 ///
 #[inline]
-pub fn fiat_25519_relax(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_25519_tight_field_element) -> () {
+pub fn fiat_25519_relax(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_25519_tight_field_element) {
   let x1: u32 = (arg1[0]);
   let x2: u32 = (arg1[1]);
   let x3: u32 = (arg1[2]);
@@ -961,7 +961,7 @@ pub fn fiat_25519_relax(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_2
 ///   eval out1 mod m = (121666 * eval arg1) mod m
 ///
 #[inline]
-pub fn fiat_25519_carry_scmul_121666(out1: &mut fiat_25519_tight_field_element, arg1: &fiat_25519_loose_field_element) -> () {
+pub fn fiat_25519_carry_scmul_121666(out1: &mut fiat_25519_tight_field_element, arg1: &fiat_25519_loose_field_element) {
   let x1: u64 = ((0x1db42 as u64) * ((arg1[9]) as u64));
   let x2: u64 = ((0x1db42 as u64) * ((arg1[8]) as u64));
   let x3: u64 = ((0x1db42 as u64) * ((arg1[7]) as u64));

--- a/fiat-rust/src/curve25519_64.rs
+++ b/fiat-rust/src/curve25519_64.rs
@@ -75,7 +75,7 @@ impl core::ops::IndexMut<usize> for fiat_25519_tight_field_element {
 ///   out1: [0x0 ~> 0x7ffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_25519_addcarryx_u51(out1: &mut u64, out2: &mut fiat_25519_u1, arg1: fiat_25519_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_25519_addcarryx_u51(out1: &mut u64, out2: &mut fiat_25519_u1, arg1: fiat_25519_u1, arg2: u64, arg3: u64) {
   let x1: u64 = (((arg1 as u64) + arg2) + arg3);
   let x2: u64 = (x1 & 0x7ffffffffffff);
   let x3: fiat_25519_u1 = ((x1 >> 51) as fiat_25519_u1);
@@ -97,7 +97,7 @@ pub fn fiat_25519_addcarryx_u51(out1: &mut u64, out2: &mut fiat_25519_u1, arg1: 
 ///   out1: [0x0 ~> 0x7ffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_25519_subborrowx_u51(out1: &mut u64, out2: &mut fiat_25519_u1, arg1: fiat_25519_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_25519_subborrowx_u51(out1: &mut u64, out2: &mut fiat_25519_u1, arg1: fiat_25519_u1, arg2: u64, arg3: u64) {
   let x1: i64 = ((((((arg2 as i128) - (arg1 as i128)) as i64) as i128) - (arg3 as i128)) as i64);
   let x2: fiat_25519_i1 = ((x1 >> 51) as fiat_25519_i1);
   let x3: u64 = (((x1 as i128) & (0x7ffffffffffff as i128)) as u64);
@@ -117,7 +117,7 @@ pub fn fiat_25519_subborrowx_u51(out1: &mut u64, out2: &mut fiat_25519_u1, arg1:
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_25519_cmovznz_u64(out1: &mut u64, arg1: fiat_25519_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_25519_cmovznz_u64(out1: &mut u64, arg1: fiat_25519_u1, arg2: u64, arg3: u64) {
   let x1: fiat_25519_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_25519_i2) - (x1 as fiat_25519_i2)) as fiat_25519_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
@@ -130,7 +130,7 @@ pub fn fiat_25519_cmovznz_u64(out1: &mut u64, arg1: fiat_25519_u1, arg2: u64, ar
 ///   eval out1 mod m = (eval arg1 * eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_25519_carry_mul(out1: &mut fiat_25519_tight_field_element, arg1: &fiat_25519_loose_field_element, arg2: &fiat_25519_loose_field_element) -> () {
+pub fn fiat_25519_carry_mul(out1: &mut fiat_25519_tight_field_element, arg1: &fiat_25519_loose_field_element, arg2: &fiat_25519_loose_field_element) {
   let x1: u128 = (((arg1[4]) as u128) * (((arg2[4]) * 0x13) as u128));
   let x2: u128 = (((arg1[4]) as u128) * (((arg2[3]) * 0x13) as u128));
   let x3: u128 = (((arg1[4]) as u128) * (((arg2[2]) * 0x13) as u128));
@@ -196,7 +196,7 @@ pub fn fiat_25519_carry_mul(out1: &mut fiat_25519_tight_field_element, arg1: &fi
 ///   eval out1 mod m = (eval arg1 * eval arg1) mod m
 ///
 #[inline]
-pub fn fiat_25519_carry_square(out1: &mut fiat_25519_tight_field_element, arg1: &fiat_25519_loose_field_element) -> () {
+pub fn fiat_25519_carry_square(out1: &mut fiat_25519_tight_field_element, arg1: &fiat_25519_loose_field_element) {
   let x1: u64 = ((arg1[4]) * 0x13);
   let x2: u64 = (x1 * 0x2);
   let x3: u64 = ((arg1[4]) * 0x2);
@@ -260,7 +260,7 @@ pub fn fiat_25519_carry_square(out1: &mut fiat_25519_tight_field_element, arg1: 
 ///   eval out1 mod m = eval arg1 mod m
 ///
 #[inline]
-pub fn fiat_25519_carry(out1: &mut fiat_25519_tight_field_element, arg1: &fiat_25519_loose_field_element) -> () {
+pub fn fiat_25519_carry(out1: &mut fiat_25519_tight_field_element, arg1: &fiat_25519_loose_field_element) {
   let x1: u64 = (arg1[0]);
   let x2: u64 = ((x1 >> 51) + (arg1[1]));
   let x3: u64 = ((x2 >> 51) + (arg1[2]));
@@ -286,7 +286,7 @@ pub fn fiat_25519_carry(out1: &mut fiat_25519_tight_field_element, arg1: &fiat_2
 ///   eval out1 mod m = (eval arg1 + eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_25519_add(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_25519_tight_field_element, arg2: &fiat_25519_tight_field_element) -> () {
+pub fn fiat_25519_add(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_25519_tight_field_element, arg2: &fiat_25519_tight_field_element) {
   let x1: u64 = ((arg1[0]) + (arg2[0]));
   let x2: u64 = ((arg1[1]) + (arg2[1]));
   let x3: u64 = ((arg1[2]) + (arg2[2]));
@@ -305,7 +305,7 @@ pub fn fiat_25519_add(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_255
 ///   eval out1 mod m = (eval arg1 - eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_25519_sub(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_25519_tight_field_element, arg2: &fiat_25519_tight_field_element) -> () {
+pub fn fiat_25519_sub(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_25519_tight_field_element, arg2: &fiat_25519_tight_field_element) {
   let x1: u64 = ((0xfffffffffffda + (arg1[0])) - (arg2[0]));
   let x2: u64 = ((0xffffffffffffe + (arg1[1])) - (arg2[1]));
   let x3: u64 = ((0xffffffffffffe + (arg1[2])) - (arg2[2]));
@@ -324,7 +324,7 @@ pub fn fiat_25519_sub(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_255
 ///   eval out1 mod m = -eval arg1 mod m
 ///
 #[inline]
-pub fn fiat_25519_opp(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_25519_tight_field_element) -> () {
+pub fn fiat_25519_opp(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_25519_tight_field_element) {
   let x1: u64 = (0xfffffffffffda - (arg1[0]));
   let x2: u64 = (0xffffffffffffe - (arg1[1]));
   let x3: u64 = (0xffffffffffffe - (arg1[2]));
@@ -349,7 +349,7 @@ pub fn fiat_25519_opp(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_255
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_25519_selectznz(out1: &mut [u64; 5], arg1: fiat_25519_u1, arg2: &[u64; 5], arg3: &[u64; 5]) -> () {
+pub fn fiat_25519_selectznz(out1: &mut [u64; 5], arg1: fiat_25519_u1, arg2: &[u64; 5], arg3: &[u64; 5]) {
   let mut x1: u64 = 0;
   fiat_25519_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u64 = 0;
@@ -375,7 +375,7 @@ pub fn fiat_25519_selectznz(out1: &mut [u64; 5], arg1: fiat_25519_u1, arg2: &[u6
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x7f]]
 #[inline]
-pub fn fiat_25519_to_bytes(out1: &mut [u8; 32], arg1: &fiat_25519_tight_field_element) -> () {
+pub fn fiat_25519_to_bytes(out1: &mut [u8; 32], arg1: &fiat_25519_tight_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_25519_u1 = 0;
   fiat_25519_subborrowx_u51(&mut x1, &mut x2, 0x0, (arg1[0]), 0x7ffffffffffed);
@@ -520,7 +520,7 @@ pub fn fiat_25519_to_bytes(out1: &mut [u8; 32], arg1: &fiat_25519_tight_field_el
 /// Input Bounds:
 ///   arg1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x7f]]
 #[inline]
-pub fn fiat_25519_from_bytes(out1: &mut fiat_25519_tight_field_element, arg1: &[u8; 32]) -> () {
+pub fn fiat_25519_from_bytes(out1: &mut fiat_25519_tight_field_element, arg1: &[u8; 32]) {
   let x1: u64 = (((arg1[31]) as u64) << 44);
   let x2: u64 = (((arg1[30]) as u64) << 36);
   let x3: u64 = (((arg1[29]) as u64) << 28);
@@ -605,7 +605,7 @@ pub fn fiat_25519_from_bytes(out1: &mut fiat_25519_tight_field_element, arg1: &[
 ///   out1 = arg1
 ///
 #[inline]
-pub fn fiat_25519_relax(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_25519_tight_field_element) -> () {
+pub fn fiat_25519_relax(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_25519_tight_field_element) {
   let x1: u64 = (arg1[0]);
   let x2: u64 = (arg1[1]);
   let x3: u64 = (arg1[2]);
@@ -624,7 +624,7 @@ pub fn fiat_25519_relax(out1: &mut fiat_25519_loose_field_element, arg1: &fiat_2
 ///   eval out1 mod m = (121666 * eval arg1) mod m
 ///
 #[inline]
-pub fn fiat_25519_carry_scmul_121666(out1: &mut fiat_25519_tight_field_element, arg1: &fiat_25519_loose_field_element) -> () {
+pub fn fiat_25519_carry_scmul_121666(out1: &mut fiat_25519_tight_field_element, arg1: &fiat_25519_loose_field_element) {
   let x1: u128 = ((0x1db42 as u128) * ((arg1[4]) as u128));
   let x2: u128 = ((0x1db42 as u128) * ((arg1[3]) as u128));
   let x3: u128 = ((0x1db42 as u128) * ((arg1[2]) as u128));

--- a/fiat-rust/src/curve25519_scalar_32.rs
+++ b/fiat-rust/src/curve25519_scalar_32.rs
@@ -80,7 +80,7 @@ impl core::ops::IndexMut<usize> for fiat_25519_scalar_non_montgomery_domain_fiel
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_25519_scalar_addcarryx_u32(out1: &mut u32, out2: &mut fiat_25519_scalar_u1, arg1: fiat_25519_scalar_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_25519_scalar_addcarryx_u32(out1: &mut u32, out2: &mut fiat_25519_scalar_u1, arg1: fiat_25519_scalar_u1, arg2: u32, arg3: u32) {
   let x1: u64 = (((arg1 as u64) + (arg2 as u64)) + (arg3 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
   let x3: fiat_25519_scalar_u1 = ((x1 >> 32) as fiat_25519_scalar_u1);
@@ -102,7 +102,7 @@ pub fn fiat_25519_scalar_addcarryx_u32(out1: &mut u32, out2: &mut fiat_25519_sca
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_25519_scalar_subborrowx_u32(out1: &mut u32, out2: &mut fiat_25519_scalar_u1, arg1: fiat_25519_scalar_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_25519_scalar_subborrowx_u32(out1: &mut u32, out2: &mut fiat_25519_scalar_u1, arg1: fiat_25519_scalar_u1, arg2: u32, arg3: u32) {
   let x1: i64 = (((arg2 as i64) - (arg1 as i64)) - (arg3 as i64));
   let x2: fiat_25519_scalar_i1 = ((x1 >> 32) as fiat_25519_scalar_i1);
   let x3: u32 = ((x1 & (0xffffffff as i64)) as u32);
@@ -123,7 +123,7 @@ pub fn fiat_25519_scalar_subborrowx_u32(out1: &mut u32, out2: &mut fiat_25519_sc
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_25519_scalar_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) -> () {
+pub fn fiat_25519_scalar_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) {
   let x1: u64 = ((arg1 as u64) * (arg2 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
   let x3: u32 = ((x1 >> 32) as u32);
@@ -143,7 +143,7 @@ pub fn fiat_25519_scalar_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_25519_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_25519_scalar_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_25519_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_25519_scalar_u1, arg2: u32, arg3: u32) {
   let x1: fiat_25519_scalar_u1 = (!(!arg1));
   let x2: u32 = ((((((0x0 as fiat_25519_scalar_i2) - (x1 as fiat_25519_scalar_i2)) as fiat_25519_scalar_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
@@ -160,7 +160,7 @@ pub fn fiat_25519_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_25519_scalar_u1,
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_25519_scalar_mul(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element, arg2: &fiat_25519_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_25519_scalar_mul(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element, arg2: &fiat_25519_scalar_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -1235,7 +1235,7 @@ pub fn fiat_25519_scalar_mul(out1: &mut fiat_25519_scalar_montgomery_domain_fiel
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_25519_scalar_square(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_25519_scalar_square(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -2311,7 +2311,7 @@ pub fn fiat_25519_scalar_square(out1: &mut fiat_25519_scalar_montgomery_domain_f
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_25519_scalar_add(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element, arg2: &fiat_25519_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_25519_scalar_add(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element, arg2: &fiat_25519_scalar_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_25519_scalar_u1 = 0;
   fiat_25519_scalar_addcarryx_u32(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -2399,7 +2399,7 @@ pub fn fiat_25519_scalar_add(out1: &mut fiat_25519_scalar_montgomery_domain_fiel
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_25519_scalar_sub(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element, arg2: &fiat_25519_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_25519_scalar_sub(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element, arg2: &fiat_25519_scalar_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_25519_scalar_u1 = 0;
   fiat_25519_scalar_subborrowx_u32(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -2469,7 +2469,7 @@ pub fn fiat_25519_scalar_sub(out1: &mut fiat_25519_scalar_montgomery_domain_fiel
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_25519_scalar_opp(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_25519_scalar_opp(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_25519_scalar_u1 = 0;
   fiat_25519_scalar_subborrowx_u32(&mut x1, &mut x2, 0x0, (0x0 as u32), (arg1[0]));
@@ -2539,7 +2539,7 @@ pub fn fiat_25519_scalar_opp(out1: &mut fiat_25519_scalar_montgomery_domain_fiel
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_25519_scalar_from_montgomery(out1: &mut fiat_25519_scalar_non_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_25519_scalar_from_montgomery(out1: &mut fiat_25519_scalar_non_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element) {
   let x1: u32 = (arg1[0]);
   let mut x2: u32 = 0;
   let mut x3: u32 = 0;
@@ -3093,7 +3093,7 @@ pub fn fiat_25519_scalar_from_montgomery(out1: &mut fiat_25519_scalar_non_montgo
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_25519_scalar_to_montgomery(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_non_montgomery_domain_field_element) -> () {
+pub fn fiat_25519_scalar_to_montgomery(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_non_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -4104,7 +4104,7 @@ pub fn fiat_25519_scalar_to_montgomery(out1: &mut fiat_25519_scalar_montgomery_d
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_25519_scalar_nonzero(out1: &mut u32, arg1: &[u32; 8]) -> () {
+pub fn fiat_25519_scalar_nonzero(out1: &mut u32, arg1: &[u32; 8]) {
   let x1: u32 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | ((arg1[3]) | ((arg1[4]) | ((arg1[5]) | ((arg1[6]) | (arg1[7]))))))));
   *out1 = x1;
 }
@@ -4121,7 +4121,7 @@ pub fn fiat_25519_scalar_nonzero(out1: &mut u32, arg1: &[u32; 8]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_25519_scalar_selectznz(out1: &mut [u32; 8], arg1: fiat_25519_scalar_u1, arg2: &[u32; 8], arg3: &[u32; 8]) -> () {
+pub fn fiat_25519_scalar_selectznz(out1: &mut [u32; 8], arg1: fiat_25519_scalar_u1, arg2: &[u32; 8], arg3: &[u32; 8]) {
   let mut x1: u32 = 0;
   fiat_25519_scalar_cmovznz_u32(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u32 = 0;
@@ -4160,7 +4160,7 @@ pub fn fiat_25519_scalar_selectznz(out1: &mut [u32; 8], arg1: fiat_25519_scalar_
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x1f]]
 #[inline]
-pub fn fiat_25519_scalar_to_bytes(out1: &mut [u8; 32], arg1: &[u32; 8]) -> () {
+pub fn fiat_25519_scalar_to_bytes(out1: &mut [u8; 32], arg1: &[u32; 8]) {
   let x1: u32 = (arg1[7]);
   let x2: u32 = (arg1[6]);
   let x3: u32 = (arg1[5]);
@@ -4264,7 +4264,7 @@ pub fn fiat_25519_scalar_to_bytes(out1: &mut [u8; 32], arg1: &[u32; 8]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0x1fffffff]]
 #[inline]
-pub fn fiat_25519_scalar_from_bytes(out1: &mut [u32; 8], arg1: &[u8; 32]) -> () {
+pub fn fiat_25519_scalar_from_bytes(out1: &mut [u32; 8], arg1: &[u8; 32]) {
   let x1: u32 = (((arg1[31]) as u32) << 24);
   let x2: u32 = (((arg1[30]) as u32) << 16);
   let x3: u32 = (((arg1[29]) as u32) << 8);
@@ -4338,7 +4338,7 @@ pub fn fiat_25519_scalar_from_bytes(out1: &mut [u32; 8], arg1: &[u8; 32]) -> () 
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_25519_scalar_set_one(out1: &mut fiat_25519_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_25519_scalar_set_one(out1: &mut fiat_25519_scalar_montgomery_domain_field_element) {
   out1[0] = 0x8d98951d;
   out1[1] = 0xd6ec3174;
   out1[2] = 0x737dcf70;
@@ -4358,7 +4358,7 @@ pub fn fiat_25519_scalar_set_one(out1: &mut fiat_25519_scalar_montgomery_domain_
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_25519_scalar_msat(out1: &mut [u32; 9]) -> () {
+pub fn fiat_25519_scalar_msat(out1: &mut [u32; 9]) {
   out1[0] = 0x5cf5d3ed;
   out1[1] = 0x5812631a;
   out1[2] = 0xa2f79cd6;
@@ -4399,7 +4399,7 @@ pub fn fiat_25519_scalar_msat(out1: &mut [u32; 9]) -> () {
 ///   out4: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 ///   out5: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_25519_scalar_divstep(out1: &mut u32, out2: &mut [u32; 9], out3: &mut [u32; 9], out4: &mut [u32; 8], out5: &mut [u32; 8], arg1: u32, arg2: &[u32; 9], arg3: &[u32; 9], arg4: &[u32; 8], arg5: &[u32; 8]) -> () {
+pub fn fiat_25519_scalar_divstep(out1: &mut u32, out2: &mut [u32; 9], out3: &mut [u32; 9], out4: &mut [u32; 8], out5: &mut [u32; 8], arg1: u32, arg2: &[u32; 9], arg3: &[u32; 9], arg4: &[u32; 8], arg5: &[u32; 8]) {
   let mut x1: u32 = 0;
   let mut x2: fiat_25519_scalar_u1 = 0;
   fiat_25519_scalar_addcarryx_u32(&mut x1, &mut x2, 0x0, (!arg1), (0x1 as u32));
@@ -4816,7 +4816,7 @@ pub fn fiat_25519_scalar_divstep(out1: &mut u32, out2: &mut [u32; 9], out3: &mut
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_25519_scalar_divstep_precomp(out1: &mut [u32; 8]) -> () {
+pub fn fiat_25519_scalar_divstep_precomp(out1: &mut [u32; 8]) {
   out1[0] = 0x36a7cb92;
   out1[1] = 0xd70af844;
   out1[2] = 0xb0b8b159;

--- a/fiat-rust/src/curve25519_scalar_64.rs
+++ b/fiat-rust/src/curve25519_scalar_64.rs
@@ -80,7 +80,7 @@ impl core::ops::IndexMut<usize> for fiat_25519_scalar_non_montgomery_domain_fiel
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_25519_scalar_addcarryx_u64(out1: &mut u64, out2: &mut fiat_25519_scalar_u1, arg1: fiat_25519_scalar_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_25519_scalar_addcarryx_u64(out1: &mut u64, out2: &mut fiat_25519_scalar_u1, arg1: fiat_25519_scalar_u1, arg2: u64, arg3: u64) {
   let x1: u128 = (((arg1 as u128) + (arg2 as u128)) + (arg3 as u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
   let x3: fiat_25519_scalar_u1 = ((x1 >> 64) as fiat_25519_scalar_u1);
@@ -102,7 +102,7 @@ pub fn fiat_25519_scalar_addcarryx_u64(out1: &mut u64, out2: &mut fiat_25519_sca
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_25519_scalar_subborrowx_u64(out1: &mut u64, out2: &mut fiat_25519_scalar_u1, arg1: fiat_25519_scalar_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_25519_scalar_subborrowx_u64(out1: &mut u64, out2: &mut fiat_25519_scalar_u1, arg1: fiat_25519_scalar_u1, arg2: u64, arg3: u64) {
   let x1: i128 = (((arg2 as i128) - (arg1 as i128)) - (arg3 as i128));
   let x2: fiat_25519_scalar_i1 = ((x1 >> 64) as fiat_25519_scalar_i1);
   let x3: u64 = ((x1 & (0xffffffffffffffff as i128)) as u64);
@@ -123,7 +123,7 @@ pub fn fiat_25519_scalar_subborrowx_u64(out1: &mut u64, out2: &mut fiat_25519_sc
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_25519_scalar_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) -> () {
+pub fn fiat_25519_scalar_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) {
   let x1: u128 = ((arg1 as u128) * (arg2 as u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
   let x3: u64 = ((x1 >> 64) as u64);
@@ -143,7 +143,7 @@ pub fn fiat_25519_scalar_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_25519_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_25519_scalar_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_25519_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_25519_scalar_u1, arg2: u64, arg3: u64) {
   let x1: fiat_25519_scalar_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_25519_scalar_i2) - (x1 as fiat_25519_scalar_i2)) as fiat_25519_scalar_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
@@ -160,7 +160,7 @@ pub fn fiat_25519_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_25519_scalar_u1,
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_25519_scalar_mul(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element, arg2: &fiat_25519_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_25519_scalar_mul(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element, arg2: &fiat_25519_scalar_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -463,7 +463,7 @@ pub fn fiat_25519_scalar_mul(out1: &mut fiat_25519_scalar_montgomery_domain_fiel
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_25519_scalar_square(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_25519_scalar_square(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -767,7 +767,7 @@ pub fn fiat_25519_scalar_square(out1: &mut fiat_25519_scalar_montgomery_domain_f
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_25519_scalar_add(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element, arg2: &fiat_25519_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_25519_scalar_add(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element, arg2: &fiat_25519_scalar_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_25519_scalar_u1 = 0;
   fiat_25519_scalar_addcarryx_u64(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -819,7 +819,7 @@ pub fn fiat_25519_scalar_add(out1: &mut fiat_25519_scalar_montgomery_domain_fiel
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_25519_scalar_sub(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element, arg2: &fiat_25519_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_25519_scalar_sub(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element, arg2: &fiat_25519_scalar_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_25519_scalar_u1 = 0;
   fiat_25519_scalar_subborrowx_u64(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -861,7 +861,7 @@ pub fn fiat_25519_scalar_sub(out1: &mut fiat_25519_scalar_montgomery_domain_fiel
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_25519_scalar_opp(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_25519_scalar_opp(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_25519_scalar_u1 = 0;
   fiat_25519_scalar_subborrowx_u64(&mut x1, &mut x2, 0x0, (0x0 as u64), (arg1[0]));
@@ -903,7 +903,7 @@ pub fn fiat_25519_scalar_opp(out1: &mut fiat_25519_scalar_montgomery_domain_fiel
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_25519_scalar_from_montgomery(out1: &mut fiat_25519_scalar_non_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_25519_scalar_from_montgomery(out1: &mut fiat_25519_scalar_non_montgomery_domain_field_element, arg1: &fiat_25519_scalar_montgomery_domain_field_element) {
   let x1: u64 = (arg1[0]);
   let mut x2: u64 = 0;
   let mut x3: u64 = 0;
@@ -1067,7 +1067,7 @@ pub fn fiat_25519_scalar_from_montgomery(out1: &mut fiat_25519_scalar_non_montgo
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_25519_scalar_to_montgomery(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_non_montgomery_domain_field_element) -> () {
+pub fn fiat_25519_scalar_to_montgomery(out1: &mut fiat_25519_scalar_montgomery_domain_field_element, arg1: &fiat_25519_scalar_non_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -1342,7 +1342,7 @@ pub fn fiat_25519_scalar_to_montgomery(out1: &mut fiat_25519_scalar_montgomery_d
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_25519_scalar_nonzero(out1: &mut u64, arg1: &[u64; 4]) -> () {
+pub fn fiat_25519_scalar_nonzero(out1: &mut u64, arg1: &[u64; 4]) {
   let x1: u64 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | (arg1[3]))));
   *out1 = x1;
 }
@@ -1359,7 +1359,7 @@ pub fn fiat_25519_scalar_nonzero(out1: &mut u64, arg1: &[u64; 4]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_25519_scalar_selectznz(out1: &mut [u64; 4], arg1: fiat_25519_scalar_u1, arg2: &[u64; 4], arg3: &[u64; 4]) -> () {
+pub fn fiat_25519_scalar_selectznz(out1: &mut [u64; 4], arg1: fiat_25519_scalar_u1, arg2: &[u64; 4], arg3: &[u64; 4]) {
   let mut x1: u64 = 0;
   fiat_25519_scalar_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u64 = 0;
@@ -1386,7 +1386,7 @@ pub fn fiat_25519_scalar_selectznz(out1: &mut [u64; 4], arg1: fiat_25519_scalar_
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x1f]]
 #[inline]
-pub fn fiat_25519_scalar_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 4]) -> () {
+pub fn fiat_25519_scalar_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 4]) {
   let x1: u64 = (arg1[3]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[1]);
@@ -1494,7 +1494,7 @@ pub fn fiat_25519_scalar_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 4]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0x1fffffffffffffff]]
 #[inline]
-pub fn fiat_25519_scalar_from_bytes(out1: &mut [u64; 4], arg1: &[u8; 32]) -> () {
+pub fn fiat_25519_scalar_from_bytes(out1: &mut [u64; 4], arg1: &[u8; 32]) {
   let x1: u64 = (((arg1[31]) as u64) << 56);
   let x2: u64 = (((arg1[30]) as u64) << 48);
   let x3: u64 = (((arg1[29]) as u64) << 40);
@@ -1568,7 +1568,7 @@ pub fn fiat_25519_scalar_from_bytes(out1: &mut [u64; 4], arg1: &[u8; 32]) -> () 
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_25519_scalar_set_one(out1: &mut fiat_25519_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_25519_scalar_set_one(out1: &mut fiat_25519_scalar_montgomery_domain_field_element) {
   out1[0] = 0xd6ec31748d98951d;
   out1[1] = 0xc6ef5bf4737dcf70;
   out1[2] = 0xfffffffffffffffe;
@@ -1584,7 +1584,7 @@ pub fn fiat_25519_scalar_set_one(out1: &mut fiat_25519_scalar_montgomery_domain_
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_25519_scalar_msat(out1: &mut [u64; 5]) -> () {
+pub fn fiat_25519_scalar_msat(out1: &mut [u64; 5]) {
   out1[0] = 0x5812631a5cf5d3ed;
   out1[1] = 0x14def9dea2f79cd6;
   out1[2] = (0x0 as u64);
@@ -1621,7 +1621,7 @@ pub fn fiat_25519_scalar_msat(out1: &mut [u64; 5]) -> () {
 ///   out4: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 ///   out5: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_25519_scalar_divstep(out1: &mut u64, out2: &mut [u64; 5], out3: &mut [u64; 5], out4: &mut [u64; 4], out5: &mut [u64; 4], arg1: u64, arg2: &[u64; 5], arg3: &[u64; 5], arg4: &[u64; 4], arg5: &[u64; 4]) -> () {
+pub fn fiat_25519_scalar_divstep(out1: &mut u64, out2: &mut [u64; 5], out3: &mut [u64; 5], out4: &mut [u64; 4], out5: &mut [u64; 4], arg1: u64, arg2: &[u64; 5], arg3: &[u64; 5], arg4: &[u64; 4], arg5: &[u64; 4]) {
   let mut x1: u64 = 0;
   let mut x2: fiat_25519_scalar_u1 = 0;
   fiat_25519_scalar_addcarryx_u64(&mut x1, &mut x2, 0x0, (!arg1), (0x1 as u64));
@@ -1854,7 +1854,7 @@ pub fn fiat_25519_scalar_divstep(out1: &mut u64, out2: &mut [u64; 5], out3: &mut
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_25519_scalar_divstep_precomp(out1: &mut [u64; 4]) -> () {
+pub fn fiat_25519_scalar_divstep_precomp(out1: &mut [u64; 4]) {
   out1[0] = 0xd70af84436a7cb92;
   out1[1] = 0x5f71c978b0b8b159;
   out1[2] = 0xe76d816974947f1a;

--- a/fiat-rust/src/curve25519_solinas_64.rs
+++ b/fiat-rust/src/curve25519_solinas_64.rs
@@ -30,7 +30,7 @@ pub type fiat_curve25519_solinas_i2 = i8;
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_curve25519_solinas_addcarryx_u64(out1: &mut u64, out2: &mut fiat_curve25519_solinas_u1, arg1: fiat_curve25519_solinas_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_curve25519_solinas_addcarryx_u64(out1: &mut u64, out2: &mut fiat_curve25519_solinas_u1, arg1: fiat_curve25519_solinas_u1, arg2: u64, arg3: u64) {
   let x1: u128 = (((arg1 as u128) + (arg2 as u128)) + (arg3 as u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
   let x3: fiat_curve25519_solinas_u1 = ((x1 >> 64) as fiat_curve25519_solinas_u1);
@@ -52,7 +52,7 @@ pub fn fiat_curve25519_solinas_addcarryx_u64(out1: &mut u64, out2: &mut fiat_cur
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_curve25519_solinas_subborrowx_u64(out1: &mut u64, out2: &mut fiat_curve25519_solinas_u1, arg1: fiat_curve25519_solinas_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_curve25519_solinas_subborrowx_u64(out1: &mut u64, out2: &mut fiat_curve25519_solinas_u1, arg1: fiat_curve25519_solinas_u1, arg2: u64, arg3: u64) {
   let x1: i128 = (((arg2 as i128) - (arg1 as i128)) - (arg3 as i128));
   let x2: fiat_curve25519_solinas_i1 = ((x1 >> 64) as fiat_curve25519_solinas_i1);
   let x3: u64 = ((x1 & (0xffffffffffffffff as i128)) as u64);
@@ -73,7 +73,7 @@ pub fn fiat_curve25519_solinas_subborrowx_u64(out1: &mut u64, out2: &mut fiat_cu
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_curve25519_solinas_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) -> () {
+pub fn fiat_curve25519_solinas_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) {
   let x1: u128 = ((arg1 as u128) * (arg2 as u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
   let x3: u64 = ((x1 >> 64) as u64);
@@ -93,7 +93,7 @@ pub fn fiat_curve25519_solinas_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u6
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_curve25519_solinas_cmovznz_u64(out1: &mut u64, arg1: fiat_curve25519_solinas_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_curve25519_solinas_cmovznz_u64(out1: &mut u64, arg1: fiat_curve25519_solinas_u1, arg2: u64, arg3: u64) {
   let x1: fiat_curve25519_solinas_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_curve25519_solinas_i2) - (x1 as fiat_curve25519_solinas_i2)) as fiat_curve25519_solinas_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
@@ -111,7 +111,7 @@ pub fn fiat_curve25519_solinas_cmovznz_u64(out1: &mut u64, arg1: fiat_curve25519
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_curve25519_solinas_mul(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &[u64; 4]) -> () {
+pub fn fiat_curve25519_solinas_mul(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &[u64; 4]) {
   let mut x1: u64 = 0;
   let mut x2: u64 = 0;
   fiat_curve25519_solinas_mulx_u64(&mut x1, &mut x2, (arg1[3]), (arg2[3]));
@@ -324,7 +324,7 @@ pub fn fiat_curve25519_solinas_mul(out1: &mut [u64; 4], arg1: &[u64; 4], arg2: &
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_curve25519_solinas_square(out1: &mut [u64; 4], arg1: &[u64; 4]) -> () {
+pub fn fiat_curve25519_solinas_square(out1: &mut [u64; 4], arg1: &[u64; 4]) {
   let mut x1: u64 = 0;
   let mut x2: u64 = 0;
   fiat_curve25519_solinas_mulx_u64(&mut x1, &mut x2, (arg1[0]), (arg1[3]));

--- a/fiat-rust/src/p224_32.rs
+++ b/fiat-rust/src/p224_32.rs
@@ -80,7 +80,7 @@ impl core::ops::IndexMut<usize> for fiat_p224_non_montgomery_domain_field_elemen
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p224_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p224_u1, arg1: fiat_p224_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p224_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p224_u1, arg1: fiat_p224_u1, arg2: u32, arg3: u32) {
   let x1: u64 = (((arg1 as u64) + (arg2 as u64)) + (arg3 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
   let x3: fiat_p224_u1 = ((x1 >> 32) as fiat_p224_u1);
@@ -102,7 +102,7 @@ pub fn fiat_p224_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p224_u1, arg1: fi
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p224_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p224_u1, arg1: fiat_p224_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p224_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p224_u1, arg1: fiat_p224_u1, arg2: u32, arg3: u32) {
   let x1: i64 = (((arg2 as i64) - (arg1 as i64)) - (arg3 as i64));
   let x2: fiat_p224_i1 = ((x1 >> 32) as fiat_p224_i1);
   let x3: u32 = ((x1 & (0xffffffff as i64)) as u32);
@@ -123,7 +123,7 @@ pub fn fiat_p224_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p224_u1, arg1: f
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_p224_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) -> () {
+pub fn fiat_p224_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) {
   let x1: u64 = ((arg1 as u64) * (arg2 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
   let x3: u32 = ((x1 >> 32) as u32);
@@ -143,7 +143,7 @@ pub fn fiat_p224_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) 
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_p224_cmovznz_u32(out1: &mut u32, arg1: fiat_p224_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p224_cmovznz_u32(out1: &mut u32, arg1: fiat_p224_u1, arg2: u32, arg3: u32) {
   let x1: fiat_p224_u1 = (!(!arg1));
   let x2: u32 = ((((((0x0 as fiat_p224_i2) - (x1 as fiat_p224_i2)) as fiat_p224_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
@@ -160,7 +160,7 @@ pub fn fiat_p224_cmovznz_u32(out1: &mut u32, arg1: fiat_p224_u1, arg2: u32, arg3
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p224_mul(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element, arg2: &fiat_p224_montgomery_domain_field_element) -> () {
+pub fn fiat_p224_mul(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element, arg2: &fiat_p224_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -997,7 +997,7 @@ pub fn fiat_p224_mul(out1: &mut fiat_p224_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p224_square(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element) -> () {
+pub fn fiat_p224_square(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -1835,7 +1835,7 @@ pub fn fiat_p224_square(out1: &mut fiat_p224_montgomery_domain_field_element, ar
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p224_add(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element, arg2: &fiat_p224_montgomery_domain_field_element) -> () {
+pub fn fiat_p224_add(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element, arg2: &fiat_p224_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p224_u1 = 0;
   fiat_p224_addcarryx_u32(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -1914,7 +1914,7 @@ pub fn fiat_p224_add(out1: &mut fiat_p224_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p224_sub(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element, arg2: &fiat_p224_montgomery_domain_field_element) -> () {
+pub fn fiat_p224_sub(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element, arg2: &fiat_p224_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p224_u1 = 0;
   fiat_p224_subborrowx_u32(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -1977,7 +1977,7 @@ pub fn fiat_p224_sub(out1: &mut fiat_p224_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p224_opp(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element) -> () {
+pub fn fiat_p224_opp(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p224_u1 = 0;
   fiat_p224_subborrowx_u32(&mut x1, &mut x2, 0x0, (0x0 as u32), (arg1[0]));
@@ -2040,7 +2040,7 @@ pub fn fiat_p224_opp(out1: &mut fiat_p224_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p224_from_montgomery(out1: &mut fiat_p224_non_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element) -> () {
+pub fn fiat_p224_from_montgomery(out1: &mut fiat_p224_non_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element) {
   let x1: u32 = (arg1[0]);
   let mut x2: u32 = 0;
   let mut x3: u32 = 0;
@@ -2515,7 +2515,7 @@ pub fn fiat_p224_from_montgomery(out1: &mut fiat_p224_non_montgomery_domain_fiel
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p224_to_montgomery(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_non_montgomery_domain_field_element) -> () {
+pub fn fiat_p224_to_montgomery(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_non_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -3131,7 +3131,7 @@ pub fn fiat_p224_to_montgomery(out1: &mut fiat_p224_montgomery_domain_field_elem
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_p224_nonzero(out1: &mut u32, arg1: &[u32; 7]) -> () {
+pub fn fiat_p224_nonzero(out1: &mut u32, arg1: &[u32; 7]) {
   let x1: u32 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | ((arg1[3]) | ((arg1[4]) | ((arg1[5]) | (arg1[6])))))));
   *out1 = x1;
 }
@@ -3148,7 +3148,7 @@ pub fn fiat_p224_nonzero(out1: &mut u32, arg1: &[u32; 7]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p224_selectznz(out1: &mut [u32; 7], arg1: fiat_p224_u1, arg2: &[u32; 7], arg3: &[u32; 7]) -> () {
+pub fn fiat_p224_selectznz(out1: &mut [u32; 7], arg1: fiat_p224_u1, arg2: &[u32; 7], arg3: &[u32; 7]) {
   let mut x1: u32 = 0;
   fiat_p224_cmovznz_u32(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u32 = 0;
@@ -3184,7 +3184,7 @@ pub fn fiat_p224_selectznz(out1: &mut [u32; 7], arg1: fiat_p224_u1, arg2: &[u32;
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
 #[inline]
-pub fn fiat_p224_to_bytes(out1: &mut [u8; 28], arg1: &[u32; 7]) -> () {
+pub fn fiat_p224_to_bytes(out1: &mut [u8; 28], arg1: &[u32; 7]) {
   let x1: u32 = (arg1[6]);
   let x2: u32 = (arg1[5]);
   let x3: u32 = (arg1[4]);
@@ -3277,7 +3277,7 @@ pub fn fiat_p224_to_bytes(out1: &mut [u8; 28], arg1: &[u32; 7]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p224_from_bytes(out1: &mut [u32; 7], arg1: &[u8; 28]) -> () {
+pub fn fiat_p224_from_bytes(out1: &mut [u32; 7], arg1: &[u8; 28]) {
   let x1: u32 = (((arg1[27]) as u32) << 24);
   let x2: u32 = (((arg1[26]) as u32) << 16);
   let x3: u32 = (((arg1[25]) as u32) << 8);
@@ -3343,7 +3343,7 @@ pub fn fiat_p224_from_bytes(out1: &mut [u32; 7], arg1: &[u8; 28]) -> () {
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p224_set_one(out1: &mut fiat_p224_montgomery_domain_field_element) -> () {
+pub fn fiat_p224_set_one(out1: &mut fiat_p224_montgomery_domain_field_element) {
   out1[0] = 0xffffffff;
   out1[1] = 0xffffffff;
   out1[2] = 0xffffffff;
@@ -3362,7 +3362,7 @@ pub fn fiat_p224_set_one(out1: &mut fiat_p224_montgomery_domain_field_element) -
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p224_msat(out1: &mut [u32; 8]) -> () {
+pub fn fiat_p224_msat(out1: &mut [u32; 8]) {
   out1[0] = (0x1 as u32);
   out1[1] = (0x0 as u32);
   out1[2] = (0x0 as u32);
@@ -3402,7 +3402,7 @@ pub fn fiat_p224_msat(out1: &mut [u32; 8]) -> () {
 ///   out4: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 ///   out5: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p224_divstep(out1: &mut u32, out2: &mut [u32; 8], out3: &mut [u32; 8], out4: &mut [u32; 7], out5: &mut [u32; 7], arg1: u32, arg2: &[u32; 8], arg3: &[u32; 8], arg4: &[u32; 7], arg5: &[u32; 7]) -> () {
+pub fn fiat_p224_divstep(out1: &mut u32, out2: &mut [u32; 8], out3: &mut [u32; 8], out4: &mut [u32; 7], out5: &mut [u32; 7], arg1: u32, arg2: &[u32; 8], arg3: &[u32; 8], arg4: &[u32; 7], arg5: &[u32; 7]) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p224_u1 = 0;
   fiat_p224_addcarryx_u32(&mut x1, &mut x2, 0x0, (!arg1), (0x1 as u32));
@@ -3773,7 +3773,7 @@ pub fn fiat_p224_divstep(out1: &mut u32, out2: &mut [u32; 8], out3: &mut [u32; 8
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p224_divstep_precomp(out1: &mut [u32; 7]) -> () {
+pub fn fiat_p224_divstep_precomp(out1: &mut [u32; 7]) {
   out1[0] = 0x800000;
   out1[1] = 0x800000;
   out1[2] = 0xfe000000;

--- a/fiat-rust/src/p224_64.rs
+++ b/fiat-rust/src/p224_64.rs
@@ -80,7 +80,7 @@ impl core::ops::IndexMut<usize> for fiat_p224_non_montgomery_domain_field_elemen
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p224_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p224_u1, arg1: fiat_p224_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p224_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p224_u1, arg1: fiat_p224_u1, arg2: u64, arg3: u64) {
   let x1: u128 = (((arg1 as u128) + (arg2 as u128)) + (arg3 as u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
   let x3: fiat_p224_u1 = ((x1 >> 64) as fiat_p224_u1);
@@ -102,7 +102,7 @@ pub fn fiat_p224_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p224_u1, arg1: fi
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p224_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p224_u1, arg1: fiat_p224_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p224_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p224_u1, arg1: fiat_p224_u1, arg2: u64, arg3: u64) {
   let x1: i128 = (((arg2 as i128) - (arg1 as i128)) - (arg3 as i128));
   let x2: fiat_p224_i1 = ((x1 >> 64) as fiat_p224_i1);
   let x3: u64 = ((x1 & (0xffffffffffffffff as i128)) as u64);
@@ -123,7 +123,7 @@ pub fn fiat_p224_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p224_u1, arg1: f
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_p224_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) -> () {
+pub fn fiat_p224_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) {
   let x1: u128 = ((arg1 as u128) * (arg2 as u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
   let x3: u64 = ((x1 >> 64) as u64);
@@ -143,7 +143,7 @@ pub fn fiat_p224_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) 
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_p224_cmovznz_u64(out1: &mut u64, arg1: fiat_p224_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p224_cmovznz_u64(out1: &mut u64, arg1: fiat_p224_u1, arg2: u64, arg3: u64) {
   let x1: fiat_p224_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_p224_i2) - (x1 as fiat_p224_i2)) as fiat_p224_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
@@ -160,7 +160,7 @@ pub fn fiat_p224_cmovznz_u64(out1: &mut u64, arg1: fiat_p224_u1, arg2: u64, arg3
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p224_mul(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element, arg2: &fiat_p224_montgomery_domain_field_element) -> () {
+pub fn fiat_p224_mul(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element, arg2: &fiat_p224_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -475,7 +475,7 @@ pub fn fiat_p224_mul(out1: &mut fiat_p224_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p224_square(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element) -> () {
+pub fn fiat_p224_square(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -791,7 +791,7 @@ pub fn fiat_p224_square(out1: &mut fiat_p224_montgomery_domain_field_element, ar
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p224_add(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element, arg2: &fiat_p224_montgomery_domain_field_element) -> () {
+pub fn fiat_p224_add(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element, arg2: &fiat_p224_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p224_u1 = 0;
   fiat_p224_addcarryx_u64(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -843,7 +843,7 @@ pub fn fiat_p224_add(out1: &mut fiat_p224_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p224_sub(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element, arg2: &fiat_p224_montgomery_domain_field_element) -> () {
+pub fn fiat_p224_sub(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element, arg2: &fiat_p224_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p224_u1 = 0;
   fiat_p224_subborrowx_u64(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -885,7 +885,7 @@ pub fn fiat_p224_sub(out1: &mut fiat_p224_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p224_opp(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element) -> () {
+pub fn fiat_p224_opp(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p224_u1 = 0;
   fiat_p224_subborrowx_u64(&mut x1, &mut x2, 0x0, (0x0 as u64), (arg1[0]));
@@ -927,7 +927,7 @@ pub fn fiat_p224_opp(out1: &mut fiat_p224_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p224_from_montgomery(out1: &mut fiat_p224_non_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element) -> () {
+pub fn fiat_p224_from_montgomery(out1: &mut fiat_p224_non_montgomery_domain_field_element, arg1: &fiat_p224_montgomery_domain_field_element) {
   let x1: u64 = (arg1[0]);
   let mut x2: u64 = 0;
   let mut x3: u64 = 0;
@@ -1115,7 +1115,7 @@ pub fn fiat_p224_from_montgomery(out1: &mut fiat_p224_non_montgomery_domain_fiel
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p224_to_montgomery(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_non_montgomery_domain_field_element) -> () {
+pub fn fiat_p224_to_montgomery(out1: &mut fiat_p224_montgomery_domain_field_element, arg1: &fiat_p224_non_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -1402,7 +1402,7 @@ pub fn fiat_p224_to_montgomery(out1: &mut fiat_p224_montgomery_domain_field_elem
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_p224_nonzero(out1: &mut u64, arg1: &[u64; 4]) -> () {
+pub fn fiat_p224_nonzero(out1: &mut u64, arg1: &[u64; 4]) {
   let x1: u64 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | (arg1[3]))));
   *out1 = x1;
 }
@@ -1419,7 +1419,7 @@ pub fn fiat_p224_nonzero(out1: &mut u64, arg1: &[u64; 4]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p224_selectznz(out1: &mut [u64; 4], arg1: fiat_p224_u1, arg2: &[u64; 4], arg3: &[u64; 4]) -> () {
+pub fn fiat_p224_selectznz(out1: &mut [u64; 4], arg1: fiat_p224_u1, arg2: &[u64; 4], arg3: &[u64; 4]) {
   let mut x1: u64 = 0;
   fiat_p224_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u64 = 0;
@@ -1446,7 +1446,7 @@ pub fn fiat_p224_selectznz(out1: &mut [u64; 4], arg1: fiat_p224_u1, arg2: &[u64;
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
 #[inline]
-pub fn fiat_p224_to_bytes(out1: &mut [u8; 28], arg1: &[u64; 4]) -> () {
+pub fn fiat_p224_to_bytes(out1: &mut [u8; 28], arg1: &[u64; 4]) {
   let x1: u64 = (arg1[3]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[1]);
@@ -1542,7 +1542,7 @@ pub fn fiat_p224_to_bytes(out1: &mut [u8; 28], arg1: &[u64; 4]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p224_from_bytes(out1: &mut [u64; 4], arg1: &[u8; 28]) -> () {
+pub fn fiat_p224_from_bytes(out1: &mut [u64; 4], arg1: &[u8; 28]) {
   let x1: u64 = (((arg1[27]) as u64) << 24);
   let x2: u64 = (((arg1[26]) as u64) << 16);
   let x3: u64 = (((arg1[25]) as u64) << 8);
@@ -1608,7 +1608,7 @@ pub fn fiat_p224_from_bytes(out1: &mut [u64; 4], arg1: &[u8; 28]) -> () {
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p224_set_one(out1: &mut fiat_p224_montgomery_domain_field_element) -> () {
+pub fn fiat_p224_set_one(out1: &mut fiat_p224_montgomery_domain_field_element) {
   out1[0] = 0xffffffff00000000;
   out1[1] = 0xffffffffffffffff;
   out1[2] = (0x0 as u64);
@@ -1624,7 +1624,7 @@ pub fn fiat_p224_set_one(out1: &mut fiat_p224_montgomery_domain_field_element) -
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p224_msat(out1: &mut [u64; 5]) -> () {
+pub fn fiat_p224_msat(out1: &mut [u64; 5]) {
   out1[0] = (0x1 as u64);
   out1[1] = 0xffffffff00000000;
   out1[2] = 0xffffffffffffffff;
@@ -1661,7 +1661,7 @@ pub fn fiat_p224_msat(out1: &mut [u64; 5]) -> () {
 ///   out4: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 ///   out5: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p224_divstep(out1: &mut u64, out2: &mut [u64; 5], out3: &mut [u64; 5], out4: &mut [u64; 4], out5: &mut [u64; 4], arg1: u64, arg2: &[u64; 5], arg3: &[u64; 5], arg4: &[u64; 4], arg5: &[u64; 4]) -> () {
+pub fn fiat_p224_divstep(out1: &mut u64, out2: &mut [u64; 5], out3: &mut [u64; 5], out4: &mut [u64; 4], out5: &mut [u64; 4], arg1: u64, arg2: &[u64; 5], arg3: &[u64; 5], arg4: &[u64; 4], arg5: &[u64; 4]) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p224_u1 = 0;
   fiat_p224_addcarryx_u64(&mut x1, &mut x2, 0x0, (!arg1), (0x1 as u64));
@@ -1894,7 +1894,7 @@ pub fn fiat_p224_divstep(out1: &mut u64, out2: &mut [u64; 5], out3: &mut [u64; 5
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p224_divstep_precomp(out1: &mut [u64; 4]) -> () {
+pub fn fiat_p224_divstep_precomp(out1: &mut [u64; 4]) {
   out1[0] = 0x7ffffffe800001;
   out1[1] = 0xff7fffff00800000;
   out1[2] = 0xffffff;

--- a/fiat-rust/src/p256_32.rs
+++ b/fiat-rust/src/p256_32.rs
@@ -80,7 +80,7 @@ impl core::ops::IndexMut<usize> for fiat_p256_non_montgomery_domain_field_elemen
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p256_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p256_u1, arg1: fiat_p256_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p256_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p256_u1, arg1: fiat_p256_u1, arg2: u32, arg3: u32) {
   let x1: u64 = (((arg1 as u64) + (arg2 as u64)) + (arg3 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
   let x3: fiat_p256_u1 = ((x1 >> 32) as fiat_p256_u1);
@@ -102,7 +102,7 @@ pub fn fiat_p256_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p256_u1, arg1: fi
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p256_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p256_u1, arg1: fiat_p256_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p256_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p256_u1, arg1: fiat_p256_u1, arg2: u32, arg3: u32) {
   let x1: i64 = (((arg2 as i64) - (arg1 as i64)) - (arg3 as i64));
   let x2: fiat_p256_i1 = ((x1 >> 32) as fiat_p256_i1);
   let x3: u32 = ((x1 & (0xffffffff as i64)) as u32);
@@ -123,7 +123,7 @@ pub fn fiat_p256_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p256_u1, arg1: f
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_p256_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) -> () {
+pub fn fiat_p256_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) {
   let x1: u64 = ((arg1 as u64) * (arg2 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
   let x3: u32 = ((x1 >> 32) as u32);
@@ -143,7 +143,7 @@ pub fn fiat_p256_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) 
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_p256_cmovznz_u32(out1: &mut u32, arg1: fiat_p256_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p256_cmovznz_u32(out1: &mut u32, arg1: fiat_p256_u1, arg2: u32, arg3: u32) {
   let x1: fiat_p256_u1 = (!(!arg1));
   let x2: u32 = ((((((0x0 as fiat_p256_i2) - (x1 as fiat_p256_i2)) as fiat_p256_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
@@ -160,7 +160,7 @@ pub fn fiat_p256_cmovznz_u32(out1: &mut u32, arg1: fiat_p256_u1, arg2: u32, arg3
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_mul(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element, arg2: &fiat_p256_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_mul(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element, arg2: &fiat_p256_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -1163,7 +1163,7 @@ pub fn fiat_p256_mul(out1: &mut fiat_p256_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_square(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_square(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -2167,7 +2167,7 @@ pub fn fiat_p256_square(out1: &mut fiat_p256_montgomery_domain_field_element, ar
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_add(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element, arg2: &fiat_p256_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_add(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element, arg2: &fiat_p256_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p256_u1 = 0;
   fiat_p256_addcarryx_u32(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -2255,7 +2255,7 @@ pub fn fiat_p256_add(out1: &mut fiat_p256_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_sub(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element, arg2: &fiat_p256_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_sub(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element, arg2: &fiat_p256_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p256_u1 = 0;
   fiat_p256_subborrowx_u32(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -2325,7 +2325,7 @@ pub fn fiat_p256_sub(out1: &mut fiat_p256_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_opp(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_opp(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p256_u1 = 0;
   fiat_p256_subborrowx_u32(&mut x1, &mut x2, 0x0, (0x0 as u32), (arg1[0]));
@@ -2395,7 +2395,7 @@ pub fn fiat_p256_opp(out1: &mut fiat_p256_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_from_montgomery(out1: &mut fiat_p256_non_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_from_montgomery(out1: &mut fiat_p256_non_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element) {
   let x1: u32 = (arg1[0]);
   let mut x2: u32 = 0;
   let mut x3: u32 = 0;
@@ -2930,7 +2930,7 @@ pub fn fiat_p256_from_montgomery(out1: &mut fiat_p256_non_montgomery_domain_fiel
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_to_montgomery(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_non_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_to_montgomery(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_non_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -3820,7 +3820,7 @@ pub fn fiat_p256_to_montgomery(out1: &mut fiat_p256_montgomery_domain_field_elem
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_p256_nonzero(out1: &mut u32, arg1: &[u32; 8]) -> () {
+pub fn fiat_p256_nonzero(out1: &mut u32, arg1: &[u32; 8]) {
   let x1: u32 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | ((arg1[3]) | ((arg1[4]) | ((arg1[5]) | ((arg1[6]) | (arg1[7]))))))));
   *out1 = x1;
 }
@@ -3837,7 +3837,7 @@ pub fn fiat_p256_nonzero(out1: &mut u32, arg1: &[u32; 8]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p256_selectznz(out1: &mut [u32; 8], arg1: fiat_p256_u1, arg2: &[u32; 8], arg3: &[u32; 8]) -> () {
+pub fn fiat_p256_selectznz(out1: &mut [u32; 8], arg1: fiat_p256_u1, arg2: &[u32; 8], arg3: &[u32; 8]) {
   let mut x1: u32 = 0;
   fiat_p256_cmovznz_u32(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u32 = 0;
@@ -3876,7 +3876,7 @@ pub fn fiat_p256_selectznz(out1: &mut [u32; 8], arg1: fiat_p256_u1, arg2: &[u32;
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
 #[inline]
-pub fn fiat_p256_to_bytes(out1: &mut [u8; 32], arg1: &[u32; 8]) -> () {
+pub fn fiat_p256_to_bytes(out1: &mut [u8; 32], arg1: &[u32; 8]) {
   let x1: u32 = (arg1[7]);
   let x2: u32 = (arg1[6]);
   let x3: u32 = (arg1[5]);
@@ -3980,7 +3980,7 @@ pub fn fiat_p256_to_bytes(out1: &mut [u8; 32], arg1: &[u32; 8]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p256_from_bytes(out1: &mut [u32; 8], arg1: &[u8; 32]) -> () {
+pub fn fiat_p256_from_bytes(out1: &mut [u32; 8], arg1: &[u8; 32]) {
   let x1: u32 = (((arg1[31]) as u32) << 24);
   let x2: u32 = (((arg1[30]) as u32) << 16);
   let x3: u32 = (((arg1[29]) as u32) << 8);
@@ -4054,7 +4054,7 @@ pub fn fiat_p256_from_bytes(out1: &mut [u32; 8], arg1: &[u8; 32]) -> () {
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_set_one(out1: &mut fiat_p256_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_set_one(out1: &mut fiat_p256_montgomery_domain_field_element) {
   out1[0] = (0x1 as u32);
   out1[1] = (0x0 as u32);
   out1[2] = (0x0 as u32);
@@ -4074,7 +4074,7 @@ pub fn fiat_p256_set_one(out1: &mut fiat_p256_montgomery_domain_field_element) -
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p256_msat(out1: &mut [u32; 9]) -> () {
+pub fn fiat_p256_msat(out1: &mut [u32; 9]) {
   out1[0] = 0xffffffff;
   out1[1] = 0xffffffff;
   out1[2] = 0xffffffff;
@@ -4115,7 +4115,7 @@ pub fn fiat_p256_msat(out1: &mut [u32; 9]) -> () {
 ///   out4: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 ///   out5: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p256_divstep(out1: &mut u32, out2: &mut [u32; 9], out3: &mut [u32; 9], out4: &mut [u32; 8], out5: &mut [u32; 8], arg1: u32, arg2: &[u32; 9], arg3: &[u32; 9], arg4: &[u32; 8], arg5: &[u32; 8]) -> () {
+pub fn fiat_p256_divstep(out1: &mut u32, out2: &mut [u32; 9], out3: &mut [u32; 9], out4: &mut [u32; 8], out5: &mut [u32; 8], arg1: u32, arg2: &[u32; 9], arg3: &[u32; 9], arg4: &[u32; 8], arg5: &[u32; 8]) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p256_u1 = 0;
   fiat_p256_addcarryx_u32(&mut x1, &mut x2, 0x0, (!arg1), (0x1 as u32));
@@ -4532,7 +4532,7 @@ pub fn fiat_p256_divstep(out1: &mut u32, out2: &mut [u32; 9], out3: &mut [u32; 9
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p256_divstep_precomp(out1: &mut [u32; 8]) -> () {
+pub fn fiat_p256_divstep_precomp(out1: &mut [u32; 8]) {
   out1[0] = 0xb8000000;
   out1[1] = 0x67ffffff;
   out1[2] = 0x38000000;

--- a/fiat-rust/src/p256_64.rs
+++ b/fiat-rust/src/p256_64.rs
@@ -80,7 +80,7 @@ impl core::ops::IndexMut<usize> for fiat_p256_non_montgomery_domain_field_elemen
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p256_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p256_u1, arg1: fiat_p256_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p256_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p256_u1, arg1: fiat_p256_u1, arg2: u64, arg3: u64) {
   let x1: u128 = (((arg1 as u128) + (arg2 as u128)) + (arg3 as u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
   let x3: fiat_p256_u1 = ((x1 >> 64) as fiat_p256_u1);
@@ -102,7 +102,7 @@ pub fn fiat_p256_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p256_u1, arg1: fi
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p256_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p256_u1, arg1: fiat_p256_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p256_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p256_u1, arg1: fiat_p256_u1, arg2: u64, arg3: u64) {
   let x1: i128 = (((arg2 as i128) - (arg1 as i128)) - (arg3 as i128));
   let x2: fiat_p256_i1 = ((x1 >> 64) as fiat_p256_i1);
   let x3: u64 = ((x1 & (0xffffffffffffffff as i128)) as u64);
@@ -123,7 +123,7 @@ pub fn fiat_p256_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p256_u1, arg1: f
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_p256_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) -> () {
+pub fn fiat_p256_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) {
   let x1: u128 = ((arg1 as u128) * (arg2 as u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
   let x3: u64 = ((x1 >> 64) as u64);
@@ -143,7 +143,7 @@ pub fn fiat_p256_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) 
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_p256_cmovznz_u64(out1: &mut u64, arg1: fiat_p256_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p256_cmovznz_u64(out1: &mut u64, arg1: fiat_p256_u1, arg2: u64, arg3: u64) {
   let x1: fiat_p256_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_p256_i2) - (x1 as fiat_p256_i2)) as fiat_p256_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
@@ -160,7 +160,7 @@ pub fn fiat_p256_cmovznz_u64(out1: &mut u64, arg1: fiat_p256_u1, arg2: u64, arg3
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_mul(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element, arg2: &fiat_p256_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_mul(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element, arg2: &fiat_p256_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -451,7 +451,7 @@ pub fn fiat_p256_mul(out1: &mut fiat_p256_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_square(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_square(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -743,7 +743,7 @@ pub fn fiat_p256_square(out1: &mut fiat_p256_montgomery_domain_field_element, ar
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_add(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element, arg2: &fiat_p256_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_add(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element, arg2: &fiat_p256_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p256_u1 = 0;
   fiat_p256_addcarryx_u64(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -795,7 +795,7 @@ pub fn fiat_p256_add(out1: &mut fiat_p256_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_sub(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element, arg2: &fiat_p256_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_sub(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element, arg2: &fiat_p256_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p256_u1 = 0;
   fiat_p256_subborrowx_u64(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -837,7 +837,7 @@ pub fn fiat_p256_sub(out1: &mut fiat_p256_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_opp(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_opp(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p256_u1 = 0;
   fiat_p256_subborrowx_u64(&mut x1, &mut x2, 0x0, (0x0 as u64), (arg1[0]));
@@ -879,7 +879,7 @@ pub fn fiat_p256_opp(out1: &mut fiat_p256_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_from_montgomery(out1: &mut fiat_p256_non_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_from_montgomery(out1: &mut fiat_p256_non_montgomery_domain_field_element, arg1: &fiat_p256_montgomery_domain_field_element) {
   let x1: u64 = (arg1[0]);
   let mut x2: u64 = 0;
   let mut x3: u64 = 0;
@@ -1031,7 +1031,7 @@ pub fn fiat_p256_from_montgomery(out1: &mut fiat_p256_non_montgomery_domain_fiel
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_to_montgomery(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_non_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_to_montgomery(out1: &mut fiat_p256_montgomery_domain_field_element, arg1: &fiat_p256_non_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -1305,7 +1305,7 @@ pub fn fiat_p256_to_montgomery(out1: &mut fiat_p256_montgomery_domain_field_elem
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_p256_nonzero(out1: &mut u64, arg1: &[u64; 4]) -> () {
+pub fn fiat_p256_nonzero(out1: &mut u64, arg1: &[u64; 4]) {
   let x1: u64 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | (arg1[3]))));
   *out1 = x1;
 }
@@ -1322,7 +1322,7 @@ pub fn fiat_p256_nonzero(out1: &mut u64, arg1: &[u64; 4]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p256_selectznz(out1: &mut [u64; 4], arg1: fiat_p256_u1, arg2: &[u64; 4], arg3: &[u64; 4]) -> () {
+pub fn fiat_p256_selectznz(out1: &mut [u64; 4], arg1: fiat_p256_u1, arg2: &[u64; 4], arg3: &[u64; 4]) {
   let mut x1: u64 = 0;
   fiat_p256_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u64 = 0;
@@ -1349,7 +1349,7 @@ pub fn fiat_p256_selectznz(out1: &mut [u64; 4], arg1: fiat_p256_u1, arg2: &[u64;
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
 #[inline]
-pub fn fiat_p256_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 4]) -> () {
+pub fn fiat_p256_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 4]) {
   let x1: u64 = (arg1[3]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[1]);
@@ -1457,7 +1457,7 @@ pub fn fiat_p256_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 4]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p256_from_bytes(out1: &mut [u64; 4], arg1: &[u8; 32]) -> () {
+pub fn fiat_p256_from_bytes(out1: &mut [u64; 4], arg1: &[u8; 32]) {
   let x1: u64 = (((arg1[31]) as u64) << 56);
   let x2: u64 = (((arg1[30]) as u64) << 48);
   let x3: u64 = (((arg1[29]) as u64) << 40);
@@ -1531,7 +1531,7 @@ pub fn fiat_p256_from_bytes(out1: &mut [u64; 4], arg1: &[u8; 32]) -> () {
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_set_one(out1: &mut fiat_p256_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_set_one(out1: &mut fiat_p256_montgomery_domain_field_element) {
   out1[0] = (0x1 as u64);
   out1[1] = 0xffffffff00000000;
   out1[2] = 0xffffffffffffffff;
@@ -1547,7 +1547,7 @@ pub fn fiat_p256_set_one(out1: &mut fiat_p256_montgomery_domain_field_element) -
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p256_msat(out1: &mut [u64; 5]) -> () {
+pub fn fiat_p256_msat(out1: &mut [u64; 5]) {
   out1[0] = 0xffffffffffffffff;
   out1[1] = 0xffffffff;
   out1[2] = (0x0 as u64);
@@ -1584,7 +1584,7 @@ pub fn fiat_p256_msat(out1: &mut [u64; 5]) -> () {
 ///   out4: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 ///   out5: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p256_divstep(out1: &mut u64, out2: &mut [u64; 5], out3: &mut [u64; 5], out4: &mut [u64; 4], out5: &mut [u64; 4], arg1: u64, arg2: &[u64; 5], arg3: &[u64; 5], arg4: &[u64; 4], arg5: &[u64; 4]) -> () {
+pub fn fiat_p256_divstep(out1: &mut u64, out2: &mut [u64; 5], out3: &mut [u64; 5], out4: &mut [u64; 4], out5: &mut [u64; 4], arg1: u64, arg2: &[u64; 5], arg3: &[u64; 5], arg4: &[u64; 4], arg5: &[u64; 4]) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p256_u1 = 0;
   fiat_p256_addcarryx_u64(&mut x1, &mut x2, 0x0, (!arg1), (0x1 as u64));
@@ -1817,7 +1817,7 @@ pub fn fiat_p256_divstep(out1: &mut u64, out2: &mut [u64; 5], out3: &mut [u64; 5
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p256_divstep_precomp(out1: &mut [u64; 4]) -> () {
+pub fn fiat_p256_divstep_precomp(out1: &mut [u64; 4]) {
   out1[0] = 0x67ffffffb8000000;
   out1[1] = 0xc000000038000000;
   out1[2] = 0xd80000007fffffff;

--- a/fiat-rust/src/p256_scalar_32.rs
+++ b/fiat-rust/src/p256_scalar_32.rs
@@ -80,7 +80,7 @@ impl core::ops::IndexMut<usize> for fiat_p256_scalar_non_montgomery_domain_field
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p256_scalar_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p256_scalar_u1, arg1: fiat_p256_scalar_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p256_scalar_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p256_scalar_u1, arg1: fiat_p256_scalar_u1, arg2: u32, arg3: u32) {
   let x1: u64 = (((arg1 as u64) + (arg2 as u64)) + (arg3 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
   let x3: fiat_p256_scalar_u1 = ((x1 >> 32) as fiat_p256_scalar_u1);
@@ -102,7 +102,7 @@ pub fn fiat_p256_scalar_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p256_scala
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p256_scalar_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p256_scalar_u1, arg1: fiat_p256_scalar_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p256_scalar_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p256_scalar_u1, arg1: fiat_p256_scalar_u1, arg2: u32, arg3: u32) {
   let x1: i64 = (((arg2 as i64) - (arg1 as i64)) - (arg3 as i64));
   let x2: fiat_p256_scalar_i1 = ((x1 >> 32) as fiat_p256_scalar_i1);
   let x3: u32 = ((x1 & (0xffffffff as i64)) as u32);
@@ -123,7 +123,7 @@ pub fn fiat_p256_scalar_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p256_scal
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_p256_scalar_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) -> () {
+pub fn fiat_p256_scalar_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) {
   let x1: u64 = ((arg1 as u64) * (arg2 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
   let x3: u32 = ((x1 >> 32) as u32);
@@ -143,7 +143,7 @@ pub fn fiat_p256_scalar_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_p256_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_p256_scalar_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p256_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_p256_scalar_u1, arg2: u32, arg3: u32) {
   let x1: fiat_p256_scalar_u1 = (!(!arg1));
   let x2: u32 = ((((((0x0 as fiat_p256_scalar_i2) - (x1 as fiat_p256_scalar_i2)) as fiat_p256_scalar_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
@@ -160,7 +160,7 @@ pub fn fiat_p256_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_p256_scalar_u1, a
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_scalar_mul(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element, arg2: &fiat_p256_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_scalar_mul(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element, arg2: &fiat_p256_scalar_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -1331,7 +1331,7 @@ pub fn fiat_p256_scalar_mul(out1: &mut fiat_p256_scalar_montgomery_domain_field_
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_scalar_square(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_scalar_square(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -2503,7 +2503,7 @@ pub fn fiat_p256_scalar_square(out1: &mut fiat_p256_scalar_montgomery_domain_fie
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_scalar_add(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element, arg2: &fiat_p256_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_scalar_add(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element, arg2: &fiat_p256_scalar_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p256_scalar_u1 = 0;
   fiat_p256_scalar_addcarryx_u32(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -2591,7 +2591,7 @@ pub fn fiat_p256_scalar_add(out1: &mut fiat_p256_scalar_montgomery_domain_field_
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_scalar_sub(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element, arg2: &fiat_p256_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_scalar_sub(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element, arg2: &fiat_p256_scalar_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p256_scalar_u1 = 0;
   fiat_p256_scalar_subborrowx_u32(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -2661,7 +2661,7 @@ pub fn fiat_p256_scalar_sub(out1: &mut fiat_p256_scalar_montgomery_domain_field_
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_scalar_opp(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_scalar_opp(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p256_scalar_u1 = 0;
   fiat_p256_scalar_subborrowx_u32(&mut x1, &mut x2, 0x0, (0x0 as u32), (arg1[0]));
@@ -2731,7 +2731,7 @@ pub fn fiat_p256_scalar_opp(out1: &mut fiat_p256_scalar_montgomery_domain_field_
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_scalar_from_montgomery(out1: &mut fiat_p256_scalar_non_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_scalar_from_montgomery(out1: &mut fiat_p256_scalar_non_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element) {
   let x1: u32 = (arg1[0]);
   let mut x2: u32 = 0;
   let mut x3: u32 = 0;
@@ -3488,7 +3488,7 @@ pub fn fiat_p256_scalar_from_montgomery(out1: &mut fiat_p256_scalar_non_montgome
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_scalar_to_montgomery(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_non_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_scalar_to_montgomery(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_non_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -4618,7 +4618,7 @@ pub fn fiat_p256_scalar_to_montgomery(out1: &mut fiat_p256_scalar_montgomery_dom
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_p256_scalar_nonzero(out1: &mut u32, arg1: &[u32; 8]) -> () {
+pub fn fiat_p256_scalar_nonzero(out1: &mut u32, arg1: &[u32; 8]) {
   let x1: u32 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | ((arg1[3]) | ((arg1[4]) | ((arg1[5]) | ((arg1[6]) | (arg1[7]))))))));
   *out1 = x1;
 }
@@ -4635,7 +4635,7 @@ pub fn fiat_p256_scalar_nonzero(out1: &mut u32, arg1: &[u32; 8]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p256_scalar_selectznz(out1: &mut [u32; 8], arg1: fiat_p256_scalar_u1, arg2: &[u32; 8], arg3: &[u32; 8]) -> () {
+pub fn fiat_p256_scalar_selectznz(out1: &mut [u32; 8], arg1: fiat_p256_scalar_u1, arg2: &[u32; 8], arg3: &[u32; 8]) {
   let mut x1: u32 = 0;
   fiat_p256_scalar_cmovznz_u32(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u32 = 0;
@@ -4674,7 +4674,7 @@ pub fn fiat_p256_scalar_selectznz(out1: &mut [u32; 8], arg1: fiat_p256_scalar_u1
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
 #[inline]
-pub fn fiat_p256_scalar_to_bytes(out1: &mut [u8; 32], arg1: &[u32; 8]) -> () {
+pub fn fiat_p256_scalar_to_bytes(out1: &mut [u8; 32], arg1: &[u32; 8]) {
   let x1: u32 = (arg1[7]);
   let x2: u32 = (arg1[6]);
   let x3: u32 = (arg1[5]);
@@ -4778,7 +4778,7 @@ pub fn fiat_p256_scalar_to_bytes(out1: &mut [u8; 32], arg1: &[u32; 8]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p256_scalar_from_bytes(out1: &mut [u32; 8], arg1: &[u8; 32]) -> () {
+pub fn fiat_p256_scalar_from_bytes(out1: &mut [u32; 8], arg1: &[u8; 32]) {
   let x1: u32 = (((arg1[31]) as u32) << 24);
   let x2: u32 = (((arg1[30]) as u32) << 16);
   let x3: u32 = (((arg1[29]) as u32) << 8);
@@ -4852,7 +4852,7 @@ pub fn fiat_p256_scalar_from_bytes(out1: &mut [u32; 8], arg1: &[u8; 32]) -> () {
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_scalar_set_one(out1: &mut fiat_p256_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_scalar_set_one(out1: &mut fiat_p256_scalar_montgomery_domain_field_element) {
   out1[0] = 0x39cdaaf;
   out1[1] = 0xc46353d;
   out1[2] = 0x58e8617b;
@@ -4872,7 +4872,7 @@ pub fn fiat_p256_scalar_set_one(out1: &mut fiat_p256_scalar_montgomery_domain_fi
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p256_scalar_msat(out1: &mut [u32; 9]) -> () {
+pub fn fiat_p256_scalar_msat(out1: &mut [u32; 9]) {
   out1[0] = 0xfc632551;
   out1[1] = 0xf3b9cac2;
   out1[2] = 0xa7179e84;
@@ -4913,7 +4913,7 @@ pub fn fiat_p256_scalar_msat(out1: &mut [u32; 9]) -> () {
 ///   out4: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 ///   out5: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p256_scalar_divstep(out1: &mut u32, out2: &mut [u32; 9], out3: &mut [u32; 9], out4: &mut [u32; 8], out5: &mut [u32; 8], arg1: u32, arg2: &[u32; 9], arg3: &[u32; 9], arg4: &[u32; 8], arg5: &[u32; 8]) -> () {
+pub fn fiat_p256_scalar_divstep(out1: &mut u32, out2: &mut [u32; 9], out3: &mut [u32; 9], out4: &mut [u32; 8], out5: &mut [u32; 8], arg1: u32, arg2: &[u32; 9], arg3: &[u32; 9], arg4: &[u32; 8], arg5: &[u32; 8]) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p256_scalar_u1 = 0;
   fiat_p256_scalar_addcarryx_u32(&mut x1, &mut x2, 0x0, (!arg1), (0x1 as u32));
@@ -5330,7 +5330,7 @@ pub fn fiat_p256_scalar_divstep(out1: &mut u32, out2: &mut [u32; 9], out3: &mut 
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p256_scalar_divstep_precomp(out1: &mut [u32; 8]) -> () {
+pub fn fiat_p256_scalar_divstep_precomp(out1: &mut [u32; 8]) {
   out1[0] = 0xb7fcfbb5;
   out1[1] = 0xd739262f;
   out1[2] = 0x20074414;

--- a/fiat-rust/src/p256_scalar_64.rs
+++ b/fiat-rust/src/p256_scalar_64.rs
@@ -80,7 +80,7 @@ impl core::ops::IndexMut<usize> for fiat_p256_scalar_non_montgomery_domain_field
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p256_scalar_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p256_scalar_u1, arg1: fiat_p256_scalar_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p256_scalar_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p256_scalar_u1, arg1: fiat_p256_scalar_u1, arg2: u64, arg3: u64) {
   let x1: u128 = (((arg1 as u128) + (arg2 as u128)) + (arg3 as u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
   let x3: fiat_p256_scalar_u1 = ((x1 >> 64) as fiat_p256_scalar_u1);
@@ -102,7 +102,7 @@ pub fn fiat_p256_scalar_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p256_scala
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p256_scalar_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p256_scalar_u1, arg1: fiat_p256_scalar_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p256_scalar_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p256_scalar_u1, arg1: fiat_p256_scalar_u1, arg2: u64, arg3: u64) {
   let x1: i128 = (((arg2 as i128) - (arg1 as i128)) - (arg3 as i128));
   let x2: fiat_p256_scalar_i1 = ((x1 >> 64) as fiat_p256_scalar_i1);
   let x3: u64 = ((x1 & (0xffffffffffffffff as i128)) as u64);
@@ -123,7 +123,7 @@ pub fn fiat_p256_scalar_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p256_scal
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_p256_scalar_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) -> () {
+pub fn fiat_p256_scalar_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) {
   let x1: u128 = ((arg1 as u128) * (arg2 as u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
   let x3: u64 = ((x1 >> 64) as u64);
@@ -143,7 +143,7 @@ pub fn fiat_p256_scalar_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_p256_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_p256_scalar_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p256_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_p256_scalar_u1, arg2: u64, arg3: u64) {
   let x1: fiat_p256_scalar_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_p256_scalar_i2) - (x1 as fiat_p256_scalar_i2)) as fiat_p256_scalar_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
@@ -160,7 +160,7 @@ pub fn fiat_p256_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_p256_scalar_u1, a
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_scalar_mul(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element, arg2: &fiat_p256_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_scalar_mul(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element, arg2: &fiat_p256_scalar_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -499,7 +499,7 @@ pub fn fiat_p256_scalar_mul(out1: &mut fiat_p256_scalar_montgomery_domain_field_
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_scalar_square(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_scalar_square(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -839,7 +839,7 @@ pub fn fiat_p256_scalar_square(out1: &mut fiat_p256_scalar_montgomery_domain_fie
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_scalar_add(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element, arg2: &fiat_p256_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_scalar_add(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element, arg2: &fiat_p256_scalar_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p256_scalar_u1 = 0;
   fiat_p256_scalar_addcarryx_u64(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -891,7 +891,7 @@ pub fn fiat_p256_scalar_add(out1: &mut fiat_p256_scalar_montgomery_domain_field_
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_scalar_sub(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element, arg2: &fiat_p256_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_scalar_sub(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element, arg2: &fiat_p256_scalar_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p256_scalar_u1 = 0;
   fiat_p256_scalar_subborrowx_u64(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -933,7 +933,7 @@ pub fn fiat_p256_scalar_sub(out1: &mut fiat_p256_scalar_montgomery_domain_field_
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_scalar_opp(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_scalar_opp(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p256_scalar_u1 = 0;
   fiat_p256_scalar_subborrowx_u64(&mut x1, &mut x2, 0x0, (0x0 as u64), (arg1[0]));
@@ -975,7 +975,7 @@ pub fn fiat_p256_scalar_opp(out1: &mut fiat_p256_scalar_montgomery_domain_field_
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_scalar_from_montgomery(out1: &mut fiat_p256_scalar_non_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_scalar_from_montgomery(out1: &mut fiat_p256_scalar_non_montgomery_domain_field_element, arg1: &fiat_p256_scalar_montgomery_domain_field_element) {
   let x1: u64 = (arg1[0]);
   let mut x2: u64 = 0;
   let mut x3: u64 = 0;
@@ -1187,7 +1187,7 @@ pub fn fiat_p256_scalar_from_montgomery(out1: &mut fiat_p256_scalar_non_montgome
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_scalar_to_montgomery(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_non_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_scalar_to_montgomery(out1: &mut fiat_p256_scalar_montgomery_domain_field_element, arg1: &fiat_p256_scalar_non_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -1509,7 +1509,7 @@ pub fn fiat_p256_scalar_to_montgomery(out1: &mut fiat_p256_scalar_montgomery_dom
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_p256_scalar_nonzero(out1: &mut u64, arg1: &[u64; 4]) -> () {
+pub fn fiat_p256_scalar_nonzero(out1: &mut u64, arg1: &[u64; 4]) {
   let x1: u64 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | (arg1[3]))));
   *out1 = x1;
 }
@@ -1526,7 +1526,7 @@ pub fn fiat_p256_scalar_nonzero(out1: &mut u64, arg1: &[u64; 4]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p256_scalar_selectznz(out1: &mut [u64; 4], arg1: fiat_p256_scalar_u1, arg2: &[u64; 4], arg3: &[u64; 4]) -> () {
+pub fn fiat_p256_scalar_selectznz(out1: &mut [u64; 4], arg1: fiat_p256_scalar_u1, arg2: &[u64; 4], arg3: &[u64; 4]) {
   let mut x1: u64 = 0;
   fiat_p256_scalar_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u64 = 0;
@@ -1553,7 +1553,7 @@ pub fn fiat_p256_scalar_selectznz(out1: &mut [u64; 4], arg1: fiat_p256_scalar_u1
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
 #[inline]
-pub fn fiat_p256_scalar_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 4]) -> () {
+pub fn fiat_p256_scalar_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 4]) {
   let x1: u64 = (arg1[3]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[1]);
@@ -1661,7 +1661,7 @@ pub fn fiat_p256_scalar_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 4]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p256_scalar_from_bytes(out1: &mut [u64; 4], arg1: &[u8; 32]) -> () {
+pub fn fiat_p256_scalar_from_bytes(out1: &mut [u64; 4], arg1: &[u8; 32]) {
   let x1: u64 = (((arg1[31]) as u64) << 56);
   let x2: u64 = (((arg1[30]) as u64) << 48);
   let x3: u64 = (((arg1[29]) as u64) << 40);
@@ -1735,7 +1735,7 @@ pub fn fiat_p256_scalar_from_bytes(out1: &mut [u64; 4], arg1: &[u8; 32]) -> () {
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p256_scalar_set_one(out1: &mut fiat_p256_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p256_scalar_set_one(out1: &mut fiat_p256_scalar_montgomery_domain_field_element) {
   out1[0] = 0xc46353d039cdaaf;
   out1[1] = 0x4319055258e8617b;
   out1[2] = (0x0 as u64);
@@ -1751,7 +1751,7 @@ pub fn fiat_p256_scalar_set_one(out1: &mut fiat_p256_scalar_montgomery_domain_fi
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p256_scalar_msat(out1: &mut [u64; 5]) -> () {
+pub fn fiat_p256_scalar_msat(out1: &mut [u64; 5]) {
   out1[0] = 0xf3b9cac2fc632551;
   out1[1] = 0xbce6faada7179e84;
   out1[2] = 0xffffffffffffffff;
@@ -1788,7 +1788,7 @@ pub fn fiat_p256_scalar_msat(out1: &mut [u64; 5]) -> () {
 ///   out4: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 ///   out5: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p256_scalar_divstep(out1: &mut u64, out2: &mut [u64; 5], out3: &mut [u64; 5], out4: &mut [u64; 4], out5: &mut [u64; 4], arg1: u64, arg2: &[u64; 5], arg3: &[u64; 5], arg4: &[u64; 4], arg5: &[u64; 4]) -> () {
+pub fn fiat_p256_scalar_divstep(out1: &mut u64, out2: &mut [u64; 5], out3: &mut [u64; 5], out4: &mut [u64; 4], out5: &mut [u64; 4], arg1: u64, arg2: &[u64; 5], arg3: &[u64; 5], arg4: &[u64; 4], arg5: &[u64; 4]) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p256_scalar_u1 = 0;
   fiat_p256_scalar_addcarryx_u64(&mut x1, &mut x2, 0x0, (!arg1), (0x1 as u64));
@@ -2021,7 +2021,7 @@ pub fn fiat_p256_scalar_divstep(out1: &mut u64, out2: &mut [u64; 5], out3: &mut 
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p256_scalar_divstep_precomp(out1: &mut [u64; 4]) -> () {
+pub fn fiat_p256_scalar_divstep_precomp(out1: &mut [u64; 4]) {
   out1[0] = 0xd739262fb7fcfbb5;
   out1[1] = 0x8ac6f75d20074414;
   out1[2] = 0xc67428bfb5e3c256;

--- a/fiat-rust/src/p384_32.rs
+++ b/fiat-rust/src/p384_32.rs
@@ -80,7 +80,7 @@ impl core::ops::IndexMut<usize> for fiat_p384_non_montgomery_domain_field_elemen
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p384_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p384_u1, arg1: fiat_p384_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p384_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p384_u1, arg1: fiat_p384_u1, arg2: u32, arg3: u32) {
   let x1: u64 = (((arg1 as u64) + (arg2 as u64)) + (arg3 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
   let x3: fiat_p384_u1 = ((x1 >> 32) as fiat_p384_u1);
@@ -102,7 +102,7 @@ pub fn fiat_p384_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p384_u1, arg1: fi
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p384_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p384_u1, arg1: fiat_p384_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p384_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p384_u1, arg1: fiat_p384_u1, arg2: u32, arg3: u32) {
   let x1: i64 = (((arg2 as i64) - (arg1 as i64)) - (arg3 as i64));
   let x2: fiat_p384_i1 = ((x1 >> 32) as fiat_p384_i1);
   let x3: u32 = ((x1 & (0xffffffff as i64)) as u32);
@@ -123,7 +123,7 @@ pub fn fiat_p384_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p384_u1, arg1: f
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_p384_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) -> () {
+pub fn fiat_p384_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) {
   let x1: u64 = ((arg1 as u64) * (arg2 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
   let x3: u32 = ((x1 >> 32) as u32);
@@ -143,7 +143,7 @@ pub fn fiat_p384_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) 
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_p384_cmovznz_u32(out1: &mut u32, arg1: fiat_p384_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p384_cmovznz_u32(out1: &mut u32, arg1: fiat_p384_u1, arg2: u32, arg3: u32) {
   let x1: fiat_p384_u1 = (!(!arg1));
   let x2: u32 = ((((((0x0 as fiat_p384_i2) - (x1 as fiat_p384_i2)) as fiat_p384_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
@@ -160,7 +160,7 @@ pub fn fiat_p384_cmovznz_u32(out1: &mut u32, arg1: fiat_p384_u1, arg2: u32, arg3
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_mul(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element, arg2: &fiat_p384_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_mul(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element, arg2: &fiat_p384_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -2667,7 +2667,7 @@ pub fn fiat_p384_mul(out1: &mut fiat_p384_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_square(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_square(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -5175,7 +5175,7 @@ pub fn fiat_p384_square(out1: &mut fiat_p384_montgomery_domain_field_element, ar
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_add(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element, arg2: &fiat_p384_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_add(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element, arg2: &fiat_p384_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p384_u1 = 0;
   fiat_p384_addcarryx_u32(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -5299,7 +5299,7 @@ pub fn fiat_p384_add(out1: &mut fiat_p384_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_sub(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element, arg2: &fiat_p384_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_sub(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element, arg2: &fiat_p384_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p384_u1 = 0;
   fiat_p384_subborrowx_u32(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -5397,7 +5397,7 @@ pub fn fiat_p384_sub(out1: &mut fiat_p384_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_opp(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_opp(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p384_u1 = 0;
   fiat_p384_subborrowx_u32(&mut x1, &mut x2, 0x0, (0x0 as u32), (arg1[0]));
@@ -5495,7 +5495,7 @@ pub fn fiat_p384_opp(out1: &mut fiat_p384_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_from_montgomery(out1: &mut fiat_p384_non_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_from_montgomery(out1: &mut fiat_p384_non_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element) {
   let x1: u32 = (arg1[0]);
   let mut x2: u32 = 0;
   let mut x3: u32 = 0;
@@ -7026,7 +7026,7 @@ pub fn fiat_p384_from_montgomery(out1: &mut fiat_p384_non_montgomery_domain_fiel
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_to_montgomery(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_non_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_to_montgomery(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_non_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -8817,7 +8817,7 @@ pub fn fiat_p384_to_montgomery(out1: &mut fiat_p384_montgomery_domain_field_elem
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_p384_nonzero(out1: &mut u32, arg1: &[u32; 12]) -> () {
+pub fn fiat_p384_nonzero(out1: &mut u32, arg1: &[u32; 12]) {
   let x1: u32 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | ((arg1[3]) | ((arg1[4]) | ((arg1[5]) | ((arg1[6]) | ((arg1[7]) | ((arg1[8]) | ((arg1[9]) | ((arg1[10]) | (arg1[11]))))))))))));
   *out1 = x1;
 }
@@ -8834,7 +8834,7 @@ pub fn fiat_p384_nonzero(out1: &mut u32, arg1: &[u32; 12]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p384_selectznz(out1: &mut [u32; 12], arg1: fiat_p384_u1, arg2: &[u32; 12], arg3: &[u32; 12]) -> () {
+pub fn fiat_p384_selectznz(out1: &mut [u32; 12], arg1: fiat_p384_u1, arg2: &[u32; 12], arg3: &[u32; 12]) {
   let mut x1: u32 = 0;
   fiat_p384_cmovznz_u32(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u32 = 0;
@@ -8885,7 +8885,7 @@ pub fn fiat_p384_selectznz(out1: &mut [u32; 12], arg1: fiat_p384_u1, arg2: &[u32
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
 #[inline]
-pub fn fiat_p384_to_bytes(out1: &mut [u8; 48], arg1: &[u32; 12]) -> () {
+pub fn fiat_p384_to_bytes(out1: &mut [u8; 48], arg1: &[u32; 12]) {
   let x1: u32 = (arg1[11]);
   let x2: u32 = (arg1[10]);
   let x3: u32 = (arg1[9]);
@@ -9033,7 +9033,7 @@ pub fn fiat_p384_to_bytes(out1: &mut [u8; 48], arg1: &[u32; 12]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p384_from_bytes(out1: &mut [u32; 12], arg1: &[u8; 48]) -> () {
+pub fn fiat_p384_from_bytes(out1: &mut [u32; 12], arg1: &[u8; 48]) {
   let x1: u32 = (((arg1[47]) as u32) << 24);
   let x2: u32 = (((arg1[46]) as u32) << 16);
   let x3: u32 = (((arg1[45]) as u32) << 8);
@@ -9139,7 +9139,7 @@ pub fn fiat_p384_from_bytes(out1: &mut [u32; 12], arg1: &[u8; 48]) -> () {
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_set_one(out1: &mut fiat_p384_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_set_one(out1: &mut fiat_p384_montgomery_domain_field_element) {
   out1[0] = (0x1 as u32);
   out1[1] = 0xffffffff;
   out1[2] = 0xffffffff;
@@ -9163,7 +9163,7 @@ pub fn fiat_p384_set_one(out1: &mut fiat_p384_montgomery_domain_field_element) -
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p384_msat(out1: &mut [u32; 13]) -> () {
+pub fn fiat_p384_msat(out1: &mut [u32; 13]) {
   out1[0] = 0xffffffff;
   out1[1] = (0x0 as u32);
   out1[2] = (0x0 as u32);
@@ -9208,7 +9208,7 @@ pub fn fiat_p384_msat(out1: &mut [u32; 13]) -> () {
 ///   out4: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 ///   out5: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p384_divstep(out1: &mut u32, out2: &mut [u32; 13], out3: &mut [u32; 13], out4: &mut [u32; 12], out5: &mut [u32; 12], arg1: u32, arg2: &[u32; 13], arg3: &[u32; 13], arg4: &[u32; 12], arg5: &[u32; 12]) -> () {
+pub fn fiat_p384_divstep(out1: &mut u32, out2: &mut [u32; 13], out3: &mut [u32; 13], out4: &mut [u32; 12], out5: &mut [u32; 12], arg1: u32, arg2: &[u32; 13], arg3: &[u32; 13], arg4: &[u32; 12], arg5: &[u32; 12]) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p384_u1 = 0;
   fiat_p384_addcarryx_u32(&mut x1, &mut x2, 0x0, (!arg1), (0x1 as u32));
@@ -9809,7 +9809,7 @@ pub fn fiat_p384_divstep(out1: &mut u32, out2: &mut [u32; 13], out3: &mut [u32; 
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p384_divstep_precomp(out1: &mut [u32; 12]) -> () {
+pub fn fiat_p384_divstep_precomp(out1: &mut [u32; 12]) {
   out1[0] = 0xfff18fff;
   out1[1] = 0xfff69400;
   out1[2] = 0xffffd3ff;

--- a/fiat-rust/src/p384_64.rs
+++ b/fiat-rust/src/p384_64.rs
@@ -80,7 +80,7 @@ impl core::ops::IndexMut<usize> for fiat_p384_non_montgomery_domain_field_elemen
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p384_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p384_u1, arg1: fiat_p384_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p384_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p384_u1, arg1: fiat_p384_u1, arg2: u64, arg3: u64) {
   let x1: u128 = (((arg1 as u128) + (arg2 as u128)) + (arg3 as u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
   let x3: fiat_p384_u1 = ((x1 >> 64) as fiat_p384_u1);
@@ -102,7 +102,7 @@ pub fn fiat_p384_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p384_u1, arg1: fi
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p384_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p384_u1, arg1: fiat_p384_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p384_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p384_u1, arg1: fiat_p384_u1, arg2: u64, arg3: u64) {
   let x1: i128 = (((arg2 as i128) - (arg1 as i128)) - (arg3 as i128));
   let x2: fiat_p384_i1 = ((x1 >> 64) as fiat_p384_i1);
   let x3: u64 = ((x1 & (0xffffffffffffffff as i128)) as u64);
@@ -123,7 +123,7 @@ pub fn fiat_p384_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p384_u1, arg1: f
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_p384_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) -> () {
+pub fn fiat_p384_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) {
   let x1: u128 = ((arg1 as u128) * (arg2 as u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
   let x3: u64 = ((x1 >> 64) as u64);
@@ -143,7 +143,7 @@ pub fn fiat_p384_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) 
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_p384_cmovznz_u64(out1: &mut u64, arg1: fiat_p384_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p384_cmovznz_u64(out1: &mut u64, arg1: fiat_p384_u1, arg2: u64, arg3: u64) {
   let x1: fiat_p384_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_p384_i2) - (x1 as fiat_p384_i2)) as fiat_p384_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
@@ -160,7 +160,7 @@ pub fn fiat_p384_cmovznz_u64(out1: &mut u64, arg1: fiat_p384_u1, arg2: u64, arg3
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_mul(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element, arg2: &fiat_p384_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_mul(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element, arg2: &fiat_p384_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -879,7 +879,7 @@ pub fn fiat_p384_mul(out1: &mut fiat_p384_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_square(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_square(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -1599,7 +1599,7 @@ pub fn fiat_p384_square(out1: &mut fiat_p384_montgomery_domain_field_element, ar
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_add(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element, arg2: &fiat_p384_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_add(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element, arg2: &fiat_p384_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p384_u1 = 0;
   fiat_p384_addcarryx_u64(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -1669,7 +1669,7 @@ pub fn fiat_p384_add(out1: &mut fiat_p384_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_sub(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element, arg2: &fiat_p384_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_sub(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element, arg2: &fiat_p384_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p384_u1 = 0;
   fiat_p384_subborrowx_u64(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -1725,7 +1725,7 @@ pub fn fiat_p384_sub(out1: &mut fiat_p384_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_opp(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_opp(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p384_u1 = 0;
   fiat_p384_subborrowx_u64(&mut x1, &mut x2, 0x0, (0x0 as u64), (arg1[0]));
@@ -1781,7 +1781,7 @@ pub fn fiat_p384_opp(out1: &mut fiat_p384_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_from_montgomery(out1: &mut fiat_p384_non_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_from_montgomery(out1: &mut fiat_p384_non_montgomery_domain_field_element, arg1: &fiat_p384_montgomery_domain_field_element) {
   let x1: u64 = (arg1[0]);
   let mut x2: u64 = 0;
   let mut x3: u64 = 0;
@@ -2265,7 +2265,7 @@ pub fn fiat_p384_from_montgomery(out1: &mut fiat_p384_non_montgomery_domain_fiel
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_to_montgomery(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_non_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_to_montgomery(out1: &mut fiat_p384_montgomery_domain_field_element, arg1: &fiat_p384_non_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -2901,7 +2901,7 @@ pub fn fiat_p384_to_montgomery(out1: &mut fiat_p384_montgomery_domain_field_elem
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_p384_nonzero(out1: &mut u64, arg1: &[u64; 6]) -> () {
+pub fn fiat_p384_nonzero(out1: &mut u64, arg1: &[u64; 6]) {
   let x1: u64 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | ((arg1[3]) | ((arg1[4]) | (arg1[5]))))));
   *out1 = x1;
 }
@@ -2918,7 +2918,7 @@ pub fn fiat_p384_nonzero(out1: &mut u64, arg1: &[u64; 6]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p384_selectznz(out1: &mut [u64; 6], arg1: fiat_p384_u1, arg2: &[u64; 6], arg3: &[u64; 6]) -> () {
+pub fn fiat_p384_selectznz(out1: &mut [u64; 6], arg1: fiat_p384_u1, arg2: &[u64; 6], arg3: &[u64; 6]) {
   let mut x1: u64 = 0;
   fiat_p384_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u64 = 0;
@@ -2951,7 +2951,7 @@ pub fn fiat_p384_selectznz(out1: &mut [u64; 6], arg1: fiat_p384_u1, arg2: &[u64;
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
 #[inline]
-pub fn fiat_p384_to_bytes(out1: &mut [u8; 48], arg1: &[u64; 6]) -> () {
+pub fn fiat_p384_to_bytes(out1: &mut [u8; 48], arg1: &[u64; 6]) {
   let x1: u64 = (arg1[5]);
   let x2: u64 = (arg1[4]);
   let x3: u64 = (arg1[3]);
@@ -3105,7 +3105,7 @@ pub fn fiat_p384_to_bytes(out1: &mut [u8; 48], arg1: &[u64; 6]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p384_from_bytes(out1: &mut [u64; 6], arg1: &[u8; 48]) -> () {
+pub fn fiat_p384_from_bytes(out1: &mut [u64; 6], arg1: &[u8; 48]) {
   let x1: u64 = (((arg1[47]) as u64) << 56);
   let x2: u64 = (((arg1[46]) as u64) << 48);
   let x3: u64 = (((arg1[45]) as u64) << 40);
@@ -3211,7 +3211,7 @@ pub fn fiat_p384_from_bytes(out1: &mut [u64; 6], arg1: &[u8; 48]) -> () {
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_set_one(out1: &mut fiat_p384_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_set_one(out1: &mut fiat_p384_montgomery_domain_field_element) {
   out1[0] = 0xffffffff00000001;
   out1[1] = 0xffffffff;
   out1[2] = (0x1 as u64);
@@ -3229,7 +3229,7 @@ pub fn fiat_p384_set_one(out1: &mut fiat_p384_montgomery_domain_field_element) -
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p384_msat(out1: &mut [u64; 7]) -> () {
+pub fn fiat_p384_msat(out1: &mut [u64; 7]) {
   out1[0] = 0xffffffff;
   out1[1] = 0xffffffff00000000;
   out1[2] = 0xfffffffffffffffe;
@@ -3268,7 +3268,7 @@ pub fn fiat_p384_msat(out1: &mut [u64; 7]) -> () {
 ///   out4: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 ///   out5: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p384_divstep(out1: &mut u64, out2: &mut [u64; 7], out3: &mut [u64; 7], out4: &mut [u64; 6], out5: &mut [u64; 6], arg1: u64, arg2: &[u64; 7], arg3: &[u64; 7], arg4: &[u64; 6], arg5: &[u64; 6]) -> () {
+pub fn fiat_p384_divstep(out1: &mut u64, out2: &mut [u64; 7], out3: &mut [u64; 7], out4: &mut [u64; 6], out5: &mut [u64; 6], arg1: u64, arg2: &[u64; 7], arg3: &[u64; 7], arg4: &[u64; 6], arg5: &[u64; 6]) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p384_u1 = 0;
   fiat_p384_addcarryx_u64(&mut x1, &mut x2, 0x0, (!arg1), (0x1 as u64));
@@ -3593,7 +3593,7 @@ pub fn fiat_p384_divstep(out1: &mut u64, out2: &mut [u64; 7], out3: &mut [u64; 7
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p384_divstep_precomp(out1: &mut [u64; 6]) -> () {
+pub fn fiat_p384_divstep_precomp(out1: &mut [u64; 6]) {
   out1[0] = 0xfff69400fff18fff;
   out1[1] = 0x2b7feffffd3ff;
   out1[2] = 0xfffedbfffffe97ff;

--- a/fiat-rust/src/p384_scalar_32.rs
+++ b/fiat-rust/src/p384_scalar_32.rs
@@ -80,7 +80,7 @@ impl core::ops::IndexMut<usize> for fiat_p384_scalar_non_montgomery_domain_field
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p384_scalar_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p384_scalar_u1, arg1: fiat_p384_scalar_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p384_scalar_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p384_scalar_u1, arg1: fiat_p384_scalar_u1, arg2: u32, arg3: u32) {
   let x1: u64 = (((arg1 as u64) + (arg2 as u64)) + (arg3 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
   let x3: fiat_p384_scalar_u1 = ((x1 >> 32) as fiat_p384_scalar_u1);
@@ -102,7 +102,7 @@ pub fn fiat_p384_scalar_addcarryx_u32(out1: &mut u32, out2: &mut fiat_p384_scala
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p384_scalar_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p384_scalar_u1, arg1: fiat_p384_scalar_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p384_scalar_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p384_scalar_u1, arg1: fiat_p384_scalar_u1, arg2: u32, arg3: u32) {
   let x1: i64 = (((arg2 as i64) - (arg1 as i64)) - (arg3 as i64));
   let x2: fiat_p384_scalar_i1 = ((x1 >> 32) as fiat_p384_scalar_i1);
   let x3: u32 = ((x1 & (0xffffffff as i64)) as u32);
@@ -123,7 +123,7 @@ pub fn fiat_p384_scalar_subborrowx_u32(out1: &mut u32, out2: &mut fiat_p384_scal
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_p384_scalar_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) -> () {
+pub fn fiat_p384_scalar_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) {
   let x1: u64 = ((arg1 as u64) * (arg2 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
   let x3: u32 = ((x1 >> 32) as u32);
@@ -143,7 +143,7 @@ pub fn fiat_p384_scalar_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_p384_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_p384_scalar_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p384_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_p384_scalar_u1, arg2: u32, arg3: u32) {
   let x1: fiat_p384_scalar_u1 = (!(!arg1));
   let x2: u32 = ((((((0x0 as fiat_p384_scalar_i2) - (x1 as fiat_p384_scalar_i2)) as fiat_p384_scalar_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
@@ -160,7 +160,7 @@ pub fn fiat_p384_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_p384_scalar_u1, a
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_scalar_mul(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element, arg2: &fiat_p384_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_scalar_mul(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element, arg2: &fiat_p384_scalar_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -2883,7 +2883,7 @@ pub fn fiat_p384_scalar_mul(out1: &mut fiat_p384_scalar_montgomery_domain_field_
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_scalar_square(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_scalar_square(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -5607,7 +5607,7 @@ pub fn fiat_p384_scalar_square(out1: &mut fiat_p384_scalar_montgomery_domain_fie
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_scalar_add(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element, arg2: &fiat_p384_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_scalar_add(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element, arg2: &fiat_p384_scalar_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p384_scalar_u1 = 0;
   fiat_p384_scalar_addcarryx_u32(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -5731,7 +5731,7 @@ pub fn fiat_p384_scalar_add(out1: &mut fiat_p384_scalar_montgomery_domain_field_
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_scalar_sub(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element, arg2: &fiat_p384_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_scalar_sub(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element, arg2: &fiat_p384_scalar_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p384_scalar_u1 = 0;
   fiat_p384_scalar_subborrowx_u32(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -5829,7 +5829,7 @@ pub fn fiat_p384_scalar_sub(out1: &mut fiat_p384_scalar_montgomery_domain_field_
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_scalar_opp(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_scalar_opp(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p384_scalar_u1 = 0;
   fiat_p384_scalar_subborrowx_u32(&mut x1, &mut x2, 0x0, (0x0 as u32), (arg1[0]));
@@ -5927,7 +5927,7 @@ pub fn fiat_p384_scalar_opp(out1: &mut fiat_p384_scalar_montgomery_domain_field_
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_scalar_from_montgomery(out1: &mut fiat_p384_scalar_non_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_scalar_from_montgomery(out1: &mut fiat_p384_scalar_non_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element) {
   let x1: u32 = (arg1[0]);
   let mut x2: u32 = 0;
   let mut x3: u32 = 0;
@@ -7743,7 +7743,7 @@ pub fn fiat_p384_scalar_from_montgomery(out1: &mut fiat_p384_scalar_non_montgome
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_scalar_to_montgomery(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_non_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_scalar_to_montgomery(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_non_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -10401,7 +10401,7 @@ pub fn fiat_p384_scalar_to_montgomery(out1: &mut fiat_p384_scalar_montgomery_dom
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_p384_scalar_nonzero(out1: &mut u32, arg1: &[u32; 12]) -> () {
+pub fn fiat_p384_scalar_nonzero(out1: &mut u32, arg1: &[u32; 12]) {
   let x1: u32 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | ((arg1[3]) | ((arg1[4]) | ((arg1[5]) | ((arg1[6]) | ((arg1[7]) | ((arg1[8]) | ((arg1[9]) | ((arg1[10]) | (arg1[11]))))))))))));
   *out1 = x1;
 }
@@ -10418,7 +10418,7 @@ pub fn fiat_p384_scalar_nonzero(out1: &mut u32, arg1: &[u32; 12]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p384_scalar_selectznz(out1: &mut [u32; 12], arg1: fiat_p384_scalar_u1, arg2: &[u32; 12], arg3: &[u32; 12]) -> () {
+pub fn fiat_p384_scalar_selectznz(out1: &mut [u32; 12], arg1: fiat_p384_scalar_u1, arg2: &[u32; 12], arg3: &[u32; 12]) {
   let mut x1: u32 = 0;
   fiat_p384_scalar_cmovznz_u32(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u32 = 0;
@@ -10469,7 +10469,7 @@ pub fn fiat_p384_scalar_selectznz(out1: &mut [u32; 12], arg1: fiat_p384_scalar_u
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
 #[inline]
-pub fn fiat_p384_scalar_to_bytes(out1: &mut [u8; 48], arg1: &[u32; 12]) -> () {
+pub fn fiat_p384_scalar_to_bytes(out1: &mut [u8; 48], arg1: &[u32; 12]) {
   let x1: u32 = (arg1[11]);
   let x2: u32 = (arg1[10]);
   let x3: u32 = (arg1[9]);
@@ -10617,7 +10617,7 @@ pub fn fiat_p384_scalar_to_bytes(out1: &mut [u8; 48], arg1: &[u32; 12]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p384_scalar_from_bytes(out1: &mut [u32; 12], arg1: &[u8; 48]) -> () {
+pub fn fiat_p384_scalar_from_bytes(out1: &mut [u32; 12], arg1: &[u8; 48]) {
   let x1: u32 = (((arg1[47]) as u32) << 24);
   let x2: u32 = (((arg1[46]) as u32) << 16);
   let x3: u32 = (((arg1[45]) as u32) << 8);
@@ -10723,7 +10723,7 @@ pub fn fiat_p384_scalar_from_bytes(out1: &mut [u32; 12], arg1: &[u8; 48]) -> () 
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_scalar_set_one(out1: &mut fiat_p384_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_scalar_set_one(out1: &mut fiat_p384_scalar_montgomery_domain_field_element) {
   out1[0] = 0x333ad68d;
   out1[1] = 0x1313e695;
   out1[2] = 0xb74f5885;
@@ -10747,7 +10747,7 @@ pub fn fiat_p384_scalar_set_one(out1: &mut fiat_p384_scalar_montgomery_domain_fi
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p384_scalar_msat(out1: &mut [u32; 13]) -> () {
+pub fn fiat_p384_scalar_msat(out1: &mut [u32; 13]) {
   out1[0] = 0xccc52973;
   out1[1] = 0xecec196a;
   out1[2] = 0x48b0a77a;
@@ -10792,7 +10792,7 @@ pub fn fiat_p384_scalar_msat(out1: &mut [u32; 13]) -> () {
 ///   out4: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 ///   out5: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p384_scalar_divstep(out1: &mut u32, out2: &mut [u32; 13], out3: &mut [u32; 13], out4: &mut [u32; 12], out5: &mut [u32; 12], arg1: u32, arg2: &[u32; 13], arg3: &[u32; 13], arg4: &[u32; 12], arg5: &[u32; 12]) -> () {
+pub fn fiat_p384_scalar_divstep(out1: &mut u32, out2: &mut [u32; 13], out3: &mut [u32; 13], out4: &mut [u32; 12], out5: &mut [u32; 12], arg1: u32, arg2: &[u32; 13], arg3: &[u32; 13], arg4: &[u32; 12], arg5: &[u32; 12]) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p384_scalar_u1 = 0;
   fiat_p384_scalar_addcarryx_u32(&mut x1, &mut x2, 0x0, (!arg1), (0x1 as u32));
@@ -11393,7 +11393,7 @@ pub fn fiat_p384_scalar_divstep(out1: &mut u32, out2: &mut [u32; 13], out3: &mut
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p384_scalar_divstep_precomp(out1: &mut [u32; 12]) -> () {
+pub fn fiat_p384_scalar_divstep_precomp(out1: &mut [u32; 12]) {
   out1[0] = 0xe6045b6a;
   out1[1] = 0x49589ae0;
   out1[2] = 0x870040ed;

--- a/fiat-rust/src/p384_scalar_64.rs
+++ b/fiat-rust/src/p384_scalar_64.rs
@@ -80,7 +80,7 @@ impl core::ops::IndexMut<usize> for fiat_p384_scalar_non_montgomery_domain_field
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p384_scalar_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p384_scalar_u1, arg1: fiat_p384_scalar_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p384_scalar_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p384_scalar_u1, arg1: fiat_p384_scalar_u1, arg2: u64, arg3: u64) {
   let x1: u128 = (((arg1 as u128) + (arg2 as u128)) + (arg3 as u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
   let x3: fiat_p384_scalar_u1 = ((x1 >> 64) as fiat_p384_scalar_u1);
@@ -102,7 +102,7 @@ pub fn fiat_p384_scalar_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p384_scala
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p384_scalar_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p384_scalar_u1, arg1: fiat_p384_scalar_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p384_scalar_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p384_scalar_u1, arg1: fiat_p384_scalar_u1, arg2: u64, arg3: u64) {
   let x1: i128 = (((arg2 as i128) - (arg1 as i128)) - (arg3 as i128));
   let x2: fiat_p384_scalar_i1 = ((x1 >> 64) as fiat_p384_scalar_i1);
   let x3: u64 = ((x1 & (0xffffffffffffffff as i128)) as u64);
@@ -123,7 +123,7 @@ pub fn fiat_p384_scalar_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p384_scal
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_p384_scalar_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) -> () {
+pub fn fiat_p384_scalar_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) {
   let x1: u128 = ((arg1 as u128) * (arg2 as u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
   let x3: u64 = ((x1 >> 64) as u64);
@@ -143,7 +143,7 @@ pub fn fiat_p384_scalar_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_p384_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_p384_scalar_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p384_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_p384_scalar_u1, arg2: u64, arg3: u64) {
   let x1: fiat_p384_scalar_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_p384_scalar_i2) - (x1 as fiat_p384_scalar_i2)) as fiat_p384_scalar_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
@@ -160,7 +160,7 @@ pub fn fiat_p384_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_p384_scalar_u1, a
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_scalar_mul(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element, arg2: &fiat_p384_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_scalar_mul(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element, arg2: &fiat_p384_scalar_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -879,7 +879,7 @@ pub fn fiat_p384_scalar_mul(out1: &mut fiat_p384_scalar_montgomery_domain_field_
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_scalar_square(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_scalar_square(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -1599,7 +1599,7 @@ pub fn fiat_p384_scalar_square(out1: &mut fiat_p384_scalar_montgomery_domain_fie
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_scalar_add(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element, arg2: &fiat_p384_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_scalar_add(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element, arg2: &fiat_p384_scalar_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p384_scalar_u1 = 0;
   fiat_p384_scalar_addcarryx_u64(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -1669,7 +1669,7 @@ pub fn fiat_p384_scalar_add(out1: &mut fiat_p384_scalar_montgomery_domain_field_
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_scalar_sub(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element, arg2: &fiat_p384_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_scalar_sub(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element, arg2: &fiat_p384_scalar_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p384_scalar_u1 = 0;
   fiat_p384_scalar_subborrowx_u64(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -1725,7 +1725,7 @@ pub fn fiat_p384_scalar_sub(out1: &mut fiat_p384_scalar_montgomery_domain_field_
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_scalar_opp(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_scalar_opp(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p384_scalar_u1 = 0;
   fiat_p384_scalar_subborrowx_u64(&mut x1, &mut x2, 0x0, (0x0 as u64), (arg1[0]));
@@ -1781,7 +1781,7 @@ pub fn fiat_p384_scalar_opp(out1: &mut fiat_p384_scalar_montgomery_domain_field_
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_scalar_from_montgomery(out1: &mut fiat_p384_scalar_non_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_scalar_from_montgomery(out1: &mut fiat_p384_scalar_non_montgomery_domain_field_element, arg1: &fiat_p384_scalar_montgomery_domain_field_element) {
   let x1: u64 = (arg1[0]);
   let mut x2: u64 = 0;
   let mut x3: u64 = 0;
@@ -2265,7 +2265,7 @@ pub fn fiat_p384_scalar_from_montgomery(out1: &mut fiat_p384_scalar_non_montgome
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_scalar_to_montgomery(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_non_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_scalar_to_montgomery(out1: &mut fiat_p384_scalar_montgomery_domain_field_element, arg1: &fiat_p384_scalar_non_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -2955,7 +2955,7 @@ pub fn fiat_p384_scalar_to_montgomery(out1: &mut fiat_p384_scalar_montgomery_dom
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_p384_scalar_nonzero(out1: &mut u64, arg1: &[u64; 6]) -> () {
+pub fn fiat_p384_scalar_nonzero(out1: &mut u64, arg1: &[u64; 6]) {
   let x1: u64 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | ((arg1[3]) | ((arg1[4]) | (arg1[5]))))));
   *out1 = x1;
 }
@@ -2972,7 +2972,7 @@ pub fn fiat_p384_scalar_nonzero(out1: &mut u64, arg1: &[u64; 6]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p384_scalar_selectznz(out1: &mut [u64; 6], arg1: fiat_p384_scalar_u1, arg2: &[u64; 6], arg3: &[u64; 6]) -> () {
+pub fn fiat_p384_scalar_selectznz(out1: &mut [u64; 6], arg1: fiat_p384_scalar_u1, arg2: &[u64; 6], arg3: &[u64; 6]) {
   let mut x1: u64 = 0;
   fiat_p384_scalar_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u64 = 0;
@@ -3005,7 +3005,7 @@ pub fn fiat_p384_scalar_selectznz(out1: &mut [u64; 6], arg1: fiat_p384_scalar_u1
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
 #[inline]
-pub fn fiat_p384_scalar_to_bytes(out1: &mut [u8; 48], arg1: &[u64; 6]) -> () {
+pub fn fiat_p384_scalar_to_bytes(out1: &mut [u8; 48], arg1: &[u64; 6]) {
   let x1: u64 = (arg1[5]);
   let x2: u64 = (arg1[4]);
   let x3: u64 = (arg1[3]);
@@ -3159,7 +3159,7 @@ pub fn fiat_p384_scalar_to_bytes(out1: &mut [u8; 48], arg1: &[u64; 6]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p384_scalar_from_bytes(out1: &mut [u64; 6], arg1: &[u8; 48]) -> () {
+pub fn fiat_p384_scalar_from_bytes(out1: &mut [u64; 6], arg1: &[u8; 48]) {
   let x1: u64 = (((arg1[47]) as u64) << 56);
   let x2: u64 = (((arg1[46]) as u64) << 48);
   let x3: u64 = (((arg1[45]) as u64) << 40);
@@ -3265,7 +3265,7 @@ pub fn fiat_p384_scalar_from_bytes(out1: &mut [u64; 6], arg1: &[u8; 48]) -> () {
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p384_scalar_set_one(out1: &mut fiat_p384_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_p384_scalar_set_one(out1: &mut fiat_p384_scalar_montgomery_domain_field_element) {
   out1[0] = 0x1313e695333ad68d;
   out1[1] = 0xa7e5f24db74f5885;
   out1[2] = 0x389cb27e0bc8d220;
@@ -3283,7 +3283,7 @@ pub fn fiat_p384_scalar_set_one(out1: &mut fiat_p384_scalar_montgomery_domain_fi
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p384_scalar_msat(out1: &mut [u64; 7]) -> () {
+pub fn fiat_p384_scalar_msat(out1: &mut [u64; 7]) {
   out1[0] = 0xecec196accc52973;
   out1[1] = 0x581a0db248b0a77a;
   out1[2] = 0xc7634d81f4372ddf;
@@ -3322,7 +3322,7 @@ pub fn fiat_p384_scalar_msat(out1: &mut [u64; 7]) -> () {
 ///   out4: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 ///   out5: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p384_scalar_divstep(out1: &mut u64, out2: &mut [u64; 7], out3: &mut [u64; 7], out4: &mut [u64; 6], out5: &mut [u64; 6], arg1: u64, arg2: &[u64; 7], arg3: &[u64; 7], arg4: &[u64; 6], arg5: &[u64; 6]) -> () {
+pub fn fiat_p384_scalar_divstep(out1: &mut u64, out2: &mut [u64; 7], out3: &mut [u64; 7], out4: &mut [u64; 6], out5: &mut [u64; 6], arg1: u64, arg2: &[u64; 7], arg3: &[u64; 7], arg4: &[u64; 6], arg5: &[u64; 6]) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p384_scalar_u1 = 0;
   fiat_p384_scalar_addcarryx_u64(&mut x1, &mut x2, 0x0, (!arg1), (0x1 as u64));
@@ -3647,7 +3647,7 @@ pub fn fiat_p384_scalar_divstep(out1: &mut u64, out2: &mut [u64; 7], out3: &mut 
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p384_scalar_divstep_precomp(out1: &mut [u64; 6]) -> () {
+pub fn fiat_p384_scalar_divstep_precomp(out1: &mut [u64; 6]) {
   out1[0] = 0x49589ae0e6045b6a;
   out1[1] = 0x3c9a5352870040ed;
   out1[2] = 0xdacb097e977dc242;

--- a/fiat-rust/src/p434_64.rs
+++ b/fiat-rust/src/p434_64.rs
@@ -80,7 +80,7 @@ impl core::ops::IndexMut<usize> for fiat_p434_non_montgomery_domain_field_elemen
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p434_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p434_u1, arg1: fiat_p434_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p434_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p434_u1, arg1: fiat_p434_u1, arg2: u64, arg3: u64) {
   let x1: u128 = (((arg1 as u128) + (arg2 as u128)) + (arg3 as u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
   let x3: fiat_p434_u1 = ((x1 >> 64) as fiat_p434_u1);
@@ -102,7 +102,7 @@ pub fn fiat_p434_addcarryx_u64(out1: &mut u64, out2: &mut fiat_p434_u1, arg1: fi
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p434_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p434_u1, arg1: fiat_p434_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p434_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p434_u1, arg1: fiat_p434_u1, arg2: u64, arg3: u64) {
   let x1: i128 = (((arg2 as i128) - (arg1 as i128)) - (arg3 as i128));
   let x2: fiat_p434_i1 = ((x1 >> 64) as fiat_p434_i1);
   let x3: u64 = ((x1 & (0xffffffffffffffff as i128)) as u64);
@@ -123,7 +123,7 @@ pub fn fiat_p434_subborrowx_u64(out1: &mut u64, out2: &mut fiat_p434_u1, arg1: f
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_p434_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) -> () {
+pub fn fiat_p434_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) {
   let x1: u128 = ((arg1 as u128) * (arg2 as u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
   let x3: u64 = ((x1 >> 64) as u64);
@@ -143,7 +143,7 @@ pub fn fiat_p434_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) 
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_p434_cmovznz_u64(out1: &mut u64, arg1: fiat_p434_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p434_cmovznz_u64(out1: &mut u64, arg1: fiat_p434_u1, arg2: u64, arg3: u64) {
   let x1: fiat_p434_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_p434_i2) - (x1 as fiat_p434_i2)) as fiat_p434_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
@@ -160,7 +160,7 @@ pub fn fiat_p434_cmovznz_u64(out1: &mut u64, arg1: fiat_p434_u1, arg2: u64, arg3
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p434_mul(out1: &mut fiat_p434_montgomery_domain_field_element, arg1: &fiat_p434_montgomery_domain_field_element, arg2: &fiat_p434_montgomery_domain_field_element) -> () {
+pub fn fiat_p434_mul(out1: &mut fiat_p434_montgomery_domain_field_element, arg1: &fiat_p434_montgomery_domain_field_element, arg2: &fiat_p434_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -1102,7 +1102,7 @@ pub fn fiat_p434_mul(out1: &mut fiat_p434_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p434_square(out1: &mut fiat_p434_montgomery_domain_field_element, arg1: &fiat_p434_montgomery_domain_field_element) -> () {
+pub fn fiat_p434_square(out1: &mut fiat_p434_montgomery_domain_field_element, arg1: &fiat_p434_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -2045,7 +2045,7 @@ pub fn fiat_p434_square(out1: &mut fiat_p434_montgomery_domain_field_element, ar
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p434_add(out1: &mut fiat_p434_montgomery_domain_field_element, arg1: &fiat_p434_montgomery_domain_field_element, arg2: &fiat_p434_montgomery_domain_field_element) -> () {
+pub fn fiat_p434_add(out1: &mut fiat_p434_montgomery_domain_field_element, arg1: &fiat_p434_montgomery_domain_field_element, arg2: &fiat_p434_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p434_u1 = 0;
   fiat_p434_addcarryx_u64(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -2124,7 +2124,7 @@ pub fn fiat_p434_add(out1: &mut fiat_p434_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p434_sub(out1: &mut fiat_p434_montgomery_domain_field_element, arg1: &fiat_p434_montgomery_domain_field_element, arg2: &fiat_p434_montgomery_domain_field_element) -> () {
+pub fn fiat_p434_sub(out1: &mut fiat_p434_montgomery_domain_field_element, arg1: &fiat_p434_montgomery_domain_field_element, arg2: &fiat_p434_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p434_u1 = 0;
   fiat_p434_subborrowx_u64(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -2187,7 +2187,7 @@ pub fn fiat_p434_sub(out1: &mut fiat_p434_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p434_opp(out1: &mut fiat_p434_montgomery_domain_field_element, arg1: &fiat_p434_montgomery_domain_field_element) -> () {
+pub fn fiat_p434_opp(out1: &mut fiat_p434_montgomery_domain_field_element, arg1: &fiat_p434_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p434_u1 = 0;
   fiat_p434_subborrowx_u64(&mut x1, &mut x2, 0x0, (0x0 as u64), (arg1[0]));
@@ -2250,7 +2250,7 @@ pub fn fiat_p434_opp(out1: &mut fiat_p434_montgomery_domain_field_element, arg1:
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p434_from_montgomery(out1: &mut fiat_p434_non_montgomery_domain_field_element, arg1: &fiat_p434_montgomery_domain_field_element) -> () {
+pub fn fiat_p434_from_montgomery(out1: &mut fiat_p434_non_montgomery_domain_field_element, arg1: &fiat_p434_montgomery_domain_field_element) {
   let x1: u64 = (arg1[0]);
   let mut x2: u64 = 0;
   let mut x3: u64 = 0;
@@ -2837,7 +2837,7 @@ pub fn fiat_p434_from_montgomery(out1: &mut fiat_p434_non_montgomery_domain_fiel
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p434_to_montgomery(out1: &mut fiat_p434_montgomery_domain_field_element, arg1: &fiat_p434_non_montgomery_domain_field_element) -> () {
+pub fn fiat_p434_to_montgomery(out1: &mut fiat_p434_montgomery_domain_field_element, arg1: &fiat_p434_non_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -3724,7 +3724,7 @@ pub fn fiat_p434_to_montgomery(out1: &mut fiat_p434_montgomery_domain_field_elem
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_p434_nonzero(out1: &mut u64, arg1: &[u64; 7]) -> () {
+pub fn fiat_p434_nonzero(out1: &mut u64, arg1: &[u64; 7]) {
   let x1: u64 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | ((arg1[3]) | ((arg1[4]) | ((arg1[5]) | (arg1[6])))))));
   *out1 = x1;
 }
@@ -3741,7 +3741,7 @@ pub fn fiat_p434_nonzero(out1: &mut u64, arg1: &[u64; 7]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p434_selectznz(out1: &mut [u64; 7], arg1: fiat_p434_u1, arg2: &[u64; 7], arg3: &[u64; 7]) -> () {
+pub fn fiat_p434_selectznz(out1: &mut [u64; 7], arg1: fiat_p434_u1, arg2: &[u64; 7], arg3: &[u64; 7]) {
   let mut x1: u64 = 0;
   fiat_p434_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u64 = 0;
@@ -3777,7 +3777,7 @@ pub fn fiat_p434_selectznz(out1: &mut [u64; 7], arg1: fiat_p434_u1, arg2: &[u64;
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x3]]
 #[inline]
-pub fn fiat_p434_to_bytes(out1: &mut [u8; 55], arg1: &[u64; 7]) -> () {
+pub fn fiat_p434_to_bytes(out1: &mut [u8; 55], arg1: &[u64; 7]) {
   let x1: u64 = (arg1[6]);
   let x2: u64 = (arg1[5]);
   let x3: u64 = (arg1[4]);
@@ -3951,7 +3951,7 @@ pub fn fiat_p434_to_bytes(out1: &mut [u8; 55], arg1: &[u64; 7]) -> () {
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0x3ffffffffffff]]
 #[inline]
-pub fn fiat_p434_from_bytes(out1: &mut [u64; 7], arg1: &[u8; 55]) -> () {
+pub fn fiat_p434_from_bytes(out1: &mut [u64; 7], arg1: &[u8; 55]) {
   let x1: u64 = (((arg1[54]) as u64) << 48);
   let x2: u64 = (((arg1[53]) as u64) << 40);
   let x3: u64 = (((arg1[52]) as u64) << 32);
@@ -4071,7 +4071,7 @@ pub fn fiat_p434_from_bytes(out1: &mut [u64; 7], arg1: &[u8; 55]) -> () {
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_p434_set_one(out1: &mut fiat_p434_montgomery_domain_field_element) -> () {
+pub fn fiat_p434_set_one(out1: &mut fiat_p434_montgomery_domain_field_element) {
   out1[0] = 0x742c;
   out1[1] = (0x0 as u64);
   out1[2] = (0x0 as u64);
@@ -4090,7 +4090,7 @@ pub fn fiat_p434_set_one(out1: &mut fiat_p434_montgomery_domain_field_element) -
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p434_msat(out1: &mut [u64; 8]) -> () {
+pub fn fiat_p434_msat(out1: &mut [u64; 8]) {
   out1[0] = 0xffffffffffffffff;
   out1[1] = 0xffffffffffffffff;
   out1[2] = 0xffffffffffffffff;
@@ -4130,7 +4130,7 @@ pub fn fiat_p434_msat(out1: &mut [u64; 8]) -> () {
 ///   out4: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 ///   out5: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p434_divstep(out1: &mut u64, out2: &mut [u64; 8], out3: &mut [u64; 8], out4: &mut [u64; 7], out5: &mut [u64; 7], arg1: u64, arg2: &[u64; 8], arg3: &[u64; 8], arg4: &[u64; 7], arg5: &[u64; 7]) -> () {
+pub fn fiat_p434_divstep(out1: &mut u64, out2: &mut [u64; 8], out3: &mut [u64; 8], out4: &mut [u64; 7], out5: &mut [u64; 7], arg1: u64, arg2: &[u64; 8], arg3: &[u64; 8], arg4: &[u64; 7], arg5: &[u64; 7]) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p434_u1 = 0;
   fiat_p434_addcarryx_u64(&mut x1, &mut x2, 0x0, (!arg1), (0x1 as u64));
@@ -4501,7 +4501,7 @@ pub fn fiat_p434_divstep(out1: &mut u64, out2: &mut [u64; 8], out3: &mut [u64; 8
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p434_divstep_precomp(out1: &mut [u64; 7]) -> () {
+pub fn fiat_p434_divstep_precomp(out1: &mut [u64; 7]) {
   out1[0] = 0x9f9776e27e1a2b72;
   out1[1] = 0x28b59f067e2393d0;
   out1[2] = 0xcf316ce1572add54;

--- a/fiat-rust/src/p448_solinas_32.rs
+++ b/fiat-rust/src/p448_solinas_32.rs
@@ -75,7 +75,7 @@ impl core::ops::IndexMut<usize> for fiat_p448_tight_field_element {
 ///   out1: [0x0 ~> 0xfffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p448_addcarryx_u28(out1: &mut u32, out2: &mut fiat_p448_u1, arg1: fiat_p448_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p448_addcarryx_u28(out1: &mut u32, out2: &mut fiat_p448_u1, arg1: fiat_p448_u1, arg2: u32, arg3: u32) {
   let x1: u32 = (((arg1 as u32) + arg2) + arg3);
   let x2: u32 = (x1 & 0xfffffff);
   let x3: fiat_p448_u1 = ((x1 >> 28) as fiat_p448_u1);
@@ -97,7 +97,7 @@ pub fn fiat_p448_addcarryx_u28(out1: &mut u32, out2: &mut fiat_p448_u1, arg1: fi
 ///   out1: [0x0 ~> 0xfffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p448_subborrowx_u28(out1: &mut u32, out2: &mut fiat_p448_u1, arg1: fiat_p448_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p448_subborrowx_u28(out1: &mut u32, out2: &mut fiat_p448_u1, arg1: fiat_p448_u1, arg2: u32, arg3: u32) {
   let x1: i32 = ((((((arg2 as i64) - (arg1 as i64)) as i32) as i64) - (arg3 as i64)) as i32);
   let x2: fiat_p448_i1 = ((x1 >> 28) as fiat_p448_i1);
   let x3: u32 = (((x1 as i64) & (0xfffffff as i64)) as u32);
@@ -117,7 +117,7 @@ pub fn fiat_p448_subborrowx_u28(out1: &mut u32, out2: &mut fiat_p448_u1, arg1: f
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_p448_cmovznz_u32(out1: &mut u32, arg1: fiat_p448_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p448_cmovznz_u32(out1: &mut u32, arg1: fiat_p448_u1, arg2: u32, arg3: u32) {
   let x1: fiat_p448_u1 = (!(!arg1));
   let x2: u32 = ((((((0x0 as fiat_p448_i2) - (x1 as fiat_p448_i2)) as fiat_p448_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
@@ -130,7 +130,7 @@ pub fn fiat_p448_cmovznz_u32(out1: &mut u32, arg1: fiat_p448_u1, arg2: u32, arg3
 ///   eval out1 mod m = (eval arg1 * eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_p448_carry_mul(out1: &mut fiat_p448_tight_field_element, arg1: &fiat_p448_loose_field_element, arg2: &fiat_p448_loose_field_element) -> () {
+pub fn fiat_p448_carry_mul(out1: &mut fiat_p448_tight_field_element, arg1: &fiat_p448_loose_field_element, arg2: &fiat_p448_loose_field_element) {
   let x1: u64 = (((arg1[15]) as u64) * ((arg2[15]) as u64));
   let x2: u64 = (((arg1[15]) as u64) * ((arg2[14]) as u64));
   let x3: u64 = (((arg1[15]) as u64) * ((arg2[13]) as u64));
@@ -637,7 +637,7 @@ pub fn fiat_p448_carry_mul(out1: &mut fiat_p448_tight_field_element, arg1: &fiat
 ///   eval out1 mod m = (eval arg1 * eval arg1) mod m
 ///
 #[inline]
-pub fn fiat_p448_carry_square(out1: &mut fiat_p448_tight_field_element, arg1: &fiat_p448_loose_field_element) -> () {
+pub fn fiat_p448_carry_square(out1: &mut fiat_p448_tight_field_element, arg1: &fiat_p448_loose_field_element) {
   let x1: u32 = (arg1[15]);
   let x2: u32 = (arg1[15]);
   let x3: u32 = (x1 * 0x2);
@@ -1001,7 +1001,7 @@ pub fn fiat_p448_carry_square(out1: &mut fiat_p448_tight_field_element, arg1: &f
 ///   eval out1 mod m = eval arg1 mod m
 ///
 #[inline]
-pub fn fiat_p448_carry(out1: &mut fiat_p448_tight_field_element, arg1: &fiat_p448_loose_field_element) -> () {
+pub fn fiat_p448_carry(out1: &mut fiat_p448_tight_field_element, arg1: &fiat_p448_loose_field_element) {
   let x1: u32 = (arg1[7]);
   let x2: u32 = (arg1[15]);
   let x3: u32 = (x2 >> 28);
@@ -1064,7 +1064,7 @@ pub fn fiat_p448_carry(out1: &mut fiat_p448_tight_field_element, arg1: &fiat_p44
 ///   eval out1 mod m = (eval arg1 + eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_p448_add(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_tight_field_element, arg2: &fiat_p448_tight_field_element) -> () {
+pub fn fiat_p448_add(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_tight_field_element, arg2: &fiat_p448_tight_field_element) {
   let x1: u32 = ((arg1[0]) + (arg2[0]));
   let x2: u32 = ((arg1[1]) + (arg2[1]));
   let x3: u32 = ((arg1[2]) + (arg2[2]));
@@ -1105,7 +1105,7 @@ pub fn fiat_p448_add(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_
 ///   eval out1 mod m = (eval arg1 - eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_p448_sub(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_tight_field_element, arg2: &fiat_p448_tight_field_element) -> () {
+pub fn fiat_p448_sub(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_tight_field_element, arg2: &fiat_p448_tight_field_element) {
   let x1: u32 = ((0x1ffffffe + (arg1[0])) - (arg2[0]));
   let x2: u32 = ((0x1ffffffe + (arg1[1])) - (arg2[1]));
   let x3: u32 = ((0x1ffffffe + (arg1[2])) - (arg2[2]));
@@ -1146,7 +1146,7 @@ pub fn fiat_p448_sub(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_
 ///   eval out1 mod m = -eval arg1 mod m
 ///
 #[inline]
-pub fn fiat_p448_opp(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_tight_field_element) -> () {
+pub fn fiat_p448_opp(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_tight_field_element) {
   let x1: u32 = (0x1ffffffe - (arg1[0]));
   let x2: u32 = (0x1ffffffe - (arg1[1]));
   let x3: u32 = (0x1ffffffe - (arg1[2]));
@@ -1193,7 +1193,7 @@ pub fn fiat_p448_opp(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p448_selectznz(out1: &mut [u32; 16], arg1: fiat_p448_u1, arg2: &[u32; 16], arg3: &[u32; 16]) -> () {
+pub fn fiat_p448_selectznz(out1: &mut [u32; 16], arg1: fiat_p448_u1, arg2: &[u32; 16], arg3: &[u32; 16]) {
   let mut x1: u32 = 0;
   fiat_p448_cmovznz_u32(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u32 = 0;
@@ -1252,7 +1252,7 @@ pub fn fiat_p448_selectznz(out1: &mut [u32; 16], arg1: fiat_p448_u1, arg2: &[u32
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
 #[inline]
-pub fn fiat_p448_to_bytes(out1: &mut [u8; 56], arg1: &fiat_p448_tight_field_element) -> () {
+pub fn fiat_p448_to_bytes(out1: &mut [u8; 56], arg1: &fiat_p448_tight_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p448_u1 = 0;
   fiat_p448_subborrowx_u28(&mut x1, &mut x2, 0x0, (arg1[0]), 0xfffffff);
@@ -1529,7 +1529,7 @@ pub fn fiat_p448_to_bytes(out1: &mut [u8; 56], arg1: &fiat_p448_tight_field_elem
 /// Input Bounds:
 ///   arg1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
 #[inline]
-pub fn fiat_p448_from_bytes(out1: &mut fiat_p448_tight_field_element, arg1: &[u8; 56]) -> () {
+pub fn fiat_p448_from_bytes(out1: &mut fiat_p448_tight_field_element, arg1: &[u8; 56]) {
   let x1: u32 = (((arg1[55]) as u32) << 20);
   let x2: u32 = (((arg1[54]) as u32) << 12);
   let x3: u32 = (((arg1[53]) as u32) << 4);
@@ -1674,7 +1674,7 @@ pub fn fiat_p448_from_bytes(out1: &mut fiat_p448_tight_field_element, arg1: &[u8
 ///   out1 = arg1
 ///
 #[inline]
-pub fn fiat_p448_relax(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_tight_field_element) -> () {
+pub fn fiat_p448_relax(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_tight_field_element) {
   let x1: u32 = (arg1[0]);
   let x2: u32 = (arg1[1]);
   let x3: u32 = (arg1[2]);

--- a/fiat-rust/src/p448_solinas_64.rs
+++ b/fiat-rust/src/p448_solinas_64.rs
@@ -75,7 +75,7 @@ impl core::ops::IndexMut<usize> for fiat_p448_tight_field_element {
 ///   out1: [0x0 ~> 0xffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p448_addcarryx_u56(out1: &mut u64, out2: &mut fiat_p448_u1, arg1: fiat_p448_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p448_addcarryx_u56(out1: &mut u64, out2: &mut fiat_p448_u1, arg1: fiat_p448_u1, arg2: u64, arg3: u64) {
   let x1: u64 = (((arg1 as u64) + arg2) + arg3);
   let x2: u64 = (x1 & 0xffffffffffffff);
   let x3: fiat_p448_u1 = ((x1 >> 56) as fiat_p448_u1);
@@ -97,7 +97,7 @@ pub fn fiat_p448_addcarryx_u56(out1: &mut u64, out2: &mut fiat_p448_u1, arg1: fi
 ///   out1: [0x0 ~> 0xffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p448_subborrowx_u56(out1: &mut u64, out2: &mut fiat_p448_u1, arg1: fiat_p448_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p448_subborrowx_u56(out1: &mut u64, out2: &mut fiat_p448_u1, arg1: fiat_p448_u1, arg2: u64, arg3: u64) {
   let x1: i64 = ((((((arg2 as i128) - (arg1 as i128)) as i64) as i128) - (arg3 as i128)) as i64);
   let x2: fiat_p448_i1 = ((x1 >> 56) as fiat_p448_i1);
   let x3: u64 = (((x1 as i128) & (0xffffffffffffff as i128)) as u64);
@@ -117,7 +117,7 @@ pub fn fiat_p448_subborrowx_u56(out1: &mut u64, out2: &mut fiat_p448_u1, arg1: f
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_p448_cmovznz_u64(out1: &mut u64, arg1: fiat_p448_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p448_cmovznz_u64(out1: &mut u64, arg1: fiat_p448_u1, arg2: u64, arg3: u64) {
   let x1: fiat_p448_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_p448_i2) - (x1 as fiat_p448_i2)) as fiat_p448_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
@@ -130,7 +130,7 @@ pub fn fiat_p448_cmovznz_u64(out1: &mut u64, arg1: fiat_p448_u1, arg2: u64, arg3
 ///   eval out1 mod m = (eval arg1 * eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_p448_carry_mul(out1: &mut fiat_p448_tight_field_element, arg1: &fiat_p448_loose_field_element, arg2: &fiat_p448_loose_field_element) -> () {
+pub fn fiat_p448_carry_mul(out1: &mut fiat_p448_tight_field_element, arg1: &fiat_p448_loose_field_element, arg2: &fiat_p448_loose_field_element) {
   let x1: u128 = (((arg1[7]) as u128) * ((arg2[7]) as u128));
   let x2: u128 = (((arg1[7]) as u128) * ((arg2[6]) as u128));
   let x3: u128 = (((arg1[7]) as u128) * ((arg2[5]) as u128));
@@ -291,7 +291,7 @@ pub fn fiat_p448_carry_mul(out1: &mut fiat_p448_tight_field_element, arg1: &fiat
 ///   eval out1 mod m = (eval arg1 * eval arg1) mod m
 ///
 #[inline]
-pub fn fiat_p448_carry_square(out1: &mut fiat_p448_tight_field_element, arg1: &fiat_p448_loose_field_element) -> () {
+pub fn fiat_p448_carry_square(out1: &mut fiat_p448_tight_field_element, arg1: &fiat_p448_loose_field_element) {
   let x1: u64 = (arg1[7]);
   let x2: u64 = (arg1[7]);
   let x3: u64 = (x1 * 0x2);
@@ -431,7 +431,7 @@ pub fn fiat_p448_carry_square(out1: &mut fiat_p448_tight_field_element, arg1: &f
 ///   eval out1 mod m = eval arg1 mod m
 ///
 #[inline]
-pub fn fiat_p448_carry(out1: &mut fiat_p448_tight_field_element, arg1: &fiat_p448_loose_field_element) -> () {
+pub fn fiat_p448_carry(out1: &mut fiat_p448_tight_field_element, arg1: &fiat_p448_loose_field_element) {
   let x1: u64 = (arg1[3]);
   let x2: u64 = (arg1[7]);
   let x3: u64 = (x2 >> 56);
@@ -470,7 +470,7 @@ pub fn fiat_p448_carry(out1: &mut fiat_p448_tight_field_element, arg1: &fiat_p44
 ///   eval out1 mod m = (eval arg1 + eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_p448_add(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_tight_field_element, arg2: &fiat_p448_tight_field_element) -> () {
+pub fn fiat_p448_add(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_tight_field_element, arg2: &fiat_p448_tight_field_element) {
   let x1: u64 = ((arg1[0]) + (arg2[0]));
   let x2: u64 = ((arg1[1]) + (arg2[1]));
   let x3: u64 = ((arg1[2]) + (arg2[2]));
@@ -495,7 +495,7 @@ pub fn fiat_p448_add(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_
 ///   eval out1 mod m = (eval arg1 - eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_p448_sub(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_tight_field_element, arg2: &fiat_p448_tight_field_element) -> () {
+pub fn fiat_p448_sub(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_tight_field_element, arg2: &fiat_p448_tight_field_element) {
   let x1: u64 = ((0x1fffffffffffffe + (arg1[0])) - (arg2[0]));
   let x2: u64 = ((0x1fffffffffffffe + (arg1[1])) - (arg2[1]));
   let x3: u64 = ((0x1fffffffffffffe + (arg1[2])) - (arg2[2]));
@@ -520,7 +520,7 @@ pub fn fiat_p448_sub(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_
 ///   eval out1 mod m = -eval arg1 mod m
 ///
 #[inline]
-pub fn fiat_p448_opp(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_tight_field_element) -> () {
+pub fn fiat_p448_opp(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_tight_field_element) {
   let x1: u64 = (0x1fffffffffffffe - (arg1[0]));
   let x2: u64 = (0x1fffffffffffffe - (arg1[1]));
   let x3: u64 = (0x1fffffffffffffe - (arg1[2]));
@@ -551,7 +551,7 @@ pub fn fiat_p448_opp(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p448_selectznz(out1: &mut [u64; 8], arg1: fiat_p448_u1, arg2: &[u64; 8], arg3: &[u64; 8]) -> () {
+pub fn fiat_p448_selectznz(out1: &mut [u64; 8], arg1: fiat_p448_u1, arg2: &[u64; 8], arg3: &[u64; 8]) {
   let mut x1: u64 = 0;
   fiat_p448_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u64 = 0;
@@ -586,7 +586,7 @@ pub fn fiat_p448_selectznz(out1: &mut [u64; 8], arg1: fiat_p448_u1, arg2: &[u64;
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
 #[inline]
-pub fn fiat_p448_to_bytes(out1: &mut [u8; 56], arg1: &fiat_p448_tight_field_element) -> () {
+pub fn fiat_p448_to_bytes(out1: &mut [u8; 56], arg1: &fiat_p448_tight_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p448_u1 = 0;
   fiat_p448_subborrowx_u56(&mut x1, &mut x2, 0x0, (arg1[0]), 0xffffffffffffff);
@@ -799,7 +799,7 @@ pub fn fiat_p448_to_bytes(out1: &mut [u8; 56], arg1: &fiat_p448_tight_field_elem
 /// Input Bounds:
 ///   arg1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
 #[inline]
-pub fn fiat_p448_from_bytes(out1: &mut fiat_p448_tight_field_element, arg1: &[u8; 56]) -> () {
+pub fn fiat_p448_from_bytes(out1: &mut fiat_p448_tight_field_element, arg1: &[u8; 56]) {
   let x1: u64 = (((arg1[55]) as u64) << 48);
   let x2: u64 = (((arg1[54]) as u64) << 40);
   let x3: u64 = (((arg1[53]) as u64) << 32);
@@ -920,7 +920,7 @@ pub fn fiat_p448_from_bytes(out1: &mut fiat_p448_tight_field_element, arg1: &[u8
 ///   out1 = arg1
 ///
 #[inline]
-pub fn fiat_p448_relax(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_tight_field_element) -> () {
+pub fn fiat_p448_relax(out1: &mut fiat_p448_loose_field_element, arg1: &fiat_p448_tight_field_element) {
   let x1: u64 = (arg1[0]);
   let x2: u64 = (arg1[1]);
   let x3: u64 = (arg1[2]);

--- a/fiat-rust/src/p521_32.rs
+++ b/fiat-rust/src/p521_32.rs
@@ -75,7 +75,7 @@ impl core::ops::IndexMut<usize> for fiat_p521_tight_field_element {
 ///   out1: [0x0 ~> 0xfffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p521_addcarryx_u28(out1: &mut u32, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p521_addcarryx_u28(out1: &mut u32, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u32, arg3: u32) {
   let x1: u32 = (((arg1 as u32) + arg2) + arg3);
   let x2: u32 = (x1 & 0xfffffff);
   let x3: fiat_p521_u1 = ((x1 >> 28) as fiat_p521_u1);
@@ -97,7 +97,7 @@ pub fn fiat_p521_addcarryx_u28(out1: &mut u32, out2: &mut fiat_p521_u1, arg1: fi
 ///   out1: [0x0 ~> 0xfffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p521_subborrowx_u28(out1: &mut u32, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p521_subborrowx_u28(out1: &mut u32, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u32, arg3: u32) {
   let x1: i32 = ((((((arg2 as i64) - (arg1 as i64)) as i32) as i64) - (arg3 as i64)) as i32);
   let x2: fiat_p521_i1 = ((x1 >> 28) as fiat_p521_i1);
   let x3: u32 = (((x1 as i64) & (0xfffffff as i64)) as u32);
@@ -119,7 +119,7 @@ pub fn fiat_p521_subborrowx_u28(out1: &mut u32, out2: &mut fiat_p521_u1, arg1: f
 ///   out1: [0x0 ~> 0x7ffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p521_addcarryx_u27(out1: &mut u32, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p521_addcarryx_u27(out1: &mut u32, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u32, arg3: u32) {
   let x1: u32 = (((arg1 as u32) + arg2) + arg3);
   let x2: u32 = (x1 & 0x7ffffff);
   let x3: fiat_p521_u1 = ((x1 >> 27) as fiat_p521_u1);
@@ -141,7 +141,7 @@ pub fn fiat_p521_addcarryx_u27(out1: &mut u32, out2: &mut fiat_p521_u1, arg1: fi
 ///   out1: [0x0 ~> 0x7ffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p521_subborrowx_u27(out1: &mut u32, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p521_subborrowx_u27(out1: &mut u32, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u32, arg3: u32) {
   let x1: i32 = ((((((arg2 as i64) - (arg1 as i64)) as i32) as i64) - (arg3 as i64)) as i32);
   let x2: fiat_p521_i1 = ((x1 >> 27) as fiat_p521_i1);
   let x3: u32 = (((x1 as i64) & (0x7ffffff as i64)) as u32);
@@ -161,7 +161,7 @@ pub fn fiat_p521_subborrowx_u27(out1: &mut u32, out2: &mut fiat_p521_u1, arg1: f
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_p521_cmovznz_u32(out1: &mut u32, arg1: fiat_p521_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_p521_cmovznz_u32(out1: &mut u32, arg1: fiat_p521_u1, arg2: u32, arg3: u32) {
   let x1: fiat_p521_u1 = (!(!arg1));
   let x2: u32 = ((((((0x0 as fiat_p521_i2) - (x1 as fiat_p521_i2)) as fiat_p521_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
@@ -174,7 +174,7 @@ pub fn fiat_p521_cmovznz_u32(out1: &mut u32, arg1: fiat_p521_u1, arg2: u32, arg3
 ///   eval out1 mod m = (eval arg1 * eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_p521_carry_mul(out1: &mut fiat_p521_tight_field_element, arg1: &fiat_p521_loose_field_element, arg2: &fiat_p521_loose_field_element) -> () {
+pub fn fiat_p521_carry_mul(out1: &mut fiat_p521_tight_field_element, arg1: &fiat_p521_loose_field_element, arg2: &fiat_p521_loose_field_element) {
   let x1: u64 = (((arg1[18]) as u64) * ((arg2[18]) as u64));
   let x2: u64 = (((arg1[18]) as u64) * (((arg2[17]) * 0x2) as u64));
   let x3: u64 = (((arg1[18]) as u64) * ((arg2[16]) as u64));
@@ -645,7 +645,7 @@ pub fn fiat_p521_carry_mul(out1: &mut fiat_p521_tight_field_element, arg1: &fiat
 ///   eval out1 mod m = (eval arg1 * eval arg1) mod m
 ///
 #[inline]
-pub fn fiat_p521_carry_square(out1: &mut fiat_p521_tight_field_element, arg1: &fiat_p521_loose_field_element) -> () {
+pub fn fiat_p521_carry_square(out1: &mut fiat_p521_tight_field_element, arg1: &fiat_p521_loose_field_element) {
   let x1: u32 = (arg1[18]);
   let x2: u32 = (x1 * 0x2);
   let x3: u32 = ((arg1[18]) * 0x2);
@@ -981,7 +981,7 @@ pub fn fiat_p521_carry_square(out1: &mut fiat_p521_tight_field_element, arg1: &f
 ///   eval out1 mod m = eval arg1 mod m
 ///
 #[inline]
-pub fn fiat_p521_carry(out1: &mut fiat_p521_tight_field_element, arg1: &fiat_p521_loose_field_element) -> () {
+pub fn fiat_p521_carry(out1: &mut fiat_p521_tight_field_element, arg1: &fiat_p521_loose_field_element) {
   let x1: u32 = (arg1[0]);
   let x2: u32 = ((x1 >> 28) + (arg1[1]));
   let x3: u32 = ((x2 >> 27) + (arg1[2]));
@@ -1049,7 +1049,7 @@ pub fn fiat_p521_carry(out1: &mut fiat_p521_tight_field_element, arg1: &fiat_p52
 ///   eval out1 mod m = (eval arg1 + eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_p521_add(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_tight_field_element, arg2: &fiat_p521_tight_field_element) -> () {
+pub fn fiat_p521_add(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_tight_field_element, arg2: &fiat_p521_tight_field_element) {
   let x1: u32 = ((arg1[0]) + (arg2[0]));
   let x2: u32 = ((arg1[1]) + (arg2[1]));
   let x3: u32 = ((arg1[2]) + (arg2[2]));
@@ -1096,7 +1096,7 @@ pub fn fiat_p521_add(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_
 ///   eval out1 mod m = (eval arg1 - eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_p521_sub(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_tight_field_element, arg2: &fiat_p521_tight_field_element) -> () {
+pub fn fiat_p521_sub(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_tight_field_element, arg2: &fiat_p521_tight_field_element) {
   let x1: u32 = ((0x1ffffffe + (arg1[0])) - (arg2[0]));
   let x2: u32 = ((0xffffffe + (arg1[1])) - (arg2[1]));
   let x3: u32 = ((0x1ffffffe + (arg1[2])) - (arg2[2]));
@@ -1143,7 +1143,7 @@ pub fn fiat_p521_sub(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_
 ///   eval out1 mod m = -eval arg1 mod m
 ///
 #[inline]
-pub fn fiat_p521_opp(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_tight_field_element) -> () {
+pub fn fiat_p521_opp(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_tight_field_element) {
   let x1: u32 = (0x1ffffffe - (arg1[0]));
   let x2: u32 = (0xffffffe - (arg1[1]));
   let x3: u32 = (0x1ffffffe - (arg1[2]));
@@ -1196,7 +1196,7 @@ pub fn fiat_p521_opp(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_p521_selectznz(out1: &mut [u32; 19], arg1: fiat_p521_u1, arg2: &[u32; 19], arg3: &[u32; 19]) -> () {
+pub fn fiat_p521_selectznz(out1: &mut [u32; 19], arg1: fiat_p521_u1, arg2: &[u32; 19], arg3: &[u32; 19]) {
   let mut x1: u32 = 0;
   fiat_p521_cmovznz_u32(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u32 = 0;
@@ -1264,7 +1264,7 @@ pub fn fiat_p521_selectznz(out1: &mut [u32; 19], arg1: fiat_p521_u1, arg2: &[u32
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x1]]
 #[inline]
-pub fn fiat_p521_to_bytes(out1: &mut [u8; 66], arg1: &fiat_p521_tight_field_element) -> () {
+pub fn fiat_p521_to_bytes(out1: &mut [u8; 66], arg1: &fiat_p521_tight_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_p521_u1 = 0;
   fiat_p521_subborrowx_u28(&mut x1, &mut x2, 0x0, (arg1[0]), 0xfffffff);
@@ -1615,7 +1615,7 @@ pub fn fiat_p521_to_bytes(out1: &mut [u8; 66], arg1: &fiat_p521_tight_field_elem
 /// Input Bounds:
 ///   arg1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x1]]
 #[inline]
-pub fn fiat_p521_from_bytes(out1: &mut fiat_p521_tight_field_element, arg1: &[u8; 66]) -> () {
+pub fn fiat_p521_from_bytes(out1: &mut fiat_p521_tight_field_element, arg1: &[u8; 66]) {
   let x1: u32 = ((((arg1[65]) as fiat_p521_u1) as u32) << 26);
   let x2: u32 = (((arg1[64]) as u32) << 18);
   let x3: u32 = (((arg1[63]) as u32) << 10);
@@ -1804,7 +1804,7 @@ pub fn fiat_p521_from_bytes(out1: &mut fiat_p521_tight_field_element, arg1: &[u8
 ///   out1 = arg1
 ///
 #[inline]
-pub fn fiat_p521_relax(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_tight_field_element) -> () {
+pub fn fiat_p521_relax(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_tight_field_element) {
   let x1: u32 = (arg1[0]);
   let x2: u32 = (arg1[1]);
   let x3: u32 = (arg1[2]);

--- a/fiat-rust/src/p521_64.rs
+++ b/fiat-rust/src/p521_64.rs
@@ -75,7 +75,7 @@ impl core::ops::IndexMut<usize> for fiat_p521_tight_field_element {
 ///   out1: [0x0 ~> 0x3ffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p521_addcarryx_u58(out1: &mut u64, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p521_addcarryx_u58(out1: &mut u64, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u64, arg3: u64) {
   let x1: u64 = (((arg1 as u64) + arg2) + arg3);
   let x2: u64 = (x1 & 0x3ffffffffffffff);
   let x3: fiat_p521_u1 = ((x1 >> 58) as fiat_p521_u1);
@@ -97,7 +97,7 @@ pub fn fiat_p521_addcarryx_u58(out1: &mut u64, out2: &mut fiat_p521_u1, arg1: fi
 ///   out1: [0x0 ~> 0x3ffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p521_subborrowx_u58(out1: &mut u64, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p521_subborrowx_u58(out1: &mut u64, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u64, arg3: u64) {
   let x1: i64 = ((((((arg2 as i128) - (arg1 as i128)) as i64) as i128) - (arg3 as i128)) as i64);
   let x2: fiat_p521_i1 = ((x1 >> 58) as fiat_p521_i1);
   let x3: u64 = (((x1 as i128) & (0x3ffffffffffffff as i128)) as u64);
@@ -119,7 +119,7 @@ pub fn fiat_p521_subborrowx_u58(out1: &mut u64, out2: &mut fiat_p521_u1, arg1: f
 ///   out1: [0x0 ~> 0x1ffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p521_addcarryx_u57(out1: &mut u64, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p521_addcarryx_u57(out1: &mut u64, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u64, arg3: u64) {
   let x1: u64 = (((arg1 as u64) + arg2) + arg3);
   let x2: u64 = (x1 & 0x1ffffffffffffff);
   let x3: fiat_p521_u1 = ((x1 >> 57) as fiat_p521_u1);
@@ -141,7 +141,7 @@ pub fn fiat_p521_addcarryx_u57(out1: &mut u64, out2: &mut fiat_p521_u1, arg1: fi
 ///   out1: [0x0 ~> 0x1ffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_p521_subborrowx_u57(out1: &mut u64, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p521_subborrowx_u57(out1: &mut u64, out2: &mut fiat_p521_u1, arg1: fiat_p521_u1, arg2: u64, arg3: u64) {
   let x1: i64 = ((((((arg2 as i128) - (arg1 as i128)) as i64) as i128) - (arg3 as i128)) as i64);
   let x2: fiat_p521_i1 = ((x1 >> 57) as fiat_p521_i1);
   let x3: u64 = (((x1 as i128) & (0x1ffffffffffffff as i128)) as u64);
@@ -161,7 +161,7 @@ pub fn fiat_p521_subborrowx_u57(out1: &mut u64, out2: &mut fiat_p521_u1, arg1: f
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_p521_cmovznz_u64(out1: &mut u64, arg1: fiat_p521_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_p521_cmovznz_u64(out1: &mut u64, arg1: fiat_p521_u1, arg2: u64, arg3: u64) {
   let x1: fiat_p521_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_p521_i2) - (x1 as fiat_p521_i2)) as fiat_p521_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
@@ -174,7 +174,7 @@ pub fn fiat_p521_cmovznz_u64(out1: &mut u64, arg1: fiat_p521_u1, arg2: u64, arg3
 ///   eval out1 mod m = (eval arg1 * eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_p521_carry_mul(out1: &mut fiat_p521_tight_field_element, arg1: &fiat_p521_loose_field_element, arg2: &fiat_p521_loose_field_element) -> () {
+pub fn fiat_p521_carry_mul(out1: &mut fiat_p521_tight_field_element, arg1: &fiat_p521_loose_field_element, arg2: &fiat_p521_loose_field_element) {
   let x1: u128 = (((arg1[8]) as u128) * (((arg2[8]) * 0x2) as u128));
   let x2: u128 = (((arg1[8]) as u128) * (((arg2[7]) * 0x2) as u128));
   let x3: u128 = (((arg1[8]) as u128) * (((arg2[6]) * 0x2) as u128));
@@ -315,7 +315,7 @@ pub fn fiat_p521_carry_mul(out1: &mut fiat_p521_tight_field_element, arg1: &fiat
 ///   eval out1 mod m = (eval arg1 * eval arg1) mod m
 ///
 #[inline]
-pub fn fiat_p521_carry_square(out1: &mut fiat_p521_tight_field_element, arg1: &fiat_p521_loose_field_element) -> () {
+pub fn fiat_p521_carry_square(out1: &mut fiat_p521_tight_field_element, arg1: &fiat_p521_loose_field_element) {
   let x1: u64 = (arg1[8]);
   let x2: u64 = (x1 * 0x2);
   let x3: u64 = ((arg1[8]) * 0x2);
@@ -436,7 +436,7 @@ pub fn fiat_p521_carry_square(out1: &mut fiat_p521_tight_field_element, arg1: &f
 ///   eval out1 mod m = eval arg1 mod m
 ///
 #[inline]
-pub fn fiat_p521_carry(out1: &mut fiat_p521_tight_field_element, arg1: &fiat_p521_loose_field_element) -> () {
+pub fn fiat_p521_carry(out1: &mut fiat_p521_tight_field_element, arg1: &fiat_p521_loose_field_element) {
   let x1: u64 = (arg1[0]);
   let x2: u64 = ((x1 >> 58) + (arg1[1]));
   let x3: u64 = ((x2 >> 58) + (arg1[2]));
@@ -474,7 +474,7 @@ pub fn fiat_p521_carry(out1: &mut fiat_p521_tight_field_element, arg1: &fiat_p52
 ///   eval out1 mod m = (eval arg1 + eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_p521_add(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_tight_field_element, arg2: &fiat_p521_tight_field_element) -> () {
+pub fn fiat_p521_add(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_tight_field_element, arg2: &fiat_p521_tight_field_element) {
   let x1: u64 = ((arg1[0]) + (arg2[0]));
   let x2: u64 = ((arg1[1]) + (arg2[1]));
   let x3: u64 = ((arg1[2]) + (arg2[2]));
@@ -501,7 +501,7 @@ pub fn fiat_p521_add(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_
 ///   eval out1 mod m = (eval arg1 - eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_p521_sub(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_tight_field_element, arg2: &fiat_p521_tight_field_element) -> () {
+pub fn fiat_p521_sub(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_tight_field_element, arg2: &fiat_p521_tight_field_element) {
   let x1: u64 = ((0x7fffffffffffffe + (arg1[0])) - (arg2[0]));
   let x2: u64 = ((0x7fffffffffffffe + (arg1[1])) - (arg2[1]));
   let x3: u64 = ((0x7fffffffffffffe + (arg1[2])) - (arg2[2]));
@@ -528,7 +528,7 @@ pub fn fiat_p521_sub(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_
 ///   eval out1 mod m = -eval arg1 mod m
 ///
 #[inline]
-pub fn fiat_p521_opp(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_tight_field_element) -> () {
+pub fn fiat_p521_opp(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_tight_field_element) {
   let x1: u64 = (0x7fffffffffffffe - (arg1[0]));
   let x2: u64 = (0x7fffffffffffffe - (arg1[1]));
   let x3: u64 = (0x7fffffffffffffe - (arg1[2]));
@@ -561,7 +561,7 @@ pub fn fiat_p521_opp(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_p521_selectznz(out1: &mut [u64; 9], arg1: fiat_p521_u1, arg2: &[u64; 9], arg3: &[u64; 9]) -> () {
+pub fn fiat_p521_selectznz(out1: &mut [u64; 9], arg1: fiat_p521_u1, arg2: &[u64; 9], arg3: &[u64; 9]) {
   let mut x1: u64 = 0;
   fiat_p521_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u64 = 0;
@@ -599,7 +599,7 @@ pub fn fiat_p521_selectznz(out1: &mut [u64; 9], arg1: fiat_p521_u1, arg2: &[u64;
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x1]]
 #[inline]
-pub fn fiat_p521_to_bytes(out1: &mut [u8; 66], arg1: &fiat_p521_tight_field_element) -> () {
+pub fn fiat_p521_to_bytes(out1: &mut [u8; 66], arg1: &fiat_p521_tight_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_p521_u1 = 0;
   fiat_p521_subborrowx_u58(&mut x1, &mut x2, 0x0, (arg1[0]), 0x3ffffffffffffff);
@@ -870,7 +870,7 @@ pub fn fiat_p521_to_bytes(out1: &mut [u8; 66], arg1: &fiat_p521_tight_field_elem
 /// Input Bounds:
 ///   arg1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x1]]
 #[inline]
-pub fn fiat_p521_from_bytes(out1: &mut fiat_p521_tight_field_element, arg1: &[u8; 66]) -> () {
+pub fn fiat_p521_from_bytes(out1: &mut fiat_p521_tight_field_element, arg1: &[u8; 66]) {
   let x1: u64 = ((((arg1[65]) as fiat_p521_u1) as u64) << 56);
   let x2: u64 = (((arg1[64]) as u64) << 48);
   let x3: u64 = (((arg1[63]) as u64) << 40);
@@ -1029,7 +1029,7 @@ pub fn fiat_p521_from_bytes(out1: &mut fiat_p521_tight_field_element, arg1: &[u8
 ///   out1 = arg1
 ///
 #[inline]
-pub fn fiat_p521_relax(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_tight_field_element) -> () {
+pub fn fiat_p521_relax(out1: &mut fiat_p521_loose_field_element, arg1: &fiat_p521_tight_field_element) {
   let x1: u64 = (arg1[0]);
   let x2: u64 = (arg1[1]);
   let x3: u64 = (arg1[2]);

--- a/fiat-rust/src/poly1305_32.rs
+++ b/fiat-rust/src/poly1305_32.rs
@@ -75,7 +75,7 @@ impl core::ops::IndexMut<usize> for fiat_poly1305_tight_field_element {
 ///   out1: [0x0 ~> 0x3ffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_poly1305_addcarryx_u26(out1: &mut u32, out2: &mut fiat_poly1305_u1, arg1: fiat_poly1305_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_poly1305_addcarryx_u26(out1: &mut u32, out2: &mut fiat_poly1305_u1, arg1: fiat_poly1305_u1, arg2: u32, arg3: u32) {
   let x1: u32 = (((arg1 as u32) + arg2) + arg3);
   let x2: u32 = (x1 & 0x3ffffff);
   let x3: fiat_poly1305_u1 = ((x1 >> 26) as fiat_poly1305_u1);
@@ -97,7 +97,7 @@ pub fn fiat_poly1305_addcarryx_u26(out1: &mut u32, out2: &mut fiat_poly1305_u1, 
 ///   out1: [0x0 ~> 0x3ffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_poly1305_subborrowx_u26(out1: &mut u32, out2: &mut fiat_poly1305_u1, arg1: fiat_poly1305_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_poly1305_subborrowx_u26(out1: &mut u32, out2: &mut fiat_poly1305_u1, arg1: fiat_poly1305_u1, arg2: u32, arg3: u32) {
   let x1: i32 = ((((((arg2 as i64) - (arg1 as i64)) as i32) as i64) - (arg3 as i64)) as i32);
   let x2: fiat_poly1305_i1 = ((x1 >> 26) as fiat_poly1305_i1);
   let x3: u32 = (((x1 as i64) & (0x3ffffff as i64)) as u32);
@@ -117,7 +117,7 @@ pub fn fiat_poly1305_subborrowx_u26(out1: &mut u32, out2: &mut fiat_poly1305_u1,
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_poly1305_cmovznz_u32(out1: &mut u32, arg1: fiat_poly1305_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_poly1305_cmovznz_u32(out1: &mut u32, arg1: fiat_poly1305_u1, arg2: u32, arg3: u32) {
   let x1: fiat_poly1305_u1 = (!(!arg1));
   let x2: u32 = ((((((0x0 as fiat_poly1305_i2) - (x1 as fiat_poly1305_i2)) as fiat_poly1305_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
@@ -130,7 +130,7 @@ pub fn fiat_poly1305_cmovznz_u32(out1: &mut u32, arg1: fiat_poly1305_u1, arg2: u
 ///   eval out1 mod m = (eval arg1 * eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_poly1305_carry_mul(out1: &mut fiat_poly1305_tight_field_element, arg1: &fiat_poly1305_loose_field_element, arg2: &fiat_poly1305_loose_field_element) -> () {
+pub fn fiat_poly1305_carry_mul(out1: &mut fiat_poly1305_tight_field_element, arg1: &fiat_poly1305_loose_field_element, arg2: &fiat_poly1305_loose_field_element) {
   let x1: u64 = (((arg1[4]) as u64) * (((arg2[4]) * 0x5) as u64));
   let x2: u64 = (((arg1[4]) as u64) * (((arg2[3]) * 0x5) as u64));
   let x3: u64 = (((arg1[4]) as u64) * (((arg2[2]) * 0x5) as u64));
@@ -196,7 +196,7 @@ pub fn fiat_poly1305_carry_mul(out1: &mut fiat_poly1305_tight_field_element, arg
 ///   eval out1 mod m = (eval arg1 * eval arg1) mod m
 ///
 #[inline]
-pub fn fiat_poly1305_carry_square(out1: &mut fiat_poly1305_tight_field_element, arg1: &fiat_poly1305_loose_field_element) -> () {
+pub fn fiat_poly1305_carry_square(out1: &mut fiat_poly1305_tight_field_element, arg1: &fiat_poly1305_loose_field_element) {
   let x1: u32 = ((arg1[4]) * 0x5);
   let x2: u32 = (x1 * 0x2);
   let x3: u32 = ((arg1[4]) * 0x2);
@@ -260,7 +260,7 @@ pub fn fiat_poly1305_carry_square(out1: &mut fiat_poly1305_tight_field_element, 
 ///   eval out1 mod m = eval arg1 mod m
 ///
 #[inline]
-pub fn fiat_poly1305_carry(out1: &mut fiat_poly1305_tight_field_element, arg1: &fiat_poly1305_loose_field_element) -> () {
+pub fn fiat_poly1305_carry(out1: &mut fiat_poly1305_tight_field_element, arg1: &fiat_poly1305_loose_field_element) {
   let x1: u32 = (arg1[0]);
   let x2: u32 = ((x1 >> 26) + (arg1[1]));
   let x3: u32 = ((x2 >> 26) + (arg1[2]));
@@ -286,7 +286,7 @@ pub fn fiat_poly1305_carry(out1: &mut fiat_poly1305_tight_field_element, arg1: &
 ///   eval out1 mod m = (eval arg1 + eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_poly1305_add(out1: &mut fiat_poly1305_loose_field_element, arg1: &fiat_poly1305_tight_field_element, arg2: &fiat_poly1305_tight_field_element) -> () {
+pub fn fiat_poly1305_add(out1: &mut fiat_poly1305_loose_field_element, arg1: &fiat_poly1305_tight_field_element, arg2: &fiat_poly1305_tight_field_element) {
   let x1: u32 = ((arg1[0]) + (arg2[0]));
   let x2: u32 = ((arg1[1]) + (arg2[1]));
   let x3: u32 = ((arg1[2]) + (arg2[2]));
@@ -305,7 +305,7 @@ pub fn fiat_poly1305_add(out1: &mut fiat_poly1305_loose_field_element, arg1: &fi
 ///   eval out1 mod m = (eval arg1 - eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_poly1305_sub(out1: &mut fiat_poly1305_loose_field_element, arg1: &fiat_poly1305_tight_field_element, arg2: &fiat_poly1305_tight_field_element) -> () {
+pub fn fiat_poly1305_sub(out1: &mut fiat_poly1305_loose_field_element, arg1: &fiat_poly1305_tight_field_element, arg2: &fiat_poly1305_tight_field_element) {
   let x1: u32 = ((0x7fffff6 + (arg1[0])) - (arg2[0]));
   let x2: u32 = ((0x7fffffe + (arg1[1])) - (arg2[1]));
   let x3: u32 = ((0x7fffffe + (arg1[2])) - (arg2[2]));
@@ -324,7 +324,7 @@ pub fn fiat_poly1305_sub(out1: &mut fiat_poly1305_loose_field_element, arg1: &fi
 ///   eval out1 mod m = -eval arg1 mod m
 ///
 #[inline]
-pub fn fiat_poly1305_opp(out1: &mut fiat_poly1305_loose_field_element, arg1: &fiat_poly1305_tight_field_element) -> () {
+pub fn fiat_poly1305_opp(out1: &mut fiat_poly1305_loose_field_element, arg1: &fiat_poly1305_tight_field_element) {
   let x1: u32 = (0x7fffff6 - (arg1[0]));
   let x2: u32 = (0x7fffffe - (arg1[1]));
   let x3: u32 = (0x7fffffe - (arg1[2]));
@@ -349,7 +349,7 @@ pub fn fiat_poly1305_opp(out1: &mut fiat_poly1305_loose_field_element, arg1: &fi
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_poly1305_selectznz(out1: &mut [u32; 5], arg1: fiat_poly1305_u1, arg2: &[u32; 5], arg3: &[u32; 5]) -> () {
+pub fn fiat_poly1305_selectznz(out1: &mut [u32; 5], arg1: fiat_poly1305_u1, arg2: &[u32; 5], arg3: &[u32; 5]) {
   let mut x1: u32 = 0;
   fiat_poly1305_cmovznz_u32(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u32 = 0;
@@ -375,7 +375,7 @@ pub fn fiat_poly1305_selectznz(out1: &mut [u32; 5], arg1: fiat_poly1305_u1, arg2
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x3]]
 #[inline]
-pub fn fiat_poly1305_to_bytes(out1: &mut [u8; 17], arg1: &fiat_poly1305_tight_field_element) -> () {
+pub fn fiat_poly1305_to_bytes(out1: &mut [u8; 17], arg1: &fiat_poly1305_tight_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_poly1305_u1 = 0;
   fiat_poly1305_subborrowx_u26(&mut x1, &mut x2, 0x0, (arg1[0]), 0x3fffffb);
@@ -471,7 +471,7 @@ pub fn fiat_poly1305_to_bytes(out1: &mut [u8; 17], arg1: &fiat_poly1305_tight_fi
 /// Input Bounds:
 ///   arg1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x3]]
 #[inline]
-pub fn fiat_poly1305_from_bytes(out1: &mut fiat_poly1305_tight_field_element, arg1: &[u8; 17]) -> () {
+pub fn fiat_poly1305_from_bytes(out1: &mut fiat_poly1305_tight_field_element, arg1: &[u8; 17]) {
   let x1: u32 = (((arg1[16]) as u32) << 24);
   let x2: u32 = (((arg1[15]) as u32) << 16);
   let x3: u32 = (((arg1[14]) as u32) << 8);
@@ -523,7 +523,7 @@ pub fn fiat_poly1305_from_bytes(out1: &mut fiat_poly1305_tight_field_element, ar
 ///   out1 = arg1
 ///
 #[inline]
-pub fn fiat_poly1305_relax(out1: &mut fiat_poly1305_loose_field_element, arg1: &fiat_poly1305_tight_field_element) -> () {
+pub fn fiat_poly1305_relax(out1: &mut fiat_poly1305_loose_field_element, arg1: &fiat_poly1305_tight_field_element) {
   let x1: u32 = (arg1[0]);
   let x2: u32 = (arg1[1]);
   let x3: u32 = (arg1[2]);

--- a/fiat-rust/src/poly1305_64.rs
+++ b/fiat-rust/src/poly1305_64.rs
@@ -75,7 +75,7 @@ impl core::ops::IndexMut<usize> for fiat_poly1305_tight_field_element {
 ///   out1: [0x0 ~> 0xfffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_poly1305_addcarryx_u44(out1: &mut u64, out2: &mut fiat_poly1305_u1, arg1: fiat_poly1305_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_poly1305_addcarryx_u44(out1: &mut u64, out2: &mut fiat_poly1305_u1, arg1: fiat_poly1305_u1, arg2: u64, arg3: u64) {
   let x1: u64 = (((arg1 as u64) + arg2) + arg3);
   let x2: u64 = (x1 & 0xfffffffffff);
   let x3: fiat_poly1305_u1 = ((x1 >> 44) as fiat_poly1305_u1);
@@ -97,7 +97,7 @@ pub fn fiat_poly1305_addcarryx_u44(out1: &mut u64, out2: &mut fiat_poly1305_u1, 
 ///   out1: [0x0 ~> 0xfffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_poly1305_subborrowx_u44(out1: &mut u64, out2: &mut fiat_poly1305_u1, arg1: fiat_poly1305_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_poly1305_subborrowx_u44(out1: &mut u64, out2: &mut fiat_poly1305_u1, arg1: fiat_poly1305_u1, arg2: u64, arg3: u64) {
   let x1: i64 = ((((((arg2 as i128) - (arg1 as i128)) as i64) as i128) - (arg3 as i128)) as i64);
   let x2: fiat_poly1305_i1 = ((x1 >> 44) as fiat_poly1305_i1);
   let x3: u64 = (((x1 as i128) & (0xfffffffffff as i128)) as u64);
@@ -119,7 +119,7 @@ pub fn fiat_poly1305_subborrowx_u44(out1: &mut u64, out2: &mut fiat_poly1305_u1,
 ///   out1: [0x0 ~> 0x7ffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_poly1305_addcarryx_u43(out1: &mut u64, out2: &mut fiat_poly1305_u1, arg1: fiat_poly1305_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_poly1305_addcarryx_u43(out1: &mut u64, out2: &mut fiat_poly1305_u1, arg1: fiat_poly1305_u1, arg2: u64, arg3: u64) {
   let x1: u64 = (((arg1 as u64) + arg2) + arg3);
   let x2: u64 = (x1 & 0x7ffffffffff);
   let x3: fiat_poly1305_u1 = ((x1 >> 43) as fiat_poly1305_u1);
@@ -141,7 +141,7 @@ pub fn fiat_poly1305_addcarryx_u43(out1: &mut u64, out2: &mut fiat_poly1305_u1, 
 ///   out1: [0x0 ~> 0x7ffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_poly1305_subborrowx_u43(out1: &mut u64, out2: &mut fiat_poly1305_u1, arg1: fiat_poly1305_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_poly1305_subborrowx_u43(out1: &mut u64, out2: &mut fiat_poly1305_u1, arg1: fiat_poly1305_u1, arg2: u64, arg3: u64) {
   let x1: i64 = ((((((arg2 as i128) - (arg1 as i128)) as i64) as i128) - (arg3 as i128)) as i64);
   let x2: fiat_poly1305_i1 = ((x1 >> 43) as fiat_poly1305_i1);
   let x3: u64 = (((x1 as i128) & (0x7ffffffffff as i128)) as u64);
@@ -161,7 +161,7 @@ pub fn fiat_poly1305_subborrowx_u43(out1: &mut u64, out2: &mut fiat_poly1305_u1,
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_poly1305_cmovznz_u64(out1: &mut u64, arg1: fiat_poly1305_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_poly1305_cmovznz_u64(out1: &mut u64, arg1: fiat_poly1305_u1, arg2: u64, arg3: u64) {
   let x1: fiat_poly1305_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_poly1305_i2) - (x1 as fiat_poly1305_i2)) as fiat_poly1305_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
@@ -174,7 +174,7 @@ pub fn fiat_poly1305_cmovznz_u64(out1: &mut u64, arg1: fiat_poly1305_u1, arg2: u
 ///   eval out1 mod m = (eval arg1 * eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_poly1305_carry_mul(out1: &mut fiat_poly1305_tight_field_element, arg1: &fiat_poly1305_loose_field_element, arg2: &fiat_poly1305_loose_field_element) -> () {
+pub fn fiat_poly1305_carry_mul(out1: &mut fiat_poly1305_tight_field_element, arg1: &fiat_poly1305_loose_field_element, arg2: &fiat_poly1305_loose_field_element) {
   let x1: u128 = (((arg1[2]) as u128) * (((arg2[2]) * 0x5) as u128));
   let x2: u128 = (((arg1[2]) as u128) * (((arg2[1]) * 0xa) as u128));
   let x3: u128 = (((arg1[1]) as u128) * (((arg2[2]) * 0xa) as u128));
@@ -214,7 +214,7 @@ pub fn fiat_poly1305_carry_mul(out1: &mut fiat_poly1305_tight_field_element, arg
 ///   eval out1 mod m = (eval arg1 * eval arg1) mod m
 ///
 #[inline]
-pub fn fiat_poly1305_carry_square(out1: &mut fiat_poly1305_tight_field_element, arg1: &fiat_poly1305_loose_field_element) -> () {
+pub fn fiat_poly1305_carry_square(out1: &mut fiat_poly1305_tight_field_element, arg1: &fiat_poly1305_loose_field_element) {
   let x1: u64 = ((arg1[2]) * 0x5);
   let x2: u64 = (x1 * 0x2);
   let x3: u64 = ((arg1[2]) * 0x2);
@@ -255,7 +255,7 @@ pub fn fiat_poly1305_carry_square(out1: &mut fiat_poly1305_tight_field_element, 
 ///   eval out1 mod m = eval arg1 mod m
 ///
 #[inline]
-pub fn fiat_poly1305_carry(out1: &mut fiat_poly1305_tight_field_element, arg1: &fiat_poly1305_loose_field_element) -> () {
+pub fn fiat_poly1305_carry(out1: &mut fiat_poly1305_tight_field_element, arg1: &fiat_poly1305_loose_field_element) {
   let x1: u64 = (arg1[0]);
   let x2: u64 = ((x1 >> 44) + (arg1[1]));
   let x3: u64 = ((x2 >> 43) + (arg1[2]));
@@ -275,7 +275,7 @@ pub fn fiat_poly1305_carry(out1: &mut fiat_poly1305_tight_field_element, arg1: &
 ///   eval out1 mod m = (eval arg1 + eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_poly1305_add(out1: &mut fiat_poly1305_loose_field_element, arg1: &fiat_poly1305_tight_field_element, arg2: &fiat_poly1305_tight_field_element) -> () {
+pub fn fiat_poly1305_add(out1: &mut fiat_poly1305_loose_field_element, arg1: &fiat_poly1305_tight_field_element, arg2: &fiat_poly1305_tight_field_element) {
   let x1: u64 = ((arg1[0]) + (arg2[0]));
   let x2: u64 = ((arg1[1]) + (arg2[1]));
   let x3: u64 = ((arg1[2]) + (arg2[2]));
@@ -290,7 +290,7 @@ pub fn fiat_poly1305_add(out1: &mut fiat_poly1305_loose_field_element, arg1: &fi
 ///   eval out1 mod m = (eval arg1 - eval arg2) mod m
 ///
 #[inline]
-pub fn fiat_poly1305_sub(out1: &mut fiat_poly1305_loose_field_element, arg1: &fiat_poly1305_tight_field_element, arg2: &fiat_poly1305_tight_field_element) -> () {
+pub fn fiat_poly1305_sub(out1: &mut fiat_poly1305_loose_field_element, arg1: &fiat_poly1305_tight_field_element, arg2: &fiat_poly1305_tight_field_element) {
   let x1: u64 = ((0x1ffffffffff6 + (arg1[0])) - (arg2[0]));
   let x2: u64 = ((0xffffffffffe + (arg1[1])) - (arg2[1]));
   let x3: u64 = ((0xffffffffffe + (arg1[2])) - (arg2[2]));
@@ -305,7 +305,7 @@ pub fn fiat_poly1305_sub(out1: &mut fiat_poly1305_loose_field_element, arg1: &fi
 ///   eval out1 mod m = -eval arg1 mod m
 ///
 #[inline]
-pub fn fiat_poly1305_opp(out1: &mut fiat_poly1305_loose_field_element, arg1: &fiat_poly1305_tight_field_element) -> () {
+pub fn fiat_poly1305_opp(out1: &mut fiat_poly1305_loose_field_element, arg1: &fiat_poly1305_tight_field_element) {
   let x1: u64 = (0x1ffffffffff6 - (arg1[0]));
   let x2: u64 = (0xffffffffffe - (arg1[1]));
   let x3: u64 = (0xffffffffffe - (arg1[2]));
@@ -326,7 +326,7 @@ pub fn fiat_poly1305_opp(out1: &mut fiat_poly1305_loose_field_element, arg1: &fi
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_poly1305_selectznz(out1: &mut [u64; 3], arg1: fiat_poly1305_u1, arg2: &[u64; 3], arg3: &[u64; 3]) -> () {
+pub fn fiat_poly1305_selectznz(out1: &mut [u64; 3], arg1: fiat_poly1305_u1, arg2: &[u64; 3], arg3: &[u64; 3]) {
   let mut x1: u64 = 0;
   fiat_poly1305_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u64 = 0;
@@ -346,7 +346,7 @@ pub fn fiat_poly1305_selectznz(out1: &mut [u64; 3], arg1: fiat_poly1305_u1, arg2
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x3]]
 #[inline]
-pub fn fiat_poly1305_to_bytes(out1: &mut [u8; 17], arg1: &fiat_poly1305_tight_field_element) -> () {
+pub fn fiat_poly1305_to_bytes(out1: &mut [u8; 17], arg1: &fiat_poly1305_tight_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_poly1305_u1 = 0;
   fiat_poly1305_subborrowx_u44(&mut x1, &mut x2, 0x0, (arg1[0]), 0xffffffffffb);
@@ -430,7 +430,7 @@ pub fn fiat_poly1305_to_bytes(out1: &mut [u8; 17], arg1: &fiat_poly1305_tight_fi
 /// Input Bounds:
 ///   arg1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0x3]]
 #[inline]
-pub fn fiat_poly1305_from_bytes(out1: &mut fiat_poly1305_tight_field_element, arg1: &[u8; 17]) -> () {
+pub fn fiat_poly1305_from_bytes(out1: &mut fiat_poly1305_tight_field_element, arg1: &[u8; 17]) {
   let x1: u64 = (((arg1[16]) as u64) << 41);
   let x2: u64 = (((arg1[15]) as u64) << 33);
   let x3: u64 = (((arg1[14]) as u64) << 25);
@@ -479,7 +479,7 @@ pub fn fiat_poly1305_from_bytes(out1: &mut fiat_poly1305_tight_field_element, ar
 ///   out1 = arg1
 ///
 #[inline]
-pub fn fiat_poly1305_relax(out1: &mut fiat_poly1305_loose_field_element, arg1: &fiat_poly1305_tight_field_element) -> () {
+pub fn fiat_poly1305_relax(out1: &mut fiat_poly1305_loose_field_element, arg1: &fiat_poly1305_tight_field_element) {
   let x1: u64 = (arg1[0]);
   let x2: u64 = (arg1[1]);
   let x3: u64 = (arg1[2]);

--- a/fiat-rust/src/secp256k1_dettman_32.rs
+++ b/fiat-rust/src/secp256k1_dettman_32.rs
@@ -28,7 +28,7 @@
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x5fffff]]
 #[inline]
-pub fn fiat_secp256k1_dettman_mul(out1: &mut [u32; 10], arg1: &[u32; 10], arg2: &[u32; 10]) -> () {
+pub fn fiat_secp256k1_dettman_mul(out1: &mut [u32; 10], arg1: &[u32; 10], arg2: &[u32; 10]) {
   let x1: u64 = ((((arg1[8]) as u64) * ((arg2[9]) as u64)) + (((arg1[9]) as u64) * ((arg2[8]) as u64)));
   let x2: u32 = ((x1 >> 26) as u32);
   let x3: u32 = ((x1 & (0x3ffffff as u64)) as u32);
@@ -117,7 +117,7 @@ pub fn fiat_secp256k1_dettman_mul(out1: &mut [u32; 10], arg1: &[u32; 10], arg2: 
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x5fffff]]
 #[inline]
-pub fn fiat_secp256k1_dettman_square(out1: &mut [u32; 10], arg1: &[u32; 10]) -> () {
+pub fn fiat_secp256k1_dettman_square(out1: &mut [u32; 10], arg1: &[u32; 10]) {
   let x1: u32 = ((arg1[8]) * 0x2);
   let x2: u32 = ((arg1[7]) * 0x2);
   let x3: u32 = ((arg1[6]) * 0x2);

--- a/fiat-rust/src/secp256k1_dettman_64.rs
+++ b/fiat-rust/src/secp256k1_dettman_64.rs
@@ -28,7 +28,7 @@
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0x1ffffffffffffe], [0x0 ~> 0x1ffffffffffffe], [0x0 ~> 0x1ffffffffffffe], [0x0 ~> 0x1ffffffffffffe], [0x0 ~> 0x17fffffffffff]]
 #[inline]
-pub fn fiat_secp256k1_dettman_mul(out1: &mut [u64; 5], arg1: &[u64; 5], arg2: &[u64; 5]) -> () {
+pub fn fiat_secp256k1_dettman_mul(out1: &mut [u64; 5], arg1: &[u64; 5], arg2: &[u64; 5]) {
   let x1: u128 = (((arg1[4]) as u128) * ((arg2[4]) as u128));
   let x2: u64 = ((x1 >> 64) as u64);
   let x3: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
@@ -79,7 +79,7 @@ pub fn fiat_secp256k1_dettman_mul(out1: &mut [u64; 5], arg1: &[u64; 5], arg2: &[
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0x1ffffffffffffe], [0x0 ~> 0x1ffffffffffffe], [0x0 ~> 0x1ffffffffffffe], [0x0 ~> 0x1ffffffffffffe], [0x0 ~> 0x17fffffffffff]]
 #[inline]
-pub fn fiat_secp256k1_dettman_square(out1: &mut [u64; 5], arg1: &[u64; 5]) -> () {
+pub fn fiat_secp256k1_dettman_square(out1: &mut [u64; 5], arg1: &[u64; 5]) {
   let x1: u64 = ((arg1[3]) * 0x2);
   let x2: u64 = ((arg1[2]) * 0x2);
   let x3: u64 = ((arg1[1]) * 0x2);

--- a/fiat-rust/src/secp256k1_montgomery_32.rs
+++ b/fiat-rust/src/secp256k1_montgomery_32.rs
@@ -80,7 +80,7 @@ impl core::ops::IndexMut<usize> for fiat_secp256k1_montgomery_non_montgomery_dom
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_secp256k1_montgomery_addcarryx_u32(out1: &mut u32, out2: &mut fiat_secp256k1_montgomery_u1, arg1: fiat_secp256k1_montgomery_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_secp256k1_montgomery_addcarryx_u32(out1: &mut u32, out2: &mut fiat_secp256k1_montgomery_u1, arg1: fiat_secp256k1_montgomery_u1, arg2: u32, arg3: u32) {
   let x1: u64 = (((arg1 as u64) + (arg2 as u64)) + (arg3 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
   let x3: fiat_secp256k1_montgomery_u1 = ((x1 >> 32) as fiat_secp256k1_montgomery_u1);
@@ -102,7 +102,7 @@ pub fn fiat_secp256k1_montgomery_addcarryx_u32(out1: &mut u32, out2: &mut fiat_s
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_secp256k1_montgomery_subborrowx_u32(out1: &mut u32, out2: &mut fiat_secp256k1_montgomery_u1, arg1: fiat_secp256k1_montgomery_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_secp256k1_montgomery_subborrowx_u32(out1: &mut u32, out2: &mut fiat_secp256k1_montgomery_u1, arg1: fiat_secp256k1_montgomery_u1, arg2: u32, arg3: u32) {
   let x1: i64 = (((arg2 as i64) - (arg1 as i64)) - (arg3 as i64));
   let x2: fiat_secp256k1_montgomery_i1 = ((x1 >> 32) as fiat_secp256k1_montgomery_i1);
   let x3: u32 = ((x1 & (0xffffffff as i64)) as u32);
@@ -123,7 +123,7 @@ pub fn fiat_secp256k1_montgomery_subborrowx_u32(out1: &mut u32, out2: &mut fiat_
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_secp256k1_montgomery_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) -> () {
+pub fn fiat_secp256k1_montgomery_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) {
   let x1: u64 = ((arg1 as u64) * (arg2 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
   let x3: u32 = ((x1 >> 32) as u32);
@@ -143,7 +143,7 @@ pub fn fiat_secp256k1_montgomery_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: 
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_secp256k1_montgomery_cmovznz_u32(out1: &mut u32, arg1: fiat_secp256k1_montgomery_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_secp256k1_montgomery_cmovznz_u32(out1: &mut u32, arg1: fiat_secp256k1_montgomery_u1, arg2: u32, arg3: u32) {
   let x1: fiat_secp256k1_montgomery_u1 = (!(!arg1));
   let x2: u32 = ((((((0x0 as fiat_secp256k1_montgomery_i2) - (x1 as fiat_secp256k1_montgomery_i2)) as fiat_secp256k1_montgomery_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
@@ -160,7 +160,7 @@ pub fn fiat_secp256k1_montgomery_cmovznz_u32(out1: &mut u32, arg1: fiat_secp256k
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_mul(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_mul(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -1403,7 +1403,7 @@ pub fn fiat_secp256k1_montgomery_mul(out1: &mut fiat_secp256k1_montgomery_montgo
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_square(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_square(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -2647,7 +2647,7 @@ pub fn fiat_secp256k1_montgomery_square(out1: &mut fiat_secp256k1_montgomery_mon
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_add(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_add(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_secp256k1_montgomery_u1 = 0;
   fiat_secp256k1_montgomery_addcarryx_u32(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -2735,7 +2735,7 @@ pub fn fiat_secp256k1_montgomery_add(out1: &mut fiat_secp256k1_montgomery_montgo
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_sub(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_sub(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_secp256k1_montgomery_u1 = 0;
   fiat_secp256k1_montgomery_subborrowx_u32(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -2805,7 +2805,7 @@ pub fn fiat_secp256k1_montgomery_sub(out1: &mut fiat_secp256k1_montgomery_montgo
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_opp(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_opp(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_secp256k1_montgomery_u1 = 0;
   fiat_secp256k1_montgomery_subborrowx_u32(&mut x1, &mut x2, 0x0, (0x0 as u32), (arg1[0]));
@@ -2875,7 +2875,7 @@ pub fn fiat_secp256k1_montgomery_opp(out1: &mut fiat_secp256k1_montgomery_montgo
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_from_montgomery(out1: &mut fiat_secp256k1_montgomery_non_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_from_montgomery(out1: &mut fiat_secp256k1_montgomery_non_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element) {
   let x1: u32 = (arg1[0]);
   let mut x2: u32 = 0;
   let mut x3: u32 = 0;
@@ -3707,7 +3707,7 @@ pub fn fiat_secp256k1_montgomery_from_montgomery(out1: &mut fiat_secp256k1_montg
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_to_montgomery(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_non_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_to_montgomery(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_non_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -4645,7 +4645,7 @@ pub fn fiat_secp256k1_montgomery_to_montgomery(out1: &mut fiat_secp256k1_montgom
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_secp256k1_montgomery_nonzero(out1: &mut u32, arg1: &[u32; 8]) -> () {
+pub fn fiat_secp256k1_montgomery_nonzero(out1: &mut u32, arg1: &[u32; 8]) {
   let x1: u32 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | ((arg1[3]) | ((arg1[4]) | ((arg1[5]) | ((arg1[6]) | (arg1[7]))))))));
   *out1 = x1;
 }
@@ -4662,7 +4662,7 @@ pub fn fiat_secp256k1_montgomery_nonzero(out1: &mut u32, arg1: &[u32; 8]) -> () 
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_selectznz(out1: &mut [u32; 8], arg1: fiat_secp256k1_montgomery_u1, arg2: &[u32; 8], arg3: &[u32; 8]) -> () {
+pub fn fiat_secp256k1_montgomery_selectznz(out1: &mut [u32; 8], arg1: fiat_secp256k1_montgomery_u1, arg2: &[u32; 8], arg3: &[u32; 8]) {
   let mut x1: u32 = 0;
   fiat_secp256k1_montgomery_cmovznz_u32(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u32 = 0;
@@ -4701,7 +4701,7 @@ pub fn fiat_secp256k1_montgomery_selectznz(out1: &mut [u32; 8], arg1: fiat_secp2
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_to_bytes(out1: &mut [u8; 32], arg1: &[u32; 8]) -> () {
+pub fn fiat_secp256k1_montgomery_to_bytes(out1: &mut [u8; 32], arg1: &[u32; 8]) {
   let x1: u32 = (arg1[7]);
   let x2: u32 = (arg1[6]);
   let x3: u32 = (arg1[5]);
@@ -4805,7 +4805,7 @@ pub fn fiat_secp256k1_montgomery_to_bytes(out1: &mut [u8; 32], arg1: &[u32; 8]) 
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_from_bytes(out1: &mut [u32; 8], arg1: &[u8; 32]) -> () {
+pub fn fiat_secp256k1_montgomery_from_bytes(out1: &mut [u32; 8], arg1: &[u8; 32]) {
   let x1: u32 = (((arg1[31]) as u32) << 24);
   let x2: u32 = (((arg1[30]) as u32) << 16);
   let x3: u32 = (((arg1[29]) as u32) << 8);
@@ -4879,7 +4879,7 @@ pub fn fiat_secp256k1_montgomery_from_bytes(out1: &mut [u32; 8], arg1: &[u8; 32]
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_set_one(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_set_one(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element) {
   out1[0] = 0x3d1;
   out1[1] = (0x1 as u32);
   out1[2] = (0x0 as u32);
@@ -4899,7 +4899,7 @@ pub fn fiat_secp256k1_montgomery_set_one(out1: &mut fiat_secp256k1_montgomery_mo
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_msat(out1: &mut [u32; 9]) -> () {
+pub fn fiat_secp256k1_montgomery_msat(out1: &mut [u32; 9]) {
   out1[0] = 0xfffffc2f;
   out1[1] = 0xfffffffe;
   out1[2] = 0xffffffff;
@@ -4940,7 +4940,7 @@ pub fn fiat_secp256k1_montgomery_msat(out1: &mut [u32; 9]) -> () {
 ///   out4: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 ///   out5: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_divstep(out1: &mut u32, out2: &mut [u32; 9], out3: &mut [u32; 9], out4: &mut [u32; 8], out5: &mut [u32; 8], arg1: u32, arg2: &[u32; 9], arg3: &[u32; 9], arg4: &[u32; 8], arg5: &[u32; 8]) -> () {
+pub fn fiat_secp256k1_montgomery_divstep(out1: &mut u32, out2: &mut [u32; 9], out3: &mut [u32; 9], out4: &mut [u32; 8], out5: &mut [u32; 8], arg1: u32, arg2: &[u32; 9], arg3: &[u32; 9], arg4: &[u32; 8], arg5: &[u32; 8]) {
   let mut x1: u32 = 0;
   let mut x2: fiat_secp256k1_montgomery_u1 = 0;
   fiat_secp256k1_montgomery_addcarryx_u32(&mut x1, &mut x2, 0x0, (!arg1), (0x1 as u32));
@@ -5357,7 +5357,7 @@ pub fn fiat_secp256k1_montgomery_divstep(out1: &mut u32, out2: &mut [u32; 9], ou
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_divstep_precomp(out1: &mut [u32; 8]) -> () {
+pub fn fiat_secp256k1_montgomery_divstep_precomp(out1: &mut [u32; 8]) {
   out1[0] = 0x31525e0a;
   out1[1] = 0xf201a418;
   out1[2] = 0xcd648d85;

--- a/fiat-rust/src/secp256k1_montgomery_64.rs
+++ b/fiat-rust/src/secp256k1_montgomery_64.rs
@@ -80,7 +80,7 @@ impl core::ops::IndexMut<usize> for fiat_secp256k1_montgomery_non_montgomery_dom
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_secp256k1_montgomery_addcarryx_u64(out1: &mut u64, out2: &mut fiat_secp256k1_montgomery_u1, arg1: fiat_secp256k1_montgomery_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_secp256k1_montgomery_addcarryx_u64(out1: &mut u64, out2: &mut fiat_secp256k1_montgomery_u1, arg1: fiat_secp256k1_montgomery_u1, arg2: u64, arg3: u64) {
   let x1: u128 = (((arg1 as u128) + (arg2 as u128)) + (arg3 as u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
   let x3: fiat_secp256k1_montgomery_u1 = ((x1 >> 64) as fiat_secp256k1_montgomery_u1);
@@ -102,7 +102,7 @@ pub fn fiat_secp256k1_montgomery_addcarryx_u64(out1: &mut u64, out2: &mut fiat_s
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_secp256k1_montgomery_subborrowx_u64(out1: &mut u64, out2: &mut fiat_secp256k1_montgomery_u1, arg1: fiat_secp256k1_montgomery_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_secp256k1_montgomery_subborrowx_u64(out1: &mut u64, out2: &mut fiat_secp256k1_montgomery_u1, arg1: fiat_secp256k1_montgomery_u1, arg2: u64, arg3: u64) {
   let x1: i128 = (((arg2 as i128) - (arg1 as i128)) - (arg3 as i128));
   let x2: fiat_secp256k1_montgomery_i1 = ((x1 >> 64) as fiat_secp256k1_montgomery_i1);
   let x3: u64 = ((x1 & (0xffffffffffffffff as i128)) as u64);
@@ -123,7 +123,7 @@ pub fn fiat_secp256k1_montgomery_subborrowx_u64(out1: &mut u64, out2: &mut fiat_
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_secp256k1_montgomery_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) -> () {
+pub fn fiat_secp256k1_montgomery_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) {
   let x1: u128 = ((arg1 as u128) * (arg2 as u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
   let x3: u64 = ((x1 >> 64) as u64);
@@ -143,7 +143,7 @@ pub fn fiat_secp256k1_montgomery_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: 
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_secp256k1_montgomery_cmovznz_u64(out1: &mut u64, arg1: fiat_secp256k1_montgomery_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_secp256k1_montgomery_cmovznz_u64(out1: &mut u64, arg1: fiat_secp256k1_montgomery_u1, arg2: u64, arg3: u64) {
   let x1: fiat_secp256k1_montgomery_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_secp256k1_montgomery_i2) - (x1 as fiat_secp256k1_montgomery_i2)) as fiat_secp256k1_montgomery_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
@@ -160,7 +160,7 @@ pub fn fiat_secp256k1_montgomery_cmovznz_u64(out1: &mut u64, arg1: fiat_secp256k
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_mul(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_mul(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -499,7 +499,7 @@ pub fn fiat_secp256k1_montgomery_mul(out1: &mut fiat_secp256k1_montgomery_montgo
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_square(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_square(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -839,7 +839,7 @@ pub fn fiat_secp256k1_montgomery_square(out1: &mut fiat_secp256k1_montgomery_mon
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_add(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_add(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_secp256k1_montgomery_u1 = 0;
   fiat_secp256k1_montgomery_addcarryx_u64(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -891,7 +891,7 @@ pub fn fiat_secp256k1_montgomery_add(out1: &mut fiat_secp256k1_montgomery_montgo
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_sub(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_sub(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_secp256k1_montgomery_u1 = 0;
   fiat_secp256k1_montgomery_subborrowx_u64(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -933,7 +933,7 @@ pub fn fiat_secp256k1_montgomery_sub(out1: &mut fiat_secp256k1_montgomery_montgo
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_opp(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_opp(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_secp256k1_montgomery_u1 = 0;
   fiat_secp256k1_montgomery_subborrowx_u64(&mut x1, &mut x2, 0x0, (0x0 as u64), (arg1[0]));
@@ -975,7 +975,7 @@ pub fn fiat_secp256k1_montgomery_opp(out1: &mut fiat_secp256k1_montgomery_montgo
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_from_montgomery(out1: &mut fiat_secp256k1_montgomery_non_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_from_montgomery(out1: &mut fiat_secp256k1_montgomery_non_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_montgomery_domain_field_element) {
   let x1: u64 = (arg1[0]);
   let mut x2: u64 = 0;
   let mut x3: u64 = 0;
@@ -1207,7 +1207,7 @@ pub fn fiat_secp256k1_montgomery_from_montgomery(out1: &mut fiat_secp256k1_montg
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_to_montgomery(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_non_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_to_montgomery(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_non_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -1469,7 +1469,7 @@ pub fn fiat_secp256k1_montgomery_to_montgomery(out1: &mut fiat_secp256k1_montgom
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_secp256k1_montgomery_nonzero(out1: &mut u64, arg1: &[u64; 4]) -> () {
+pub fn fiat_secp256k1_montgomery_nonzero(out1: &mut u64, arg1: &[u64; 4]) {
   let x1: u64 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | (arg1[3]))));
   *out1 = x1;
 }
@@ -1486,7 +1486,7 @@ pub fn fiat_secp256k1_montgomery_nonzero(out1: &mut u64, arg1: &[u64; 4]) -> () 
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_selectznz(out1: &mut [u64; 4], arg1: fiat_secp256k1_montgomery_u1, arg2: &[u64; 4], arg3: &[u64; 4]) -> () {
+pub fn fiat_secp256k1_montgomery_selectznz(out1: &mut [u64; 4], arg1: fiat_secp256k1_montgomery_u1, arg2: &[u64; 4], arg3: &[u64; 4]) {
   let mut x1: u64 = 0;
   fiat_secp256k1_montgomery_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u64 = 0;
@@ -1513,7 +1513,7 @@ pub fn fiat_secp256k1_montgomery_selectznz(out1: &mut [u64; 4], arg1: fiat_secp2
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 4]) -> () {
+pub fn fiat_secp256k1_montgomery_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 4]) {
   let x1: u64 = (arg1[3]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[1]);
@@ -1621,7 +1621,7 @@ pub fn fiat_secp256k1_montgomery_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 4]) 
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_from_bytes(out1: &mut [u64; 4], arg1: &[u8; 32]) -> () {
+pub fn fiat_secp256k1_montgomery_from_bytes(out1: &mut [u64; 4], arg1: &[u8; 32]) {
   let x1: u64 = (((arg1[31]) as u64) << 56);
   let x2: u64 = (((arg1[30]) as u64) << 48);
   let x3: u64 = (((arg1[29]) as u64) << 40);
@@ -1695,7 +1695,7 @@ pub fn fiat_secp256k1_montgomery_from_bytes(out1: &mut [u64; 4], arg1: &[u8; 32]
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_set_one(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_set_one(out1: &mut fiat_secp256k1_montgomery_montgomery_domain_field_element) {
   out1[0] = 0x1000003d1;
   out1[1] = (0x0 as u64);
   out1[2] = (0x0 as u64);
@@ -1711,7 +1711,7 @@ pub fn fiat_secp256k1_montgomery_set_one(out1: &mut fiat_secp256k1_montgomery_mo
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_msat(out1: &mut [u64; 5]) -> () {
+pub fn fiat_secp256k1_montgomery_msat(out1: &mut [u64; 5]) {
   out1[0] = 0xfffffffefffffc2f;
   out1[1] = 0xffffffffffffffff;
   out1[2] = 0xffffffffffffffff;
@@ -1748,7 +1748,7 @@ pub fn fiat_secp256k1_montgomery_msat(out1: &mut [u64; 5]) -> () {
 ///   out4: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 ///   out5: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_divstep(out1: &mut u64, out2: &mut [u64; 5], out3: &mut [u64; 5], out4: &mut [u64; 4], out5: &mut [u64; 4], arg1: u64, arg2: &[u64; 5], arg3: &[u64; 5], arg4: &[u64; 4], arg5: &[u64; 4]) -> () {
+pub fn fiat_secp256k1_montgomery_divstep(out1: &mut u64, out2: &mut [u64; 5], out3: &mut [u64; 5], out4: &mut [u64; 4], out5: &mut [u64; 4], arg1: u64, arg2: &[u64; 5], arg3: &[u64; 5], arg4: &[u64; 4], arg5: &[u64; 4]) {
   let mut x1: u64 = 0;
   let mut x2: fiat_secp256k1_montgomery_u1 = 0;
   fiat_secp256k1_montgomery_addcarryx_u64(&mut x1, &mut x2, 0x0, (!arg1), (0x1 as u64));
@@ -1981,7 +1981,7 @@ pub fn fiat_secp256k1_montgomery_divstep(out1: &mut u64, out2: &mut [u64; 5], ou
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_divstep_precomp(out1: &mut [u64; 4]) -> () {
+pub fn fiat_secp256k1_montgomery_divstep_precomp(out1: &mut [u64; 4]) {
   out1[0] = 0xf201a41831525e0a;
   out1[1] = 0x9953f9ddcd648d85;
   out1[2] = 0xe86029463db210a9;

--- a/fiat-rust/src/secp256k1_montgomery_scalar_32.rs
+++ b/fiat-rust/src/secp256k1_montgomery_scalar_32.rs
@@ -80,7 +80,7 @@ impl core::ops::IndexMut<usize> for fiat_secp256k1_montgomery_scalar_non_montgom
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_addcarryx_u32(out1: &mut u32, out2: &mut fiat_secp256k1_montgomery_scalar_u1, arg1: fiat_secp256k1_montgomery_scalar_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_addcarryx_u32(out1: &mut u32, out2: &mut fiat_secp256k1_montgomery_scalar_u1, arg1: fiat_secp256k1_montgomery_scalar_u1, arg2: u32, arg3: u32) {
   let x1: u64 = (((arg1 as u64) + (arg2 as u64)) + (arg3 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
   let x3: fiat_secp256k1_montgomery_scalar_u1 = ((x1 >> 32) as fiat_secp256k1_montgomery_scalar_u1);
@@ -102,7 +102,7 @@ pub fn fiat_secp256k1_montgomery_scalar_addcarryx_u32(out1: &mut u32, out2: &mut
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_subborrowx_u32(out1: &mut u32, out2: &mut fiat_secp256k1_montgomery_scalar_u1, arg1: fiat_secp256k1_montgomery_scalar_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_subborrowx_u32(out1: &mut u32, out2: &mut fiat_secp256k1_montgomery_scalar_u1, arg1: fiat_secp256k1_montgomery_scalar_u1, arg2: u32, arg3: u32) {
   let x1: i64 = (((arg2 as i64) - (arg1 as i64)) - (arg3 as i64));
   let x2: fiat_secp256k1_montgomery_scalar_i1 = ((x1 >> 32) as fiat_secp256k1_montgomery_scalar_i1);
   let x3: u32 = ((x1 & (0xffffffff as i64)) as u32);
@@ -123,7 +123,7 @@ pub fn fiat_secp256k1_montgomery_scalar_subborrowx_u32(out1: &mut u32, out2: &mu
 ///   out1: [0x0 ~> 0xffffffff]
 ///   out2: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: u32) {
   let x1: u64 = ((arg1 as u64) * (arg2 as u64));
   let x2: u32 = ((x1 & (0xffffffff as u64)) as u32);
   let x3: u32 = ((x1 >> 32) as u32);
@@ -143,7 +143,7 @@ pub fn fiat_secp256k1_montgomery_scalar_mulx_u32(out1: &mut u32, out2: &mut u32,
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_secp256k1_montgomery_scalar_u1, arg2: u32, arg3: u32) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_secp256k1_montgomery_scalar_u1, arg2: u32, arg3: u32) {
   let x1: fiat_secp256k1_montgomery_scalar_u1 = (!(!arg1));
   let x2: u32 = ((((((0x0 as fiat_secp256k1_montgomery_scalar_i2) - (x1 as fiat_secp256k1_montgomery_scalar_i2)) as fiat_secp256k1_montgomery_scalar_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
@@ -160,7 +160,7 @@ pub fn fiat_secp256k1_montgomery_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_s
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_mul(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_mul(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -1403,7 +1403,7 @@ pub fn fiat_secp256k1_montgomery_scalar_mul(out1: &mut fiat_secp256k1_montgomery
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_square(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_square(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -2647,7 +2647,7 @@ pub fn fiat_secp256k1_montgomery_scalar_square(out1: &mut fiat_secp256k1_montgom
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_add(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_add(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_secp256k1_montgomery_scalar_u1 = 0;
   fiat_secp256k1_montgomery_scalar_addcarryx_u32(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -2735,7 +2735,7 @@ pub fn fiat_secp256k1_montgomery_scalar_add(out1: &mut fiat_secp256k1_montgomery
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_sub(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_sub(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_secp256k1_montgomery_scalar_u1 = 0;
   fiat_secp256k1_montgomery_scalar_subborrowx_u32(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -2805,7 +2805,7 @@ pub fn fiat_secp256k1_montgomery_scalar_sub(out1: &mut fiat_secp256k1_montgomery
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_opp(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_opp(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) {
   let mut x1: u32 = 0;
   let mut x2: fiat_secp256k1_montgomery_scalar_u1 = 0;
   fiat_secp256k1_montgomery_scalar_subborrowx_u32(&mut x1, &mut x2, 0x0, (0x0 as u32), (arg1[0]));
@@ -2875,7 +2875,7 @@ pub fn fiat_secp256k1_montgomery_scalar_opp(out1: &mut fiat_secp256k1_montgomery
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_from_montgomery(out1: &mut fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_from_montgomery(out1: &mut fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) {
   let x1: u32 = (arg1[0]);
   let mut x2: u32 = 0;
   let mut x3: u32 = 0;
@@ -3707,7 +3707,7 @@ pub fn fiat_secp256k1_montgomery_scalar_from_montgomery(out1: &mut fiat_secp256k
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_to_montgomery(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_to_montgomery(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element) {
   let x1: u32 = (arg1[1]);
   let x2: u32 = (arg1[2]);
   let x3: u32 = (arg1[3]);
@@ -4909,7 +4909,7 @@ pub fn fiat_secp256k1_montgomery_scalar_to_montgomery(out1: &mut fiat_secp256k1_
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffff]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_nonzero(out1: &mut u32, arg1: &[u32; 8]) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_nonzero(out1: &mut u32, arg1: &[u32; 8]) {
   let x1: u32 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | ((arg1[3]) | ((arg1[4]) | ((arg1[5]) | ((arg1[6]) | (arg1[7]))))))));
   *out1 = x1;
 }
@@ -4926,7 +4926,7 @@ pub fn fiat_secp256k1_montgomery_scalar_nonzero(out1: &mut u32, arg1: &[u32; 8])
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_selectznz(out1: &mut [u32; 8], arg1: fiat_secp256k1_montgomery_scalar_u1, arg2: &[u32; 8], arg3: &[u32; 8]) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_selectznz(out1: &mut [u32; 8], arg1: fiat_secp256k1_montgomery_scalar_u1, arg2: &[u32; 8], arg3: &[u32; 8]) {
   let mut x1: u32 = 0;
   fiat_secp256k1_montgomery_scalar_cmovznz_u32(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u32 = 0;
@@ -4965,7 +4965,7 @@ pub fn fiat_secp256k1_montgomery_scalar_selectznz(out1: &mut [u32; 8], arg1: fia
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_to_bytes(out1: &mut [u8; 32], arg1: &[u32; 8]) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_to_bytes(out1: &mut [u8; 32], arg1: &[u32; 8]) {
   let x1: u32 = (arg1[7]);
   let x2: u32 = (arg1[6]);
   let x3: u32 = (arg1[5]);
@@ -5069,7 +5069,7 @@ pub fn fiat_secp256k1_montgomery_scalar_to_bytes(out1: &mut [u8; 32], arg1: &[u3
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_from_bytes(out1: &mut [u32; 8], arg1: &[u8; 32]) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_from_bytes(out1: &mut [u32; 8], arg1: &[u8; 32]) {
   let x1: u32 = (((arg1[31]) as u32) << 24);
   let x2: u32 = (((arg1[30]) as u32) << 16);
   let x3: u32 = (((arg1[29]) as u32) << 8);
@@ -5143,7 +5143,7 @@ pub fn fiat_secp256k1_montgomery_scalar_from_bytes(out1: &mut [u32; 8], arg1: &[
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_set_one(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_set_one(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) {
   out1[0] = 0x2fc9bebf;
   out1[1] = 0x402da173;
   out1[2] = 0x50b75fc4;
@@ -5163,7 +5163,7 @@ pub fn fiat_secp256k1_montgomery_scalar_set_one(out1: &mut fiat_secp256k1_montgo
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_msat(out1: &mut [u32; 9]) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_msat(out1: &mut [u32; 9]) {
   out1[0] = 0xd0364141;
   out1[1] = 0xbfd25e8c;
   out1[2] = 0xaf48a03b;
@@ -5204,7 +5204,7 @@ pub fn fiat_secp256k1_montgomery_scalar_msat(out1: &mut [u32; 9]) -> () {
 ///   out4: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 ///   out5: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_divstep(out1: &mut u32, out2: &mut [u32; 9], out3: &mut [u32; 9], out4: &mut [u32; 8], out5: &mut [u32; 8], arg1: u32, arg2: &[u32; 9], arg3: &[u32; 9], arg4: &[u32; 8], arg5: &[u32; 8]) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_divstep(out1: &mut u32, out2: &mut [u32; 9], out3: &mut [u32; 9], out4: &mut [u32; 8], out5: &mut [u32; 8], arg1: u32, arg2: &[u32; 9], arg3: &[u32; 9], arg4: &[u32; 8], arg5: &[u32; 8]) {
   let mut x1: u32 = 0;
   let mut x2: fiat_secp256k1_montgomery_scalar_u1 = 0;
   fiat_secp256k1_montgomery_scalar_addcarryx_u32(&mut x1, &mut x2, 0x0, (!arg1), (0x1 as u32));
@@ -5621,7 +5621,7 @@ pub fn fiat_secp256k1_montgomery_scalar_divstep(out1: &mut u32, out2: &mut [u32;
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_divstep_precomp(out1: &mut [u32; 8]) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_divstep_precomp(out1: &mut [u32; 8]) {
   out1[0] = 0x2b9cb4e9;
   out1[1] = 0xd7431a4d;
   out1[2] = 0x32d9c503;

--- a/fiat-rust/src/secp256k1_montgomery_scalar_64.rs
+++ b/fiat-rust/src/secp256k1_montgomery_scalar_64.rs
@@ -80,7 +80,7 @@ impl core::ops::IndexMut<usize> for fiat_secp256k1_montgomery_scalar_non_montgom
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_addcarryx_u64(out1: &mut u64, out2: &mut fiat_secp256k1_montgomery_scalar_u1, arg1: fiat_secp256k1_montgomery_scalar_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_addcarryx_u64(out1: &mut u64, out2: &mut fiat_secp256k1_montgomery_scalar_u1, arg1: fiat_secp256k1_montgomery_scalar_u1, arg2: u64, arg3: u64) {
   let x1: u128 = (((arg1 as u128) + (arg2 as u128)) + (arg3 as u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
   let x3: fiat_secp256k1_montgomery_scalar_u1 = ((x1 >> 64) as fiat_secp256k1_montgomery_scalar_u1);
@@ -102,7 +102,7 @@ pub fn fiat_secp256k1_montgomery_scalar_addcarryx_u64(out1: &mut u64, out2: &mut
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0x1]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_subborrowx_u64(out1: &mut u64, out2: &mut fiat_secp256k1_montgomery_scalar_u1, arg1: fiat_secp256k1_montgomery_scalar_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_subborrowx_u64(out1: &mut u64, out2: &mut fiat_secp256k1_montgomery_scalar_u1, arg1: fiat_secp256k1_montgomery_scalar_u1, arg2: u64, arg3: u64) {
   let x1: i128 = (((arg2 as i128) - (arg1 as i128)) - (arg3 as i128));
   let x2: fiat_secp256k1_montgomery_scalar_i1 = ((x1 >> 64) as fiat_secp256k1_montgomery_scalar_i1);
   let x3: u64 = ((x1 & (0xffffffffffffffff as i128)) as u64);
@@ -123,7 +123,7 @@ pub fn fiat_secp256k1_montgomery_scalar_subborrowx_u64(out1: &mut u64, out2: &mu
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 ///   out2: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: u64) {
   let x1: u128 = ((arg1 as u128) * (arg2 as u128));
   let x2: u64 = ((x1 & (0xffffffffffffffff as u128)) as u64);
   let x3: u64 = ((x1 >> 64) as u64);
@@ -143,7 +143,7 @@ pub fn fiat_secp256k1_montgomery_scalar_mulx_u64(out1: &mut u64, out2: &mut u64,
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_secp256k1_montgomery_scalar_u1, arg2: u64, arg3: u64) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_secp256k1_montgomery_scalar_u1, arg2: u64, arg3: u64) {
   let x1: fiat_secp256k1_montgomery_scalar_u1 = (!(!arg1));
   let x2: u64 = ((((((0x0 as fiat_secp256k1_montgomery_scalar_i2) - (x1 as fiat_secp256k1_montgomery_scalar_i2)) as fiat_secp256k1_montgomery_scalar_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
@@ -160,7 +160,7 @@ pub fn fiat_secp256k1_montgomery_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_s
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_mul(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_mul(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -499,7 +499,7 @@ pub fn fiat_secp256k1_montgomery_scalar_mul(out1: &mut fiat_secp256k1_montgomery
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_square(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_square(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -839,7 +839,7 @@ pub fn fiat_secp256k1_montgomery_scalar_square(out1: &mut fiat_secp256k1_montgom
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_add(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_add(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_secp256k1_montgomery_scalar_u1 = 0;
   fiat_secp256k1_montgomery_scalar_addcarryx_u64(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -891,7 +891,7 @@ pub fn fiat_secp256k1_montgomery_scalar_add(out1: &mut fiat_secp256k1_montgomery
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_sub(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_sub(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg2: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_secp256k1_montgomery_scalar_u1 = 0;
   fiat_secp256k1_montgomery_scalar_subborrowx_u64(&mut x1, &mut x2, 0x0, (arg1[0]), (arg2[0]));
@@ -933,7 +933,7 @@ pub fn fiat_secp256k1_montgomery_scalar_sub(out1: &mut fiat_secp256k1_montgomery
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_opp(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_opp(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) {
   let mut x1: u64 = 0;
   let mut x2: fiat_secp256k1_montgomery_scalar_u1 = 0;
   fiat_secp256k1_montgomery_scalar_subborrowx_u64(&mut x1, &mut x2, 0x0, (0x0 as u64), (arg1[0]));
@@ -975,7 +975,7 @@ pub fn fiat_secp256k1_montgomery_scalar_opp(out1: &mut fiat_secp256k1_montgomery
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_from_montgomery(out1: &mut fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_from_montgomery(out1: &mut fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) {
   let x1: u64 = (arg1[0]);
   let mut x2: u64 = 0;
   let mut x3: u64 = 0;
@@ -1207,7 +1207,7 @@ pub fn fiat_secp256k1_montgomery_scalar_from_montgomery(out1: &mut fiat_secp256k
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_to_montgomery(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_to_montgomery(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element, arg1: &fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_element) {
   let x1: u64 = (arg1[1]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[3]);
@@ -1529,7 +1529,7 @@ pub fn fiat_secp256k1_montgomery_scalar_to_montgomery(out1: &mut fiat_secp256k1_
 /// Output Bounds:
 ///   out1: [0x0 ~> 0xffffffffffffffff]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_nonzero(out1: &mut u64, arg1: &[u64; 4]) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_nonzero(out1: &mut u64, arg1: &[u64; 4]) {
   let x1: u64 = ((arg1[0]) | ((arg1[1]) | ((arg1[2]) | (arg1[3]))));
   *out1 = x1;
 }
@@ -1546,7 +1546,7 @@ pub fn fiat_secp256k1_montgomery_scalar_nonzero(out1: &mut u64, arg1: &[u64; 4])
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_selectznz(out1: &mut [u64; 4], arg1: fiat_secp256k1_montgomery_scalar_u1, arg2: &[u64; 4], arg3: &[u64; 4]) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_selectznz(out1: &mut [u64; 4], arg1: fiat_secp256k1_montgomery_scalar_u1, arg2: &[u64; 4], arg3: &[u64; 4]) {
   let mut x1: u64 = 0;
   fiat_secp256k1_montgomery_scalar_cmovznz_u64(&mut x1, arg1, (arg2[0]), (arg3[0]));
   let mut x2: u64 = 0;
@@ -1573,7 +1573,7 @@ pub fn fiat_secp256k1_montgomery_scalar_selectznz(out1: &mut [u64; 4], arg1: fia
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff], [0x0 ~> 0xff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 4]) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_to_bytes(out1: &mut [u8; 32], arg1: &[u64; 4]) {
   let x1: u64 = (arg1[3]);
   let x2: u64 = (arg1[2]);
   let x3: u64 = (arg1[1]);
@@ -1681,7 +1681,7 @@ pub fn fiat_secp256k1_montgomery_scalar_to_bytes(out1: &mut [u8; 32], arg1: &[u6
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_from_bytes(out1: &mut [u64; 4], arg1: &[u8; 32]) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_from_bytes(out1: &mut [u64; 4], arg1: &[u8; 32]) {
   let x1: u64 = (((arg1[31]) as u64) << 56);
   let x2: u64 = (((arg1[30]) as u64) << 48);
   let x3: u64 = (((arg1[29]) as u64) << 40);
@@ -1755,7 +1755,7 @@ pub fn fiat_secp256k1_montgomery_scalar_from_bytes(out1: &mut [u64; 4], arg1: &[
 ///   0 ≤ eval out1 < m
 ///
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_set_one(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_set_one(out1: &mut fiat_secp256k1_montgomery_scalar_montgomery_domain_field_element) {
   out1[0] = 0x402da1732fc9bebf;
   out1[1] = 0x4551231950b75fc4;
   out1[2] = (0x1 as u64);
@@ -1771,7 +1771,7 @@ pub fn fiat_secp256k1_montgomery_scalar_set_one(out1: &mut fiat_secp256k1_montgo
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_msat(out1: &mut [u64; 5]) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_msat(out1: &mut [u64; 5]) {
   out1[0] = 0xbfd25e8cd0364141;
   out1[1] = 0xbaaedce6af48a03b;
   out1[2] = 0xfffffffffffffffe;
@@ -1808,7 +1808,7 @@ pub fn fiat_secp256k1_montgomery_scalar_msat(out1: &mut [u64; 5]) -> () {
 ///   out4: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 ///   out5: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_divstep(out1: &mut u64, out2: &mut [u64; 5], out3: &mut [u64; 5], out4: &mut [u64; 4], out5: &mut [u64; 4], arg1: u64, arg2: &[u64; 5], arg3: &[u64; 5], arg4: &[u64; 4], arg5: &[u64; 4]) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_divstep(out1: &mut u64, out2: &mut [u64; 5], out3: &mut [u64; 5], out4: &mut [u64; 4], out5: &mut [u64; 4], arg1: u64, arg2: &[u64; 5], arg3: &[u64; 5], arg4: &[u64; 4], arg5: &[u64; 4]) {
   let mut x1: u64 = 0;
   let mut x2: fiat_secp256k1_montgomery_scalar_u1 = 0;
   fiat_secp256k1_montgomery_scalar_addcarryx_u64(&mut x1, &mut x2, 0x0, (!arg1), (0x1 as u64));
@@ -2041,7 +2041,7 @@ pub fn fiat_secp256k1_montgomery_scalar_divstep(out1: &mut u64, out2: &mut [u64;
 /// Output Bounds:
 ///   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 #[inline]
-pub fn fiat_secp256k1_montgomery_scalar_divstep_precomp(out1: &mut [u64; 4]) -> () {
+pub fn fiat_secp256k1_montgomery_scalar_divstep_precomp(out1: &mut [u64; 4]) {
   out1[0] = 0xd7431a4d2b9cb4e9;
   out1[1] = 0xab67d35a32d9c503;
   out1[2] = 0xadf6c7e5859ce35f;

--- a/src/Stringification/Rust.v
+++ b/src/Stringification/Rust.v
@@ -391,7 +391,7 @@ Module Rust.
     let '(args, rets, body) := f in
     ((if inline then "#[inline]" ++ String.NewLine else "") ++ (if private then "fn " else "pub fn ") ++ name ++
       "(" ++ String.concat ", " (to_arg_list internal_private all_private prefix Out rets ++ to_arg_list_for_each_lhs_of_arrow internal_private all_private prefix args) ++
-      ") -> () {")%string :: (List.map (fun s => "  " ++ s)%string (to_strings internal_private prefix body)) ++ ["}"%string]%list.
+      ") {")%string :: (List.map (fun s => "  " ++ s)%string (to_strings internal_private prefix body)) ++ ["}"%string]%list.
 
   (** In Rust, there is no munging of return arguments (they remain
       passed by pointers), so all variables are live *)


### PR DESCRIPTION
The cargo clippy reports as an issue returning an empty tuple and recommends remove it.

[1] https://rust-lang.github.io/rust-clippy/master/index.html#/unused_unit/