### PR TITLE
Adapt to Coq's PR #18445 fixing inheritance of multiple signatures of implicit arguments in notations

### DIFF
--- a/src/Compilers/Named/ContextProperties/Proper.v
+++ b/src/Compilers/Named/ContextProperties/Proper.v
@@ -23,7 +23,7 @@ Section with_context.
   Local Notation lookupb := (@lookupb base_type_code Name var Context).
   Local Notation extend := (@extend base_type_code Name var Context).
   Local Notation remove := (@remove base_type_code Name var Context).
-  Local Notation lookup := (@lookup base_type_code Name var Context).
+  Local Notation lookup t := (@lookup base_type_code Name var Context t).
 
   Global Instance context_equiv_Equivalence : Equivalence context_equiv | 10.
   Proof. split; repeat intro; congruence. Qed.


### PR DESCRIPTION
With coq/coq#18445, notations hiding constants with multiple signatures of implicit arguments inherit as expected the underlying implicit arguments.

File `src/Compilers/Named/ContextProperties/Proper.v` was depending on the "bug". We adapt it by changing the notation so that it becomes indifferent to potential insertion of maximal implicit arguments.

Note that this is one possible fix among others (for instance, it is probably also possible to change the signatures of the underlying constant).

It is (a priori) backwards compatible and can be merged as soon as now.