### PR TITLE
[CI] Add `merge_group:` trigger for merge queue

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -3,6 +3,7 @@ name: Test Generated C
 on:
   push:
   pull_request:
+  merge_group:
   schedule:
     - cron: '0 0 1 * *'
 

--- a/.github/workflows/coq-debian.yml
+++ b/.github/workflows/coq-debian.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ master , sp2019latest ]
   pull_request:
+  merge_group:
   workflow_dispatch:
   schedule:
     - cron: '0 0 1 * *'
@@ -101,5 +102,5 @@ jobs:
     - name: make only-test-amd64-files
       shell: in-debian-chroot.sh {0}
       run: etc/ci/github-actions-make.sh -j2 only-test-amd64-files SLOWEST_FIRST=1
-      env: 
+      env:
         ALLOW_DIFF: 1

--- a/.github/workflows/coq-macos.yml
+++ b/.github/workflows/coq-macos.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ master , sp2019latest , v8.6 , v8.8 , v8.10 ]
   pull_request:
+  merge_group:
   workflow_dispatch:
   schedule:
     - cron: '0 0 1 * *'

--- a/.github/workflows/coq-windows.yml
+++ b/.github/workflows/coq-windows.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches: [ master , sp2019latest , v8.6 , v8.8 , v8.10 ]
   pull_request:
+  merge_group:
   workflow_dispatch:
   schedule:
     - cron: '0 0 1 * *'

--- a/.github/workflows/docker-coq.yml
+++ b/.github/workflows/docker-coq.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ master , sp2019latest , v8.6 , v8.8 , v8.10 ]
   pull_request:
+  merge_group:
   workflow_dispatch:
   schedule:
     - cron: '0 0 1 * *'
@@ -121,5 +122,5 @@ jobs:
       run: chmod +x src/ExtractionOCaml/*
     - name: only-test-amd64-files
       run: etc/ci/github-actions-make.sh -f Makefile.examples -j2 only-test-amd64-files SLOWEST_FIRST=1
-      env: 
+      env:
         ALLOW_DIFF: 1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,7 @@ name: Test Generated Go
 on:
   push:
   pull_request:
+  merge_group:
   schedule:
     - cron: '0 0 1 * *'
 

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -3,6 +3,7 @@ name: Test Generated Java
 on:
   push:
   pull_request:
+  merge_group:
   schedule:
     - cron: '0 0 1 * *'
 

--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -3,6 +3,7 @@ name: Test Generated JSON
 on:
   push:
   pull_request:
+  merge_group:
   schedule:
     - cron: '0 0 1 * *'
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,6 +3,7 @@ name: Test Generated Rust
 on:
   push:
   pull_request:
+  merge_group:
   schedule:
     - cron: '0 0 1 * *'
 

--- a/.github/workflows/zig.yml
+++ b/.github/workflows/zig.yml
@@ -3,6 +3,7 @@ name: Test Generated Zig
 on:
   push:
   pull_request:
+  merge_group:
   schedule:
     - cron: "0 0 1 * *"
 


### PR DESCRIPTION
As per
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions this will allow us to enable merge queues in
https://github.com/mit-plv/fiat-crypto/settings/branch_protection_rules/3303819

Note that this doesn't actually change any behavior when this setting is not enabled, but I plan to enable this setting shortly. (cc @andres-erbsen )