### PR TITLE
Use objects instead of arrays in coq-opam-package.yml

### DIFF
--- a/.github/workflows/coq-opam-package.yml
+++ b/.github/workflows/coq-opam-package.yml
@@ -18,34 +18,23 @@ jobs:
       matrix:
         coq-version: ['dev', '8.18.0', '8.17.0']
         ocaml-compiler: ['4.11.1']
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        extra-ocaml-repositories: ['', 'opam-repository-mingw: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset']
-        coq-extra-flags: ['-async-proofs-j 1', '']
-        opam-jobs-flag: ['-j 1', '']
-        exclude:
-        - os: 'ubuntu-latest'
-          coq-extra-flags: '-async-proofs-j 1'
-        - os: 'macos-latest'
-          coq-extra-flags: '-async-proofs-j 1'
-        - os: 'windows-latest'
-          coq-extra-flags: ''
+        os: [{name: 'Ubuntu',
+              runs-on: 'ubuntu-latest',
+              coq-extra-flags: '',
+              extra-ocaml-repositories: '',
+              opam-jobs-flag: ''},
+             {name: 'macOS',
+              runs-on: 'macos-latest',
+              coq-extra-flags: '',
+              extra-ocaml-repositories: '',
+              opam-jobs-flag: ''},
+             {name: 'Windows',
+              runs-on: 'windows-latest',
+              coq-extra-flags: '-async-proofs-j 1',
+              extra-ocaml-repositories: 'opam-repository-mingw: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset',
+              opam-jobs-flag: '-j 1'}]
 
-        - os: 'ubuntu-latest'
-          opam-jobs-flag: '-j 1'
-        - os: 'macos-latest'
-          opam-jobs-flag: '-j 1'
-        - os: 'windows-latest'
-          opam-jobs-flag: ''
-
-        - os: 'ubuntu-latest'
-          extra-ocaml-repositories: 'opam-repository-mingw: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset'
-        - os: 'macos-latest'
-          extra-ocaml-repositories: 'opam-repository-mingw: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset'
-        - os: 'windows-latest'
-          extra-ocaml-repositories: ''
-
-
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os.runs-on }}
 
     env:
       OPAMYES: "true"
@@ -55,8 +44,8 @@ jobs:
       uses: ocaml/setup-ocaml@v2
       with:
         ocaml-compiler: ${{ matrix.ocaml-compiler }}
-        opam-repositories: |
-          ${{ matrix.extra-ocaml-repositories }}
+        opam-repositories: |-
+          ${{ matrix.os.extra-ocaml-repositories }}
           default: https://github.com/ocaml/opam-repository.git
 
     - name: echo Linux build params
@@ -143,9 +132,9 @@ jobs:
         echo ::endgroup::
 
     - run: opam exec -- opam-depext coq-fiat-crypto
-    - run: opam install coq-fiat-crypto --with-test ${{ matrix.opam-jobs-flag }}
+    - run: opam install coq-fiat-crypto --with-test ${{ matrix.os.opam-jobs-flag }}
       env:
-        COQEXTRAFLAGS: ${{ matrix.coq-extra-flags }}
+        COQEXTRAFLAGS: ${{ matrix.os.coq-extra-flags }}
 
     - name: cat opam logs (Linux, Mac)
       run: |


### PR DESCRIPTION
Addresses the specific complaint in https://github.com/ocaml/setup-ocaml/issues/720. A run of this workflow can be seen [on my fork](https://github.com/dra27/fiat-crypto/actions/runs/7003071299). In particular, the "Set up OCaml" step has this for the three Windows jobs:

```yaml
Run ocaml/setup-ocaml@v2
  with:
    ocaml-compiler: 4.11.1
    opam-repositories: opam-repository-mingw: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
  default: https://github.com/ocaml/opam-repository.git
```
(both `opam-repository-mingw` and `default` for `opam-repositories`) but the 6 macOS and Ubuntu jobs have:

```yaml
Run ocaml/setup-ocaml@v2
  with:
    ocaml-compiler: 4.11.1
    opam-repositories: 
  default: https://github.com/ocaml/opam-repository.git
```

Likewise, the step "Run `opam install coq-fiat-crypto --with-test` visibly still has `-j 1` appended on the Windows jobs and similarly the `COQEXTRAFLAGS` environment variable is only set on Windows.