### PR TITLE
Revert "Bump actions/download-artifact and actions/upload-artifact from 3 to 4 (#1786)"

### DIFF
--- a/.github/workflows/coq-alpine.yml
+++ b/.github/workflows/coq-alpine.yml
@@ -61,23 +61,23 @@ jobs:
 #      shell: alpine.sh {0}
 #      run: make install-standalone-js-of-ocaml
     - name: upload standalone files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: standalone-${{ matrix.alpine }}
         path: dist/fiat_crypto
 #    - name: upload standalone js files
-#      uses: actions/upload-artifact@v4
+#      uses: actions/upload-artifact@v3
 #      with:
 #        name: standalone-html-${{ matrix.alpine }}
 #        path: fiat-html
     - name: upload OCaml files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ExtractionOCaml-${{ matrix.alpine }}
         path: src/ExtractionOCaml
       if: always ()
 #    - name: upload js_of_ocaml files
-#      uses: actions/upload-artifact@v4
+#      uses: actions/upload-artifact@v3
 #      with:
 #        name: ExtractionJsOfOCaml-${{ matrix.alpine }}
 #        path: src/ExtractionJsOfOCaml
@@ -88,7 +88,7 @@ jobs:
     - run: tar -czvf generated-files.tgz fiat-*/
       if: ${{ failure() }}
     - name: upload generated files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: generated-files-${{ matrix.alpine }}
         path: generated-files.tgz
@@ -97,7 +97,7 @@ jobs:
       shell: alpine.sh {0}
       run: make TIMED=1 TIMING=1 -j1 standalone-haskell GHCFLAGS='+RTS -M7G -RTS'
     - name: upload Haskell files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ExtractionHaskell-${{ matrix.alpine }}
         path: src/ExtractionHaskell
