### PR TITLE
[CI] Use {upload,download}-artifact@v4 in MacOS

### DIFF
--- a/.github/workflows/coq-macos.yml
+++ b/.github/workflows/coq-macos.yml
@@ -75,22 +75,22 @@ jobs:
       run: opam exec -- etc/ci/github-actions-make.sh -j2 only-test-amd64-files-lite SLOWEST_FIRST=1
 
     - name: upload OCaml files
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ExtractionOCaml-${{ matrix.os.arch }}
         path: src/ExtractionOCaml
     - name: upload js_of_ocaml files
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ExtractionJsOfOCaml-${{ matrix.os.arch }}
         path: src/ExtractionJsOfOCaml
     - name: upload standalone files
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: standalone-macos-${{ matrix.os.arch }}
         path: dist/fiat_crypto
     - name: upload standalone js files
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: standalone-html-macos-${{ matrix.os.arch }}
         path: fiat-html
@@ -105,7 +105,7 @@ jobs:
     - name: display per-line timing info
       run: etc/ci/github-actions-display-per-line-timing.sh
 #    - name: upload timing and .vo info
-#      uses: actions/upload-artifact@v3
+#      uses: actions/upload-artifact@v4
 #      with:
 #        name: build-outputs-${{ matrix.os.arch }}
 #        path: .
@@ -122,12 +122,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Download standalone MacOS x86_64
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: standalone-macos-x86_64
         path: dist-x86_64/
     - name: Download standalone MacOS arm64
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: standalone-macos-arm64
         path: dist-arm64/
@@ -136,7 +136,7 @@ jobs:
         mkdir -p dist
         lipo -create -output dist/fiat_crypto dist-x86_64/fiat_crypto dist-arm64/fiat_crypto
     - name: upload universal binary
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: standalone-macos
         path: dist/fiat_crypto
@@ -159,7 +159,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Download standalone MacOS${{ matrix.arch }}
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: standalone-macos${{ matrix.arch }}
         path: dist/
@@ -194,7 +194,7 @@ jobs:
         fetch-depth: 0 # Fetch all history for all tags and branches
         tags: true     # Fetch all tags as well, `fetch-depth: 0` might be sufficient depending on Git version
     - name: Download standalone MacOS${{ matrix.arch }}
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: standalone-macos${{ matrix.arch }}
         path: dist/


### PR DESCRIPTION
Maybe this time it's more stable. The v3 version will be removed in
November 2024 according to
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

```
git grep --name-only -- -artifact@v3 | grep coq-macos | xargs sed -i 's/-artifact@v3/-artifact@v4/g'
```

On top of #1891