### PR TITLE
bump rupicola

### DIFF
--- a/src/Bedrock/End2End/Poly1305/Field1305.v
+++ b/src/Bedrock/End2End/Poly1305/Field1305.v
@@ -15,8 +15,8 @@ Section Field.
   Definition s : Z := 2^130.
   Definition c : list (Z * Z) := [(1, 5)]%Z.
 
-  Existing Instances Defaults32.default_parameters
-           Defaults32.default_parameters_ok.
+  Existing Instances Bitwidth32.BW32
+    Defaults32.default_parameters Defaults32.default_parameters_ok.
   Definition prefix : string := "fe1305_"%string.
 
   (* Define Poly1305 field *)

--- a/src/Bedrock/Field/Synthesis/Examples/p224_64_new.v
+++ b/src/Bedrock/Field/Synthesis/Examples/p224_64_new.v
@@ -26,8 +26,8 @@ Section Field.
   Definition n : nat := 4.
   Definition m : Z := (2^224 - 2^96 + 1)%Z.
 
-  Existing Instances Defaults32.default_parameters
-           Defaults32.default_parameters_ok.
+  Existing Instances Bitwidth32.BW32
+    Defaults32.default_parameters Defaults32.default_parameters_ok.
   Definition prefix : string := "p224_"%string.
 
   (* Define p224 field *)


### PR DESCRIPTION
Two changes are needed because coqutil's Bitwidth instances are now `#[export]` instead of `#[global]`.