@@ -132,7 +132,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Download standalone ${{ matrix.alpine }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: standalone-${{ matrix.alpine }}
         path: dist/
@@ -167,7 +167,7 @@ jobs:
         fetch-depth: 0 # Fetch all history for all tags and branches
         tags: true     # Fetch all tags as well, `fetch-depth: 0` might be sufficient depending on Git version
     - name: Download standalone edge
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: standalone-edge
         path: dist/

--- a/.github/workflows/coq-debian.yml
+++ b/.github/workflows/coq-debian.yml
@@ -52,7 +52,7 @@ jobs:
     - run: tar -czvf generated-files.tgz fiat-*/
       if: ${{ failure() }}
     - name: upload generated files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: generated-files-${{ matrix.env.DEBIAN }}
         path: generated-files.tgz
@@ -67,23 +67,23 @@ jobs:
       shell: in-debian-chroot.sh {0}
       run: etc/ci/github-actions-make.sh install-standalone-js-of-ocaml
     - name: upload standalone files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: standalone-${{ matrix.env.DEBIAN }}
         path: dist/fiat_crypto
     - name: upload standalone js files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: standalone-html-${{ matrix.env.DEBIAN }}
         path: fiat-html
     - name: upload OCaml files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ExtractionOCaml-${{ matrix.env.DEBIAN }}
         path: src/ExtractionOCaml
       if: always ()
     - name: upload js_of_ocaml files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ExtractionJsOfOCaml-${{ matrix.env.DEBIAN }}
         path: src/ExtractionJsOfOCaml
@@ -92,7 +92,7 @@ jobs:
       shell: in-debian-chroot.sh {0}
       run: etc/ci/github-actions-make.sh -j1 standalone-haskell GHCFLAGS='+RTS -M7G -RTS'
     - name: upload Haskell files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ExtractionHaskell-${{ matrix.env.DEBIAN }}
         path: src/ExtractionHaskell
@@ -126,7 +126,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Download standalone ${{ matrix.debian }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: standalone-${{ matrix.debian }}
         path: dist/
@@ -166,7 +166,7 @@ jobs:
         fetch-depth: 0 # Fetch all history for all tags and branches
         tags: true     # Fetch all tags as well, `fetch-depth: 0` might be sufficient depending on Git version
     - name: Download standalone sid
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: standalone-sid
         path: dist/

--- a/.github/workflows/coq-docker.yml
+++ b/.github/workflows/coq-docker.yml
@@ -65,19 +65,19 @@ jobs:
         export: CI ALLOW_DIFF COQCHKEXTRAFLAGS
         custom_script: etc/ci/github-actions-docker-make.sh ${EXTRA_GH_REPORTIFY} -j2 pre-standalone-extracted
     - name: upload OCaml files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ExtractionOCaml-${{ matrix.env.COQ_VERSION }}
         path: src/ExtractionOCaml
       if: always ()
     - name: upload js_of_ocaml source files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ExtractionJsOfOCaml-source-${{ matrix.env.COQ_VERSION }}
         path: src/ExtractionJsOfOCaml
       if: always ()
     - name: upload Haskell source files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ExtractionHaskell-source-${{ matrix.env.COQ_VERSION }}
         path: src/ExtractionHaskell
@@ -85,13 +85,13 @@ jobs:
     - name: install-standalone-unified-ocaml
       run: make -f Makefile.standalone install-standalone-unified-ocaml BINDIR=dist
     - name: upload standalone files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: standalone-docker-coq-${{ matrix.env.DOCKER_COQ_VERSION }}
         path: dist/fiat_crypto
     - run: git config --file .gitmodules --get-regexp path | awk '{ print $2 }' | xargs tar -czvf fiat-crypto-build.tar.gz src
     - name: Upload built files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: build-outputs-docker-coq-${{ matrix.env.DOCKER_COQ_VERSION }}-ocaml-${{ matrix.env.DOCKER_OCAML_VERSION }}
         path: fiat-crypto-build.tar.gz
@@ -150,7 +150,7 @@ jobs:
       with:
         submodules: recursive
     - name: Download a Build Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: build-outputs-docker-coq-${{ matrix.env.DOCKER_COQ_VERSION }}-ocaml-${{ matrix.env.DOCKER_OCAML_VERSION }}
         path: .
@@ -192,7 +192,7 @@ jobs:
     - name: echo build params
       run: etc/ci/describe-system-config.sh
     - name: Download a Build Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: ExtractionJsOfOCaml-source-${{ matrix.coq-version }}
         path: src/ExtractionJsOfOCaml
@@ -203,13 +203,13 @@ jobs:
     - name: install-standalone-js-of-ocaml
       run: make -f Makefile.standalone install-standalone-js-of-ocaml
     - name: upload js_of_ocaml build files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ExtractionJsOfOCaml-${{ matrix.coq-version }}-ocaml-${{ matrix.ocaml-compiler }}
         path: src/ExtractionJsOfOCaml
       if: always ()
     - name: Upload js_of_ocaml outputs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: fiat-html-js-of-ocaml
         path: fiat-html
@@ -253,7 +253,7 @@ jobs:
     - name: echo build params
       run: etc/ci/describe-system-config.sh
     - name: Download a Build Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: ExtractionJsOfOCaml-source-${{ matrix.coq-version }}
         path: src/ExtractionJsOfOCaml
@@ -264,13 +264,13 @@ jobs:
     - name: install-standalone-wasm-of-ocaml
       run: make -f Makefile.standalone install-standalone-wasm-of-ocaml
     - name: upload wasm_of_ocaml build files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ExtractionJsOfOCaml-${{ matrix.coq-version }}-ocaml-${{ matrix.ocaml-compiler }}+wasm
         path: src/ExtractionJsOfOCaml
       if: always ()
     - name: Upload wasm_of_ocaml outputs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: fiat-html-wasm-of-ocaml
         path: fiat-html
@@ -288,14 +288,14 @@ jobs:
         fetch-depth: 0 # Fetch all history for all tags and branches, for fiat-html/version.js
         tags: true     # Fetch all tags as well, `fetch-depth: 0` might be sufficient depending on Git version
     - name: Download a Build Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: fiat-html-js-of-ocaml
         path: fiat-html
     - run: find fiat-html
     - run: ls -la fiat-html
     - name: Download a Build Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: fiat-html-wasm-of-ocaml
         path: fiat-html
@@ -334,21 +334,19 @@ jobs:
       with:
         submodules: recursive
     - name: Download a Build Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: ExtractionOCaml-${{ matrix.coq-version }}
         path: src/ExtractionOCaml
     - name: make binaries executable
       run: git check-ignore src/ExtractionOCaml/* | grep -v '\.' | xargs chmod +x
-    - name: touch binaries to prevent rebuilding
-      run: git check-ignore src/ExtractionOCaml/* | grep -v '\.' | xargs touch
     - name: generated-files
       run: etc/ci/github-actions-make.sh --warnings -f Makefile.examples -j2 generated-files
       if: github.event_name == 'pull_request'
     - run: tar -czvf generated-files.tgz fiat-*/
       if: ${{ failure() }}
     - name: upload generated files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: generated-files-${{ matrix.coq-version }}
         path: generated-files.tgz
@@ -369,14 +367,14 @@ jobs:
       with:
         submodules: recursive
     - name: Download a Build Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: ExtractionHaskell-source-${{ matrix.coq-version }}
         path: src/ExtractionHaskell
     - name: standalone-haskell
       run: etc/ci/github-actions-make.sh -f Makefile.standalone -j1 standalone-haskell GHCFLAGS='+RTS -M7G -RTS'
     - name: upload Haskell files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ExtractionHaskell-${{ matrix.coq-version }}
         path: src/ExtractionHaskell
@@ -398,7 +396,7 @@ jobs:
       with:
         submodules: recursive
     - name: Download a Build Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: ExtractionOCaml-master
         path: src/ExtractionOCaml
@@ -423,7 +421,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Download standalone Docker
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: standalone-docker-coq-${{ matrix.docker-coq-version }}
         path: dist/
@@ -468,7 +466,7 @@ jobs:
         fetch-depth: 0 # Fetch all history for all tags and branches
         tags: true     # Fetch all tags as well, `fetch-depth: 0` might be sufficient depending on Git version
     - name: Download standalone Docker
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: standalone-docker-coq-dev
         path: dist/

--- a/.github/workflows/coq-macos.yml
+++ b/.github/workflows/coq-macos.yml
@@ -90,22 +90,22 @@ jobs:
         etc/ci/github-actions-make.sh -j2 only-test-amd64-files-lite SLOWEST_FIRST=1
 
     - name: upload OCaml files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ExtractionOCaml
         path: src/ExtractionOCaml
     - name: upload js_of_ocaml files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ExtractionJsOfOCaml
         path: src/ExtractionJsOfOCaml
     - name: upload standalone files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: standalone-macos
         path: dist/fiat_crypto
     - name: upload standalone js files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: standalone-html-macos
         path: fiat-html
@@ -126,7 +126,7 @@ jobs:
     - name: display per-line timing info
       run: etc/ci/github-actions-display-per-line-timing.sh
 #    - name: upload timing and .vo info
-#      uses: actions/upload-artifact@v4
+#      uses: actions/upload-artifact@v3
 #      with:
 #        name: build-outputs
 #        path: .
@@ -143,7 +143,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Download standalone MacOS
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: standalone-macos
         path: dist/
@@ -174,7 +174,7 @@ jobs:
         fetch-depth: 0 # Fetch all history for all tags and branches
         tags: true     # Fetch all tags as well, `fetch-depth: 0` might be sufficient depending on Git version
     - name: Download standalone MacOS
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: standalone-macos
         path: dist/

--- a/.github/workflows/coq-windows.yml
+++ b/.github/workflows/coq-windows.yml
@@ -103,22 +103,22 @@ jobs:
         %CYGWIN_ROOT%\bin\bash.exe -l -c 'cd "%cd%"; opam exec -- etc/ci/github-actions-make.sh -j${NJOBS} only-test-amd64-files-lite SLOWEST_FIRST=1'
       shell: cmd
     - name: upload OCaml files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ExtractionOCaml
         path: src/ExtractionOCaml
     - name: upload js_of_ocaml files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ExtractionJsOfOCaml
         path: src/ExtractionJsOfOCaml
     - name: upload standalone files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: standalone-windows
         path: dist/fiat_crypto.exe
     - name: upload standalone js files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: standalone-html-windows
         path: fiat-html
@@ -142,7 +142,7 @@ jobs:
         %CYGWIN_ROOT%\bin\bash.exe -l -c 'cd "%cd%"; etc/ci/github-actions-display-per-line-timing.sh'
       shell: cmd
 #    - name: upload timing and .vo info
-#      uses: actions/upload-artifact@v4
+#      uses: actions/upload-artifact@v3
 #      with:
 #        name: build-outputs
 #        path: .
@@ -159,7 +159,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Download standalone Windows
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: standalone-windows
         path: dist/
@@ -194,7 +194,7 @@ jobs:
         fetch-depth: 0 # Fetch all history for all tags and branches
         tags: true     # Fetch all tags as well, `fetch-depth: 0` might be sufficient depending on Git version
     - name: Download standalone Windows
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: standalone-windows
         path: dist/

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -29,7 +29,7 @@ jobs:
       run: make only-test-java-files EXTERNAL_DEPENDENCIES=1
     - name: make documentation
       run: make only-javadoc EXTERNAL_DEPENDENCIES=1
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v3
       with:
         name: fiat-javadoc
         path: fiat-java/doc


### PR DESCRIPTION
This reverts commit 723baacab7bdd8187d47b2aa07796294ceb95f84.

v4 is buggy and has a very high failure rate, see also https://github.com/actions/download-artifact/issues/249