### PR TITLE
Use WebWorkers and a cache for js-of-ocaml

### DIFF
--- a/fiat-html/fiat-crypto.html
+++ b/fiat-html/fiat-crypto.html
@@ -51,6 +51,7 @@
             <button type="button" id="cancelButton" disabled>Cancel</button>
             <span id="status" class="status-span hidden"></span>
             <a id="permalink" class="permalink-span hidden" href="#">Pseudopermalink</a>
+            <button type="button" id="clearCacheButton">Clear Cache</button>
         </div>
     </form>
     <div id="error" class="error hidden"></div>
@@ -64,7 +65,6 @@
         <button class="copy-button" data-target="stderr">Copy</button>
       </div>
     </div>
-    <script src="fiat_crypto.js"></script>
     <script src="main.js"></script>
     <script src="copy-button.js"></script>
 </body>

--- a/fiat-html/fiat_crypto_worker.js
+++ b/fiat-html/fiat_crypto_worker.js
@@ -1,0 +1,5 @@
+self.importScripts("fiat_crypto.js");
+self.onmessage = function(e) {
+    const result = synthesize(e.data);
+    postMessage(result);
+};


### PR DESCRIPTION
Now that `--enable effects` means we're no longer hitting recursion limits, it's useful to not block the UI thread and to use a cache (currently in localStorage).

On top of #1737.  Separate PR so that we can finally merge #1737.