### PR TITLE
[CI] Drop alpine workaround

### DIFF
--- a/.github/workflows/coq-alpine.yml
+++ b/.github/workflows/coq-alpine.yml
@@ -37,12 +37,6 @@ jobs:
         branch: ${{ matrix.alpine }}
         extra-repositories: https://dl-cdn.alpinelinux.org/alpine/edge/testing
         packages: git make jq gcc musl-dev python3 ocaml ocaml-findlib ghc cabal coq ocaml-zarith bash sudo
-    - name: work around coq issue 15663
-      shell: alpine.sh --root {0}
-      run: |
-        ln -s /usr/lib/coq /usr/lib/ocaml/coq
-        ln -s /usr/lib/coq-core /usr/lib/ocaml/coq-core
-        ln -s /usr/lib/coqide-server /usr/lib/ocaml/coqide-server
     - name: host build params
       run: etc/ci/describe-system-config.sh
     - name: chroot build params


### PR DESCRIPTION
Once https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/57766 is merged we will no longer require this workaround.