### PR TITLE
Fix typos

### DIFF
--- a/src/Bedrock/Field/Synthesis/New/WordByWordMontgomery.v
+++ b/src/Bedrock/Field/Synthesis/New/WordByWordMontgomery.v
@@ -767,9 +767,9 @@ Definition field_parameters_prefixed
     (prefix ++ "inv")
     (prefix ++ "from_bytes")
     (prefix ++ "to_bytes")
-    (prefix ++ "felem_copy")
-    (prefix ++ "small_literal")
     (prefix ++ "select_znz")
+    (prefix ++ "felem_copy")
+    (prefix ++ "from_word")
 .
 
 


### PR DESCRIPTION
Before,

```Coq
field_parameters_prefixed =
fun (M_pos : positive) (a24 : F M_pos) (prefix : string) =>
{|
 (* ... *)
  select_znz := prefix ++ "felem_copy";
  felem_copy := prefix ++ "small_literal";
  from_word := prefix ++ "select_znz"
|}
     : forall M_pos : positive, F M_pos -> string -> FieldParameters
```

After,

```Coq
field_parameters_prefixed =
fun (M_pos : positive) (a24 : F M_pos) (prefix : string) =>
{|
 (* ... *)
  select_znz := prefix ++ "select_znz";
  felem_copy := prefix ++ "felem_copy";
  from_word := prefix ++ "from_word"
|}
     : forall M_pos : positive, F M_pos -> string -> FieldParameters
```