### PR TITLE
rust: ensure generated files pass clippy linter.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: cargo build
       run: cargo build --verbose
+    - name: cargo clippy
+      run: cargo clippy -- -D warnings
     - name: cargo test
       run: cargo test --verbose
     - name: curve25519-dalek test


### PR DESCRIPTION
Checks whether rust files satisfy clippy linter.

Depends on:
[] #1668 
[] #1669 
[] #1670 
[] #1671