### PR TITLE
Only upload one copy of linux binaries to releases

### DIFF
--- a/.github/workflows/coq-alpine.yml
+++ b/.github/workflows/coq-alpine.yml
@@ -161,6 +161,9 @@ jobs:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # Fetch all history for all tags and branches
+        tags: true     # Fetch all tags as well, `fetch-depth: 0` might be sufficient depending on Git version
     - name: Download standalone edge
       uses: actions/download-artifact@v3
       with:
@@ -171,9 +174,15 @@ jobs:
     - name: Unpack files
       run: |
         mkdir dist
-        mv dist-edge/standalone.tar.gz dist/fiat-crypto-alpine-edge.tar.gz
+        echo "::group::find arch"
+        ( cd dist-edge && tar -xzvf standalone.tar.gz )
+        arch="$(etc/ci/find-arch.sh dist-edge/word_by_word_montgomery "unknown")"
+        tag="$(git describe --tags HEAD)"
+        fname="Fiat-Cryptography_${tag}_Linux_${arch}.tar.gz"
+        echo "$fname"
+        mv dist-edge/standalone.tar.gz "dist/$fname"
         find dist
-        tar -tvf dist/fiat-crypto-alpine-edge.tar.gz
+        tar -tvf "dist/$fname"
     - name: Upload artifacts to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/coq-debian.yml
+++ b/.github/workflows/coq-debian.yml
@@ -149,13 +149,16 @@ jobs:
           echo "::endgroup::"
         done
 
-  publish-standalone:
+  publish-standalone-dry-run:
     runs-on: ubuntu-latest
     needs: build
-    permissions:
-      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+#    permissions:
+#      contents: write  # IMPORTANT: mandatory for making GitHub Releases
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # Fetch all history for all tags and branches
+        tags: true     # Fetch all tags as well, `fetch-depth: 0` might be sufficient depending on Git version
     - name: Download standalone sid
       uses: actions/download-artifact@v3
       with:
@@ -166,34 +169,40 @@ jobs:
     - name: Unpack files
       run: |
         mkdir dist
-        mv dist-sid/standalone.tar.gz dist/fiat-crypto-sid.tar.gz
+        echo "::group::find arch"
+        ( cd dist-sid && tar -xzvf standalone.tar.gz )
+        arch="$(etc/ci/find-arch.sh dist-sid/word_by_word_montgomery "unknown")"
+        tag="$(git describe --tags HEAD)"
+        fname="Fiat-Cryptography_${tag}_Linux_debian_sid_${arch}.tar.gz"
+        echo "$fname"
+        mv dist-sid/standalone.tar.gz "dist/$fname"
         find dist
