### PR TITLE
[sp2019latest] (partial) compatibility with coq/coq#19310

### DIFF
--- a/src/Util/ZUtil/Hints/Core.v
+++ b/src/Util/ZUtil/Hints/Core.v
@@ -112,6 +112,15 @@ Module Coq.
     End PreOmega.
   End omega.
 End Coq.
+Module Stdlib.
+  Module omega.
+    Module PreOmega.
+      Definition Z_of_nat' := Z.of_nat.
+      Ltac hide_Z_of_nat a := idtac.
+      Ltac zify_nat_op := idtac.
+    End PreOmega.
+  End omega.
+End Stdlib.
 
 Ltac Coq.omega.PreOmega.zify_nat_op ::=
  match goal with


### PR DESCRIPTION
coq/coq#19310 rewrites the Coq prefix to Stdlib on the fly