### PR TITLE
Revert "[CI] Pin action steps that use setup-ocaml to ubuntu 22.04"

### DIFF
--- a/.github/workflows/coq-docker.yml
+++ b/.github/workflows/coq-docker.yml
@@ -194,7 +194,7 @@ jobs:
 
   build-js-of-ocaml:
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -243,7 +243,7 @@ jobs:
 
   build-wasm-of-ocaml:
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/coq-opam-package.yml
+++ b/.github/workflows/coq-opam-package.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         coq-version: ['dev', '8.19.0', '8.18.0']
         os: [{name: 'Ubuntu',
-              runs-on: 'ubuntu-22.04',
+              runs-on: 'ubuntu-latest',
               ocaml-compiler: '4.09.1',
               coq-extra-flags: '',
               ocamlfind-pin: '',


### PR DESCRIPTION
Reverts mit-plv/fiat-crypto#1971

Now that https://github.com/ocaml/setup-ocaml/pull/879 has been merged