-        tar -tvf dist/fiat-crypto-sid.tar.gz
-    - name: Upload artifacts to GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      # Upload to GitHub Release using the `gh` CLI.
-      # `dist/` contains the built packages
-      run: >-
-        gh release upload
-        '${{ github.ref_name }}' dist/**
-        --repo '${{ github.repository }}'
-      if: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' }}
+        tar -tvf "dist/$fname"
+#    - name: Upload artifacts to GitHub Release
+#      env:
+#        GITHUB_TOKEN: ${{ github.token }}
+#      # Upload to GitHub Release using the `gh` CLI.
+#      # `dist/` contains the built packages
+#      run: >-
+#        gh release upload
+#        '${{ github.ref_name }}' dist/**
+#        --repo '${{ github.repository }}'
+#      if: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' }}
 
   debian-check-all:
     runs-on: ubuntu-latest
-    needs: [build, test-standalone, publish-standalone]
+    needs: [build, test-standalone, publish-standalone-dry-run]
     if: always()
     steps:
     - run: echo 'build passed'
       if: ${{ needs.build.result == 'success' }}
     - run: echo 'test-standalone passed'
       if: ${{ needs.test-standalone.result == 'success' }}
-    - run: echo 'publish-standalone passed'
-      if: ${{ needs.publish-standalone.result == 'success' }}
+    - run: echo 'publish-standalone-dry-run passed'
+      if: ${{ needs.publish-standalone-dry-run.result == 'success' }}
     - run: echo 'build failed' && false
       if: ${{ needs.build.result != 'success' }}
     - run: echo 'test-standalone failed' && false
       if: ${{ needs.test-standalone.result != 'success' }}
-    - run: echo 'publish-standalone failed' && false
-      if: ${{ needs.publish-standalone.result != 'success' }}
+    - run: echo 'publish-standalone-dry-run failed' && false
+      if: ${{ needs.publish-standalone-dry-run.result != 'success' }}

--- a/.github/workflows/coq-docker.yml
+++ b/.github/workflows/coq-docker.yml
@@ -202,13 +202,16 @@ jobs:
             echo "::endgroup::"
           done
 
-  publish-standalone:
+  publish-standalone-dry-run:
     runs-on: ubuntu-latest
     needs: build
-    permissions:
-      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+#    permissions:
+#      contents: write  # IMPORTANT: mandatory for making GitHub Releases
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # Fetch all history for all tags and branches
+        tags: true     # Fetch all tags as well, `fetch-depth: 0` might be sufficient depending on Git version
     - name: Download standalone Docker
       uses: actions/download-artifact@v3
       with:
@@ -219,23 +222,29 @@ jobs:
     - name: Unpack files
       run: |
         mkdir dist
-        mv dist-docker-coq-dev/standalone.tar.gz dist/fiat-crypto-docker-coq-dev.tar.gz
+        echo "::group::find arch"
+        ( cd dist-docker-coq-dev && tar -xzvf standalone.tar.gz )
+        arch="$(etc/ci/find-arch.sh dist-docker-coq-dev/word_by_word_montgomery "unknown")"
+        tag="$(git describe --tags HEAD)"
+        fname="Fiat-Cryptography_${tag}_Linux_docker_dev_${arch}.tar.gz"
+        echo "$fname"
+        mv dist-docker-coq-dev/standalone.tar.gz "dist/$fname"
         find dist
-        tar -tvf dist/fiat-crypto-docker-coq-dev.tar.gz
-    - name: Upload artifacts to GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      # Upload to GitHub Release using the `gh` CLI.
-      # `dist/` contains the built packages
-      run: >-
-        gh release upload
-        '${{ github.ref_name }}' dist/**
-        --repo '${{ github.repository }}'
-      if: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' }}
+        tar -tvf "dist/$fname"
+#    - name: Upload artifacts to GitHub Release
+#      env:
+#        GITHUB_TOKEN: ${{ github.token }}
+#      # Upload to GitHub Release using the `gh` CLI.
+#      # `dist/` contains the built packages
+#      run: >-
+#        gh release upload
+#        '${{ github.ref_name }}' dist/**
+#        --repo '${{ github.repository }}'
+#      if: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name == 'release' }}
 
   docker-check-all:
     runs-on: ubuntu-latest
-    needs: [build, test-amd64, test-standalone, publish-standalone]
+    needs: [build, test-amd64, test-standalone, publish-standalone-dry-run]
     if: always()
     steps:
     - run: echo 'build passed'
@@ -244,13 +253,13 @@ jobs:
       if: ${{ needs.test-amd64.result == 'success' }}
     - run: echo 'test-standalone passed'
       if: ${{ needs.test-standalone.result == 'success' }}
-    - run: echo 'publish-standalone passed'
-      if: ${{ needs.publish-standalone.result == 'success' }}
+    - run: echo 'publish-standalone-dry-run passed'
+      if: ${{ needs.publish-standalone-dry-run.result == 'success' }}
     - run: echo 'build failed' && false
       if: ${{ needs.build.result != 'success' }}
     - run: echo 'test-amd64 failed' && false
       if: ${{ needs.test-amd64.result != 'success' }}
     - run: echo 'test-standalone failed' && false
       if: ${{ needs.test-standalone.result != 'success' }}
-    - run: echo 'publish-standalone failed' && false
-      if: ${{ needs.publish-standalone.result != 'success' }}
+    - run: echo 'publish-standalone-dry-run failed' && false
+      if: ${{ needs.publish-standalone-dry-run.result != 'success' }}

--- a/.github/workflows/coq-macos.yml
+++ b/.github/workflows/coq-macos.yml
@@ -147,6 +147,9 @@ jobs:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # Fetch all history for all tags and branches
+        tags: true     # Fetch all tags as well, `fetch-depth: 0` might be sufficient depending on Git version
     - name: Download standalone MacOS
       uses: actions/download-artifact@v3
       with:
@@ -157,9 +160,14 @@ jobs:
     - name: Unpack files
       run: |
         mkdir dist
-        mv dist-macos/standalone.tar.gz dist/fiat-crypto-macos.tar.gz
+        ( cd dist-macos && tar -xzvf standalone.tar.gz )
+        arch="$(etc/ci/find-arch.sh dist-macos/word_by_word_montgomery)"
+        tag="$(git describe --tags HEAD)"
+        fname="Fiat-Cryptography_${tag}_macOS_${arch}.tar.gz"
+        echo "$fname"
+        mv dist-macos/standalone.tar.gz "dist/$fname"
         find dist
-        tar -tvf dist/fiat-crypto-macos.tar.gz
+        tar -tvf "dist/$fname"
     - name: Upload artifacts to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/coq-windows.yml
+++ b/.github/workflows/coq-windows.yml
@@ -174,6 +174,9 @@ jobs:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # Fetch all history for all tags and branches
+        tags: true     # Fetch all tags as well, `fetch-depth: 0` might be sufficient depending on Git version
     - name: Download standalone Windows
       uses: actions/download-artifact@v3
       with:
@@ -184,9 +187,14 @@ jobs:
     - name: Unpack files
       run: |
         mkdir dist
-        mv dist-windows/standalone.zip dist/fiat-crypto-windows.zip
+        ( cd dist-windows && unzip standalone.zip )
+        arch="$(etc/ci/find-arch.sh dist-windows/word_by_word_montgomery "x86_64")"
+        tag="$(git describe --tags HEAD)"
+        fname="Fiat-Cryptography_${tag}_Windows_${arch}.zip"
+        echo "$fname"
+        mv dist-windows/standalone.zip "dist/$fname"
         find dist
-        unzip -l dist/fiat-crypto-windows.zip
+        unzip -l "dist/$fname"
     - name: Upload artifacts to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/etc/ci/find-arch.sh
+++ b/etc/ci/find-arch.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+usage() {
+    >&2 printf "%s FILENAME [DEFAULT_ARCH]\n" "$0"
+}
+
+fname="$1"
+default="$2"
+if [ -z "$fname" ] || [ "$fname" = "-h" ] || [ "$fname" = "--help" ]; then
+    usage
+fi
+if [ -z "$fname" ]; then
+    exit 1
+fi
+
+if [ ! -z "${SHELL}" ]; then
+    run() {
+        "${SHELL}" -c "$*" || true
+    }
+else
+    run() {
+        /bin/sh -c "$*" || true
+    }
+fi
+
+if [ ! -z "$CI" ]; then
+    group() {
+        echo "::group::$*"
+        run "$@"
+        echo "::endgroup::"
+    }
+else
+    group() { run "$@"; }
+fi
+
+>&2 group file "$fname"
+>&2 group otool -L "$fname" || true
+>&2 group lipo -info "$fname" || true
+file_info="$(file "$fname" 2>&1)"
+case "${file_info}" in
+    *x86_64*|*x86-64*)
+        arch=x86_64
+        ;;
+    *)
+        if [ -z "$default" ]; then
+            arch="$(printf "%s\n" "${file_info}" | awk '{print $NF}')"
+        else
+            arch="$default"
+        fi
+        >&2 echo "::warning::Unknown architecture ${file_info} (using ${arch})"
+        ;;
+esac
+
+printf "%s\n" "$arch"


### PR DESCRIPTION
We upload the statically-linked Alpine edge binaries, as these are
probably the most portable.

Note that the statically-linked Alpine binaries are actually smaller
than the Debian executables (~35 MB archive vs ~41 MB archive), though
the Debian ones are pie (position-independent executables, supporting
Address Space Layout Randomization).

Current names file names:
fiat-crypto-windows.zip
fiat-crypto-macos.tar.gz
fiat-crypto-linux-x86_64.tar.gz

Suggestions welcome cc @andres-erbsen 