### PR TITLE
Verified Bedrock2 code for Number-Theoretic Transform

### DIFF
--- a/src/NTT/BedrockNTT.v
+++ b/src/NTT/BedrockNTT.v
@@ -1,0 +1,1280 @@
+Require Import Spec.ModularArithmetic.
+Require Import Crypto.NTT.RupicolaUtils.
+Require Import Crypto.NTT.CyclotomicDecomposition.
+Require Import Crypto.NTT.RupicolaNTT.
+Require Import bedrock2.Array.
+Require Import bedrock2.Loops.
+Require Import bedrock2.Map.Separation.
+Require Import bedrock2.Map.SeparationLogic.
+Require Import bedrock2.NotationsCustomEntry.
+Require Import bedrock2.ProgramLogic.
+Require Import bedrock2.Scalars.
+Require Import bedrock2.Semantics.
+Require Import bedrock2.Syntax.
+Require Import bedrock2.WeakestPrecondition.
+Require Import bedrock2.WeakestPreconditionProperties.
+Require Import bedrock2.ZnWords.
+Require Import coqutil.Byte.
+Require Import coqutil.Map.Interface.
+Require Import coqutil.Map.Properties.
+Require Import coqutil.Map.OfListWord.
+From coqutil.Tactics Require Import Tactics letexists eabstract rdelta reference_to_string ident_of_string.
+Require Import coqutil.Word.Bitwidth.
+Require Import coqutil.Word.Interface.
+Require Import coqutil.Word.Properties.
+Require Import Coq.Init.Byte.
+Require Import Coq.Lists.List.
+Require Import Coq.ZArith.ZArith.
+Require Import Rupicola.Lib.Api.
+Require Import Rupicola.Lib.Core.
+Require Import Rupicola.Lib.Arrays.
+Require Import Rupicola.Lib.InlineTables.
+Require Import Rupicola.Lib.Loops.
+
+Section Utils.
+  (* TODO: move somewhere *)
+  Lemma set_nth_eq {A: Type} n (l: list A) x:
+    ListUtil.set_nth n x l = replace_nth n l x.
+  Proof.
+    revert n x; induction l; intros.
+    - destruct n; reflexivity.
+    - destruct n; [reflexivity|].
+      simpl. rewrite <- ListUtil.cons_set_nth, IHl. reflexivity.
+  Qed.
+
+  Lemma Forall2_replace_nth {A B: Type} (R: A -> B -> Prop) i x y xs ys:
+    Forall2 R xs ys ->
+    R x y ->
+    Forall2 R (replace_nth i xs x) (replace_nth i ys y).
+  Proof.
+    intros HF HR.
+    apply Forall2_nth_error_iff. split.
+    - do 2 rewrite replace_nth_length.
+      eapply Forall2_length; eauto.
+    - do 2 rewrite <- set_nth_eq.
+      intros. rewrite ListUtil.nth_set_nth in H, H0.
+      rewrite (Forall2_length HF) in H.
+      destruct (Nat.eq_dec k i).
+      + destruct (lt_dec _ _); [|congruence].
+        inversion H; inversion H0; subst; assumption.
+      + eapply Forall2_nth_error_iff; eauto.
+  Qed.
+End Utils.
+
+Section __.
+  Context {width: Z} {BW: Bitwidth width} {word: word.word width} {mem: map.map word Byte.byte}.
+  Context {locals: map.map String.string word}.
+  Context {ext_spec: bedrock2.Semantics.ExtSpec}.
+  Context {word_ok : word.ok word} {mem_ok : map.ok mem}.
+  Context {locals_ok : map.ok locals}.
+  Context {ext_spec_ok : Semantics.ext_spec.ok ext_spec}.
+
+  Context {ntt ntt_inverse: String.string}.
+  Context {q: positive}.
+  Local Notation F := (F q).
+  Context {n km1: nat}.
+  Context (zeta: F) (c:F) (zetas: list F).
+
+  (* Assume we have a partial word evaluation function, returns none if input is invalid *)
+  Context {feval: word -> option F}.
+  Context {F_to_Z: Convertible F Z}.
+  Local Instance F_to_word: Convertible F word := fun x => word.of_Z (cast x).
+  (* Converting a field element to a word, and back is correct *)
+  Hypothesis feval_ok: forall x, feval (cast x) = Some x.
+  (* For montgomery, F_to_Z would be something like fun x => F.to_Z (to_montgomery x), it's not necessarily F.to_Z *)
+
+  (* The field operations we need *)
+  Context {add sub mul: String.string}.
+
+  Hypothesis n_ge_km1: (km1 <= n)%nat.
+  Hypothesis n_lt_width: (n < Z.to_nat width)%nat.
+  Hypothesis zetas_length_ok: length zetas = Nat.pow 2 km1.
+
+  (* This is only needed because we need 2^(width/8) * 2^km1 ≤ 2^width to use InlineTables... Not a problem in practice *)
+  Hypothesis km1p3_le_with: (km1 + 3 <= Z.to_nat width)%nat.
+
+  Notation NTT_gallina := (@NTT_gallina q n km1 zetas).
+  Notation NTT_inverse_gallina := (@NTT_inverse_gallina q n km1 zetas c).
+
+  Local Instance F_default: HasDefault F := 0%F.
+
+  Definition spec_of_binop {name: String.string} (model: F -> F -> F): spec_of name :=
+    fnspec! name (x y: word) / (a b: F) ~> (res: word),
+      { requires tr mem :=
+          feval x = Some a /\ feval y = Some b;
+        ensures tr' mem' :=
+          tr'= tr /\ mem' = mem /\ feval res = Some (model a b)
+      }.
+
+  (* Assume add sub mul are correct *)
+  (* Definition spec_of_binop {name: String.string} (model: F -> F -> F): spec_of name := *)
+  (*   fnspec! name (x y: word) / (a b: F) ~> (res: word), *)
+  (*     { requires tr mem := *)
+  (*         x = cast a /\ y = cast b; *)
+  (*       ensures tr' mem' := *)
+  (*         tr'= tr /\ mem' = mem /\ res = cast (model a b) *)
+  (*     }. *)
+
+  Instance spec_of_add: spec_of add :=
+    spec_of_binop F.add.
+  Instance spec_of_sub: spec_of sub :=
+    spec_of_binop F.sub.
+  Instance spec_of_mul: spec_of mul :=
+    spec_of_binop F.mul.
+
+  Instance spec_of_ntt: spec_of ntt :=
+    fnspec! ntt (p_ptr: word) / (p: ListArray.t F) R,
+      { requires tr mem :=
+          exists p',
+          Forall2 (fun x y => feval y = Some x) p p' /\
+          mem =* (sizedlistarray_value access_size.word (Nat.pow 2 n) p_ptr p') * R;
+        ensures tr' mem' :=
+          tr' = tr /\
+          exists p',
+          Forall2 (fun x y => feval y = Some x) (NTT_gallina p) p' /\
+          mem' =* (sizedlistarray_value access_size.word (Nat.pow 2 n) p_ptr p') * R }.
+
+  (* Instance spec_of_ntt: spec_of ntt := *)
+  (*   fnspec! ntt (p_ptr: word) / (p: ListArray.t F) R, *)
+  (*     { requires tr mem := *)
+  (*         mem =* (sizedlistarray_value access_size.word (Nat.pow 2 n) p_ptr (List.map cast p)) * R; *)
+  (*       ensures tr' mem' := *)
+  (*         tr' = tr /\ *)
+  (*         mem' =* (sizedlistarray_value access_size.word (Nat.pow 2 n) p_ptr (List.map cast (NTT_gallina p))) * R }. *)
+
+  Instance spec_of_ntt_inverse: spec_of ntt_inverse :=
+    fnspec! ntt_inverse (p_ptr: word) / (p: ListArray.t F) R,
+      { requires tr mem :=
+          exists p',
+          Forall2 (fun x y => feval y = Some x) p p' /\
+          mem =* (sizedlistarray_value access_size.word (Nat.pow 2 n) p_ptr p') * R;
+        ensures tr' mem' :=
+          tr' = tr /\
+          exists p',
+          Forall2 (fun x y => feval y = Some x) (NTT_inverse_gallina p) p' /\
+          mem' =* (sizedlistarray_value access_size.word (Nat.pow 2 n) p_ptr p') * R }.
+
+  (* Instance spec_of_ntt_inverse: spec_of ntt_inverse := *)
+  (*   fnspec! ntt_inverse (p_ptr: word) / (p: ListArray.t F) R, *)
+  (*     { requires tr mem := *)
+  (*         mem =* (sizedlistarray_value access_size.word (Nat.pow 2 n) p_ptr (List.map cast p)) * R; *)
+  (*       ensures tr' mem' := *)
+  (*         tr' = tr /\ *)
+  (*         mem' =* (sizedlistarray_value access_size.word (Nat.pow 2 n) p_ptr (List.map cast (NTT_inverse_gallina p))) * R }. *)
+
+  Definition br2_ntt :=
+    func! (p) {
+      m = coq:(0);
+      len = coq:(Z.pow 2 (Z.of_nat n));
+      while (coq:(Z.pow 2 (Z.of_nat (n - km1))) < len) {
+        old_len = len;
+        len = len >> coq:(1);
+        start = coq:(0);
+        while (start < coq:(Z.pow 2 (Z.of_nat n))) {
+          m = m + coq:(1);
+          z = coq:(expr.inlinetable access_size.word (to_byte_table (List.map cast zetas)) (expr.op bopname.mul (expr.literal (width / 8)) (expr.var "m")));
+          j = start;
+          while (j < (start + len)) {
+            x = load(coq:(offset (expr.var "p") bedrock_expr:(j + len) (expr.literal (Z.of_nat (@Memory.bytes_per width access_size.word)))));
+            unpack! tmp = $mul(z, x);
+            y = load(coq:(offset (expr.var "p") bedrock_expr:(j) (expr.literal (Z.of_nat (@Memory.bytes_per width access_size.word)))));
+            unpack! x = $sub(y, tmp);
+            store(coq:(offset (expr.var "p") bedrock_expr:(j + len) (expr.literal (Z.of_nat (@Memory.bytes_per width access_size.word)))), x);
+            unpack! x = $add(y, tmp);
+            store(coq:(offset (expr.var "p") bedrock_expr:(j) (expr.literal (Z.of_nat (@Memory.bytes_per width access_size.word)))), x);
+            j = j + coq:(1)
+          };
+          start = start + old_len
+        }
+      }
+    }.
+
+  Definition br2_ntt_inverse :=
+    func! (p) {
+      m = coq:(Z.of_nat (Nat.pow 2 km1));
+      len = coq:(Z.of_nat (Nat.pow 2 (n - km1)));
+      while (len < coq:(Z.of_nat (Nat.pow 2 n))) {
+        start = coq:(0);
+        old_len = len;
+        len = len << coq:(1);
+        while (start < coq:(Z.of_nat (Nat.pow 2 n))) {
+          m = m - coq:(1);
+          z = coq:(expr.inlinetable access_size.word (to_byte_table (List.map cast zetas)) (expr.op bopname.mul (expr.literal (width / 8)) (expr.var "m")));
+          j = start;
+          while (j < start + old_len) {
+            tmp = load(coq:(offset (expr.var "p") bedrock_expr:(j) (expr.literal (Z.of_nat (@Memory.bytes_per width access_size.word)))));
+            x = load(coq:(offset (expr.var "p") bedrock_expr:(j + old_len) (expr.literal (Z.of_nat (@Memory.bytes_per width access_size.word)))));
+            unpack! y = $add(tmp, x);
+            store(coq:(offset (expr.var "p") bedrock_expr:(j) (expr.literal (Z.of_nat (@Memory.bytes_per width access_size.word)))), y);
+            unpack! x = $sub(x, tmp);
+            unpack! y = $mul(z, x);
+            store(coq:(offset (expr.var "p") bedrock_expr:(j + old_len) (expr.literal (Z.of_nat (@Memory.bytes_per width access_size.word)))), y);
+            j = j + coq:(1)
+          };
+          start = start + len
+        }
+      };
+      j = coq:(0);
+      while (j < coq:(Z.of_nat (Nat.pow 2 n))) {
+        x = load(coq:(offset (expr.var "p") bedrock_expr:(j) (expr.literal (Z.of_nat (@Memory.bytes_per width access_size.word)))));
+        unpack! x = $mul(coq:(@cast _ Z _ c), x);
+        store(coq:(offset (expr.var "p") bedrock_expr:(j) (expr.literal (Z.of_nat (@Memory.bytes_per width access_size.word)))), x);
+        j = j + coq:(1)
+      }
+    }.
+
+  Lemma br2_ntt_ok:
+    program_logic_goal_for br2_ntt
+      (forall functions : map.rep,
+          map.get functions ntt = Some br2_ntt ->
+          spec_of_mul functions ->
+          spec_of_sub functions -> spec_of_add functions -> spec_of_ntt functions).
+  Proof.
+    Local Opaque Memory.bytes_per to_byte_table Z.pow Z.of_nat List.map Z.div Z.sub Z.add Nat.sub cast F.F.
+    repeat straightline.
+    unfold NTT_gallina. unfold nlet.
+    apply wp_while.
+    (* First loop invariant *)
+    pose (loop_inv1:= fun (fuel: nat) (tr': Semantics.trace) (mem': mem) (loc: locals) =>
+                        (fuel <= km1)%nat /\
+                        let i := (km1 - fuel)%nat in
+                        tr' = tr /\
+                        exists p' px,
+                        layer_decomposition_loop zetas i \< 0, 2 ^ Z.of_nat n, p \> = \< (2 ^ Z.of_nat i) - 1, 2 ^ Z.of_nat (n - i), px \> /\
+                        Forall2 (fun x y => feval y = Some x) px p' /\
+                        map.get loc "p" = Some p_ptr /\
+                        map.get loc "m" = Some (word.of_Z (Z.of_nat ((Nat.pow 2 i) - 1))) /\
+                        map.get loc "len" = Some (word.of_Z (Z.of_nat (Nat.pow 2 (n - i)))) /\
+                        (sizedlistarray_value access_size.word (Nat.pow 2 n) p_ptr p' * R)%sep mem').
+    exists nat, lt, loop_inv1.
+    split; [apply lt_wf|].
+    split. (* Invariant holds at beginning *)
+    { exists km1. repeat split; [Lia.lia|..].
+      exists x, p. repeat split.
+      - unfold layer_decomposition_loop. rewrite PeanoNat.Nat.sub_diag.
+        rewrite <- fold_left_as_nd_ranged_for_all.
+        rewrite z_range_nil by Lia.lia. simpl.
+        rewrite Z.pow_0_r, Z.sub_diag, PeanoNat.Nat.sub_0_r. reflexivity.
+      - assumption.
+      (* These map goals could be automated *)
+      - unfold l1, l0, l. do 2 (rewrite map.get_put_diff by congruence).
+        apply map.get_put_same.
+      - unfold l1, l0, l. rewrite map.get_put_diff by congruence.
+        rewrite map.get_put_same. unfold m. rewrite PeanoNat.Nat.sub_diag.
+        reflexivity.
+      - unfold l1. rewrite map.get_put_same. unfold len.
+        rewrite PeanoNat.Nat.sub_diag, PeanoNat.Nat.sub_0_r.
+        rewrite Nat2Z.inj_pow. reflexivity.
+      - assumption. }
+    intros fuel tr' mem' loc' Hinv.
+    destruct Hinv as (Hfuel & -> & p' & px' & HF1 & Heq & Hp & Hm & Hlen & Hseps).
+    eexists. split.
+    { apply expr_compile_word_ltu.
+      - apply expr_compile_Z_literal.
+      - apply expr_compile_var. eauto. }
+    split.
+    { (* Invariant preservation *)
+      intro Hb. rewrite Nat2Z.inj_pow in Hb.
+      rewrite <- word.morph_ltu in Hb.
+      2-3: split; try Lia.lia.
+      2-3: apply Zpow_facts.Zpower_lt_monotone; Lia.lia.
+      generalize (Zlt_cases (2 ^ Z.of_nat (n - km1)) (Z.of_nat 2 ^ Z.of_nat (n - (km1 - fuel)))).
+      rewrite word.unsigned_b2w in Hb.
+      destruct (_ <? _); intros Hlt1; [|cbv in Hb; congruence].
+      assert (Hfnz: (fuel <> 0)%nat) by (intro X; subst fuel; rewrite PeanoNat.Nat.sub_0_r in Hlt1; Lia.lia).
+      repeat straightline. eexists. split; [apply expr_compile_var; eauto|].
+      repeat straightline. eexists. split; [apply expr_compile_word_sru; [apply expr_compile_var; unfold l; rewrite map.get_put_diff by congruence; eauto|apply expr_compile_Z_literal]|].
+      repeat straightline.
+      assert (Hp1: map.get l1 "p" = Some p_ptr).
+      { unfold l1, l0, l; repeat (rewrite map.get_put_diff by congruence). auto. }
+      assert (Hm1: map.get l1 "m" = Some (word.of_Z (Z.of_nat ((Nat.pow 2 (km1 - fuel)) - 1)))).
+      { unfold l1, l0, l. repeat (rewrite map.get_put_diff by congruence). auto. }
+      assert (Hlen1: map.get l1 "len" = Some (word.of_Z (Z.of_nat (Nat.pow 2 (n - (km1 - (fuel - 1))))))).
+      { unfold l1, l0, l; repeat (rewrite map.get_put_diff by congruence).
+        rewrite map.get_put_same, <- word.morph_shiftr.
+        2: Lia.lia.
+        2: split; [|rewrite Nat2Z.inj_pow; apply Zpow_facts.Zpower_lt_monotone]; Lia.lia.
+        rewrite Z.shiftr_div_pow2 by Lia.lia.
+        replace (2 ^ 1) with (Z.of_nat (Nat.pow 2 1)) by reflexivity.
+        rewrite <- Nat2Z.inj_div, <- PeanoNat.Nat.pow_sub_r by Lia.lia.
+        f_equal. f_equal. f_equal. f_equal.
+        clear -Hfuel n_ge_km1 Hfnz. Lia.lia. }
+      assert (Hold_len1: map.get l1 "old_len" = Some _) by (unfold l1, l0, l; repeat (rewrite map.get_put_diff by congruence); apply map.get_put_same).
+      apply wp_while.
+      (* second loop *)
+      pose (loop_inv2:= fun (fuel2: nat) (tr': Semantics.trace) (mem': mem) (loc: locals) =>
+                        (fuel2 <= Nat.pow 2 (km1 - fuel))%nat /\
+                        let i := ((Nat.pow 2 (km1 - fuel) - fuel2))%nat in
+                        tr' = tr /\
+                        exists p'' px'',
+                        polynomial_list_loop zetas (Z.of_nat i) (2 ^ Z.of_nat (n - (km1 - fuel))) (2 ^ Z.of_nat (n - (km1 - (fuel - 1)))) \< (2 ^ Z.of_nat (km1 - fuel) - 1), 0, px' \> = \< (((2 ^ Z.of_nat (km1 - fuel)) - 1) + (Z.of_nat i)), (Z.of_nat i * (2 ^ Z.of_nat (n - (km1 - fuel)))), px'' \> /\
+                        Forall2 (fun x y => feval y = Some x) px'' p'' /\
+                        map.get loc "p" = Some p_ptr /\
+                        map.get loc "m" = Some (word.of_Z (Z.of_nat ((Nat.pow 2 (km1 - fuel)) - 1 + i))) /\
+                        map.get loc "len" = Some (word.of_Z (Z.of_nat (Nat.pow 2 (n - (km1 - (fuel - 1)))))) /\
+                        map.get loc "old_len" = Some (word.of_Z (Z.of_nat (Nat.pow 2 (n - (km1 - fuel))))) /\
+                        map.get loc "start" = Some (word.of_Z (Z.of_nat (i * (Nat.pow 2 (n - (km1 - fuel)))))) /\
+                        (sizedlistarray_value access_size.word (Nat.pow 2 n) p_ptr p'' * R)%sep mem').
+      exists nat, lt, loop_inv2. split; [apply lt_wf|]. split.
+      { (* invariant holds at beginning *)
+        exists (2 ^ (km1 - fuel))%nat. repeat split; [Lia.lia|].
+        exists p', px'. repeat split; auto.
+        - rewrite PeanoNat.Nat.sub_diag. unfold polynomial_list_loop.
+          rewrite <- fold_left_as_nd_ranged_for_all.
+          rewrite z_range_nil by Lia.lia. simpl.
+          rewrite Z.add_0_r, Z.mul_0_l. reflexivity.
+        - rewrite Hm1, PeanoNat.Nat.sub_diag, PeanoNat.Nat.add_0_r. reflexivity.
+        - rewrite PeanoNat.Nat.sub_diag, PeanoNat.Nat.mul_0_l.
+          apply map.get_put_same. }
+      intros fuel2 tr2 mem2 l2 Hinv2.
+      destruct Hinv2 as (Hfuel2 & -> & p2 & px2 & Heq2 & HF2 & Hp2 & Hm2 & Hlen2 & Hold_len2 & Hstart2 & Hseps2).
+      eexists; split.
+      { apply expr_compile_word_ltu.
+        - apply expr_compile_var. eauto.
+        - apply expr_compile_Z_literal. }
+      rewrite <- word.morph_ltu.
+      2-3: split; try Lia.lia.
+      4: apply Zpow_facts.Zpower_lt_monotone; Lia.lia.
+      2: apply Nat2Z.is_nonneg.
+      2:{ rewrite Nat.mul_sub_distr_r, <- PeanoNat.Nat.pow_add_r.
+          assert (km1 - fuel + _ = n)%nat as -> by (clear -Hfnz Hfuel n_ge_km1; Lia.lia).
+          assert (2 ^ width = Z.of_nat (2 ^ (Z.to_nat width))) as -> by (rewrite Nat2Z.inj_pow, Z2Nat.id by (clear -n_lt_width; Lia.lia); reflexivity).
+          apply Nat2Z.inj_lt.
+          eapply Nat.le_lt_trans; [|eapply PeanoNat.Nat.pow_lt_mono_r; try eassumption; Lia.lia].
+          clear; Lia.lia. }
+      rewrite word.unsigned_b2w. split.
+      { (* Invariant preservation *) intro Hcond.
+        assert (fuel2 <> 0)%nat as Hfnz2.
+        { destruct (Nat.eq_dec fuel2 0%nat) as [->|]; auto.
+          elim Hcond. clear Hcond. rewrite PeanoNat.Nat.sub_0_r.
+          rewrite <- Nat.pow_add_r.
+          assert (_ - _ + _ = n)%nat as -> by (clear -Hfnz Hfuel n_ge_km1; Lia.lia).
+          rewrite Nat2Z.inj_pow, Z.ltb_irrefl. reflexivity. }
+        repeat straightline.
+        eexists. split.
+        { apply expr_compile_word_add.
+          - apply expr_compile_var. eauto.
+          - apply expr_compile_Z_literal. }
+        rewrite <- word.ring_morph_add.
+        repeat straightline. exists (cast (InlineTable.get zetas ((2 ^ (km1 - fuel) - 1 + 2 ^ (km1 - fuel) - fuel2) + 1)%nat)).
+        split.
+        { eexists; split.
+          - apply map.get_put_same.
+          - cbn. rewrite <- word.ring_morph_mul.
+            unfold load.
+            assert (Z.of_nat _ + 1 = Z.of_nat _ + Z.of_nat 1) as -> by reflexivity.
+            rewrite <- Nat2Z.inj_add.
+            erewrite load_from_word_table; auto.
+            2:{ rewrite length_to_byte_table, map_length.
+                rewrite zetas_length_ok. assert (width / 8 = 4 \/ width / 8 = 8) as Hw.
+                { clear -BW.
+                  destruct width_cases as [-> | ->]; [left|right]; reflexivity. }
+                rewrite Nat2Z.inj_mul, Z2Nat.id by (clear -Hw; destruct Hw; Lia.lia).
+                rewrite Nat2Z.inj_pow.
+                transitivity (2 ^ 3 * 2 ^ Z.of_nat km1).
+                - apply Z.mul_le_mono_nonneg_r.
+                  + apply Z.lt_le_incl, ZLib.Z.pow2_pos, Nat2Z.is_nonneg.
+                  + clear -Hw. destruct Hw as [-> | ->]; Lia.lia.
+                - rewrite <- Z.pow_add_r by Lia.lia.
+                  apply Z.pow_le_mono_r; Lia.lia. }
+            eexists; split; [reflexivity|].
+            unfold InlineTable.get. rewrite map_nth.
+            repeat f_equal. cbv [cast Convertible_self id].
+            clear -n_ge_km1 Hfuel Hfuel2; Lia.lia.
+            rewrite map_length, zetas_length_ok.
+            eapply (Nat.lt_le_trans _ (2 ^ (km1 - (fuel - 1)))%nat).
+            + assert (km1 - (fuel - 1) = S (km1 - fuel))%nat as -> by (clear -Hfuel Hfnz; Lia.lia).
+              rewrite Nat.pow_succ_r'. clear -Hfuel2 Hfnz2. Lia.lia.
+            + apply Nat.pow_le_mono; clear -km1p3_le_with; Lia.lia. }
+        repeat straightline. eexists. split.
+        { apply expr_compile_var. unfold l4, l3.
+          do 2 rewrite map.get_put_diff by congruence.
+          apply Hstart2. }
+        repeat straightline.
+        apply wp_while.
+        assert (Hj: map.get l5 "j" = Some _) by (apply map.get_put_same).
+        assert (Hz: map.get l5 "z" = Some _) by (unfold l5; rewrite map.get_put_diff by congruence; apply map.get_put_same).
+        assert (Hm3: map.get l5 "m" = Some _) by (unfold l5, l4; do 2 (rewrite map.get_put_diff by congruence); apply map.get_put_same).
+        assert (Hstart3: map.get l5 "start" = Some _) by (unfold l5, l4, l3; repeat (rewrite map.get_put_diff by congruence); eassumption).
+        assert (Hold_len3: map.get l5 "old_len" = Some _) by (unfold l5, l4, l3; repeat (rewrite map.get_put_diff by congruence); eassumption).
+        assert (Hlen3: map.get l5 "len" = Some _) by (unfold l5, l4, l3; repeat (rewrite map.get_put_diff by congruence); eassumption).
+        assert (Hp3: map.get l5 "p" = Some _) by (unfold l5, l4, l3; repeat (rewrite map.get_put_diff by congruence); eassumption).
+        pose (loop_inv3 := fun (fuel3:nat) (tr': Semantics.trace) (mem': mem) (loc: locals) =>
+                        (fuel3 <= Nat.pow 2 (n - (km1 - (fuel - 1))))%nat /\
+                        let i := (Nat.pow 2 (n - (km1 - (fuel - 1))) - fuel3)%nat in
+                        tr' = tr /\
+                        let px'' := polynomial_decompose_loop (Z.of_nat i) (Z.of_nat ((2 ^ (km1 - fuel) - fuel2) * 2 ^ (n - (km1 - fuel)))) (Z.of_nat (2 ^ (n - (km1 - (fuel - 1))))) (InlineTable.get zetas (2 ^ (km1 - fuel) - 1 + 2 ^ (km1 - fuel) - fuel2 + 1)%nat) px2 in
+                        exists p'',
+                        Forall2 (fun x y => feval y = Some x) px'' p'' /\
+                        map.get loc "p" = Some p_ptr /\
+                        map.get loc "m" = Some (word.of_Z (Z.of_nat (2 ^ (km1 - fuel) - 1 + (2 ^ (km1 - fuel) - fuel2)) + 1)) /\
+                        map.get loc "len" = Some (word.of_Z (Z.of_nat (2 ^ (n - (km1 - (fuel - 1)))))) /\
+                        map.get loc "old_len" = Some (word.of_Z (Z.of_nat (2 ^ (n - (km1 - fuel))))) /\
+                        map.get loc "start" = Some (word.of_Z (Z.of_nat ((2 ^ (km1 - fuel) - fuel2) * 2 ^ (n - (km1 - fuel))))) /\
+                        map.get loc "j" = Some (word.of_Z (Z.of_nat ((2 ^ (km1 - fuel) - fuel2) * 2 ^ (n - (km1 - fuel)) + i))) /\
+                        map.get loc "z" = Some (cast (InlineTable.get zetas (2 ^ (km1 - fuel) - 1 + 2 ^ (km1 - fuel) - fuel2 + 1)%nat)) /\
+                        (sizedlistarray_value access_size.word (Nat.pow 2 n) p_ptr p'' * R)%sep mem').
+        exists nat, lt, loop_inv3. split; [apply lt_wf|].
+        split.
+        { (* Invariant holds at beginning *)
+          exists (2 ^ (n - (km1 - (fuel - 1))))%nat. split; [reflexivity|].
+          intros. split; [reflexivity|]. intros.
+          assert (i = 0)%nat as -> by (clear; Lia.lia).
+          exists p2. repeat split; auto.
+          - assert (px'' = px2) as ->; auto.
+            unfold px'', polynomial_decompose_loop.
+            rewrite Z.add_0_r, <- fold_left_as_nd_ranged_for_all.
+            unfold z_range. rewrite z_range'_seq; [|apply Nat2Z.is_nonneg].
+            rewrite <- Nat2Z.inj_sub by reflexivity.
+            repeat rewrite Nat2Z.id. rewrite Nat.sub_diag, ListUtil.seq_len_0.
+            rewrite ListUtil.List.map_nil; reflexivity.
+          - rewrite Nat.add_0_r. auto. }
+        intros fuel3 tr3 m3 loc3 Hinv3.
+        destruct Hinv3 as (Hfuel3 & -> & p3 & HF3 & Hp4 & Hm4 & Hlen4 & Hold_len4 & Hstart4 & Hj4 & Hz4 & Hseps4).
+        eexists; split.
+        { apply expr_compile_word_ltu.
+          - apply expr_compile_var. eauto.
+          - apply expr_compile_Z_add; apply expr_compile_var; eauto. }
+        rewrite <- word.morph_ltu.
+        3: rewrite <- Nat2Z.inj_add.
+        2-3: split; try (apply Nat2Z.is_nonneg).
+        2-3: assert (2 ^ width = Z.of_nat (2 ^ (Z.to_nat width))) as -> by (rewrite Nat2Z.inj_pow, Z2Nat.id by (clear -n_lt_width; Lia.lia); reflexivity).
+        2-3: apply Nat2Z.inj_lt.
+        2-3: eapply (Nat.le_lt_trans _ (Nat.pow 2 n)); [|apply Nat.pow_lt_mono_r; auto].
+        2-3: rewrite Nat.mul_sub_distr_r, <- PeanoNat.Nat.pow_add_r.
+        2-3: assert (km1 - fuel + _ = n)%nat as -> by (clear -Hfnz Hfuel n_ge_km1; Lia.lia).
+        2: transitivity (2 ^ n - fuel2 * 2 ^ (n - (km1 - fuel)) + (2 ^ (n - (km1 - (fuel - 1)))))%nat; [clear; Lia.lia|].
+        2-3: rewrite <- (Nat.mul_1_l (Nat.pow 2 (n - (km1 - (fuel - 1))))).
+        2-3: assert (n - (km1 - fuel) = S (n - (km1 - (fuel - 1))))%nat as -> by (clear -n_ge_km1 Hfuel Hfnz; Lia.lia).
+        2-3: rewrite Nat.pow_succ_r'.
+        2-3: assert (Nat.pow 2 n = (Nat.pow 2 (km1 - (fuel - 1))) * (Nat.pow 2 (n - (km1 - (fuel - 1)))))%nat as -> by (rewrite <- Nat.pow_add_r; f_equal; clear -n_ge_km1 Hfuel Hfnz; Lia.lia).
+        2-3: rewrite Nat.mul_assoc, <- Nat.mul_sub_distr_r, <- Nat.mul_add_distr_r.
+        2-3: apply Nat.mul_le_mono_r; clear -Hfuel Hfuel2 Hfnz Hfnz2 n_ge_km1.
+        2-3: generalize (Nat.pow_nonzero 2%nat (km1 - (fuel - 1)) ltac:(Lia.lia)); Lia.lia.
+        rewrite word.unsigned_b2w, <- Nat2Z.inj_add. split; intro Hcond2.
+        { (* Invariant preservation *)
+          clear Hb. match goal with | [H: Z.b2z (?a <? ?b) <> _ |- _] => generalize (Zlt_cases a b); destruct (a <? b); cbv in H; [clear H|congruence]; intro H end.
+          apply Nat2Z.inj_lt in Hcond2.
+          assert (fuel3 <> 0)%nat as Hfnz3.
+          { destruct (Nat.eq_dec fuel3 0%nat) as [->|]; auto.
+            clear -Hcond2 Hfuel Hfuel2 Hfuel3 n_ge_km1 Hfnz Hfnz2.
+            Lia.lia. }
+          generalize (SizedListArray_length (sz:=access_size.word) _ _ _ _ _ Hseps4). intro Xlen.
+          assert ((2 ^ (km1 - fuel) - fuel2) * 2 ^ (n - (km1 - fuel)) + (2 ^ (n - (km1 - (fuel - 1))) - fuel3) + 2 ^ (n - (km1 - (fuel - 1))) < 2 ^ n)%nat as idx_ok.
+          { clear -Hfuel Hfuel2 Hfuel3 n_ge_km1 Hfnz Hfnz2 Hfnz3.
+            rewrite Nat.mul_sub_distr_r, <- Nat.pow_add_r.
+            assert (km1 - fuel + _ = n)%nat as -> by Lia.lia.
+            assert (2 ^ n - fuel2 * 2 ^ (n - (km1 - fuel)) + (2 ^ (n - (km1 - (fuel - 1))) - fuel3) + 2 ^ (n - (km1 - (fuel - 1))) = 2 ^ n - fuel2 * 2 ^ (n - (km1 - fuel)) + (2 * 2 ^ (n - (km1 - (fuel - 1))) - fuel3))%nat as -> by Lia.lia.
+            rewrite <- Nat.pow_succ_r'.
+            assert (S (n - (km1 - (fuel - 1))) = (n - (km1 - fuel)))%nat as -> by Lia.lia.
+            generalize (NatUtil.pow_nonzero 2 n ltac:(Lia.lia)).
+            generalize (NatUtil.pow_nonzero 2 (km1 - fuel) ltac:(Lia.lia)).
+            generalize (NatUtil.pow_nonzero 2 (n - (km1 - fuel)) ltac:(Lia.lia)).
+            generalize (NatUtil.pow_nonzero 2 (n - (km1 - (fuel - 1))) ltac:(Lia.lia)).
+            generalize (Nat.pow_lt_mono_r 2%nat (n - (km1 - (fuel - 1)))%nat (n - (km1 - fuel))%nat ltac:(Lia.lia) ltac:(Lia.lia)).
+            intros. assert (2 ^ n - fuel2 * 2 ^ (n - (km1 - fuel)) + (2 ^ (n - (km1 - fuel)) - fuel3) = 2 ^ n - (fuel2 - 1) * 2 ^ (n - (km1 - fuel)) - fuel3)%nat as ->; [|Lia.lia].
+            rewrite Nat.add_sub_assoc; [|Lia.lia]. f_equal.
+            assert (Nat.pow 2 n = Nat.pow 2 ((km1 - fuel)+ (n - (km1 - fuel))))%nat as -> by (f_equal; Lia.lia).
+            rewrite Nat.pow_add_r. repeat rewrite <- Nat.mul_sub_distr_r.
+            rewrite <- (Nat.mul_1_l (Nat.pow 2 (n - (km1 - fuel))))%nat at 2.
+            rewrite <- Nat.mul_add_distr_r. f_equal. Lia.lia. }
+          set (px3 := (polynomial_decompose_loop (Z.of_nat (2 ^ (n - (km1 - (fuel - 1))) - fuel3))
+                      (Z.of_nat ((2 ^ (km1 - fuel) - fuel2) * 2 ^ (n - (km1 - fuel))))
+                      (Z.of_nat (2 ^ (n - (km1 - (fuel - 1)))))
+                      (InlineTable.get zetas (2 ^ (km1 - fuel) - 1 + 2 ^ (km1 - fuel) - fuel2 + 1)%nat)
+                      px2)).
+          set (j := ((2 ^ (km1 - fuel) - fuel2) * 2 ^ (n - (km1 - fuel)) + (2 ^ (n - (km1 - (fuel - 1))) - fuel3))%nat).
+          set (len4 := (2 ^ (n - (km1 - (fuel - 1))))%nat).
+          eapply weaken_cmd.
+          { eapply (@compile_word_sizedlistarray_get _ _ _ _ _ _ _ _ _ nat); eauto.
+            - repeat straightline. eexists; split; eauto.
+            - instantiate (1 := (j + len4)%nat).
+              cbv [cast Convertible_self id].
+              repeat straightline. eexists; split; eauto.
+              repeat straightline. eexists; split; eauto.
+              rewrite Nat2Z.inj_add, word.ring_morph_add. reflexivity.
+            - cbv [cast Convertible_self id].
+              apply Nat2Z.inj_lt. clear -idx_ok. Lia.lia.
+            - repeat straightline. eexists; split; [repeat straightline|straightline_call].
+              + eexists; split; [rewrite map.get_put_diff by congruence; eauto|repeat straightline].
+                eexists; split; [apply map.get_put_same|repeat straightline].
+              + split; [apply feval_ok|].
+                instantiate (1 := ListArray.get px3 (j + len4)%nat).
+                unfold v, ListArray.get. fold px3 in HF3.
+                do 2 rewrite <- nth_default_eq.
+                eapply (ListUtil.Forall2_forall_iff (fun x y => feval y = Some x)); eauto.
+                * eapply Forall2_length; eauto.
+                * cbv [cast Convertible_self id]. cbn in Xlen.
+                  rewrite (Forall2_length HF3), Xlen.
+                  clear -idx_ok; Lia.lia.
+              + destruct H4 as (? & -> & -> & -> & ZZ).
+                eexists; split; [reflexivity|].
+                eapply weaken_cmd.
+                { eapply (@compile_word_sizedlistarray_get _ _ _ _ _ _ _ _ _ nat); eauto.
+                  - repeat straightline. eexists; split; [repeat (rewrite map.get_put_diff by congruence)|]; eauto.
+                  - eapply expr_compile_var. cbv [cast Convertible_self id].
+                    repeat (rewrite map.get_put_diff by congruence). eauto.
+                  - cbv [cast Convertible_self id].
+                    apply Nat2Z.inj_lt. clear -idx_ok. Lia.lia.
+                  - intros. repeat straightline.
+                    eexists; split; [repeat straightline|straightline_call].
+                    + eexists; split; [apply map.get_put_same|repeat straightline].
+                      eexists; split; [rewrite map.get_put_diff by congruence; apply map.get_put_same|].
+                      repeat straightline.
+                    + split; eauto. unfold v0.
+                      instantiate (1 := ListArray.get px3 j).
+                      unfold v, ListArray.get. fold px3 in HF3.
+                      do 2 rewrite <- nth_default_eq.
+                      eapply (ListUtil.Forall2_forall_iff (fun x y => feval y = Some x)); eauto.
+                      * eapply Forall2_length; eauto.
+                      * cbv [cast Convertible_self id]. cbn in Xlen.
+                        rewrite (Forall2_length HF3), Xlen.
+                        clear -idx_ok; Lia.lia.
+                    + destruct H4 as (? & -> & -> & -> & ZZ2).
+                      eexists; split; [reflexivity|].
+                      eapply weaken_cmd.
+                      { eapply (@compile_word_sizedlistarray_put _ _ _ _ _ _ _ _ _ _ _ nat); eauto.
+                        - eapply expr_compile_var.
+                          repeat rewrite map.get_put_diff by congruence. auto.
+                        - cbv [cast Convertible_self id].
+                          eapply expr_compile_nat_add; eapply expr_compile_var; repeat rewrite map.get_put_diff by congruence; eauto.
+                        - eapply expr_compile_var; apply map.get_put_same.
+                        - cbv [cast Convertible_self id].
+                          clear -idx_ok. Lia.lia.
+                        - repeat straightline. eexists; split; [repeat straightline|straightline_call].
+                          + eexists; split; [repeat rewrite map.get_put_diff by congruence; apply map.get_put_same|repeat straightline].
+                            eexists; split; [repeat rewrite map.get_put_diff by congruence; apply map.get_put_same|repeat straightline].
+                          + split; eauto. unfold v0.
+                            instantiate (1 := ListArray.get px3 j).
+                            unfold v, ListArray.get. fold px3 in HF3.
+                            do 2 rewrite <- nth_default_eq.
+                            eapply (ListUtil.Forall2_forall_iff (fun x y => feval y = Some x)); eauto.
+                            * eapply Forall2_length; eauto.
+                            * cbv [cast Convertible_self id]. cbn in Xlen.
+                              rewrite (Forall2_length HF3), Xlen.
+                              clear -idx_ok; Lia.lia.
+                          + destruct H5 as (? & -> & -> & -> & ZZ3).
+                            eexists; split; [reflexivity|].
+                            eapply weaken_cmd.
+                            { eapply (@compile_word_sizedlistarray_put _ _ _ _ _ _ _ _ _ _ _ nat); eauto.
+                              - eapply expr_compile_var.
+                                repeat rewrite map.get_put_diff by congruence; eauto.
+                              - cbv [cast Convertible_self id].
+                                eapply expr_compile_var; repeat rewrite map.get_put_diff by congruence; eauto.
+                              - eapply expr_compile_var; apply map.get_put_same.
+                              - cbv [cast Convertible_self id].
+                                apply Nat2Z.inj_lt. clear -idx_ok. Lia.lia.
+                              - repeat straightline.
+                                eexists; split; repeat straightline.
+                                + eexists; split; repeat straightline.
+                                  repeat rewrite map.get_put_diff by congruence; eauto.
+                                + instantiate (2 := fun _ t m l => loop_inv3 (fuel3 - 1)%nat t m l).
+                                  simpl. repeat split.
+                                  * clear -Hfnz3 Hfuel3; Lia.lia.
+                                  * eexists; repeat split; eauto.
+                                    2-8: unfold l6; repeat rewrite map.get_put_diff by congruence; try apply map.get_put_same; eauto.
+                                    2:{ rewrite map.get_put_same, <- word.ring_morph_add. do 2 f_equal.
+                                        assert (1%Z = Z.of_nat 1)%nat as -> by reflexivity.
+                                        rewrite <- Nat2Z.inj_add. f_equal.
+                                        clear -Hfnz Hfnz2 Hfnz3 Hfuel Hfuel2 Hfuel3 n_ge_km1; Lia.lia. }
+                                    unfold polynomial_decompose_loop.
+                                    match goal with
+                                    | |- context [nd_ranged_for_all _ _ ?body _] => assert (nd_ranged_for_all _ _ _ _ = body px3 (Z.of_nat j)) as -> end.
+                                    2:{ unfold v2, v1, nlet; simpl.
+                                        unfold ListArray.put, ListArray.get.
+                                        cbv [cast Convertible_Z_nat Convertible_self id].
+                                        repeat rewrite <- Nat2Z.inj_add.
+                                        repeat rewrite Nat2Z.id. fold j.
+                                        eapply Forall2_replace_nth; eauto.
+                                        eapply Forall2_replace_nth; eauto. }
+                                    unfold nlet.
+                                    rewrite <- fold_left_as_nd_ranged_for_all.
+                                    unfold z_range. rewrite z_range'_seq by (apply Nat2Z.is_nonneg).
+                                    match goal with
+                                    | |- context [seq ?from _] =>
+                                        assert (seq from _ = seq from (Z.to_nat (Z.of_nat ((2 ^ (km1 - fuel) - fuel2) * 2 ^ (n - (km1 - fuel))) + Z.of_nat (2 ^ (n - (km1 - (fuel - 1))) - fuel3) - Z.of_nat ((2 ^ (km1 - fuel) - fuel2) * 2 ^ (n - (km1 - fuel))))) ++ [j]) as ->
+                                    end.
+                                    { do 2 rewrite Z.add_simpl_l.
+                                      repeat rewrite Nat2Z.id.
+                                      assert (2 ^ (n - (km1 - (fuel - 1))) - (fuel3 - 1) = S (2 ^ (n - (km1 - (fuel - 1))) - fuel3))%nat as ->; [|rewrite seq_S; reflexivity].
+                                      clear -Hfnz Hfnz2 Hfnz3 Hfuel Hfuel2 Hfuel3 n_ge_km1.
+                                      Lia.lia. }
+                                    rewrite map_app, fold_left_app. cbn [List.map fold_left].
+                                    rewrite <- z_range'_seq by (apply Nat2Z.is_nonneg).
+                                    assert (z_range' _ _ = z_range (Z.of_nat ((2 ^ (km1 - fuel) - fuel2) * 2 ^ (n - (km1 - fuel)))) (Z.of_nat ((2 ^ (km1 - fuel) - fuel2) * 2 ^ (n - (km1 - fuel))) + Z.of_nat (2 ^ (n - (km1 - (fuel - 1))) - fuel3))) as -> by reflexivity.
+                                    rewrite fold_left_as_nd_ranged_for_all.
+                                    assert (nd_ranged_for_all _ _ _ _ = px3) as -> by reflexivity.
+                                    reflexivity. }
+                            instantiate (2 := fun _ t m l => loop_inv3 (fuel3 - 1)%nat t m l). auto. }
+                      instantiate (2 := fun _ t m l => loop_inv3 (fuel3 - 1)%nat t m l). auto. }
+                instantiate (2 := fun _ t m l => loop_inv3 (fuel3 - 1)%nat t m l). auto. }
+          simpl. intros. eexists; split; [eauto|clear -Hfnz3; Lia.lia]. }
+        { (* Can conclude *)
+          clear Hb. match goal with | [H: Z.b2z (?a <? ?b) = 0%Z |- _] => generalize (Zlt_cases a b); destruct (a <? b); cbv in H; [congruence|clear H]; intro H end.
+          apply Nat2Z.inj_ge in Hcond2.
+          assert (fuel3 = 0)%nat as ->.
+          { destruct (Nat.eq_dec fuel3 0%nat); auto.
+            clear -Hcond2 n0 Hfuel Hfuel2 Hfuel3 n_ge_km1 Hfnz Hfnz2.
+            generalize (NatUtil.pow_nonzero 2 (n - (km1 - fuel)) ltac:(Lia.lia)).
+            generalize (NatUtil.pow_nonzero 2 (n - (km1 - (fuel - 1))) ltac:(Lia.lia)).
+            Lia.lia. }
+          repeat straightline. eexists. split.
+          { apply expr_compile_Z_add; apply expr_compile_var; eauto. }
+          repeat straightline. exists (fuel2 - 1)%nat. split; [|clear -Hfnz2; Lia.lia].
+          split; [clear -Hfnz2 Hfuel2; Lia.lia|].
+          split; [reflexivity|].
+          unfold l6. repeat rewrite map.get_put_diff by congruence.
+          rewrite map.get_put_same. eexists; eexists; repeat split; eauto.
+          - unfold polynomial_list_loop.
+            rewrite <- fold_left_as_nd_ranged_for_all.
+            unfold z_range; rewrite z_range'_seq by reflexivity.
+            rewrite Nat.sub_0_r, Z.sub_0_r, Nat2Z.id.
+            replace ((2 ^ (km1 - fuel) - (fuel2 - 1)))%nat with (S (2 ^ (km1 - fuel) - fuel2))%nat at 1 by (clear -Hfnz2 Hfnz Hfuel Hfuel2 n_ge_km1; Lia.lia).
+            rewrite seq_S, List.map_app, fold_left_app.
+            rewrite Nat.add_0_l. cbn [List.map fold_left].
+            rewrite <- z_range'_seq by reflexivity.
+            assert (z_range' 0 _ = z_range 0 (Z.of_nat (2 ^ (km1 - fuel) - fuel2))) as ->.
+            { unfold z_range. rewrite Z.sub_0_r, Nat2Z.id. reflexivity. }
+            rewrite fold_left_as_nd_ranged_for_all.
+            unfold polynomial_list_loop in Heq2; rewrite Heq2.
+            unfold nlet; simpl. f_equal.
+            { clear -Hfnz2 Hfnz Hfuel Hfuel2 n_ge_km1.
+              Lia.lia. }
+            f_equal.
+            { clear -Hfnz2 Hfnz Hfuel Hfuel2 n_ge_km1.
+              rewrite <- (Z.mul_1_l (2 ^ Z.of_nat (n - (km1 - fuel)))) at 2.
+              rewrite <- Z.mul_add_distr_r. f_equal. Lia.lia. }
+            f_equal.
+            + rewrite Nat2Z.inj_pow; reflexivity.
+            + assert (2 ^ Z.of_nat (n - (km1 - fuel)) = Z.of_nat (Nat.pow 2 _)) as -> by (rewrite Nat2Z.inj_pow; reflexivity).
+              rewrite <- Nat2Z.inj_mul. reflexivity.
+            + rewrite Nat2Z.inj_pow. reflexivity.
+            + unfold InlineTable.get. cbv [cast Convertible_Z_nat Convertible_self id].
+              f_equal. repeat rewrite Z2Nat.inj_add by (clear; Lia.lia).
+              rewrite Z2Nat.inj_sub by (clear; Lia.lia).
+              rewrite Z2Nat.inj_pow, Nat2Z.id by (clear; Lia.lia).
+              rewrite Nat2Z.inj_sub by assumption.
+              rewrite Z2Nat.inj_sub by (clear; Lia.lia).
+              repeat rewrite Nat2Z.id. f_equal.
+              clear -Hfnz2 Hfnz Hfuel Hfuel2 n_ge_km1.
+              generalize (NatUtil.pow_nonzero 2 (n - (km1 - fuel)) ltac:(Lia.lia)).
+              assert (Z.to_nat 2 = 2)%nat as -> by reflexivity.
+              assert (Z.to_nat 1 = 1)%nat as -> by reflexivity.
+               Lia.lia.
+          - rewrite Hm4. assert (1 = Z.of_nat 1%nat) as -> by reflexivity.
+            rewrite <- Nat2Z.inj_add. f_equal. f_equal. f_equal.
+            clear -Hfnz2 Hfnz Hfuel Hfuel2 n_ge_km1.
+            generalize (NatUtil.pow_nonzero 2 (km1 - fuel) ltac:(Lia.lia)). Lia.lia.
+          - rewrite <- Nat2Z.inj_add. f_equal. f_equal. f_equal.
+            clear -Hfnz2 Hfnz Hfuel Hfuel2 n_ge_km1.
+            generalize (NatUtil.pow_nonzero 2 (km1 - fuel) ltac:(Lia.lia)).
+            generalize (NatUtil.pow_nonzero 2 (n - (km1 - fuel)) ltac:(Lia.lia)).
+            intros. rewrite <- (Nat.mul_1_l (Nat.pow 2 (n - (km1 - fuel)))) at 2.
+            rewrite <- Nat.mul_add_distr_r. f_equal. Lia.lia. } }
+      { (* Out of loop, conclude *) intro Hcond.
+        generalize (Zlt_cases (Z.of_nat ((2 ^ (km1 - fuel) - fuel2) * 2 ^ (n - (km1 - fuel)))) (2 ^ Z.of_nat n)).
+        destruct (_ <? _); intros Hcondd; cbv in Hcond; [congruence|clear Hcond].
+        assert (fuel2 = 0)%nat as ->.
+        { destruct (Nat.eq_dec fuel2 0%nat); auto.
+          replace (2 ^ Z.of_nat n) with (Z.of_nat (Nat.pow 2 n)) in Hcondd by (rewrite Nat2Z.inj_pow; reflexivity).
+          apply Nat2Z.inj_ge in Hcondd.
+          rewrite Nat.mul_sub_distr_r, <- PeanoNat.Nat.pow_add_r in Hcondd.
+          replace (km1 - fuel + _)%nat with n in Hcondd by (clear -Hfnz Hfuel n_ge_km1; Lia.lia).
+          clear -Hcondd n0.
+          generalize (NatUtil.pow_nonzero 2 (n - (km1 - fuel)) ltac:(Lia.lia)).
+          generalize (NatUtil.pow_nonzero 2 n ltac:(Lia.lia)).
+          Lia.lia. }
+        exists (fuel - 1)%nat. split; [|clear -Hfnz; Lia.lia].
+        repeat split; [clear -Hfuel; Lia.lia|].
+        exists p2, px2. repeat split; auto.
+        - unfold layer_decomposition_loop.
+          rewrite <- fold_left_as_nd_ranged_for_all.
+          assert (km1 - (fuel - 1) = S (km1 - fuel))%nat as -> by (clear -Hfuel Hfnz; Lia.lia).
+          unfold z_range. rewrite Z.sub_0_r, Nat2Z.id.
+          rewrite z_range'_seq, seq_S, map_app, fold_left_app by reflexivity.
+          rewrite PeanoNat.Nat.add_0_l.
+          rewrite <- z_range'_seq by reflexivity.
+          assert (z_range' 0 _ = z_range 0 (Z.of_nat (km1 - fuel))) as ->.
+          { unfold z_range. rewrite Z.sub_0_r, Nat2Z.id. reflexivity. }
+          rewrite fold_left_as_nd_ranged_for_all.
+          unfold layer_decomposition_loop in HF1. rewrite HF1.
+          cbn [List.map fold_left]. unfold nlet.
+          rewrite PeanoNat.Nat.sub_0_r in Heq2.
+          rewrite Z2Nat.Z.pow_Zpow in Heq2.
+          assert ((Z.shiftr (2 ^ Z.of_nat (n - (km1 - fuel))) 1) = (2 ^ Z.of_nat (n - (km1 - (fuel - 1))))) as ->.
+          { rewrite Z.shiftr_div_pow2 by Lia.lia.
+            rewrite <- Z.pow_sub_r; [|congruence|clear -n_ge_km1 Hfuel Hfnz; Lia.lia].
+            f_equal. clear -n_ge_km1 Hfuel Hfnz; Lia.lia. }
+          replace (Z.of_nat 2) with 2%Z in Heq2 by reflexivity.
+          rewrite Heq2.
+          f_equal; [|f_equal].
+          + rewrite (Nat2Z.inj_succ (km1 - fuel)), Z.pow_succ_r by (apply Nat2Z.is_nonneg). Lia.lia.
+          + f_equal. f_equal. clear -Hfuel Hfnz. Lia.lia.
+        - rewrite Hm2. f_equal.
+          f_equal. rewrite PeanoNat.Nat.sub_0_r.
+          f_equal. assert (km1 - (fuel - 1) = S (km1 - fuel))%nat as -> by (clear -Hfuel Hfnz; Lia.lia).
+          rewrite Nat.pow_succ_r'. clear. Lia.lia. } }
+    (* Out of loop, conclude *)
+    intros Hb. rewrite <- word.morph_ltu in Hb.
+    2-3: split; try Lia.lia.
+    3: rewrite Nat2Z.inj_pow.
+    2-3: apply Zpow_facts.Zpower_lt_monotone; Lia.lia.
+    rewrite word.unsigned_b2w in Hb.
+    generalize (Zlt_cases (2 ^ Z.of_nat (n - km1)) (Z.of_nat (2 ^ (n - (km1 - fuel))))).
+    destruct (_ <? _); intros; [cbv in Hb; congruence|].
+    assert (fuel = 0)%nat as ->.
+    { generalize (Zpow_facts.Zpower_le_monotone 2 (Z.of_nat (n - km1)) (Z.of_nat (n - (km1 - fuel))) ltac:(Lia.lia) ltac:(Lia.lia)).
+      intro. assert (n - km1 = n - (km1 - fuel))%nat; [|Lia.lia].
+      apply Nat2Z.inj_iff. rewrite Nat2Z.inj_pow in H4.
+      apply (Z.pow_inj_r 2); Lia.lia. }
+    repeat red. split; [reflexivity|].
+    split; [reflexivity|].
+    rewrite PeanoNat.Nat.sub_0_r in HF1.
+    rewrite HF1. eexists; split; eauto.
+    Unshelve.
+    all: try (apply ""); try (apply (fun _ => unit)); simpl; intros; apply tt.
+  Qed.
+
+  Lemma br2_ntt_inverse_ok:
+    program_logic_goal_for br2_ntt_inverse
+      (forall functions : map.rep,
+          map.get functions ntt_inverse = Some br2_ntt_inverse ->
+          spec_of_mul functions ->
+          spec_of_sub functions -> spec_of_add functions -> spec_of_ntt_inverse functions).
+  Proof.
+    Local Opaque Memory.bytes_per to_byte_table Z.pow Z.of_nat List.map Z.div Z.sub Z.add Nat.sub Nat.pow cast F.F F.to_Z.
+    repeat straightline.
+    unfold NTT_inverse_gallina. unfold nlet.
+    apply wp_while.
+    set (loop_inv1 := fun (fuel1: nat) (tr': Semantics.trace) (mem': mem) (loc': locals) =>
+                        (fuel1 <= km1)%nat /\
+                        tr' = tr /\
+                        map.get loc' "p" = Some p_ptr /\
+                        let i := (km1 - fuel1)%nat in
+                        exists p' px',
+                        inverse_layer_decomposition_loop (km1:=km1) zetas i \< 2 ^ Z.of_nat km1, 2 ^ Z.of_nat (n - km1), p \> = \< (2 ^ Z.of_nat fuel1), 2 ^ Z.of_nat (n - fuel1), px' \> /\
+                        Forall2 (fun x y => feval y = Some x) px' p' /\
+                        map.get loc' "m" = Some (word.of_Z (Z.of_nat (Nat.pow 2 fuel1))) /\
+                        map.get loc' "len" = Some (word.of_Z (Z.of_nat (Nat.pow 2 (n - fuel1)))) /\
+                        (sizedlistarray_value access_size.word (Nat.pow 2 n) p_ptr p' * R)%sep mem').
+    exists nat, lt, loop_inv1; split; [apply lt_wf|]. split.
+    { (* loop_inv1 holds at beginning *)
+      exists km1. repeat split; [reflexivity|unfold l1, l0; repeat (rewrite map.get_put_diff by congruence); apply map.get_put_same|].
+      rewrite Nat.sub_diag. intros; subst i.
+      exists x, p. repeat split; auto.
+      - unfold l1, l0; repeat (rewrite map.get_put_diff by congruence); apply map.get_put_same.
+      - apply map.get_put_same. }
+    intros fuel1 ? mem1 loc1 Hinv1.
+    destruct Hinv1 as (Hfuel1 & -> & Hptr1 & p1 & px1 & Heq1 & HF1 & Hm1 & Hlen1 & Hp1).
+    eexists; split.
+    { apply expr_compile_Z_ltb_u; [apply expr_compile_var; eauto|apply expr_compile_Z_literal|..].
+      all: split; [apply Nat2Z.is_nonneg|].
+      all: assert (2 ^ width = Z.of_nat (Nat.pow 2 (Z.to_nat width))) as -> by (rewrite Nat2Z.inj_pow, Z2Nat.id by Lia.lia; reflexivity).
+      all: apply Nat2Z.inj_lt, Nat.pow_lt_mono_r; Lia.lia. }
+    rewrite word.unsigned_b2w.
+    match goal with | |- context [Z.b2z (Z.of_nat ?a <? Z.of_nat ?b)] => generalize (Zlt_cases (Z.of_nat a) (Z.of_nat b)); intro Hcond1 end.
+    split; intros Hb; destruct (_ <? _); cbv in Hb; try congruence; clear Hb; [apply Nat2Z.inj_lt in Hcond1|apply Nat2Z.inj_ge in Hcond1].
+    { (* loop_inv1 preserved *)
+      assert (fuel1 <> 0)%nat as Hfnz1 by (intro; subst fuel1; rewrite Nat.sub_0_r in Hcond1; clear -Hcond1; Lia.lia).
+      repeat straightline. eexists; split; [eapply expr_compile_var; unfold l; rewrite map.get_put_diff by congruence; eauto|].
+      repeat straightline.
+      eexists; split; [eapply expr_compile_word_slu; [eapply expr_compile_var; unfold l0, l; repeat (rewrite map.get_put_diff by congruence); eauto|apply expr_compile_Z_literal]|].
+      repeat straightline.
+      apply wp_while.
+      set (loop_inv2 := fun (fuel2: nat) (tr': Semantics.trace) (mem': mem) (loc': locals) =>
+                        (fuel2 <= Nat.pow 2 (fuel1 - 1))%nat /\
+                        tr' = tr /\
+                        map.get loc' "p" = Some p_ptr /\
+                        let i := ((Nat.pow 2 (fuel1 - 1)) - fuel2)%nat in
+                        exists p' px',
+                        inverse_polynomial_list_loop zetas (Z.of_nat i) (Z.of_nat (2 ^ (n - fuel1))) (Z.of_nat (2 ^ (n - (fuel1 - 1)))) \< Z.of_nat (2 ^ fuel1) , 0%Z, px1 \> = \< Z.of_nat ((2 ^ fuel1) - i) , Z.of_nat (i * (2 ^ (n - (fuel1 - 1)))), px' \> /\
+                        Forall2 (fun x y => feval y = Some x) px' p' /\
+                        map.get loc' "m" = Some (word.of_Z (Z.of_nat ((2 ^ fuel1) - i))) /\
+                        map.get loc' "len" = Some (word.of_Z (Z.of_nat (Nat.pow 2 (n - (fuel1 - 1))))) /\
+                        map.get loc' "old_len" = Some (word.of_Z (Z.of_nat (Nat.pow 2 (n - fuel1)))) /\
+                        map.get loc' "start" = Some (word.of_Z (Z.of_nat (i * (2 ^ (n - (fuel1 - 1)))))) /\
+                        (sizedlistarray_value access_size.word (Nat.pow 2 n) p_ptr p' * R)%sep mem').
+      exists nat, lt, loop_inv2. split; [apply lt_wf|].
+      split.
+      { (* loop_inv2 holds at start *)
+        exists (Nat.pow 2 (fuel1 - 1)). repeat split; [reflexivity|..].
+        - unfold l1, l0, l. repeat (rewrite map.get_put_diff by congruence). auto.
+        - rewrite Nat.sub_diag. intro; subst i.
+          rewrite Nat.sub_0_r, Nat.mul_0_l.
+          unfold l1, l0, l. repeat (rewrite map.get_put_diff by congruence).
+          exists p1, px1; repeat split; auto.
+          + rewrite map.get_put_same.
+            rewrite <- word.morph_shiftl by Lia.lia.
+            f_equal. f_equal. rewrite Z.shiftl_mul_pow2 by Lia.lia.
+            assert (2 ^ 1 = Z.of_nat (2 ^ 1)) as -> by reflexivity.
+            rewrite <- Nat2Z.inj_mul, <- Nat.pow_add_r. f_equal.
+            f_equal. clear -Hfuel1 Hfnz1 n_ge_km1. Lia.lia.
+          + repeat (rewrite map.get_put_diff by congruence).
+            apply map.get_put_same.
+          + repeat (rewrite map.get_put_diff by congruence).
+            apply map.get_put_same. }
+      intros fuel2 ? mem2 loc2 Hinv2.
+      destruct Hinv2 as (Hfuel2 & -> & Hptr2 & p2 & px2 & Heq2 & HF2 & Hm2 & Hlen2 & Hold_len2 & Hstart2 & Hp2).
+      eexists; split.
+      { apply expr_compile_Z_ltb_u; [apply expr_compile_var; eauto|apply expr_compile_Z_literal|..].
+        all: split; [apply Nat2Z.is_nonneg|].
+        all: assert (Z.pow 2 width = Z.of_nat (Nat.pow 2 (Z.to_nat width))) as -> by (rewrite Nat2Z.inj_pow, Z2Nat.id by Lia.lia; reflexivity).
+        all: apply Nat2Z.inj_lt.
+        rewrite Nat.mul_sub_distr_r, <- Nat.pow_add_r.
+        assert (fuel1 - 1 + _ = n)%nat as -> by (clear -Hfuel1 Hfnz1 n_ge_km1; Lia.lia).
+        apply (Nat.le_lt_trans _ (Nat.pow 2 n)); [Lia.lia|].
+        all: apply Nat.pow_lt_mono_r; Lia.lia. }
+      rewrite word.unsigned_b2w.
+      match goal with | |- context [Z.b2z (Z.of_nat ?a <? Z.of_nat ?b)] => generalize (Zlt_cases (Z.of_nat a) (Z.of_nat b)); intro Hcond2 end.
+      split; intros Hb; destruct (_ <? _); cbv in Hb; try congruence; clear Hb; [apply Nat2Z.inj_lt in Hcond2|apply Nat2Z.inj_ge in Hcond2].
+      { (* loop_inv2 is preserved *)
+        assert (fuel2 <> 0)%nat as Hfnz2.
+        { intro; subst fuel2. rewrite Nat.sub_0_r in Hcond2.
+          rewrite <- Nat.pow_add_r in Hcond2.
+          replace (fuel1 - 1 + _)%nat with n in Hcond2 by Lia.lia. Lia.lia. }
+        repeat straightline. eexists; split.
+        { eapply expr_compile_nat_sub.
+          - eapply expr_compile_var; eauto.
+          - instantiate (1:=1%nat). apply expr_compile_Z_literal.
+          - assert (Nat.pow 2 fuel1 = 2 * Nat.pow 2 (fuel1 - 1))%nat as ->.
+            rewrite <- Nat.pow_succ_r'. f_equal. Lia.lia.
+            generalize (NatUtil.pow_nonzero 2 (fuel1 - 1)%nat ltac:(Lia.lia)). Lia.lia. }
+        straightline.
+        eapply weaken_cmd.
+        { eapply (compile_inlinetable_get_any_as_word (K:=nat)).
+          1,3: cbv [cast Convertible_self id].
+          2: eapply expr_compile_var; apply map.get_put_same.
+          - rewrite zetas_length_ok. apply (Nat.lt_le_trans _ (Nat.pow 2 fuel1)); [|apply Nat.pow_le_mono_r; try Lia.lia].
+            generalize (NatUtil.pow_nonzero 2 fuel1 ltac:(Lia.lia)); Lia.lia.
+          - rewrite length_to_byte_table, map_length, zetas_length_ok.
+            rewrite Nat2Z.inj_mul, Z2Nat.id by Lia.lia.
+            assert (width / 8 = 4 \/ width / 8 = 8) as Hw.
+            { clear -BW. destruct width_cases as [-> | ->]; [left|right]; reflexivity. }
+            rewrite Nat2Z.inj_pow.
+            transitivity (2 ^ 3 * 2 ^ Z.of_nat km1).
+            + apply Z.mul_le_mono_nonneg_r.
+              * apply Z.lt_le_incl, ZLib.Z.pow2_pos, Nat2Z.is_nonneg.
+              * clear -Hw. destruct Hw as [-> | ->]; Lia.lia.
+            + rewrite <- Z.pow_add_r by Lia.lia.
+              apply Z.pow_le_mono_r; Lia.lia.
+          - repeat straightline. unfold l.
+            eexists; split; [apply expr_compile_var; repeat (rewrite map.get_put_diff by congruence); eauto|].
+            repeat straightline.
+            apply wp_while.
+            set (loop_inv3 := fun (fuel3: nat) (tr': Semantics.trace) (mem': mem) (loc': locals) =>
+                        (fuel3 <= Nat.pow 2 (n - fuel1))%nat /\
+                        tr' = tr /\
+                        map.get loc' "p" = Some p_ptr /\
+                        let i := ((Nat.pow 2 (n - fuel1)) - fuel3)%nat in
+                        let px3 := inverse_polynomial_decompose_loop (Z.of_nat i) (Z.of_nat ((2 ^ (fuel1 - 1) - fuel2) * 2 ^ (n - (fuel1 - 1)))) (Z.of_nat (2 ^ (n - fuel1))) v px2 in
+                        exists p',
+                        Forall2 (fun x y => feval y = Some x) px3 p' /\
+                        map.get loc' "m" = Some (word.of_Z (Z.of_nat (2 ^ fuel1 - (2 ^ (fuel1 - 1) - fuel2) - 1))) /\
+                        map.get loc' "len" = Some (word.of_Z (Z.of_nat (Nat.pow 2 (n - (fuel1 - 1))))) /\
+                        map.get loc' "old_len" = Some (word.of_Z (Z.of_nat (Nat.pow 2 (n - fuel1)))) /\
+                        map.get loc' "start" = Some (word.of_Z (Z.of_nat ((2 ^ (fuel1 - 1) - fuel2) * 2 ^ (n - (fuel1 - 1))))) /\
+                        map.get loc' "j" = Some (word.of_Z (Z.of_nat ((2 ^ (fuel1 - 1) - fuel2) * 2 ^ (n - (fuel1 - 1)) + i))) /\
+                        map.get loc' "z" = Some (cast v) /\
+                        (sizedlistarray_value access_size.word (Nat.pow 2 n) p_ptr p' * R)%sep mem').
+            exists nat, lt, loop_inv3. split; [apply lt_wf|].
+            split.
+            { (* loop_inv3 holds at beginning *)
+              exists (Nat.pow 2 (n - fuel1)). repeat split; [reflexivity|..].
+              - unfold l. repeat (rewrite map.get_put_diff by congruence); auto.
+              - exists p2. repeat split; auto.
+                + rewrite Nat.sub_diag. assert (inverse_polynomial_decompose_loop _ _ _ _ _ = px2) as ->; [|assumption].
+                  unfold inverse_polynomial_decompose_loop.
+                  rewrite Z.add_0_r, <- fold_left_as_nd_ranged_for_all.
+                  unfold z_range; rewrite z_range'_seq by (apply Nat2Z.is_nonneg).
+                  rewrite Z.sub_diag. simpl. cbn [List.map].
+                  rewrite ListUtil.List.fold_left_nil. reflexivity.
+                + unfold l. repeat (rewrite map.get_put_diff by congruence).
+                  apply map.get_put_same.
+                + unfold l. repeat (rewrite map.get_put_diff by congruence); auto.
+                + unfold l. repeat (rewrite map.get_put_diff by congruence); auto.
+                + unfold l. repeat (rewrite map.get_put_diff by congruence); auto.
+                + rewrite Nat.sub_diag, Nat.add_0_r. apply map.get_put_same.
+                + unfold l. repeat (rewrite map.get_put_diff by congruence).
+                  apply map.get_put_same. }
+            intros fuel3 ? mem3 loc3 Hinv3.
+            destruct Hinv3 as (Hfuel3 & -> & Hptr3 & p3 & HF3 & Hm3 & Hlen3 & Hold_len3 & Hstart3 & Hj3 & Hz3 & Hp3).
+            eexists; split.
+            { apply expr_compile_Z_ltb_u; [eapply expr_compile_var|eapply expr_compile_nat_add; eapply expr_compile_var|..]; eauto.
+              all: split; [apply Nat2Z.is_nonneg|].
+              all: assert (Z.pow 2 width = Z.of_nat (Nat.pow 2 (Z.to_nat width))) as -> by (rewrite Nat2Z.inj_pow, Z2Nat.id; Lia.lia).
+              all: apply Nat2Z.inj_lt.
+              all: eapply (Nat.le_lt_trans _ (Nat.pow 2 n)); [|apply Nat.pow_lt_mono_r; auto].
+              all: rewrite Nat.mul_sub_distr_r, <- PeanoNat.Nat.pow_add_r.
+              all: assert (fuel1 - 1 + _ = n)%nat as -> by (clear -Hfnz1 Hfuel1 n_ge_km1; Lia.lia).
+              1: transitivity (2 ^ n - fuel2 * 2 ^ (n - (fuel1 - 1)) + 2 ^ (n - fuel1))%nat; [clear; Lia.lia|].
+              all: rewrite <- (Nat.mul_1_l (Nat.pow 2 (n - fuel1))).
+              all: assert (n - (fuel1 - 1) = S (n - fuel1))%nat as -> by (clear -Hfnz1 Hfuel1 n_ge_km1; Lia.lia).
+              all: rewrite Nat.pow_succ_r'.
+              all: assert (Nat.pow 2 n = (Nat.pow 2 fuel1) * (Nat.pow 2 (n - fuel1)))%nat as -> by (rewrite <- Nat.pow_add_r; f_equal; Lia.lia).
+              all: rewrite Nat.mul_assoc, <- Nat.mul_sub_distr_r, <- Nat.mul_add_distr_r.
+              all: apply Nat.mul_le_mono_r.
+              all: generalize (Nat.pow_nonzero 2 fuel1 ltac:(Lia.lia)).
+              all: clear -Hfuel1 Hfnz1 Hfuel2 Hfnz2 n_ge_km1; Lia.lia. }
+            rewrite word.unsigned_b2w.
+            match goal with | |- context [Z.b2z (Z.of_nat ?a <? Z.of_nat ?b)] => generalize (Zlt_cases (Z.of_nat a) (Z.of_nat b)); intro Hcond3 end.
+            split; intros Hb; destruct (_ <? _); cbv in Hb; try congruence; clear Hb; [apply Nat2Z.inj_lt in Hcond3|apply Nat2Z.inj_ge in Hcond3].
+            { (* loop_inv3 preservation *)
+              assert (fuel3 <> 0)%nat as Hfnz3.
+              { intro; subst fuel3. rewrite Nat.sub_0_r in Hcond3.
+                clear -Hcond3. Lia.lia. }
+              (* Memory accesses are in bounds *)
+              assert ((2 ^ (fuel1 - 1) - fuel2) * 2 ^ (n - (fuel1 - 1)) + (2 ^ (n - fuel1) - fuel3) + 2 ^ (n - fuel1) < 2 ^ n)%nat as idx_ok.
+              { rewrite Nat.mul_sub_distr_r, <- Nat.pow_add_r.
+                assert (fuel1 - 1 + _ = n)%nat as -> by (clear -Hfuel1 Hfnz1 Hfuel2 Hfnz2 n_ge_km1; Lia.lia).
+                apply (Nat.lt_le_trans _ (2 ^ n - fuel2 * 2 ^ (n - (fuel1 - 1)) + (2 * 2 ^ (n - fuel1)))); [clear -Hfuel1 Hfnz1 Hfuel2 Hfnz2 Hfuel3 Hfnz3 n_ge_km1; Lia.lia|].
+                rewrite <- Nat.pow_succ_r'.
+                assert (n - (fuel1 - 1) = S (n - fuel1))%nat as <- by (clear -Hfnz1 Hfuel1 n_ge_km1; Lia.lia).
+                clear -Hfuel1 Hfnz1 Hfuel2 Hfnz2 Hfuel3 Hfnz3 n_ge_km1.
+                assert (Nat.pow 2 n = (Nat.pow 2 (fuel1 - 1)) * (Nat.pow 2 (n - (fuel1 - 1))))%nat as -> by (rewrite <- Nat.pow_add_r; f_equal; Lia.lia).
+                rewrite <- Nat.mul_sub_distr_r.
+                rewrite <- (Nat.mul_1_l (2 ^ (n - (fuel1 - 1)))) at 2.
+                rewrite <- Nat.mul_add_distr_r.
+                apply Nat.mul_le_mono_r. Lia.lia. }
+              generalize (length_of_sizedlistarray_value_R Hp3). intro Xlen.
+              cbn in Xlen. eapply weaken_cmd.
+              { eapply (compile_word_sizedlistarray_get _ nat); eauto.
+                - eapply expr_compile_var. auto.
+                - eapply expr_compile_var.
+                  cbv [cast Convertible_self id]. eauto.
+                - cbv [cast Convertible_self id]. apply Nat2Z.inj_lt.
+                  clear -idx_ok. Lia.lia.
+                - intros. eapply weaken_cmd.
+                  { eapply (compile_word_sizedlistarray_get _ nat); eauto.
+                    - eapply expr_compile_var.
+                      rewrite map.get_put_diff by congruence; auto.
+                    - cbv [cast Convertible_self id].
+                      eapply expr_compile_nat_add; eapply expr_compile_var; rewrite map.get_put_diff by congruence; eauto.
+                    - cbv [cast Convertible_self id].
+                      apply Nat2Z.inj_lt. exact idx_ok.
+                    - intros. repeat straightline.
+                      eexists; split; [repeat straightline|].
+                      + eexists; split; [repeat rewrite map.get_put_diff by congruence; apply map.get_put_same|].
+                        repeat straightline. eexists; split; [apply map.get_put_same|].
+                        repeat straightline.
+                      + straightline_call.
+                        { unfold v0, v1, ListArray.get.
+                          do 2 rewrite <- nth_default_eq.
+                          split; eapply (ListUtil.Forall2_forall_iff (fun x y => feval y = Some x)); eauto; try (apply (Forall2_length HF3)).
+                          all: cbv [cast Convertible_self id]; rewrite (Forall2_length HF3), Xlen.
+                          all: clear -idx_ok; Lia.lia. }
+                        destruct H4 as (? & -> & -> & -> & ZZ).
+                        eexists; split; [reflexivity|].
+                        eapply weaken_cmd.
+                        { eapply (compile_word_sizedlistarray_put _ nat); eauto.
+                          - eapply expr_compile_var; repeat (rewrite map.get_put_diff by congruence); auto.
+                          - cbv [cast Convertible_self id].
+                            eapply expr_compile_var; repeat (rewrite map.get_put_diff by congruence); eauto.
+                          - cbv [cast].
+                            eapply expr_compile_var. apply map.get_put_same.
+                          - cbv [cast Convertible_self id].
+                            apply Nat2Z.inj_lt. clear -idx_ok. Lia.lia.
+                          - repeat straightline.
+                            eexists; split; [repeat straightline|].
+                            + eexists; split; [repeat rewrite map.get_put_diff by congruence; apply map.get_put_same|repeat straightline].
+                              eexists; split; [repeat rewrite map.get_put_diff by congruence; apply map.get_put_same|repeat straightline].
+                            + straightline_call.
+                              { unfold v0, v1, ListArray.get.
+                                do 2 rewrite <- nth_default_eq.
+                                split; eapply (ListUtil.Forall2_forall_iff (fun x y => feval y = Some x)); eauto; try (apply (Forall2_length HF3)).
+                                all: cbv [cast Convertible_self id]; rewrite (Forall2_length HF3), Xlen.
+                                all: clear -idx_ok; Lia.lia. }
+                              repeat straightline.
+                              unfold l'. eexists; split; [repeat straightline|].
+                              * eexists; split; [repeat rewrite map.get_put_diff by congruence; eauto|repeat straightline].
+                                eexists; split; [apply map.get_put_same|repeat straightline].
+                              * straightline_call; [split; eauto; eapply feval_ok|].
+                                destruct H5 as (? & -> & -> & -> & ZZ2).
+                                eexists; split; [repeat straightline; reflexivity|].
+                                eapply weaken_cmd.
+                                { eapply (compile_word_sizedlistarray_put _ nat); eauto.
+                                  - eapply expr_compile_var; repeat (rewrite map.get_put_diff by congruence); auto.
+                                  - cbv [cast Convertible_self id].
+                                    eapply expr_compile_nat_add; eapply expr_compile_var; repeat (rewrite map.get_put_diff by congruence); eauto.
+                                  - cbv [cast]. eapply expr_compile_var.
+                                    apply map.get_put_same.
+                                  - cbv [cast Convertible_self id].
+                                    apply Nat2Z.inj_lt.
+                                    clear -idx_ok; Lia.lia.
+                                  - intros. repeat straightline.
+                                    eexists; split.
+                                    + eapply expr_compile_nat_add.
+                                      * eapply expr_compile_var.
+                                        repeat (rewrite map.get_put_diff by congruence).
+                                        eauto.
+                                      * instantiate (1:=1%nat).
+                                        apply expr_compile_Z_literal.
+                                    + repeat straightline.
+                                      instantiate (2 := fun _ t m l => loop_inv3 (fuel3 - 1)%nat t m l).
+                                      simpl. unfold l. repeat split.
+                                      * clear -Hfuel3; Lia.lia.
+                                      * repeat (rewrite map.get_put_diff by congruence); auto.
+                                      * repeat (rewrite map.get_put_diff by congruence); auto.
+                                        eexists; repeat split; eauto.
+                                        2:{ rewrite map.get_put_same. f_equal. f_equal. f_equal.
+                                            Lia.lia. }
+                                        2:{ repeat rewrite map.get_put_diff by congruence. eauto. }
+                                        unfold v3, v2, inverse_polynomial_decompose_loop.
+                                        rewrite <- fold_left_as_nd_ranged_for_all.
+                                        assert (z_range _ _ = z_range (Z.of_nat ((2 ^ (fuel1 - 1) - fuel2) * 2 ^ (n - (fuel1 - 1)))) (Z.of_nat ((2 ^ (fuel1 - 1) - fuel2) * 2 ^ (n - (fuel1 - 1))) + Z.of_nat (2 ^ (n - fuel1) - fuel3)) ++ [(Z.of_nat ((2 ^ (fuel1 - 1) - fuel2) * 2 ^ (n - (fuel1 - 1))) + Z.of_nat (2 ^ (n - fuel1) - fuel3))]) as ->.
+                                        { unfold z_range. do 2 (rewrite z_range'_seq; [|apply Nat2Z.is_nonneg]).
+                                          rewrite Nat2Z.id.
+                                          repeat rewrite <- Nat2Z.inj_add, <- Nat2Z.inj_sub by Lia.lia.
+                                          repeat rewrite Nat2Z.id.
+                                          assert ((2 ^ (fuel1 - 1) - fuel2) * 2 ^ (n - (fuel1 - 1)) + (2 ^ (n - fuel1) - (fuel3 - 1)) - (2 ^ (fuel1 - 1) - fuel2) * 2 ^ (n - (fuel1 - 1)) = S ((2 ^ (fuel1 - 1) - fuel2) * 2 ^ (n - (fuel1 - 1)) + (2 ^ (n - fuel1) - fuel3) - (2 ^ (fuel1 - 1) - fuel2) * 2 ^ (n - (fuel1 - 1))))%nat as -> by Lia.lia.
+                                          rewrite seq_S, map_app.
+                                          f_equal. cbn [List.map]. f_equal.
+                                          Lia.lia. }
+                                        rewrite fold_left_app, fold_left_as_nd_ranged_for_all.
+                                        assert (nd_ranged_for_all _ _ _ _ = inverse_polynomial_decompose_loop (Z.of_nat (2 ^ (n - fuel1) - fuel3)) (Z.of_nat ((2 ^ (fuel1 - 1) - fuel2) * 2 ^ (n - (fuel1 - 1)))) (Z.of_nat (2 ^ (n - fuel1))) v px2) as -> by reflexivity.
+                                        rewrite <- Nat2Z.inj_add.
+                                        cbn [fold_left]. unfold nlet, v3, v2, v1, v0, ListArray.put, ListArray.get.
+                                        cbv [cast Convertible_Z_nat Convertible_self id].
+                                        repeat rewrite <- Nat2Z.inj_add.
+                                        repeat rewrite Nat2Z.id. repeat rewrite <- nth_default_eq.
+                                        apply Forall2_replace_nth; [|rewrite ZZ2; reflexivity].
+                                        apply Forall2_replace_nth; [|rewrite ZZ; reflexivity]. auto. }
+                                simpl. instantiate (2 := fun _ t m l => loop_inv3 (fuel3 - 1)%nat t m l). auto. }
+                        simpl. instantiate (2 := fun _ t m l => loop_inv3 (fuel3 - 1)%nat t m l). auto. }
+                  simpl. instantiate (2 := fun _ t m l => loop_inv3 (fuel3 - 1)%nat t m l). auto. }
+              simpl. intros. exists (fuel3 - 1)%nat; split; [assumption|Lia.lia]. }
+            { assert (fuel3 = 0)%nat as ->.
+              { clear -Hcond3. destruct (Nat.eq_dec fuel3 0); auto.
+                generalize (NatUtil.pow_nonzero 2 (n - fuel1) ltac:(Lia.lia)); Lia.lia. }
+              repeat straightline.
+              eexists; split.
+              - eapply expr_compile_nat_add; apply expr_compile_var; eauto.
+              - repeat straightline.
+                instantiate (2 := fun _ t m l => loop_inv2 (fuel2 - 1)%nat t m l).
+                simpl. repeat split.
+                + clear -Hfuel2. Lia.lia.
+                + unfold l. rewrite map.get_put_diff by congruence. auto.
+                + rewrite Nat.sub_0_r in *.
+                  set (px3 := (inverse_polynomial_decompose_loop (Z.of_nat (2 ^ (n - fuel1))) (Z.of_nat ((2 ^ (fuel1 - 1) - fuel2) * 2 ^ (n - (fuel1 - 1)))) (Z.of_nat (2 ^ (n - fuel1))) v px2)).
+                  eexists; exists px3; repeat split; eauto.
+                  2-5: unfold l; repeat (rewrite map.get_put_diff by congruence); auto.
+                  * unfold inverse_polynomial_list_loop.
+                    rewrite <- fold_left_as_nd_ranged_for_all.
+                    unfold z_range. rewrite z_range'_seq by reflexivity.
+                    assert (seq _ _ = (seq (Z.to_nat 0) (Z.to_nat (Z.of_nat (2 ^ (fuel1 - 1) - fuel2) - 0))) ++ [(2 ^ (fuel1 - 1) - fuel2)%nat]) as ->.
+                    { repeat rewrite Z.sub_0_r, Nat2Z.id.
+                      assert (Nat.pow 2 (fuel1 - 1) - (fuel2 - 1) = S (Nat.pow 2 (fuel1 - 1) - fuel2))%nat as ->; [|rewrite seq_S; reflexivity].
+                      clear -Hfuel1 Hfuel2 Hfnz1 Hfnz2 n_ge_km1; Lia.lia. }
+                    rewrite map_app, fold_left_app.
+                    rewrite <- z_range'_seq by reflexivity. fold z_range.
+                    assert (z_range' _ _ = z_range 0 (Z.of_nat (2 ^ (fuel1 - 1) - fuel2))) as -> by reflexivity.
+                    rewrite fold_left_as_nd_ranged_for_all.
+                    unfold inverse_polynomial_list_loop in Heq2. rewrite Heq2.
+                    cbn [List.map fold_left].
+                    unfold nlet. f_equal; [|f_equal].
+                    { assert (1 = Z.of_nat 1) as -> by reflexivity.
+                      assert (Nat.pow 2 fuel1 = 2 * (Nat.pow 2 (fuel1 - 1)))%nat as ->.
+                      { rewrite <- Nat.pow_succ_r'; f_equal. clear -Hfnz1; Lia.lia. }
+                      rewrite <- Nat2Z.inj_sub by Lia.lia. f_equal.
+                      clear -Hfuel1 Hfuel2 Hfnz1 Hfnz2 n_ge_km1.
+                      Lia.lia. }
+                    { rewrite <- Nat2Z.inj_add. f_equal.
+                      clear -Hfuel1 Hfuel2 Hfnz1 Hfnz2 n_ge_km1.
+                      generalize (NatUtil.pow_nonzero 2 (fuel1 - 1) ltac:(Lia.lia)).
+                      generalize (NatUtil.pow_nonzero 2 (n - (fuel1 - 1)) ltac:(Lia.lia)).
+                      intros. assert (_ - (fuel2 - 1) = Nat.pow 2 (fuel1 - 1) - fuel2 + 1)%nat as ->; Lia.lia. }
+                    { unfold px3. f_equal. unfold v.
+                      unfold InlineTable.get. f_equal.
+                      cbv [cast Convertible_self id Convertible_Z_nat].
+                      assert (1 = Z.of_nat 1) as -> by reflexivity.
+                      assert (Nat.pow 2 fuel1 = 2 * (Nat.pow 2 (fuel1 - 1)))%nat as ->.
+                      { rewrite <- Nat.pow_succ_r'; f_equal. clear -Hfnz1; Lia.lia. }
+                      rewrite <- Nat2Z.inj_sub by Lia.lia. rewrite Nat2Z.id. reflexivity. }
+                  * rewrite Hm3. f_equal. f_equal. f_equal.
+                    clear -Hfuel1 Hfuel2 Hfnz1 Hfnz2 n_ge_km1.
+                    Lia.lia.
+                  * rewrite map.get_put_same. f_equal. f_equal. f_equal.
+                    clear -Hfuel1 Hfuel2 Hfnz1 Hfnz2 n_ge_km1.
+                    generalize (NatUtil.pow_nonzero 2 (fuel1 - 1) ltac:(Lia.lia)).
+                    generalize (NatUtil.pow_nonzero 2 (n - (fuel1 - 1)) ltac:(Lia.lia)).
+                    intros. assert (_ - (fuel2 - 1) = Nat.pow 2 (fuel1 - 1) - fuel2 + 1)%nat as ->; Lia.lia. } }
+        simpl. intros. exists (fuel2 - 1)%nat; split; [assumption|Lia.lia]. }
+      { assert (fuel2 = 0)%nat as ->.
+        { rewrite Nat.mul_sub_distr_r, <- Nat.pow_add_r in Hcond2.
+          clear -Hfuel1 Hfnz1 n_ge_km1 Hcond2.
+          replace (fuel1 - 1 + _)%nat with n in Hcond2 by Lia.lia.
+          generalize (NatUtil.pow_nonzero 2 (n - (fuel1 - 1)) ltac:(Lia.lia)).
+          generalize (NatUtil.pow_nonzero 2 n ltac:(Lia.lia)). Lia.lia. }
+        rewrite Nat.sub_0_r in *.
+        exists (fuel1 - 1)%nat. split; [|Lia.lia].
+        repeat split; [Lia.lia|auto|].
+        exists p2, px2; repeat split; auto.
+        - assert (km1 - (fuel1 - 1) = S (km1 - fuel1))%nat as -> by Lia.lia.
+          unfold inverse_layer_decomposition_loop.
+          rewrite <- fold_left_as_nd_ranged_for_all.
+          unfold z_range; rewrite z_range'_seq by reflexivity.
+          rewrite Z.sub_0_r, Nat2Z.id, seq_S, map_app, fold_left_app, Nat.add_0_l.
+          cbn [List.map fold_left].
+          assert (fold_left _ _ _ = inverse_layer_decomposition_loop (km1:=km1) zetas (km1 - fuel1) \< 2 ^ Z.of_nat km1, 2 ^ Z.of_nat (n - km1), p \>) as ->.
+          { unfold inverse_layer_decomposition_loop.
+            rewrite <- fold_left_as_nd_ranged_for_all.
+            unfold z_range. rewrite z_range'_seq by reflexivity.
+            rewrite Z.sub_0_r, Nat2Z.id. reflexivity. }
+          rewrite Heq1. unfold nlet.
+          assert (inverse_polynomial_list_loop zetas _ _ _ _ = inverse_polynomial_list_loop zetas (Z.of_nat (2 ^ (fuel1 - 1))) (Z.of_nat (2 ^ (n - fuel1))) (Z.of_nat (2 ^ (n - (fuel1 - 1)))) \< Z.of_nat (2 ^ fuel1), 0, px1 \>) as ->.
+          2:{ rewrite Heq2. f_equal; [|f_equal].
+              - assert ((Nat.pow 2 fuel1) - (Nat.pow 2 (fuel1 - 1)) = Nat.pow 2 (fuel1 - 1))%nat as ->; [|rewrite Nat2Z.inj_pow; reflexivity].
+                assert (Nat.pow 2 fuel1 = 2 * Nat.pow 2 (fuel1 - 1))%nat as ->; [|Lia.lia].
+                rewrite <- Nat.pow_succ_r'. f_equal; Lia.lia.
+              - rewrite Z.shiftl_mul_pow2, <- Z.pow_add_r by Lia.lia.
+                f_equal. Lia.lia. }
+          f_equal.
+          + rewrite Nat2Z.inj_pow. f_equal.
+            Lia.lia.
+          + rewrite Nat2Z.inj_pow. reflexivity.
+          + rewrite Z.shiftl_mul_pow2, <- Z.pow_add_r by Lia.lia.
+            rewrite Nat2Z.inj_pow. f_equal. Lia.lia.
+          + rewrite Nat2Z.inj_pow. reflexivity.
+        - rewrite Hm2. do 3 f_equal.
+          generalize (Nat.pow_nonzero 2 (fuel1 - 1) ltac:(Lia.lia)); intros.
+          assert (Nat.pow 2 fuel1 = 2 * (Nat.pow 2 (fuel1 - 1)))%nat as ->; [|Lia.lia].
+          assert (Nat.pow 2 fuel1 = Nat.pow 2 (S (fuel1 - 1)))%nat as -> by (f_equal; Lia.lia).
+          apply Nat.pow_succ_r'. } }
+    { assert (fuel1 = 0)%nat as ->.
+      { assert (n - fuel1 = n)%nat; [|Lia.lia].
+        apply (Nat.pow_inj_r 2); [Lia.lia|].
+        generalize (Nat.pow_le_mono_r 2 (n - fuel1) n ltac:(congruence) ltac:(clear; Lia.lia)).
+        clear -Hcond1; Lia.lia. }
+      repeat rewrite Nat.sub_0_r in *.
+      rewrite Heq1. repeat straightline.
+      apply wp_while.
+      set (loop_inv4 := fun (fuel4: nat) (tr': Semantics.trace) (mem': mem) (loc': locals) =>
+                        (fuel4 <= Nat.pow 2 n)%nat /\
+                        tr' = tr /\
+                        map.get loc' "p" = Some p_ptr /\
+                        let i := ((Nat.pow 2 n) - fuel4)%nat in
+                        exists p4,
+                        Forall2 (fun x y => feval y = Some x) (div_loop c (Z.of_nat i) px1) p4 /\
+                        map.get loc' "j" = Some (word.of_Z (Z.of_nat i)) /\
+                        (sizedlistarray_value access_size.word (Nat.pow 2 n) p_ptr p4 * R)%sep mem').
+      exists nat, lt, loop_inv4; split; [apply lt_wf|].
+      split.
+      { exists (Nat.pow 2 n). unfold loop_inv4. rewrite Nat.sub_diag.
+        repeat split; [Lia.lia|..].
+        - unfold l; rewrite map.get_put_diff by congruence; auto.
+        - exists p1; repeat split; auto.
+          apply map.get_put_same. }
+      intros fuel4 ? mem4 loc4 Hinv4.
+      destruct Hinv4 as (Hfuel4 & -> & Hptr4 & p4 & HF4 & Hj & Hp4).
+      eexists; split.
+      { apply expr_compile_Z_ltb_u; [apply expr_compile_var; eauto|apply expr_compile_Z_literal|..].
+        all: split; [apply Nat2Z.is_nonneg|].
+        all: assert (2 ^ width = Z.of_nat (Nat.pow 2 (Z.to_nat width))) as -> by (rewrite Nat2Z.inj_pow, Z2Nat.id by Lia.lia; reflexivity).
+        all: apply Nat2Z.inj_lt.
+        1: apply (Nat.le_lt_trans _ (Nat.pow 2 n)); [clear; Lia.lia|].
+        all: apply Nat.pow_lt_mono_r; Lia.lia. }
+      rewrite word.unsigned_b2w.
+      match goal with | |- context [Z.b2z (Z.of_nat ?a <? Z.of_nat ?b)] => generalize (Zlt_cases (Z.of_nat a) (Z.of_nat b)); intro Hcond4 end.
+      split; intros Hb; destruct (_ <? _); cbv in Hb; try congruence; clear Hb; [apply Nat2Z.inj_lt in Hcond4|apply Nat2Z.inj_ge in Hcond4].
+      { assert (fuel4 <> 0)%nat as Hfnz4 by (intro; subst fuel4; clear -Hcond4; Lia.lia).
+        eapply weaken_cmd.
+        { eapply (compile_word_sizedlistarray_get _ nat); eauto.
+          - eapply expr_compile_var; auto.
+          - cbv [cast Convertible_self id].
+            eapply expr_compile_var; eauto.
+          - cbv [cast Convertible_self id].
+            apply Nat2Z.inj_lt. clear -Hfuel4 Hfnz4. Lia.lia.
+          - repeat straightline. eexists; split.
+            + repeat straightline. eexists; split; [apply map.get_put_same|].
+              repeat straightline.
+            + straightline_call.
+              { split; [generalize (feval_ok c); cbv [cast F_to_word]; eauto|].
+                unfold v, ListArray.get. rewrite <- nth_default_eq.
+                apply (ListUtil.Forall2_forall_iff (fun x y => feval y = Some x)); eauto.
+                - apply (Forall2_length HF4).
+                - cbv [cast Convertible_self id].
+                  rewrite (Forall2_length HF4).
+                  generalize (length_of_sizedlistarray_value_R Hp4). intro Xlen.
+                  cbn in Xlen. rewrite Xlen. Lia.lia. }
+              destruct H4 as (? & -> & -> & -> & ZZ3).
+              eexists; split; [repeat straightline; reflexivity|].
+              eapply weaken_cmd.
+              * eapply (compile_word_sizedlistarray_put _ nat); eauto.
+                1-3: repeat straightline; repeat (rewrite map.get_put_diff by congruence).
+                2: cbv [cast Convertible_self id].
+                1-3: eexists; split; eauto.
+                apply map.get_put_same.
+                cbv [cast Convertible_self id]. apply Nat2Z.inj_lt; auto.
+                intros. repeat straightline.
+                eexists; split; [eapply expr_compile_nat_add; [eapply expr_compile_var; repeat (rewrite map.get_put_diff by congruence); eauto|instantiate(1:=1%nat); eapply expr_compile_Z_literal]|].
+                repeat straightline.
+                instantiate (2 := fun _ t m l => loop_inv4 (fuel4 - 1)%nat t m l).
+                repeat split.
+                { clear -Hfuel4 Hfnz4; Lia.lia. }
+                { unfold l. repeat (rewrite map.get_put_diff by congruence); auto. }
+                { eexists; repeat split; eauto.
+                  - unfold div_loop. rewrite <- fold_left_as_nd_ranged_for_all.
+                    unfold z_range. rewrite z_range'_seq by reflexivity.
+                    rewrite Z2Nat.inj_sub, Nat2Z.id by reflexivity.
+                    rewrite Nat.sub_0_r.
+                    assert ((Nat.pow 2 n) - _ = S (Nat.pow 2 n - fuel4))%nat as -> by (clear -Hfnz4 Hfuel4; Lia.lia).
+                    rewrite seq_S, map_app, fold_left_app, Nat.add_0_l.
+                    cbn [List.map fold_left].
+                    assert (List.map _ _ = z_range 0 (Z.of_nat (2 ^ n - fuel4))) as ->; [|rewrite fold_left_as_nd_ranged_for_all; unfold nlet].
+                    { unfold z_range. rewrite z_range'_seq, Z.sub_0_r, Nat2Z.id by reflexivity; reflexivity. }
+                    unfold v0, v. unfold ListArray.put, ListArray.get.
+                    cbv [cast Convertible_Z_nat Convertible_self id].
+                    assert (nd_ranged_for_all _ _ _ _ = div_loop c (Z.of_nat (2 ^ n - fuel4)) px1) as -> by reflexivity.
+                    rewrite Nat2Z.id. apply Forall2_replace_nth; eauto.
+                    rewrite ZZ3. rewrite <- nth_default_eq. reflexivity.
+                  - unfold l. rewrite map.get_put_same. f_equal. f_equal.
+                    f_equal. clear -Hfuel4 Hfnz4; Lia.lia. }
+              * instantiate (2 := fun _ t m l => loop_inv4 (fuel4 - 1)%nat t m l).
+                simpl. auto. }
+        { simpl; intros. eexists; split; eauto.
+          clear -Hfnz4; Lia.lia. } }
+      { assert (fuel4 = 0)%nat as -> by (generalize (NatUtil.pow_nonzero 2 n ltac:(congruence)); clear -Hcond4; Lia.lia).
+        rewrite Nat.sub_0_r in *.
+        repeat straightline. eexists; split; eauto.
+        assert (2 ^ Z.of_nat n = Z.of_nat (Nat.pow 2 n)) as ->; [|assumption].
+        rewrite Nat2Z.inj_pow; reflexivity. } }
+      Unshelve.
+      all: try (apply (fun _ => unit)).
+      all: try (apply "").
+      all: simpl; intros; apply tt.
+  Qed.
+End __.
+
+Section Zetas.
+  Context {q: positive} {zeta: F q}.
+
+  (* Computes the list of ζ^0 to ζ^n, hence the length is (n + 1) *)
+  Fixpoint make_zetas (n: nat): list (F q) :=
+    match n with
+    | O => [1%F]
+    | S n => 1%F::(List.map (F.mul zeta) (make_zetas n))
+    end.
+
+  Lemma make_zetas_spec n:
+    forall k, (k <= n)%nat ->
+         nth_error (make_zetas n) k = Some (F.pow zeta (N.of_nat k)).
+  Proof.
+    induction n; intros.
+    - assert (k = 0)%nat as -> by Lia.lia. simpl.
+      rewrite ModularArithmeticTheorems.F.pow_0_r. reflexivity.
+    - simpl. destruct k.
+      + simpl. rewrite ModularArithmeticTheorems.F.pow_0_r. reflexivity.
+      + simpl. rewrite nth_error_map.
+        rewrite IHn by Lia.lia. simpl.
+        rewrite <- ModularArithmeticTheorems.F.pow_succ_r.
+        assert (N.succ (N.of_nat k) = N.pos (Pos.of_succ_nat k)) as -> by Lia.lia.
+        reflexivity.
+  Qed.
+
+  Lemma make_zetas_length n:
+    length (make_zetas n) = S n.
+  Proof.
+    induction n; [reflexivity|].
+    simpl. rewrite map_length, IHn. reflexivity.
+  Qed.
+End Zetas.
+

--- a/src/NTT/CyclotomicDecomposition.v
+++ b/src/NTT/CyclotomicDecomposition.v
@@ -1,0 +1,2512 @@
+Require Import Coq.PArith.BinPosDef. Local Open Scope positive_scope.
+Require Import Coq.NArith.BinNat.
+From Coq.Classes Require Import Morphisms.
+Require Import Spec.ModularArithmetic.
+Require Import Arithmetic.ModularArithmeticTheorems.
+Require Import Coq.ZArith.Znumtheory.
+Require Import Coq.ZArith.Znumtheory Coq.Lists.List. Import ListNotations.
+Require Import NTT.Polynomial.
+Require PrimeFieldTheorems.
+
+Require Import coqutil.Datatypes.List.
+
+Section Utils.
+  (* These should be moved to ListUtil ? Maybe ? *)
+  Lemma fold_right_eq_ext {A B: Type} {eq: A->A->Prop}
+    `{RelationClasses.Equivalence A eq}
+    (f g: B -> A -> A) (v: A) (xs: list B):
+    (forall x y1 y2, In x xs -> eq y1 y2 -> eq (f x y1) (g x y2)) ->
+    eq (fold_right f v xs) (fold_right g v xs).
+  Proof.
+    induction xs; intros X; [reflexivity|].
+    simpl. etransitivity; [eapply X; [apply in_eq|]|reflexivity].
+    apply IHxs; intros; apply X; auto. apply in_cons; auto.
+  Qed.
+
+  Lemma flat_map_constant_nth_error {A B: Type} (c: nat) (f: A -> list B) (l: list A):
+    (forall x : A, In x l -> length (f x) = c) ->
+    forall k x, nth_error (flat_map f l) k = Some x ->
+           exists y, nth_error l (PeanoNat.Nat.div k c) = Some y /\
+                nth_error (f y) (PeanoNat.Nat.modulo k c) = Some x.
+  Proof.
+    destruct (NatUtil.nat_eq_dec c 0%nat) as [->|Hcnz].
+    { intros Hl k x Hx. apply nth_error_In in Hx.
+      apply in_flat_map in Hx. destruct Hx as [z [Hz Hzz]].
+      apply Hl in Hz. apply ListUtil.length0_nil in Hz.
+      rewrite Hz in Hzz. elim (in_nil Hzz). }
+    induction l; intros Hl k x Hx; simpl in Hx.
+    - rewrite nth_error_nil in Hx; inversion Hx.
+    - rewrite ListUtil.nth_error_app, Hl in Hx; [|apply in_eq].
+      destruct (Compare_dec.lt_dec k c).
+      + rewrite PeanoNat.Nat.div_small, PeanoNat.Nat.mod_small by Lia.lia.
+        simpl. eexists; split; eauto.
+      + apply IHl in Hx; [|intros; apply Hl; apply in_cons; auto].
+        assert (k = (k - c) + c)%nat as -> by Lia.lia.
+        rewrite NatUtil.div_minus by Lia.lia.
+        assert (k - c + c = (k - c) + 1 * c)%nat as -> by Lia.lia.
+        rewrite PeanoNat.Nat.Div0.mod_add.
+        assert (_ + 1 = S (PeanoNat.Nat.div (k - c) c))%nat as -> by Lia.lia.
+        simpl. exact Hx.
+  Qed.
+
+  Lemma Forall2_flat_map {X A B: Type} (R: A -> B -> Prop) (f: X -> list A) (g: X -> list B)
+    (l: list X):
+    (forall x, In x l -> length (f x) = length (g x)) ->
+    (forall x, In x l -> Forall2 R (f x) (g x)) ->
+    Forall2 R (flat_map f l) (flat_map g l).
+  Proof.
+    induction l; intros Hl Hf; [constructor|].
+    simpl. apply Forall2_app; [apply Hf; left; reflexivity|].
+    apply IHl; intros; [apply Hl|apply Hf]; right; auto.
+  Qed.
+
+  Lemma map2_map_combine {A B C: Type} (f: A -> B -> C):
+    forall (l: list A) (l': list B),
+      ListUtil.List.map2 f l l' = map (fun x => f (fst x) (snd x)) (combine l l').
+  Proof.
+    induction l; intros; [reflexivity|].
+    destruct l'; [reflexivity|]. simpl.
+    rewrite IHl. reflexivity.
+  Qed.
+
+  Lemma nth_error_map2 {A B C: Type} (f: A -> B -> C):
+    forall (l: list A) (l': list B) (k: nat) (a: A) (b: B),
+      nth_error l k = Some a ->
+      nth_error l' k = Some b ->
+      nth_error (ListUtil.List.map2 f l l') k = Some (f a b).
+  Proof.
+    intros l l' k a b Ha Hb.
+    rewrite map2_map_combine, nth_error_map, ListUtil.nth_error_combine.
+    rewrite Ha, Hb; reflexivity.
+  Qed.
+
+  Lemma flat_map_map2 {X A B C: Type} (f: A -> B -> C) (g: X -> list A) (h: X -> list B)
+    (l: list X):
+    (forall x, In x l -> length (g x) = length (h x)) ->
+    ListUtil.List.map2 f (flat_map g l) (flat_map h l) = flat_map (fun x => ListUtil.List.map2 f (g x) (h x)) l.
+  Proof.
+    intros Hx. induction l; [reflexivity|].
+    simpl. rewrite ListUtil.map2_app by (apply Hx; left; reflexivity).
+    rewrite IHl; [reflexivity|]. intros; apply Hx; right; auto.
+  Qed.
+
+  Lemma Forall2_app_inv {A B} (R: A -> B -> Prop) (l1 l1': list A) (l2 l2': list B):
+    length l1 = length l2 ->
+    Forall2 R (l1 ++ l1') (l2 ++ l2') ->
+    Forall2 R l1 l2 /\ Forall2 R l1' l2'.
+  Proof.
+    revert l1' l2 l2'. induction l1; intros l1' l2 l2' Hlength HF.
+    - destruct l2; [|simpl in Hlength; Lia.lia].
+      simpl in HF. split; auto; constructor.
+    - destruct l2; simpl in Hlength; [congruence|].
+      do 2 rewrite <- app_comm_cons in HF.
+      inversion HF; subst. apply IHl1 in H4; [|Lia.lia].
+      destruct H4. split; auto.
+  Qed.
+
+  Lemma Forall2_nth_error_iff {A B} (R: A -> B -> Prop) (l1: list A) (l2: list B):
+    Forall2 R l1 l2 <-> (length l1 = length l2 /\ forall k v1 v2, nth_error l1 k = Some v1 -> nth_error l2 k = Some v2 -> R v1 v2).
+  Proof.
+    split.
+    - intros; split; [eapply Forall2_length; eauto|].
+      induction H; intros.
+      + rewrite nth_error_nil in H; congruence.
+      + destruct k; simpl in *.
+        * inversion H1; inversion H2; subst x; subst y; auto.
+        * eapply IHForall2; eauto.
+    - revert l2; induction l1; intros l2 [HA HB].
+      + destruct l2; [constructor|simpl in HA; congruence].
+      + destruct l2; [simpl in HA; congruence|].
+        simpl in HA. constructor.
+        * apply (HB O); reflexivity.
+        * apply IHl1. split; [Lia.lia|].
+          intros. apply (HB (S k)); auto.
+  Qed.
+
+  Section Fold_right_monoid.
+    Context {A}{eq}{op}{id}{monoid: @Hierarchy.monoid A eq op id}.
+
+    Lemma fold_right_monoid_op:
+      forall a l, eq (fold_right op a l) (op (fold_right op id l) a).
+    Proof.
+      induction l; simpl.
+      - rewrite Hierarchy.left_identity. reflexivity.
+      - rewrite IHl. rewrite Hierarchy.associative. reflexivity.
+    Qed.
+
+    Lemma fold_right_monoid_app:
+      forall l1 l2, eq (fold_right op id (l1 ++ l2)) (op (fold_right op id l1) (fold_right op id l2)).
+    Proof. intros. rewrite fold_right_app, fold_right_monoid_op. reflexivity. Qed.
+
+    Lemma fold_right_monoid_concat:
+      forall l, eq (fold_right op id (concat l)) (fold_right op id (map (fold_right op id) l)).
+    Proof. induction l; [reflexivity|]. simpl; rewrite fold_right_monoid_app, IHl. reflexivity. Qed.
+
+    Lemma fold_right_monoid_singleton:
+      forall a, eq (fold_right op id (a::nil)) a.
+    Proof. intros; simpl. rewrite Hierarchy.right_identity. reflexivity. Qed.
+  End Fold_right_monoid.
+
+  (* TODO: I did not notice there was a chunk function in coqutil, replace below with it *)
+  Fixpoint chunks2 {A} (l: list A): list (list A) :=
+    match l with
+    | nil => nil
+    | a::nil => [[a]]
+    | a1::a2::l' => [a1; a2]::(chunks2 l')
+    end.
+
+  Lemma chunks2_eq {A} (l: list A):
+    chunks2 l = match l with
+                | nil => nil
+                | _ => (firstn 2 l)::(chunks2 (skipn 2 l))
+                end.
+  Proof.
+    destruct l; [reflexivity|].
+    destruct l; reflexivity.
+  Qed.
+
+  Lemma chunks2_cons {A} (l: list A):
+    l <> nil ->
+    chunks2 l = (firstn 2 l)::(chunks2 (skipn 2 l)).
+  Proof. intro X. rewrite chunks2_eq at 1. destruct l; congruence. Qed.
+
+  Lemma chunks2_length {A} (l: list A):
+    length (chunks2 l) = ((PeanoNat.Nat.div (length l) 2) + (PeanoNat.Nat.modulo (length l) 2))%nat.
+  Proof.
+    assert (forall n (xs: list A), (length xs <= n) -> length (chunks2 xs) = (PeanoNat.Nat.div (length xs) 2) + (PeanoNat.Nat.modulo (length xs) 2))%nat as IH.
+    { induction n; intros xs Hxs.
+      - destruct xs; [|simpl in Hxs; Lia.lia]. reflexivity.
+      - destruct (@Decidable.dec_eq_list_nil_r _ xs) as [->|Hnn]; [reflexivity|].
+        rewrite chunks2_cons; auto. cbn [length].
+        rewrite IHn by (rewrite skipn_length; simpl in *; Lia.lia).
+        rewrite skipn_length. assert (length xs = 1 \/ 2 <= length xs)%nat as [->|Hle] by (destruct xs; simpl in *; [congruence|]; Lia.lia); [reflexivity|].
+        set (m := (length xs - 2)%nat). assert (length xs = m + 2)%nat as -> by Lia.lia.
+        rewrite NatUtil.div_minus by Lia.lia.
+        assert (m + 2 = m + 1 * 2)%nat as -> by Lia.lia.
+        rewrite PeanoNat.Nat.Div0.mod_add. Lia.lia. }
+    apply (IH _ _ ltac:(reflexivity)).
+  Qed.
+
+  Lemma chunks2_elem_length_exact {A} (l: list A):
+    PeanoNat.Nat.Even (length l) ->
+    Forall (fun x => length x = 2%nat) (chunks2 l).
+  Proof.
+    assert (IH: forall n (xs: list A), (length xs <= n) -> PeanoNat.Nat.Even (length xs) -> Forall (fun x => length x = 2%nat) (chunks2 xs)).
+    { induction n; intros xs Hxs Heven.
+      - destruct xs; [|simpl in Hxs; Lia.lia]. constructor.
+      - destruct (@Decidable.dec_eq_list_nil_r _ xs) as [->|Hnn]; [constructor|].
+        rewrite chunks2_cons; auto.
+        assert (2 <= length xs)%nat as Hle.
+        { destruct xs; [congruence|]; destruct xs; simpl in *; try Lia.lia.
+          apply PeanoNat.Nat.Even_succ in Heven. eelim PeanoNat.Nat.Even_Odd_False; eauto.
+          exists O. Lia.lia. }
+        constructor; [rewrite firstn_length; Lia.lia|].
+        apply IHn; rewrite skipn_length; [Lia.lia|].
+        apply (proj1 (PeanoNat.Nat.Even_succ_succ _)).
+        assert (S (S _) = length xs) as -> by Lia.lia. auto. }
+    apply (IH _ _ ltac:(reflexivity)).
+  Qed.
+
+  Lemma chunks2_concat {A} (l: list A):
+    l = concat (chunks2 l).
+  Proof.
+    assert (IH: forall n (xs: list A), (length xs <= n) -> xs = concat (chunks2 xs)).
+    { induction n; intros xs Hxs.
+      - destruct xs; [|simpl in Hxs; Lia.lia].
+        reflexivity.
+      - rewrite chunks2_eq. destruct xs; [reflexivity|].
+        cbn [concat]. rewrite <- IHn by (rewrite skipn_length; simpl in *; Lia.lia).
+        rewrite firstn_skipn; reflexivity. }
+    apply (IH _ _ ltac:(reflexivity)).
+  Qed.
+
+  Lemma chunks2_nth_error {A} (l: list A):
+    forall k, nth_error l k = Option.bind (nth_error (chunks2 l) (PeanoNat.Nat.div k 2)) (fun chunk => nth_error chunk (PeanoNat.Nat.modulo k 2)).
+  Proof.
+    assert (IH: forall n (xs: list A), (length xs <= n) -> forall k : nat, nth_error xs k = Option.bind (nth_error (chunks2 xs) (PeanoNat.Nat.div k 2)) (fun chunk : list A => nth_error chunk (PeanoNat.Nat.modulo k 2))).
+    { induction n; intros xs Hxs k.
+      - destruct xs; simpl in Hxs; [|Lia.lia].
+        simpl. repeat rewrite nth_error_nil. reflexivity.
+      - rewrite (PeanoNat.Nat.Div0.div_mod k 2) at 1.
+        destruct (@Decidable.dec_eq_list_nil_r _ xs) as [->|Hnn]; [simpl; repeat rewrite nth_error_nil; reflexivity|].
+        rewrite chunks2_cons; auto. rewrite nth_error_cons.
+        assert (length xs = 1 \/ 2 <= length xs)%nat as [He|Hle] by (destruct xs; simpl in *; [congruence|]; Lia.lia).
+        + rewrite skipn_all2 by Lia.lia. cbn [chunks2].
+          destruct xs; [congruence|]. destruct xs; [|simpl in He; Lia.lia].
+          destruct k; [reflexivity|].
+          destruct k; [reflexivity|].
+          assert (S (S k) = k + 2)%nat as -> by Lia.lia.
+          rewrite NatUtil.div_minus by Lia.lia.
+          rewrite (ListUtil.nth_error_length_error _ (2 * _ + _)%nat [a]) by (simpl; Lia.lia).
+          rewrite PeanoNat.Nat.add_1_r, nth_error_nil. reflexivity.
+        + destruct k; [simpl; destruct xs; reflexivity|].
+          destruct k; [simpl; destruct xs; [reflexivity|destruct xs; reflexivity]|].
+          assert (S (S k) = k + 2)%nat as -> by Lia.lia.
+          rewrite NatUtil.div_minus by Lia.lia.
+          rewrite PeanoNat.Nat.add_1_r.
+          assert (k + 2 = k + 1 * 2)%nat as -> by Lia.lia.
+          rewrite PeanoNat.Nat.Div0.mod_add.
+          rewrite <- IHn by (rewrite skipn_length; Lia.lia).
+          rewrite <- (firstn_skipn 2 xs) at 1.
+          rewrite nth_error_app2; rewrite firstn_length_le; try Lia.lia.
+          rewrite (PeanoNat.Nat.Div0.div_mod k 2) at 3. f_equal. Lia.lia. }
+    apply (IH _ _ ltac:(reflexivity)).
+  Qed.
+
+  Lemma chunks2_Forall2 {A B} (R: A -> B -> Prop) (l1: list A) (l2: list B):
+    Forall2 R l1 l2 ->
+    Forall2 (Forall2 R) (chunks2 l1) (chunks2 l2).
+  Proof.
+    assert (IH: forall n (xs1: list A) (xs2: list B), (length xs1 <= n) -> Forall2 R xs1 xs2 -> Forall2 (Forall2 R) (chunks2 xs1) (chunks2 xs2)).
+    { induction n; intros xs1 xs2 Hxs1 HR.
+      - destruct xs1; simpl in Hxs1; [|Lia.lia].
+        inversion HR; subst xs2. constructor.
+      - destruct (@Decidable.dec_eq_list_nil_r _ xs1) as [->|Hnn1]; [inversion HR; subst xs2; constructor|].
+        generalize (Forall2_length HR); intro Hlength.
+        destruct (@Decidable.dec_eq_list_nil_r _ xs2) as [->|Hnn2]; [destruct xs1; simpl in Hlength; try congruence; Lia.lia|].
+        rewrite (chunks2_cons xs1), (chunks2_cons xs2); auto.
+        rewrite <- (firstn_skipn 2 xs1), <- (firstn_skipn 2 xs2) in HR.
+        apply Forall2_app_inv in HR; [|repeat rewrite firstn_length; Lia.lia].
+        destruct HR. constructor; auto.
+        apply IHn; auto. rewrite skipn_length. Lia.lia. }
+    apply (IH _ _ _ ltac:(reflexivity)).
+  Qed.
+
+  Lemma chunks2_map {A B} (f: A -> B) (l: list A):
+    chunks2 (map f l) = map (map f) (chunks2 l).
+  Proof.
+    assert (IH: forall n (xs: list A), length xs <= n -> chunks2 (map f xs) = map (map f) (chunks2 xs)).
+    { induction n; intros xs Hxs.
+      - destruct xs; simpl in Hxs; [|Lia.lia]. reflexivity.
+      - destruct xs; [reflexivity|].
+        destruct xs; [reflexivity|].
+        simpl in *. rewrite IHn by Lia.lia. reflexivity. }
+    apply (IH _ _ ltac:(reflexivity)).
+  Qed.
+
+  Lemma chunks2_app2 {A} (l1 l2: list A):
+    length l1 = 2%nat ->
+    chunks2 (l1 ++ l2) = l1::(chunks2 l2).
+  Proof.
+    intro X. destruct l1; [|destruct l1; [|destruct l1]]; simpl in X; try congruence.
+    reflexivity.
+  Qed.
+
+  Lemma chunks2_flat_map_constant2 {A B} (f: A -> list B) (l: list A):
+    (forall x : A, In x l -> length (f x) = 2%nat) ->
+    chunks2 (flat_map f l) = map f l.
+  Proof.
+    induction l; intros X; [reflexivity|].
+    simpl. rewrite chunks2_app2; [|apply X; left; auto].
+    rewrite IHl; [reflexivity|]. intros; apply X; right; auto.
+  Qed.
+
+  Lemma chunk_concat {A} (l: list (list A)) (sz: nat) (szn0: (sz <> 0)%nat)
+    (Hl: Forall (fun l => length l = sz) l):
+    chunk sz (concat l) = l.
+  Proof.
+    induction Hl; [reflexivity|].
+    simpl. rewrite chunk_app_chunk; auto.
+    rewrite IHHl. reflexivity.
+  Qed.
+
+  Lemma skipn_flat_map_constant_length {A B: Type} (c: nat) (f: A -> list B)
+    (l: list A):
+    (forall x, In x l -> length (f x) = c) ->
+    forall k, skipn (k * c) (flat_map f l) = flat_map f (skipn k l).
+  Proof.
+    assert (HS: forall l, (forall x, In x l -> length (f x) = c) -> skipn c (flat_map f l) = flat_map f (skipn 1 l)).
+    { clear l; induction l; intro Hlen.
+      - simpl. apply skipn_nil.
+      - simpl. rewrite skipn_app_r; auto.
+        rewrite Hlen; auto. left; reflexivity. }
+    induction k; [reflexivity|].
+    assert (S k * c = c + k * c)%nat as -> by Lia.lia.
+    rewrite <- skipn_skipn, IHk.
+    rewrite HS; [|intros; apply H; eapply ListUtil.In_skipn; eauto].
+    rewrite skipn_skipn. f_equal.
+  Qed.
+
+  Global Instance Forall2_Equivalence {A: Type} {R: A -> A -> Prop} `{Equivalence _ R}:
+    Equivalence (Forall2 R).
+  Proof.
+    constructor.
+    - intro. apply Forall2_nth_error_iff. split; [reflexivity|].
+      intros k v1 v2 Hv1 Hv2. rewrite Hv2 in Hv1; inversion Hv1; subst v1; reflexivity.
+    - intros x y Hxy. apply Forall2_nth_error_iff in Hxy.
+      apply Forall2_nth_error_iff. destruct Hxy as [Heq Hxy].
+      split; auto. intros k v1 v2 Hv1 Hv2.
+      symmetry. eapply Hxy; eauto.
+    - intros x y z Hxy Hyz. apply Forall2_nth_error_iff in Hxy, Hyz.
+      destruct Hxy as [Heq1 Hxy]. destruct Hyz as [Heq2 Hyz].
+      apply Forall2_nth_error_iff. split; [congruence|].
+      intros k v1 v2 Hv1 Hv2.
+      generalize (ListUtil.nth_error_value_length _ _ _ _ Hv1). intro Hlt.
+      rewrite Heq1 in Hlt.
+      apply ListUtil.nth_error_length_exists_value in Hlt.
+      destruct Hlt as [v3 Hv3]. etransitivity; eauto.
+  Qed.
+
+  Lemma Forall2_map {A B: Type} {R: A -> A -> Prop} {R': B -> B -> Prop}
+    `{Equivalence _ R} `{Equivalence _ R'}:
+    forall f l1 l2,
+      Forall2 R l1 l2 ->
+      Proper (R ==> R') f ->
+      Forall2 R' (map f l1) (map f l2).
+  Proof.
+    intros f l1 l2 HA HB. apply Forall2_nth_error_iff.
+    split; [repeat rewrite map_length; eapply Forall2_length; eauto|].
+    intros k v1 v2 Hv1 Hv2.
+    rewrite nth_error_map in Hv1, Hv2.
+    destruct (nth_error l1 k) as [a1|] eqn:Ha1; simpl in Hv1; [|congruence].
+    destruct (nth_error l2 k) as [a2|] eqn:Ha2; simpl in Hv2; [|congruence].
+    inversion Hv1; inversion Hv2; subst v1; subst v2. apply HB.
+    apply Forall2_nth_error_iff in HA. eapply (proj2 HA); eauto.
+  Qed.
+
+  Lemma Forall2_map_in {X A B: Type} {R: A -> B -> Prop}:
+    forall (l: list X) f g,
+      (forall x, In x l -> R (f x) (g x)) ->
+      Forall2 R (map f l) (map g l).
+  Proof.
+    induction l; intros f g HR; [constructor|].
+    simpl. constructor; auto.
+    - apply HR. left. reflexivity.
+    - apply IHl. intros; apply HR; right; auto.
+  Qed.
+
+  Lemma Forall_chunk_length_eq {A: Type} (k c: nat):
+    forall (l: list A),
+      (length l = k * c)%nat ->
+      Forall (fun ck => length ck = k) (chunk k l).
+  Proof.
+    induction c; intros l Hl.
+    - rewrite PeanoNat.Nat.mul_0_r in Hl.
+      apply ListUtil.length0_nil in Hl. subst l.
+      rewrite chunk_nil. constructor.
+    - destruct (NatUtil.nat_eq_dec k 0%nat) as [->|Hknz].
+      + rewrite PeanoNat.Nat.mul_0_l in Hl.
+        apply ListUtil.length0_nil in Hl. subst l.
+        rewrite chunk_nil. constructor.
+      + rewrite <- (firstn_skipn k l).
+        rewrite chunk_app_chunk; auto.
+        2: apply firstn_length_le; Lia.lia.
+        constructor; [apply firstn_length_le; Lia.lia|].
+        apply IHc. rewrite skipn_length. Lia.lia.
+  Qed.
+
+  Lemma skipn_concat_same_length {A: Type} (k c : nat) (l: list (list A)):
+    Forall (fun x => length x = c) l ->
+    skipn (k * c) (concat l) = concat (skipn k l).
+  Proof.
+    revert l. induction k; intros l HF.
+    - rewrite PeanoNat.Nat.mul_0_l; reflexivity.
+    - destruct l as [|x].
+      + rewrite skipn_nil, concat_nil. reflexivity.
+      + rewrite skipn_cons, <- IHk; [|inversion HF; auto].
+        simpl. rewrite <- ListUtil.skipn_skipn.
+        rewrite skipn_app_r; auto.
+        inversion HF; auto.
+  Qed.
+
+  Lemma chunk_map {A B: Type} (f: A -> B) (n: nat):
+    forall l,
+      (n <> 0)%nat ->
+      chunk n (map f l) = map (map f) (chunk n l).
+  Proof.
+    intros l Hn. apply nth_error_ext.
+    intro i. rewrite nth_error_map.
+    destruct (Compare_dec.lt_dec i (length (chunk n l))) as [Hlt|Hnlt]; rewrite length_chunk in * by assumption.
+    - rewrite nth_error_chunk; auto.
+      2: rewrite map_length; auto.
+      rewrite nth_error_chunk; auto.
+      simpl. rewrite skipn_map, firstn_map. reflexivity.
+    - rewrite ListUtil.nth_error_length_error.
+      2: rewrite length_chunk, map_length; auto; Lia.lia.
+      rewrite ListUtil.nth_error_length_error.
+      2: rewrite length_chunk; auto; Lia.lia.
+      reflexivity.
+  Qed.
+
+End Utils.
+
+Section CyclotomicDecomposition.
+  Context {q: positive} {prime_q: prime q}.
+  Local Notation F := (F q). (* This is to have F.pow available, there is no Fpow defined for a general field *)
+  Local Open Scope F_scope.
+  Context {field: @Hierarchy.field F eq F.zero F.one F.opp F.add F.sub F.mul F.inv F.div}
+    {char_ge_3: @Ring.char_ge F eq F.zero F.one F.opp F.add F.sub F.mul (BinNat.N.succ_pos (BinNat.N.two))}.
+  Context {P}{poly_ops: @Polynomial.polynomial_ops F P}.
+  Context {poly_defs: @Polynomial.polynomial_defs F eq F.zero F.one F.opp F.add F.sub F.mul P _}.
+  Context {zeta: F} {km1: N} {Hkm1: zeta ^ (N.pow 2 km1) = F.opp 1}.
+
+  Local Notation Peq := (@Polynomial.Peq F eq P _).
+  Local Notation Pmod := (@Polynomial.Pmod F F.zero P _ F.div).
+  Local Notation Pmul := (@Polynomial.Pmul _ _ poly_ops).
+  Local Notation Pconst := (@Polynomial.Pconst _ _ poly_ops).
+  Local Notation negacyclic := (@Polynomial.negacyclic F P _).
+  Local Notation posicyclic := (@Polynomial.posicyclic F P _).
+  Local Notation coprime := (Polynomial.coprime (poly_defs:=poly_defs) (Fdiv:=F.div)).
+  Local Notation Pquotl := (@Polynomial.Pquotl F eq F.zero P _ F.div).
+  Local Notation of_pl := (Polynomial.of_pl (poly_defs:=poly_defs) (Finv:=F.inv) (Fdiv:=F.div) (field:=field)).
+
+  Lemma zeta_pow_nz:
+    forall k, zeta ^ k <> 0.
+  Proof.
+    apply N.peano_ind.
+    - rewrite F.pow_0_r. symmetry; apply Hierarchy.zero_neq_one.
+    - intros n IH. rewrite F.pow_succ_r.
+      intro X. apply Hierarchy.zero_product_zero_factor in X.
+      destruct X as [X|X]; [|elim IH; auto].
+      rewrite X in Hkm1. rewrite F.pow_0_l in Hkm1 by Lia.lia.
+      symmetry in Hkm1. apply Group.inv_id_iff in Hkm1.
+      rewrite Group.inv_inv in Hkm1.
+      symmetry in Hkm1. apply Hierarchy.zero_neq_one in Hkm1; auto.
+  Qed.
+
+  Lemma zeta_pow_succ_km1:
+    zeta ^ (N.pow 2 (N.succ km1)) = 1.
+  Proof.
+    rewrite N.pow_succ_r', N.mul_comm, <- F.pow_pow_l, Hkm1.
+    rewrite F.pow_2_r, (@Ring.mul_opp_l F eq _ _ _ _ _ _ _ 1 _), (@Ring.mul_opp_r F eq _ _ _ _ _ _ _ _ 1).
+    rewrite (@Group.inv_inv F _ _ _ _ _).
+    apply Hierarchy.left_identity.
+  Qed.
+
+  Lemma zeta_pow_mod:
+    forall k, zeta ^ k = zeta ^ (k mod (N.pow 2 (N.succ km1))).
+  Proof.
+    intros k; rewrite (N.Div0.div_mod k (N.pow 2 (N.succ km1))) at 1.
+    rewrite F.pow_add_r, <- F.pow_pow_l.
+    rewrite zeta_pow_succ_km1, F.pow_1_l.
+    apply Hierarchy.left_identity.
+  Qed.
+
+  Lemma neg_zeta_power_eq:
+    forall k,
+      F.opp (zeta ^ k) = zeta ^ (N.add (N.pow 2 km1) k).
+  Proof.
+    intros k. rewrite F.pow_add_r, Hkm1.
+    rewrite Ring.mul_opp_l, (@Hierarchy.left_identity F eq F.mul _ _ _).
+    reflexivity.
+  Qed.
+
+  Fixpoint cyclotomic_decompose (i: nat) :=
+    match i with
+    | O => [2 ^ km1]%N
+    | S i => flat_map (fun n => [N.div n 2%N; N.add (2 ^ km1) (N.div n 2)])%N (cyclotomic_decompose i)
+    end.
+
+  Definition cyclotomic_decomposition (n: nat) (i: nat) :=
+    List.map (fun j => posicyclic (Nat.pow 2 (n - i)%nat) (zeta ^ j)) (cyclotomic_decompose i).
+
+  (* We only keep one half of the coefficients since the other half can be recovered from it *)
+  Fixpoint zeta_powers (i: nat) :=
+    match i with
+    | O => cyclotomic_decompose O
+    | S i => (zeta_powers i) ++ (List.map (fun k => nth_default 0%N (cyclotomic_decompose (S i)) (2 * k)%nat) (seq 0%nat (Nat.pow 2 i)))
+    end.
+
+  Lemma zeta_powers_length (i: nat):
+    length (zeta_powers i) = Nat.pow 2 i.
+  Proof.
+    induction i; [reflexivity|].
+    simpl; rewrite app_length, map_length, seq_length, IHi.
+    Lia.lia.
+  Qed.
+
+  Lemma cyclotomic_decompose_length i:
+    length (cyclotomic_decompose i) = Nat.pow 2 i.
+  Proof.
+    induction i; [reflexivity|].
+    rewrite PeanoNat.Nat.pow_succ_r'. simpl.
+    erewrite flat_map_constant_length; [|simpl; reflexivity].
+    rewrite IHi; Lia.lia.
+  Qed.
+
+  Lemma cyclotomic_decomposition_length n i:
+    length (cyclotomic_decomposition n i) = Nat.pow 2 i.
+  Proof. unfold cyclotomic_decomposition; rewrite map_length, cyclotomic_decompose_length. reflexivity. Qed.
+
+  Context {n: nat} {Hnkm1: (n >= N.to_nat km1)%nat}.
+
+  Lemma cyclotomic_decompose_mod:
+    forall i, (i <= N.to_nat km1)%nat ->
+         (forall p, In p (cyclotomic_decompose i) -> (p mod (2 ^ (km1 - N.of_nat i)) = 0)%N /\ (p < N.pow 2 (N.succ km1))%N).
+  Proof.
+    induction i; intros Hi p Hin.
+    - simpl. simpl in Hin. destruct Hin as [<-|Hin]; [|elim Hin].
+      rewrite N.sub_0_r, N.Div0.mod_same, N.pow_succ_r'.
+      split; Lia.lia.
+    - specialize (IHi ltac:(Lia.lia)).
+      apply In_nth_error in Hin. destruct Hin as [k Hin].
+      simpl in Hin. eapply flat_map_constant_nth_error in Hin; [|simpl; reflexivity].
+      destruct Hin as (n1 & (Hn1 & Hn2)).
+      destruct (IHi n1 ltac:(eapply nth_error_In; eauto)) as [A B].
+      assert (km1 - N.of_nat i = N.succ (km1 - N.of_nat (S i)) :> _)%N as C by Lia.lia.
+      rewrite C, N.pow_succ_r' in A.
+      apply N.Div0.div_exact in A.
+      assert (n1/2 = 2 ^ (km1 - N.of_nat (S i)) * (n1 / (2 * 2 ^ (km1 - N.of_nat (S i)))) :> _)%N as D.
+      { rewrite A at 1. assert (2 * 2 ^ (km1 - N.of_nat (S i)) * (n1 / (2 * 2 ^ (km1 - N.of_nat (S i)))) = (2 ^ (km1 - N.of_nat (S i)) * (n1 / (2 * 2 ^ (km1 - N.of_nat (S i))))) * 2 :> _)%N as -> by Lia.lia.
+        rewrite N.div_mul by Lia.lia. reflexivity. }
+      assert (PeanoNat.Nat.modulo k 2 = 0%nat :> _ \/ PeanoNat.Nat.modulo k 2 = 1%nat :> _)%nat as E by (generalize (NatUtil.mod_bound_lt k 2 ltac:(Lia.lia)); Lia.lia).
+      destruct E as [E|E]; rewrite E in Hn2; simpl in Hn2; inversion Hn2; subst p.
+      + split.
+        * rewrite D, N.mul_comm. apply N.Div0.mod_mul.
+        * rewrite N.pow_succ_r' in B.
+          apply N.Div0.div_lt_upper_bound in B.
+          rewrite N.pow_succ_r'; Lia.lia.
+      + split.
+        * rewrite D.
+          assert (2 ^ km1 = 2 ^ ((km1 - N.of_nat (S i)) + N.of_nat (S i)))%N as -> by (f_equal; Lia.lia).
+          rewrite N.pow_add_r, <- N.mul_add_distr_l, N.mul_comm. apply N.Div0.mod_mul.
+        * rewrite N.pow_succ_r' in B.
+          apply N.Div0.div_lt_upper_bound in B.
+          rewrite N.pow_succ_r'; Lia.lia.
+  Qed.
+
+  Lemma cyclotomic_decompose_S_nth_error:
+    forall i, (S i <= N.to_nat km1)%nat ->
+         forall k v,
+           nth_error (cyclotomic_decompose i) k = Some v ->
+           nth_error (cyclotomic_decompose (S i)) (2 * k) = Some (v / 2)%N /\
+           nth_error (cyclotomic_decompose (S i)) (2 * k + 1) = Some (2 ^ km1 + v / 2)%N /\
+           (v = 2 * (v / 2))%N.
+  Proof.
+    intros i Hi k v Hv.
+    cbn [cyclotomic_decompose].
+    generalize (ListUtil.nth_error_value_length _ _ _ _ Hv).
+    rewrite cyclotomic_decompose_length. intro Hk.
+    assert (Hlt: (2 * k + 1 < PeanoNat.Nat.pow 2 (S i))%nat) by (rewrite PeanoNat.Nat.pow_succ_r'; Lia.lia).
+    destruct (ListUtil.nth_error_length_exists_value (2 * k) (cyclotomic_decompose (S i)) ltac:(rewrite cyclotomic_decompose_length; Lia.lia)) as [v1 Hv1].
+    destruct (ListUtil.nth_error_length_exists_value (2 * k + 1) (cyclotomic_decompose (S i)) ltac:(rewrite cyclotomic_decompose_length; Lia.lia)) as [v2 Hv2].
+    cbn [cyclotomic_decompose] in Hv1, Hv2.
+    destruct (flat_map_constant_nth_error 2%nat (fun n0 : N => [(n0 / 2)%N; (2 ^ km1 + n0 / 2)%N]) _ ltac:(reflexivity) _ _ Hv1) as [y [Hy1 Hy1']].
+    destruct (flat_map_constant_nth_error 2%nat (fun n0 : N => [(n0 / 2)%N; (2 ^ km1 + n0 / 2)%N]) _ ltac:(reflexivity) _ _ Hv2) as [y2 [Hy2 Hy2']].
+    assert (PeanoNat.Nat.div (2 * k) 2 = k) as HA by (symmetry; apply (PeanoNat.Nat.div_unique _ 2 k 0 ltac:(Lia.lia)); Lia.lia).
+    rewrite HA in Hy1. clear HA.
+    assert (PeanoNat.Nat.div (2 * k + 1) 2 = k) as HA by (symmetry; apply (PeanoNat.Nat.div_unique _ 2 k 1 ltac:(Lia.lia)); Lia.lia).
+    rewrite HA in Hy2. clear HA.
+    assert (y = y2) by congruence; subst y2.
+    assert (v = y) by congruence; subst y.
+    assert (PeanoNat.Nat.modulo (2 * k) 2 = 0)%nat as HA by (symmetry; apply (PeanoNat.Nat.mod_unique _ 2 k 0 ltac:(Lia.lia)); Lia.lia).
+    rewrite HA in Hy1'; clear HA.
+    assert (PeanoNat.Nat.modulo (2 * k + 1) 2 = 1)%nat as HA by (symmetry; apply (PeanoNat.Nat.mod_unique _ 2 k 1 ltac:(Lia.lia)); Lia.lia).
+    rewrite HA in Hy2'; clear HA.
+    simpl in Hy1', Hy2'.
+    split; [congruence|]. split; [congruence|].
+    apply ListUtil.List.nth_error_In in Hv.
+    destruct (cyclotomic_decompose_mod i ltac:(Lia.lia) _ Hv) as [HA HB].
+    apply N.Div0.div_exact.
+    apply N.Div0.mod_divides. apply N.Div0.mod_divides in HA.
+    destruct HA as [a HA]. rewrite HA.
+    assert (km1 - N.of_nat i = N.succ (km1 - N.of_nat (S i)))%N as -> by Lia.lia.
+    rewrite N.pow_succ_r'. exists (2 ^ (km1 - N.of_nat (S i)) * a)%N. Lia.lia.
+  Qed.
+
+  Lemma zeta_powers_In:
+    forall i, (i <= N.to_nat km1)%nat ->
+         forall x, In x (zeta_powers i) ->
+              (x <= N.pow 2 km1)%N.
+  Proof.
+    induction i; intros Hi x Hx.
+    - cbn in Hx. destruct Hx as [<- | Hx]; [reflexivity|elim Hx].
+    - cbn [zeta_powers] in Hx. apply in_app_or in Hx.
+      destruct Hx as [Hx|Hx].
+      + apply IHi; auto. Lia.lia.
+      + apply in_map_iff in Hx. destruct Hx as [y [Hy Hy']].
+        apply in_seq in Hy'. rewrite PeanoNat.Nat.add_0_l in Hy'.
+        destruct (ListUtil.nth_error_length_exists_value y (cyclotomic_decompose i) ltac:(rewrite cyclotomic_decompose_length; Lia.lia)) as [v Hv].
+        generalize (nth_error_In _ _ Hv). intro Hin.
+        apply cyclotomic_decompose_mod in Hin; [|Lia.lia].
+        destruct Hin as [Hv1 Hv2].
+        apply cyclotomic_decompose_S_nth_error in Hv; [|Lia.lia].
+        destruct Hv as [Hv1' [Hv2' Hv_eq]].
+        rewrite (ListUtil.nth_error_value_eq_nth_default _ _ _ Hv1') in Hy.
+        subst x. assert (N.pow 2 km1 = N.div (N.pow 2 (N.succ km1)) 2) as -> by (rewrite N.pow_succ_r, N.mul_comm, N.div_mul by Lia.lia; reflexivity).
+        apply N.Div0.div_le_mono. Lia.lia.
+  Qed.
+
+  Lemma cyclotomic_decomposition_0:
+    Peq (negacyclic (Nat.pow 2 n) F.one) (List.fold_right Pmul Pone (cyclotomic_decomposition n 0%nat)).
+  Proof.
+    simpl. rewrite (@Hierarchy.right_identity P Peq Pmul _ _), Hkm1, Polynomial.posicyclic_opp.
+    rewrite PeanoNat.Nat.sub_0_r. reflexivity.
+  Qed.
+
+  Lemma cyclotomic_decompose_zeta_powers_nth:
+    forall i j k, (S i <= j)%nat ->
+             (k < Nat.pow 2 i)%nat ->
+             exists v, nth_error (zeta_powers j) (Nat.pow 2 i + k) = Some v /\
+                  nth_error (cyclotomic_decompose (S i)) (2 * k)%nat = Some v.
+  Proof.
+    assert (IH: forall j i, (S i <= j)%nat -> exists tl, zeta_powers j = zeta_powers i ++ (map (fun k : nat => nth_default 0%N (cyclotomic_decompose (S i)) (2 * k)) (seq 0 (Nat.pow 2 i))) ++ tl).
+    { induction j; intros i Hi; [Lia.lia|].
+      assert (S i <= j \/ i = j) as [Hlt|<-] by Lia.lia.
+      - simpl. destruct (IHj _ Hlt) as [tl Heq].
+        rewrite Heq. repeat rewrite <- List.app_assoc.
+        eexists; f_equal.
+      - exists nil. rewrite List.app_nil_r. reflexivity. }
+    intros i j k Hj Hk.
+    generalize (zeta_powers_length j); intros Hlenj.
+    generalize (PeanoNat.Nat.pow_le_mono_r 2%nat _ _ ltac:(Lia.lia) Hj).
+    rewrite PeanoNat.Nat.pow_succ_r'; intro Hle.
+    destruct (ListUtil.nth_error_length_exists_value (Nat.pow 2 i + k) (zeta_powers j) ltac:(Lia.lia)) as [x Hx].
+    eexists; split; eauto.
+    destruct (IH _ _ Hj) as [tl Heq].
+    rewrite Heq, nth_error_app2 in Hx by (rewrite zeta_powers_length; Lia.lia).
+    rewrite zeta_powers_length in Hx.
+    rewrite nth_error_app1 in Hx by (rewrite map_length, seq_length; Lia.lia).
+    rewrite nth_error_map in Hx.
+    replace (Nat.pow 2 i + k - _)%nat with k in Hx by Lia.lia.
+    rewrite ListUtil.nth_error_seq in Hx.
+    destruct (Compare_dec.lt_dec k (Nat.pow 2 i)) as [_|]; [|Lia.lia].
+    rewrite PeanoNat.Nat.add_0_l in Hx. cbn [option_map] in Hx.
+    erewrite ListUtil.nth_error_Some_nth_default; eauto.
+    rewrite cyclotomic_decompose_length, PeanoNat.Nat.pow_succ_r'. Lia.lia.
+  Qed.
+
+  Lemma cyclotomic_decomposition_S_chunks2:
+    forall i,
+      (S i <= N.to_nat km1)%nat ->
+      Forall2 (fun p pp =>
+                 exists p1 p2, pp = [p1; p2] /\ coprime p1 p2 /\ Peq p (Pmul p1 p2)
+                          /\ exists k, Peq p (posicyclic (2 * (Nat.pow 2 (n - S i))) (F.mul (zeta^k) (zeta^k)))
+                                 /\ Peq p1 (posicyclic (Nat.pow 2 (n - S i)) (zeta^k))
+                                 /\ Peq p2 (negacyclic (Nat.pow 2 (n - S i)) (zeta^k)))
+        (cyclotomic_decomposition n i)
+        (chunks2 (cyclotomic_decomposition n (S i))).
+  Proof.
+    intros i Hi.
+    unfold cyclotomic_decomposition. rewrite chunks2_map.
+    cbn [cyclotomic_decompose]. rewrite chunks2_flat_map_constant2 by reflexivity.
+    apply Forall2_nth_error_iff.
+    repeat rewrite map_length. split; [reflexivity|].
+    intros k v1 v2 Hv1 Hv2. rewrite ListUtil.nth_error_map in Hv1.
+    do 2 rewrite ListUtil.nth_error_map in Hv2.
+    destruct (nth_error (cyclotomic_decompose i) k) as [v|] eqn:Hv; simpl in Hv1, Hv2; [|congruence].
+    inversion Hv1; inversion Hv2; subst v1; subst v2; clear Hv1; clear Hv2.
+    eexists; eexists; split; [reflexivity|].
+    apply nth_error_In in Hv. apply cyclotomic_decompose_mod in Hv; [|Lia.lia].
+    destruct Hv as [Hv1 Hv2].
+    rewrite <- neg_zeta_power_eq, Polynomial.posicyclic_opp.
+    split; [apply Polynomial.posicyclic_decomposition_coprime; [generalize (NatUtil.pow_nonzero 2 (n - S i)%nat); Lia.lia|apply zeta_pow_nz]|].
+    rewrite <- Polynomial.posicyclic_decomposition.
+    assert (Nat.pow 2 (n - i) = 2 * Nat.pow 2 (n - (S i)))%nat as -> by (rewrite <- PeanoNat.Nat.pow_succ_r'; f_equal; Lia.lia).
+    assert (zeta ^ v = zeta ^ (v / 2) * zeta ^ (v / 2)) as ->; [|split; [reflexivity|exists (v/2)%N; split; [reflexivity|split; [reflexivity|apply Polynomial.posicyclic_opp]]]].
+    rewrite <- F.pow_2_r, F.pow_pow_l.
+    assert (v / 2 * 2 = v :> _)%N as ->; [|reflexivity].
+    rewrite (N.Div0.div_mod v 2) at 2.
+    assert (v mod 2 = 0 :> _)%N as ->; [|Lia.lia].
+    apply N.Div0.mod_divides. apply N.Div0.mod_divides in Hv1.
+    destruct Hv1 as [c Hc]. rewrite Hc.
+    assert (km1 - N.of_nat i = N.succ (km1 - N.of_nat (S i)) :> _)%N as -> by Lia.lia.
+    rewrite N.pow_succ_r'. exists (2 ^ (km1 - N.of_nat (S i)) * c)%N; Lia.lia.
+  Qed.
+
+  Lemma cyclotomic_decomposition_S:
+    forall i,
+      (S i <= N.to_nat km1)%nat ->
+      forall k p1 p2, nth_error (cyclotomic_decomposition n (S i)) (2 * k)%nat = Some p1 ->
+                 nth_error (cyclotomic_decomposition n (S i)) (2 * k + 1)%nat = Some p2 ->
+                 coprime p1 p2 /\
+                 exists p, nth_error (cyclotomic_decomposition n i) k = Some p /\
+                      Peq p (Pmul p1 p2).
+  Proof.
+    intros i Hi k p1 p2 Hp1 Hp2.
+    unfold cyclotomic_decomposition in *.
+    rewrite nth_error_map in *.
+    destruct (nth_error (cyclotomic_decompose (S i)) (2 * k)) as [n1|] eqn:Hn1; [|inversion Hp1].
+    destruct (nth_error (cyclotomic_decompose (S i)) (2 * k + 1)) as [n2|] eqn:Hn2; [|inversion Hp2].
+    simpl in Hp1, Hp2. unfold cyclotomic_decompose in Hn1, Hn2.
+    fold cyclotomic_decompose in Hn1, Hn2.
+    eapply flat_map_constant_nth_error in Hn1; [|simpl; reflexivity].
+    eapply flat_map_constant_nth_error in Hn2; [|simpl; reflexivity].
+    rewrite (PeanoNat.Nat.mul_comm 2%nat k), PeanoNat.Nat.div_mul, PeanoNat.Nat.Div0.mod_mul in Hn1 by Lia.lia.
+    rewrite <- (PeanoNat.Nat.div_unique (2 * k + 1)%nat 2 k 1 ltac:(Lia.lia) ltac:(reflexivity)) in Hn2.
+    rewrite <- (PeanoNat.Nat.mod_unique (2 * k + 1)%nat 2 k 1 ltac:(Lia.lia) ltac:(reflexivity)) in Hn2.
+    simpl in Hn1, Hn2. destruct Hn1 as (n0 & (Hn0 & Hn1)). rewrite Hn0 in Hn2.
+    destruct Hn2 as (n0' & (Hn0' & Hn2)). inversion Hn0'; subst n0'; clear Hn0'.
+    rewrite Hn0; simpl. inversion Hn1; subst n1; clear Hn1.
+    inversion Hn2; subst n2; clear Hn2.
+    inversion Hp1; subst p1; clear Hp1.
+    inversion Hp2; subst p2; clear Hp2.
+    rewrite F.pow_add_r, Hkm1, (@Ring.mul_opp_l F eq F.zero F.one F.opp _ _ _ _).
+    rewrite (@Hierarchy.left_identity F eq _ _ _).
+    rewrite Polynomial.posicyclic_opp.
+    split; [apply Polynomial.posicyclic_decomposition_coprime; [generalize (NatUtil.pow_nonzero 2 (n - S i)%nat); Lia.lia|apply zeta_pow_nz]|].
+    eexists; split; [reflexivity|].
+    rewrite Polynomial.posicyclic_opp, <- Polynomial.posicyclic_decomposition.
+    rewrite <- PeanoNat.Nat.pow_succ_r'.
+    assert (S (n - S i) = n - i :> _)%nat as -> by Lia.lia.
+    rewrite <- F.pow_2_r, F.pow_pow_l.
+    assert (n0 / 2 * 2 = n0 :> _)%N as ->; [|reflexivity].
+    rewrite (N.Div0.div_mod n0 2) at 2.
+    assert (n0 mod 2 = 0 :> _)%N as ->; [|Lia.lia].
+    apply nth_error_In in Hn0.
+    apply cyclotomic_decompose_mod in Hn0; [|Lia.lia].
+    destruct Hn0 as [X _].
+    apply N.Div0.mod_divides. apply N.Div0.mod_divides in X.
+    destruct X as [c Hc]. rewrite Hc.
+    assert (km1 - N.of_nat i = N.succ (km1 - N.of_nat (S i)) :> _)%N as -> by Lia.lia.
+    rewrite N.pow_succ_r'. exists (2 ^ (km1 - N.of_nat (S i)) * c)%N; Lia.lia.
+  Qed.
+
+  Lemma cyclotomic_decomposition_product_S:
+    forall i,
+      (S i <= N.to_nat km1)%nat ->
+      Peq (List.fold_right Pmul Pone (cyclotomic_decomposition n i)) (List.fold_right Pmul Pone (cyclotomic_decomposition n (S i))).
+  Proof.
+    intros i Hi.
+    assert (IH: forall k, Peq (fold_right Pmul Pone (firstn k (cyclotomic_decomposition n i))) (fold_right Pmul Pone (firstn (2*k) (cyclotomic_decomposition n (S i))))).
+    { induction k; [reflexivity|].
+      destruct (Decidable.dec_le_nat (length (cyclotomic_decomposition n i)) k) as [Hle|Hgt].
+      - assert (Hle': length (cyclotomic_decomposition n (S i)) <= 2 * k).
+        { rewrite cyclotomic_decomposition_length in *.
+          rewrite PeanoNat.Nat.pow_succ_r'. Lia.lia. }
+        do 2 rewrite firstn_all2 in IHk by assumption.
+        do 2 rewrite firstn_all2 by Lia.lia. assumption.
+      - rewrite (ListUtil.firstn_succ Pzero) by Lia.lia.
+        assert (2 * S k = S (S (2 * k)) :> _)%nat as -> by Lia.lia.
+        assert (Hgt': S (2 * k) < length (cyclotomic_decomposition n (S i))).
+        { rewrite cyclotomic_decomposition_length in *.
+          rewrite PeanoNat.Nat.pow_succ_r'. Lia.lia. }
+        do 2 rewrite (ListUtil.firstn_succ Pzero) by Lia.lia.
+        repeat rewrite (@fold_right_monoid_app P Peq Pmul _ _).
+        rewrite <- IHk. repeat rewrite (@fold_right_monoid_singleton P Peq Pmul _ _).
+        rewrite <- (@Hierarchy.associative P Peq Pmul _).
+        generalize (ListUtil.nth_error_Some_nth_default (2 * k) Pzero (cyclotomic_decomposition n (S i)) ltac:(Lia.lia)). intro H2k.
+        assert (S (2 * k) = 2 * k + 1 :> _)%nat as -> by Lia.lia.
+        generalize (ListUtil.nth_error_Some_nth_default (2 * k + 1) Pzero (cyclotomic_decomposition n (S i)) ltac:(Lia.lia)). intro H2kp1.
+        generalize (ListUtil.nth_error_Some_nth_default k Pzero (cyclotomic_decomposition n i) ltac:(Lia.lia)). intro Hk.
+        generalize (cyclotomic_decomposition_S i Hi k _ _ H2k H2kp1).
+        intros [_ [x [He Hmul]]].
+        rewrite Hk in He. inversion He; subst x; clear He.
+        rewrite <- Hmul. reflexivity. }
+    rewrite <- (ListUtil.List.firstn_all (cyclotomic_decomposition n i)).
+    rewrite <- (ListUtil.List.firstn_all (cyclotomic_decomposition n (S i))).
+    do 2 rewrite cyclotomic_decomposition_length.
+    rewrite PeanoNat.Nat.pow_succ_r'. apply IH.
+  Qed.
+
+  Lemma cyclotomic_decompose_product:
+    forall i,
+      (i <= N.to_nat km1)%nat ->
+      Peq (negacyclic (Nat.pow 2 n) 1) (List.fold_right Pmul Pone (cyclotomic_decomposition n i)).
+  Proof.
+    induction i; intro Hi.
+    - unfold cyclotomic_decomposition; simpl. rewrite PeanoNat.Nat.sub_0_r, Hkm1, Polynomial.posicyclic_opp.
+      rewrite (@Hierarchy.right_identity P Peq Pmul _ _). reflexivity.
+    - rewrite IHi by Lia.lia. apply cyclotomic_decomposition_product_S; auto.
+  Qed.
+
+  Lemma cyclotomic_decompose_inv:
+    forall i, (i <= N.to_nat km1)%nat ->
+         forall k, (k < Nat.pow 2 i)%nat ->
+              forall a b,
+                nth_error (cyclotomic_decompose i) k = Some a ->
+                nth_error (cyclotomic_decompose i) (Nat.pow 2 i - 1 - k)%nat = Some b ->
+                (a + b = N.pow 2 (N.succ km1))%N /\ (F.mul (F.pow zeta a) (F.pow zeta b) = 1)%F.
+  Proof.
+    induction i; intros Hi k Hk a b Ha Hb.
+    - simpl in Hk. assert (k = 0)%nat as -> by Lia.lia.
+      simpl in Ha, Hb. inversion Ha; subst a; clear Ha.
+      inversion Hb; subst b; clear Hb.
+      rewrite N.pow_succ_r', <- F.pow_2_r, F.pow_pow_l.
+      split; [Lia.lia|].
+      rewrite N.mul_comm, <- N.pow_succ_r', zeta_pow_succ_km1. reflexivity.
+    - simpl in Ha, Hb. rewrite PeanoNat.Nat.add_0_r in Hb.
+      eapply flat_map_constant_nth_error in Ha, Hb; try (simpl; reflexivity).
+      destruct Ha as [a' [Ha1 Ha2]]. destruct Hb as [b' [Hb1 Hb2]].
+      assert (Nat.pow 2 i + Nat.pow 2 i = 2 * Nat.pow 2 i)%nat as He by Lia.lia.
+      rewrite He, <- PeanoNat.Nat.pow_succ_r' in Hb1, Hb2. clear He.
+      rewrite PeanoNat.Nat.pow_succ_r' in Hk.
+      apply PeanoNat.Nat.Div0.div_lt_upper_bound in Hk.
+      assert (Nat.modulo k 2 = 0 \/ Nat.modulo k 2 = 1)%nat as Hkmod by (generalize (NatUtil.mod_bound_lt k 2 ltac:(Lia.lia)); Lia.lia).
+      assert (PeanoNat.Nat.div (PeanoNat.Nat.pow 2 (S i) - 1 - k) 2 = Nat.pow 2 i - 1 - Nat.div k 2)%nat as He.
+      { rewrite (PeanoNat.Nat.div_mod_eq k 2) at 1.
+        rewrite PeanoNat.Nat.pow_succ_r', PeanoNat.Nat.sub_add_distr.
+        assert (2 * PeanoNat.Nat.pow 2 i - 1 - 2 * PeanoNat.Nat.div k 2 - PeanoNat.Nat.modulo k 2 = 2 * (PeanoNat.Nat.pow 2 i - PeanoNat.Nat.div k 2 - 1) + (1 - PeanoNat.Nat.modulo k 2))%nat as -> by Lia.lia.
+        rewrite NatUtil.div_add_l' by Lia.lia.
+        rewrite (PeanoNat.Nat.div_small (1 - _)) by Lia.lia.
+        Lia.lia. }
+      rewrite He in Hb1.
+      assert (PeanoNat.Nat.modulo (PeanoNat.Nat.pow 2 (S i) - 1 - k) 2 = 1 - Nat.modulo k 2)%nat as He2.
+      { rewrite PeanoNat.Nat.pow_succ_r', (PeanoNat.Nat.div_mod_eq k 2) at 1.
+        assert (2 * PeanoNat.Nat.pow 2 i - 1 - _ = 2 * (PeanoNat.Nat.pow 2 i - 1 - Nat.div k 2) + (1 - Nat.modulo k 2))%nat as -> by Lia.lia.
+        rewrite NatUtil.mod_add_l' by Lia.lia.
+        apply PeanoNat.Nat.mod_small. Lia.lia. }
+      rewrite He2 in Hb2. clear He He2.
+      generalize (IHi ltac:(Lia.lia) _ Hk a' b' Ha1 Hb1).
+      generalize (cyclotomic_decompose_mod i ltac:(Lia.lia)). intros X.
+      apply nth_error_In in Ha1, Hb1. apply X in Ha1, Hb1.
+      destruct Ha1 as [Ha1 _]. destruct Hb1 as [Hb1 _].
+      apply (proj1 (N.Div0.mod_divides _ _)) in Ha1, Hb1.
+      destruct Ha1 as [ac Ha1]. destruct Hb1 as [bc Hb1].
+      assert (km1 - N.of_nat i = N.succ (km1 - N.of_nat (S i)))%N as He by Lia.lia.
+      rewrite He, N.pow_succ_r' in Ha1, Hb1. intros [Y Z].
+      rewrite N.pow_succ_r', Ha1, Hb1, <- N.mul_add_distr_l in Y.
+      rewrite <- N.mul_assoc in Y. apply N.mul_cancel_l in Y; [|Lia.lia].
+      rewrite <- N.mul_assoc, N.mul_comm in Ha1, Hb1.
+      rewrite <- F.pow_add_r.
+      assert ((a + b)%N = (2 ^ N.succ km1)%N) as ->; [|split; [reflexivity|apply zeta_pow_succ_km1]].
+      destruct Hkmod as [-> | ->] in Ha2, Hb2.
+      + simpl in Ha2, Hb2. inversion Ha2; subst a; clear Ha2.
+        inversion Hb2; subst b; clear Hb2.
+        rewrite Ha1, Hb1, N.div_mul, N.div_mul by Lia.lia.
+        transitivity (2 * 2 ^ km1)%N; [Lia.lia|].
+        rewrite N.pow_succ_r'. reflexivity.
+      + simpl in Ha2, Hb2. inversion Ha2; subst a; clear Ha2.
+        inversion Hb2; subst b; clear Hb2.
+        rewrite Ha1, Hb1, N.div_mul, N.div_mul by Lia.lia.
+        transitivity (2 * 2 ^ km1)%N; [Lia.lia|].
+        rewrite N.pow_succ_r'. reflexivity.
+  Qed.
+
+  Lemma cyclotomic_decomposition_degree (i: nat) (Hle: i <= N.to_nat km1):
+    forall k p, nth_error (cyclotomic_decomposition n i) k = Some p ->
+           degree p = Some (Nat.pow 2 (n - i)).
+  Proof.
+    intros k p Hp.
+    unfold cyclotomic_decomposition in Hp.
+    rewrite nth_error_map in Hp; destruct (nth_error (cyclotomic_decompose i) k); simpl in Hp; try congruence.
+    inversion Hp; subst p; clear Hp.
+    apply Polynomial.posicyclic_degree.
+    generalize (NatUtil.pow_nonzero 2 (n - i)%nat ltac:(Lia.lia)). Lia.lia.
+  Qed.
+
+  Section NTT.
+    Local Notation Pmod_cyclotomic_list := (@Pmod_cyclotomic_list F F.zero F.add F.sub F.mul).
+    Local Notation of_list := (@of_list F F.zero P poly_ops).
+
+    Lemma Pmod_cyclotomic_decomposition_list (i: nat) (p: P):
+      (S i <= N.to_nat km1) ->
+      (measure p <= Nat.pow 2 (n - i))%nat ->
+      forall k, (k < Nat.pow 2 i)%nat ->
+           Peq (Pmod p (List.nth_default Pzero (cyclotomic_decomposition n (S i)) (2 * k)))
+               (of_list (firstn (Nat.pow 2 (n - S i)) (Pmod_cyclotomic_list (to_list (Nat.pow 2 (n - i)) p) (Nat.pow 2 (n - S i)) (List.nth_default F.zero (List.map (fun x => F.pow zeta x) (cyclotomic_decompose (S i))) (2 * k))))) /\
+           Peq (Pmod p (List.nth_default Pzero (cyclotomic_decomposition n (S i)) (2 * k + 1)))
+               (of_list (skipn (Nat.pow 2 (n - S i)) (Pmod_cyclotomic_list (to_list (Nat.pow 2 (n - i)) p) (Nat.pow 2 (n - S i)) (List.nth_default F.zero (List.map (fun x => F.pow zeta x) (cyclotomic_decompose (S i))) (2 * k))))).
+    Proof.
+      intros Hi Hp k Hk.
+      generalize (ListUtil.nth_error_length_exists_value (2 * k) (cyclotomic_decompose (S i)) ltac:(rewrite cyclotomic_decompose_length, PeanoNat.Nat.pow_succ_r'; Lia.lia)).
+      intros [x0 Hx0].
+      generalize (cyclotomic_decomposition_S_chunks2 i Hi). intro HF.
+      apply Forall2_nth_error_iff in HF. destruct HF as [HF1 HF2].
+      generalize (ListUtil.nth_error_length_exists_value k (cyclotomic_decomposition n i) ltac:(rewrite cyclotomic_decomposition_length; Lia.lia)).
+      intros [p1 Hp1].
+      generalize (ListUtil.nth_error_length_exists_value k (chunks2 (cyclotomic_decomposition n (S i))) ltac:(rewrite <- HF1, cyclotomic_decomposition_length; Lia.lia)).
+      intros [v Hv].
+      destruct (HF2 k p1 v Hp1 Hv) as [p2 [p3 [-> [Hcoprime [HEQ X]]]]].
+      destruct X as [kp [Hpeq1 [Hpeq2 Hpeq3]]].
+      generalize (chunks2_nth_error (cyclotomic_decomposition n (S i)) (2 * k)). intro HX.
+      rewrite PeanoNat.Nat.mul_comm, PeanoNat.Nat.div_mul, Hv, PeanoNat.Nat.Div0.mod_mul in HX by Lia.lia.
+      simpl in HX. rewrite PeanoNat.Nat.mul_comm in HX.
+      rewrite (ListUtil.nth_error_value_eq_nth_default _ _ _ HX).
+      unfold cyclotomic_decomposition in HX.
+      rewrite nth_error_map, Hx0 in HX.
+      simpl in HX. inversion HX; subst p2; clear HX.
+      generalize (chunks2_nth_error (cyclotomic_decomposition n (S i)) (2 * k + 1)). intro HX.
+      rewrite <- (PeanoNat.Nat.div_unique (2 * k + 1) 2 k 1 ltac:(Lia.lia) ltac:(reflexivity)) in HX.
+      rewrite <- (PeanoNat.Nat.mod_unique (2 * k + 1) 2 k 1 ltac:(Lia.lia) ltac:(reflexivity)) in HX.
+      rewrite Hv in HX. cbn [Option.bind nth_error] in HX.
+      rewrite (ListUtil.nth_error_value_eq_nth_default _ _ _ HX).
+      rewrite (Polynomial.peq_mod_proper (poly_ops:=poly_ops) p p ltac:(reflexivity) _ _ Hpeq3).
+      assert (Heq: zeta ^ kp = zeta ^ x0).
+      { generalize (Hpeq2 0%nat).
+        unfold posicyclic. rewrite sub_definition, sub_definition, const_definition, base_definition, const_definition.
+        generalize (NatUtil.pow_nonzero 2 (n - S i) ltac:(Lia.lia)).
+        destruct (Decidable.dec_eq_nat (Nat.pow 2 (n - S i)) 0); [Lia.lia|].
+        rewrite Hierarchy.ring_sub_definition, Hierarchy.ring_sub_definition, Hierarchy.left_identity, Hierarchy.left_identity.
+        intros _ Z. apply Group.inv_bijective. auto. }
+      repeat rewrite (ListUtil.map_nth_default _ _ _ _ 0%N) by (rewrite cyclotomic_decompose_length, PeanoNat.Nat.pow_succ_r'; Lia.lia).
+      rewrite (ListUtil.nth_error_value_eq_nth_default _ _ _ Hx0).
+      rewrite Heq. assert (Hp': (measure p <= 2 * Nat.pow 2 (n - S i))).
+      { rewrite <- PeanoNat.Nat.pow_succ_r'.
+        assert (S (n - S i) = n - i)%nat as -> by Lia.lia. assumption. }
+      unfold posicyclic, negacyclic.
+      assert (Nat.pow 2 (n - i) = 2 * Nat.pow 2 (n - S i))%nat as ->.
+      { rewrite <- PeanoNat.Nat.pow_succ_r'. f_equal. Lia.lia. }
+      apply (Pmod_cyclotomic_list_correct (poly_ops:=poly_ops) (poly_defs:=poly_defs) p (Nat.pow 2 (n - S i)) (zeta ^ x0) ltac:(generalize (NatUtil.pow_nonzero 2 (n - S i) ltac:(Lia.lia)); Lia.lia) Hp').
+    Qed.
+
+    Definition NTT_phi_layer_aux (i: nat) (pl: list P): list P :=
+      List.fold_left
+        (fun l k =>
+           List.app l [(Pmod (List.nth_default Pzero pl k) (List.nth_default Pzero (cyclotomic_decomposition n (S i)) (2 * k))); (Pmod (List.nth_default Pzero pl k) (List.nth_default Pzero (cyclotomic_decomposition n (S i)) (2 * k + 1)))])
+        (seq 0 (Nat.pow 2 i))
+        nil.
+
+    Definition fold_left_chunked {A} {B}
+      (sz: nat) (f: nat -> A -> list B -> A) (l: list B) (a: A) :=
+      List.fold_left (fun acc '(i, chunk) => f i acc chunk) (enumerate 0%nat (chunk sz l)) a.
+
+    Definition NTT_phi_layer_list (i: nat) (l: list F): list F :=
+      (fold_left_chunked (Nat.pow 2 (n - i)%nat) (fun k l chunk => List.app l (Pmod_cyclotomic_list chunk (Nat.pow 2 (n - S i)%nat) (List.nth_default F.zero (List.map (fun x => F.pow zeta x) (cyclotomic_decompose (S i))) (2 * k)))) l nil).
+
+    Lemma NTT_phi_layer_list_spec (i: nat) (pl: list P):
+      (S i <= N.to_nat km1)%nat ->
+      Forall2 (fun p q => Peq p (Pmod p q)) pl (cyclotomic_decomposition n i) ->
+      Forall2 Peq (NTT_phi_layer_aux i pl) (List.map of_list (chunk (Nat.pow 2 (n - S i)) (NTT_phi_layer_list i (concat (List.map (fun p => to_list (Nat.pow 2 (n - i)) p) pl))))).
+    Proof.
+      intros Hi HF. unfold NTT_phi_layer_list, fold_left_chunked.
+      assert (Hnz: forall k, Nat.pow 2 k <> 0%nat) by (intros; apply NatUtil.pow_nonzero; Lia.lia).
+      assert (HF': Forall (fun l : list F => length l = Nat.pow 2 (n - i)) (map (fun p : P => to_list (Nat.pow 2 (n - i)) p) pl)).
+      { apply Forall_map. apply Forall_forall.
+        intros. apply to_list_length. }
+      rewrite (chunk_concat _ _ ltac:(apply Hnz) HF').
+      rewrite (@ListUtil.fold_left_ext _ _ _ (fun acc ic => acc ++ (Pmod_cyclotomic_list (snd ic) (Nat.pow 2 (n - S i)) (nth_default 0 (map (fun x => zeta ^ x) (cyclotomic_decompose (S i))) (2 * (fst ic)))))).
+      2: intros x y; destruct y; simpl; reflexivity.
+      rewrite <- ListUtil.eq_flat_map_fold_left.
+      unfold NTT_phi_layer_aux. rewrite <- ListUtil.eq_flat_map_fold_left.
+      unfold enumerate. rewrite map_length, (Forall2_length HF), cyclotomic_decomposition_length.
+      apply Forall2_nth_error_iff. split.
+      - rewrite map_length, length_chunk by apply Hnz.
+        erewrite flat_map_const_length by (simpl; reflexivity).
+        erewrite flat_map_constant_length.
+        2:{ intros x Hx; unfold Pmod_cyclotomic_list.
+            destruct x as [k l]. apply in_combine_r in Hx.
+            apply in_map_iff in Hx. destruct Hx as [x [Hx Hx2]].
+            simpl. instantiate (1 := Nat.pow 2 (n - i)).
+            apply ListUtil.fold_left_invariant.
+            - subst l; rewrite to_list_length. reflexivity.
+            - intros. repeat rewrite ListUtil.length_set_nth. auto. }
+        rewrite combine_length, seq_length, map_length.
+        rewrite (Forall2_length HF), cyclotomic_decomposition_length.
+        rewrite PeanoNat.Nat.min_id, <- PeanoNat.Nat.pow_add_r.
+        assert (i + (n - i) = S i + (n - S i))%nat as -> by Lia.lia.
+        rewrite PeanoNat.Nat.pow_add_r, Nat.div_up_exact by apply Hnz.
+        rewrite PeanoNat.Nat.pow_succ_r'. reflexivity.
+      - intros k v1 v2 Hv1 Hv2.
+        eapply flat_map_constant_nth_error in Hv1; [|simpl; reflexivity].
+        apply nth_error_map_Some in Hv2.
+        destruct Hv1 as [k1 [Hk1 Hv1]].
+        rewrite ListUtil.nth_error_seq in Hk1.
+        rewrite PeanoNat.Nat.add_0_l in Hk1.
+        destruct (Compare_dec.lt_dec (PeanoNat.Nat.div k 2) (Nat.pow 2 i)) as [Hklt1|]; [|congruence].
+        destruct Hv2 as [chk [Hchk Hv2]].
+        set (f := (fun y : nat * list F => Pmod_cyclotomic_list (snd y) (Nat.pow 2 (n - S i)) (nth_default 0 (map (fun x : N => zeta ^ x) (cyclotomic_decompose (S i))) (2 * fst y)))).
+        fold f in Hchk.
+        assert (Hklt: (k < Nat.div_up (length (flat_map f (combine (seq 0 (Nat.pow 2 i)) (map (fun p : P => to_list (Nat.pow 2 (n - i)) p) pl)))) (Nat.pow 2 (n - S i)))).
+        { erewrite flat_map_constant_length.
+          2:{ unfold f, Pmod_cyclotomic_list.
+              instantiate (1 := Nat.pow 2 (n - i)). intros x Hx.
+              apply ListUtil.fold_left_invariant.
+              - destruct x. apply in_combine_r in Hx.
+                apply in_map_iff in Hx. destruct Hx as [x [Hx _]].
+                subst l. simpl. rewrite to_list_length. reflexivity.
+              - intros. repeat rewrite ListUtil.length_set_nth. auto. }
+          rewrite combine_length, seq_length, map_length, (Forall2_length HF), cyclotomic_decomposition_length.
+          rewrite PeanoNat.Nat.min_id, <- PeanoNat.Nat.pow_add_r.
+          assert (i + (n - i) = S i + (n - S i))%nat as -> by Lia.lia.
+          rewrite PeanoNat.Nat.pow_add_r, Nat.div_up_exact by apply Hnz.
+          rewrite PeanoNat.Nat.pow_succ_r'.
+          rewrite (PeanoNat.Nat.Div0.div_mod k 2%nat).
+          generalize (NatUtil.mod_bound_lt k 2 ltac:(Lia.lia)). Lia.lia. }
+        generalize (nth_error_chunk (Nat.pow 2 (n - S i)) ltac:(apply Hnz) (flat_map f (combine (seq 0 (Nat.pow 2 i )) (map (fun p : P => to_list (Nat.pow 2 (n - i)) p) pl))) k Hklt).
+        rewrite Hchk. intro X; inversion X; subst chk; clear X.
+        rewrite <- Hv2.
+        assert (v1 = Pmod (nth_default Pzero pl k1) (nth_default Pzero (cyclotomic_decomposition n (S i)) k)) as ->.
+        { assert (PeanoNat.Nat.modulo k 2 = 0 \/ PeanoNat.Nat.modulo k 2 = 1)%nat as Hkmodeq by (generalize (NatUtil.mod_bound_lt k 2 ltac:(Lia.lia)); Lia.lia).
+          destruct Hkmodeq as [Hkmodeq|Hkmodeq]; rewrite Hkmodeq in Hv1; cbn [nth_error] in Hv1; inversion Hv1; subst v1; repeat f_equal; rewrite (PeanoNat.Nat.Div0.div_mod k 2%nat); rewrite Hkmodeq; assert (k1 = PeanoNat.Nat.div k 2) as -> by congruence; Lia.lia. }
+        assert (Hm1: (measure (nth_default Pzero pl k1) <= Nat.pow 2 (n - i))%nat).
+        { assert (k1 = PeanoNat.Nat.div k 2) by congruence. subst k1.
+          generalize (ListUtil.nth_error_length_exists_value (PeanoNat.Nat.div k 2) pl ltac:(rewrite (Forall2_length HF), cyclotomic_decomposition_length; Lia.lia)).
+          intros [p1 Hp1].
+          rewrite (ListUtil.nth_error_value_eq_nth_default _ _ _ Hp1).
+          generalize (ListUtil.nth_error_length_exists_value (PeanoNat.Nat.div k 2) (cyclotomic_decomposition n i) ltac:(rewrite cyclotomic_decomposition_length; Lia.lia)).
+          intros [q1 Hq1].
+          apply Forall2_nth_error_iff in HF.
+          destruct HF as [_ HF]. unfold measure.
+          rewrite (Polynomial.peq_proper_degree (poly_defs:=poly_defs) _ _ (HF _ _ _ Hp1 Hq1)).
+          assert (Hqnz: not (Peq q1 Pzero)).
+          { intro Heq. apply cyclotomic_decomposition_degree in Hq1; try Lia.lia.
+            rewrite (Polynomial.peq_proper_degree (poly_defs:=poly_defs) _ _ Heq) in Hq1.
+            rewrite Polynomial.degree_zero in Hq1. congruence. }
+          generalize (Polynomial.Pmod_degree_lt (poly_defs:=poly_defs) p1 q1 Hqnz).
+          rewrite (cyclotomic_decomposition_degree i ltac:(Lia.lia) _ _ Hq1).
+          unfold degree_lt. simpl. Lia.lia. }
+        generalize (Pmod_cyclotomic_decomposition_list i (nth_default Pzero pl k1) Hi Hm1 k1 ltac:(assert (k1 = PeanoNat.Nat.div k 2) as -> by congruence; Lia.lia)).
+        intros [HA HB].
+        assert (Hkeq: (k = 2 * k1 + PeanoNat.Nat.modulo k 2)%nat).
+        { rewrite (PeanoNat.Nat.Div0.div_mod k 2) at 1.
+          assert (k1 = PeanoNat.Nat.div k 2) as <- by congruence. reflexivity. }
+        assert (k * Nat.pow 2 (n - S i) = k1 * Nat.pow 2 (n - i) + PeanoNat.Nat.modulo k 2 * Nat.pow 2 (n - S i))%nat as ->.
+        { rewrite Hkeq at 1. assert (n - i = S (n - S i))%nat as -> by Lia.lia.
+          rewrite PeanoNat.Nat.pow_succ_r'. Lia.lia. }
+        rewrite <- ListUtil.skipn_skipn.
+        rewrite skipn_flat_map_constant_length.
+        2:{ unfold f. intros x Hx. destruct x as [n1 l1].
+            apply in_combine_r in Hx. apply in_map_iff in Hx.
+            destruct Hx as [x [Hl1 Hx]]. subst l1.
+            unfold Pmod_cyclotomic_list; simpl.
+            apply ListUtil.fold_left_invariant.
+            - rewrite to_list_length; reflexivity.
+            - intros. repeat (rewrite ListUtil.length_set_nth); auto. }
+        rewrite ListUtil.skipn_combine, ListUtil.skipn_seq, skipn_map.
+        rewrite PeanoNat.Nat.add_0_r.
+        rewrite ListUtil.firstn_skipn_add.
+        assert (PeanoNat.Nat.modulo k 2 = 0 \/ PeanoNat.Nat.modulo k 2 = 1)%nat as Hkmodeq by (generalize (NatUtil.mod_bound_lt k 2 ltac:(Lia.lia)); Lia.lia).
+        rewrite <- (ListUtil.firstn_firstn (Nat.pow 2 (n - i))).
+        2:{ assert (n - i = S (n - S i))%nat as -> by Lia.lia.
+            rewrite PeanoNat.Nat.pow_succ_r'.
+            destruct Hkmodeq as [-> | ->]; Lia.lia. }
+        rewrite <- (ListUtil.map_nth_default_seq Pzero (Nat.pow 2 i) pl ltac:(rewrite (Forall2_length HF), cyclotomic_decomposition_length; Lia.lia)) at 2.
+        rewrite skipn_map, ListUtil.skipn_seq, PeanoNat.Nat.add_0_r.
+        rewrite map_map, ListUtil.combine_map_r.
+        assert (Nat.pow 2 i - k1 = S (Nat.pred (Nat.pow 2 i - k1)))%nat as ->.
+        { assert (k1 = PeanoNat.Nat.div k 2)%nat as -> by congruence. Lia.lia. }
+        cbn [seq combine map flat_map].
+        rewrite firstn_app_l.
+        2:{ unfold f; simpl. unfold Pmod_cyclotomic_list; simpl.
+            apply ListUtil.fold_left_invariant.
+            - rewrite to_list_length. reflexivity.
+            - intros. repeat (rewrite ListUtil.length_set_nth). auto. }
+        unfold f. cbn [fst snd]. rewrite Hkeq at 1.
+        destruct Hkmodeq as [-> | ->].
+        { rewrite PeanoNat.Nat.add_0_r, HA, PeanoNat.Nat.mul_0_l, PeanoNat.Nat.add_0_l.
+          reflexivity. }
+        { rewrite HB, PeanoNat.Nat.mul_1_l.
+          rewrite firstn_all2; [reflexivity|].
+          assert (_ + _ = 2 * Nat.pow 2 (n - S i))%nat as -> by Lia.lia.
+          rewrite <- PeanoNat.Nat.pow_succ_r'.
+          assert (S (n - S i) = n - i)%nat as -> by Lia.lia.
+          apply PeanoNat.Nat.eq_le_incl.
+          unfold Pmod_cyclotomic_list. apply ListUtil.fold_left_invariant.
+          - apply to_list_length.
+          - intros; repeat (rewrite ListUtil.length_set_nth). auto. }
+    Qed.
+
+    Program Definition NTT_phi_layer (i: nat) (pl: Pquotl (cyclotomic_decomposition n i)): Pquotl (cyclotomic_decomposition n (S i)) :=
+      NTT_phi_layer_aux i (proj1_sig pl).
+    Next Obligation.
+      unfold NTT_phi_layer_aux.
+      rewrite <- ListUtil.eq_flat_map_fold_left.
+      apply Forall2_nth_error_iff.
+      erewrite flat_map_constant_length; [|simpl; reflexivity].
+      rewrite cyclotomic_decomposition_length, seq_length; split; [simpl; Lia.lia|].
+      intros. eapply flat_map_constant_nth_error in H; [|simpl; reflexivity].
+      destruct H as [y [HA HB]].
+      rewrite ListUtil.nth_error_seq in HA. destruct (Compare_dec.lt_dec (PeanoNat.Nat.div k 2) (Nat.pow 2 i)); try congruence.
+      set (k' := PeanoNat.Nat.div k 2). fold k' in HA.
+      rewrite PeanoNat.Nat.add_0_l in HA. inversion HA; subst y; clear HA.
+      set (r := PeanoNat.Nat.modulo k 2). fold r in HB.
+      assert (r = 0 \/ r = 1)%nat as HEQ by (generalize (NatUtil.mod_bound_lt k 2 ltac:(Lia.lia)); unfold r; Lia.lia).
+      assert (k = 2 * k' + r)%nat as Hk by (apply PeanoNat.Nat.div_mod_eq).
+      rewrite Hk in H1. eapply (ListUtil.nth_error_value_eq_nth_default) in H1.
+      instantiate (1:=Pzero) in H1.
+      rewrite <- H1. simpl in HB.
+      assert ((k' + (k' + 0) + 1) = 2 * k' + 1)%nat as Hx by Lia.lia; rewrite Hx in HB; clear Hx.
+      assert (k' + (k' + 0) = 2 * k' + 0)%nat as Hx by Lia.lia; rewrite Hx in HB; clear Hx.
+      destruct HEQ as [-> | ->]; simpl in HB; inversion HB; subst v1; clear HB; rewrite Polynomial.Pmod_mod_eq; reflexivity.
+    Qed.
+
+    Lemma NTT_phi_layer_list_length:
+      forall i l, length (NTT_phi_layer_list i l) = length l.
+    Proof.
+      intros i l. unfold NTT_phi_layer_list.
+      unfold fold_left_chunked.
+      set (f := (fun (acc : list F) '(i0, chunk) => acc ++ Pmod_cyclotomic_list chunk (Nat.pow 2 (n - S i)) (nth_default 0 (map (fun x : N => zeta ^ x) (cyclotomic_decompose (S i))) (2 * i0)))).
+      assert (forall x acc, length (fold_left f x acc) = length acc + list_sum (map (fun y => length (snd y)) x))%nat as IH.
+      { induction x; [simpl; Lia.lia|].
+        simpl. intros. rewrite IHx. destruct a; simpl.
+        rewrite app_length. assert (length (Pmod_cyclotomic_list _ _ _) = length l0) as ->; [|Lia.lia].
+        unfold Pmod_cyclotomic_list. apply ListUtil.fold_left_invariant; [reflexivity|].
+        intros. repeat (rewrite ListUtil.length_set_nth). auto. }
+      rewrite IH. unfold enumerate.
+      rewrite <- (map_map snd), ListUtil.map_snd_combine.
+      rewrite seq_length, firstn_all, <- concat_length, concat_chunk.
+      simpl; Lia.lia.
+    Qed.
+
+    Program Fixpoint NTT_phi (i: nat) (pl: Pquotl (cyclotomic_decomposition n 0%nat)): Pquotl (cyclotomic_decomposition n i) :=
+      match i with
+      | O => pl
+      | S i => NTT_phi_layer i (NTT_phi i pl)
+      end.
+
+    Lemma NTT_phi_proj1_sig (i: nat) (pl: Pquotl (cyclotomic_decomposition n 0%nat)):
+      proj1_sig (NTT_phi i pl) =
+        nat_rect (fun _ => list P) (proj1_sig pl) NTT_phi_layer_aux i.
+    Proof.
+      induction i; [reflexivity|].
+      simpl. rewrite IHi. reflexivity.
+    Qed.
+
+    Definition NTT_phi_list (i: nat) (l: list F) :=
+      nat_rect (fun _ => list F) l NTT_phi_layer_list i.
+
+    Lemma NTT_phi_list_length:
+      forall i l, length (NTT_phi_list i l) = length l.
+    Proof.
+      unfold NTT_phi_list. induction i; [reflexivity|].
+      intros. simpl. rewrite NTT_phi_layer_list_length, IHi.
+      reflexivity.
+    Qed.
+
+    Global Instance peq_proper_to_list {m:nat}: Proper (Peq ==> Logic.eq) (to_list m).
+    Proof.
+      intros x y Heq.
+      unfold to_list. apply nth_error_ext.
+      intro k. rewrite nth_error_map, nth_error_map, ListUtil.nth_error_seq, PeanoNat.Nat.add_0_l.
+      destruct (Compare_dec.lt_dec k m); [simpl|reflexivity].
+      rewrite Heq. reflexivity.
+    Qed.
+
+    Lemma to_list_of_list (m: nat) (l: list F) (Hm: length l = m :> nat):
+      to_list m (of_list l) = l :> _.
+    Proof.
+      apply nth_error_ext; intros k.
+      unfold to_list, of_list. rewrite nth_error_map.
+      rewrite ListUtil.nth_error_seq, PeanoNat.Nat.add_0_l.
+      destruct (Compare_dec.lt_dec k m) as [Hlt|Hnlt].
+      - rewrite <- Hm in Hlt.
+        destruct (ListUtil.nth_error_length_exists_value _ _ Hlt) as [x Hx].
+        rewrite Hx. simpl. f_equal. rewrite Pdecompose_coeff.
+        destruct (Decidable.dec_lt_nat k (length l)); [|Lia.lia].
+        apply ListUtil.nth_error_value_eq_nth_default; auto.
+      - rewrite <- Hm in Hnlt.
+        rewrite ListUtil.nth_error_length_error by Lia.lia. reflexivity.
+    Qed.
+
+    Lemma NTT_phi_list_spec (i: nat) (pl: Pquotl (cyclotomic_decomposition n 0%nat)):
+      (i <= N.to_nat km1) ->
+      Forall2 Peq
+        (proj1_sig (NTT_phi i pl))
+        (map of_list (chunk (Nat.pow 2 (n - i)) (NTT_phi_list i (concat (map (fun p : P => to_list (Nat.pow 2 n) p) (proj1_sig pl)))))).
+    Proof.
+      induction i; intro Hi.
+      - rewrite PeanoNat.Nat.sub_0_r.
+        destruct pl as [pl Hpl].
+        generalize (Forall2_length Hpl); rewrite cyclotomic_decomposition_length.
+        rewrite PeanoNat.Nat.pow_0_r. intro Hlen.
+        destruct pl; [simpl in Hlen; congruence|].
+        destruct pl; [|simpl in Hlen; congruence].
+        simpl. rewrite app_nil_r.
+        rewrite chunk_small.
+        2: rewrite to_list_length; generalize (NatUtil.pow_nonzero 2 n ltac:(Lia.lia)); Lia.lia.
+        simpl. repeat constructor.
+        symmetry. apply Polynomial.of_list_to_list.
+        unfold cyclotomic_decomposition in Hpl.
+        simpl in Hpl. inversion Hpl.
+        rewrite (Polynomial.peq_proper_degree (poly_defs:=poly_defs) _ _ H2).
+        rewrite PeanoNat.Nat.sub_0_r.
+        assert (Hnz: not (Peq (posicyclic (Nat.pow 2 n) (zeta ^ 2 ^km1)) Pzero)).
+        { intro Heq. generalize (Heq (Nat.pow 2 n)).
+          rewrite zero_definition. unfold posicyclic.
+          rewrite sub_definition, base_definition, const_definition.
+          destruct (Decidable.dec_eq_nat _ _); [|congruence].
+          generalize (NatUtil.pow_nonzero 2 n ltac:(Lia.lia)).
+          intro. destruct (Nat.pow 2 n); [congruence|].
+          rewrite Hierarchy.ring_sub_definition, Group.inv_id, Hierarchy.right_identity.
+          apply Hierarchy.one_neq_zero. }
+        generalize (Polynomial.Pmod_degree_lt (poly_defs:=poly_defs) p (posicyclic (Nat.pow 2 n) (zeta ^ 2 ^km1)) Hnz).
+        rewrite (Polynomial.posicyclic_degree (poly_defs:=poly_defs)) by (generalize (NatUtil.pow_nonzero 2 n ltac:(Lia.lia)); Lia.lia).
+        auto.
+      - specialize (IHi ltac:(Lia.lia)).
+        rewrite NTT_phi_proj1_sig. simpl. rewrite <- NTT_phi_proj1_sig.
+        unfold NTT_phi_list. simpl.
+        assert (nat_rect _ _ _ i = NTT_phi_list i (concat (map (fun p : P => to_list (Nat.pow 2 n) p) (proj1_sig pl)))) as -> by reflexivity.
+        generalize (NTT_phi_layer_list_spec i (proj1_sig (NTT_phi i pl)) Hi (proj2_sig (NTT_phi i pl))).
+        intro X. etransitivity; eauto.
+        assert (concat (map (fun p : P => to_list (Nat.pow 2 (n - i)) p) (proj1_sig (NTT_phi i pl))) = NTT_phi_list i (concat (map (fun p : P => to_list (Nat.pow 2 n) p) (proj1_sig pl)))) as ->; [|reflexivity].
+        assert (map _ (proj1_sig (NTT_phi i pl)) = map (fun p : P => to_list (Nat.pow 2 (n - i)) p) (map of_list (chunk (Nat.pow 2 (n - i)) (NTT_phi_list i (concat (map (fun p : P => to_list (Nat.pow 2 n) p) (proj1_sig pl))))))) as ->.
+        { apply nth_error_ext; intros j.
+          rewrite nth_error_map, nth_error_map.
+          apply Forall2_nth_error_iff in IHi.
+          destruct IHi as [Hl Hv].
+          destruct (Compare_dec.lt_dec j (length (proj1_sig (NTT_phi i pl)))) as [Hlt|Hnlt].
+          - destruct (ListUtil.nth_error_length_exists_value _ _ Hlt) as [vv Hvv].
+            rewrite Hl in Hlt. destruct (ListUtil.nth_error_length_exists_value _ _ Hlt) as [vv2 Hvv2].
+            rewrite Hvv, Hvv2. simpl.
+            f_equal. generalize (Hv _ _ _ Hvv Hvv2). intro D.
+            rewrite D. reflexivity.
+          - rewrite ListUtil.nth_error_length_error by Lia.lia.
+            rewrite Hl in Hnlt.
+            rewrite ListUtil.nth_error_length_error by Lia.lia.
+            reflexivity. }
+        rewrite map_map, map_ext_id, concat_chunk; [reflexivity|].
+        intros x Hx. apply to_list_of_list.
+        eapply (@Forall_In _ (fun z => length z = Nat.pow 2 (n - i)) _ _ x Hx).
+        Unshelve.
+        eapply Forall_chunk_length_eq. instantiate (1 := Nat.pow 2 i).
+        rewrite <- PeanoNat.Nat.pow_add_r.
+        assert (n - i + i = n)%nat as -> by Lia.lia.
+        rewrite NTT_phi_list_length.
+        rewrite (length_concat_same_length (Nat.pow 2 n)).
+        { rewrite map_length. destruct pl as [pl Hpl]. simpl.
+          rewrite (Forall2_length Hpl), cyclotomic_decomposition_length.
+          rewrite PeanoNat.Nat.pow_0_r. Lia.lia. }
+        { apply Forall_forall. intros o Ho.
+          apply in_map_iff in Ho. destruct Ho as [b [Hb1 Hb2]].
+          subst o. rewrite to_list_length. reflexivity. }
+    Qed.
+
+    Lemma NTT_phi_0 pl:
+      NTT_phi 0%nat pl = pl.
+    Proof. reflexivity. Qed.
+
+    Lemma NTT_phi_S i pl:
+      NTT_phi (S i) pl = NTT_phi_layer i (NTT_phi i pl).
+    Proof. reflexivity. Qed.
+
+    Local Notation NTT_psi2 := (@Polynomial.NTT_base_psi_unpacked F F.one F.add P _ F.inv).
+
+    Local Notation NTT_psi2_list := (@Polynomial.NTT_base_psi_unpacked_list F F.zero F.add F.sub F.mul).
+
+    Definition NTT_psi_layer_aux (i: nat) (pl: list P): list P :=
+      List.fold_left
+        (fun l k => List.app l [NTT_psi2 (Nat.pow 2 (n - S i)) (F.pow zeta (List.nth_default 0%N (cyclotomic_decompose (S i)) (2 * k))) (List.nth_default Pzero pl (2 * k)%nat) (List.nth_default Pzero pl (2 * k + 1)%nat)])
+        (seq 0 (Nat.pow 2 i))
+        nil.
+
+    Local Instance NTT_psi_layer_aux_proper_peq {i:nat}:
+      Proper (Forall2 Peq ==> Forall2 Peq) (NTT_psi_layer_aux i).
+    Proof.
+      intros pl1 pl2 Heq. unfold NTT_psi_layer_aux.
+      repeat rewrite <- ListUtil.eq_flat_map_fold_left.
+      repeat rewrite ListUtil.flat_map_singleton.
+      apply Forall2_nth_error_iff.
+      split; [repeat rewrite map_length; reflexivity|].
+      intros k v1 v2 Hv1 Hv2.
+      rewrite nth_error_map in Hv1, Hv2.
+      rewrite ListUtil.nth_error_seq, PeanoNat.Nat.add_0_l in Hv1, Hv2.
+      destruct (Compare_dec.lt_dec k (Nat.pow 2 i)); cbn [option_map] in Hv1, Hv2; [|congruence].
+      set (a := zeta ^ nth_default 0%N (cyclotomic_decompose (S i)) (2 * k)).
+      fold a in Hv1, Hv2.
+      assert (v1 = NTT_psi2 (Nat.pow 2 (n - S i)) a (nth_default Pzero pl1 (2 * k)) (nth_default Pzero pl1 (2 * k + 1))) as -> by congruence.
+      assert (v2 = NTT_psi2 (Nat.pow 2 (n - S i)) a (nth_default Pzero pl2 (2 * k)) (nth_default Pzero pl2 (2 * k + 1))) as -> by congruence.
+      clear Hv1 Hv2.
+      apply peq_NTT_base_psi_unpacked_proper.
+      - destruct (Compare_dec.lt_dec (2 * k) (length pl1)) as [Hlt|Hnlt].
+        + apply ListUtil.Forall2_forall_iff; auto.
+          apply (Forall2_length Heq).
+        + repeat rewrite ListUtil.nth_default_out_of_bounds; try Lia.lia; try reflexivity.
+          rewrite <- (Forall2_length Heq); Lia.lia.
+      - destruct (Compare_dec.lt_dec (2 * k + 1) (length pl1)) as [Hlt|Hnlt].
+        + apply ListUtil.Forall2_forall_iff; auto.
+          apply (Forall2_length Heq).
+        + repeat rewrite ListUtil.nth_default_out_of_bounds; try Lia.lia; try reflexivity.
+          rewrite <- (Forall2_length Heq); Lia.lia.
+    Qed.
+
+    Lemma NTT_psi_layer_aux_const_mul (i: nat) (c:F) (pl: list P):
+      Forall2 Peq
+        (NTT_psi_layer_aux i (map (fun p => Pmul (Pconst c) p) pl))
+        (map (fun p => Pmul (Pconst c) p) (NTT_psi_layer_aux i pl)).
+    Proof.
+      unfold NTT_psi_layer_aux. do 2 rewrite <- ListUtil.eq_flat_map_fold_left.
+      do 2 rewrite ListUtil.flat_map_singleton.
+      rewrite map_map. apply Forall2_nth_error_iff.
+      split; [repeat rewrite map_length; reflexivity|].
+      intros k v1 v2 Hv1 Hv2.
+      rewrite nth_error_map in Hv1, Hv2.
+      destruct (nth_error (seq 0 (Nat.pow 2 i))) as [m|] eqn:Hm; [|simpl in Hv1; congruence].
+      cbn [option_map] in Hv1, Hv2.
+      inversion Hv1; inversion Hv2; subst v1; subst v2; clear Hv1; clear Hv2.
+      set (a := zeta ^ _).
+      destruct (Compare_dec.lt_dec (m + (m + 0) + 1) (length pl)) as [Hlt|Hnlt].
+      - assert (m + (m + 0) < length pl) as Hlt' by Lia.lia.
+        rewrite (@ListUtil.map_nth_default _ _ _ _ Pzero _ _ Hlt).
+        rewrite (@ListUtil.map_nth_default _ _ _ _ Pzero _ _ Hlt').
+        unfold NTT_psi2. repeat rewrite <- (Hierarchy.left_distributive (Pconst c)).
+        repeat rewrite (Hierarchy.associative _ (Pconst c)).
+        do 2 rewrite (Hierarchy.commutative _ (Pconst c)).
+        do 2 rewrite <- (Hierarchy.associative (Pconst c)).
+        rewrite <- (Hierarchy.left_distributive (Pconst c)).
+        reflexivity.
+      - rewrite (ListUtil.nth_default_out_of_bounds (m + (m + 0) + 1) (map _ _)) by (rewrite map_length; Lia.lia).
+        rewrite (ListUtil.nth_default_out_of_bounds (m + (m + 0) + 1) pl) by (Lia.lia).
+        destruct (Compare_dec.lt_dec (m + (m + 0)) (length pl)) as [Hlt|Hnlt'].
+        + rewrite (@ListUtil.map_nth_default _ _ _ _ Pzero _ _ Hlt).
+          unfold NTT_psi2. do 2 rewrite Hierarchy.ring_sub_definition.
+          rewrite Group.inv_id.
+          repeat rewrite Hierarchy.right_identity.
+          repeat rewrite (Hierarchy.associative _ (Pconst c)).
+          do 2 rewrite (Hierarchy.commutative _ (Pconst c)).
+          do 2 rewrite <- (Hierarchy.associative (Pconst c)).
+          rewrite <- (Hierarchy.left_distributive (Pconst c)).
+          reflexivity.
+        + rewrite (ListUtil.nth_default_out_of_bounds (m + (m + 0)) (map _ _)) by (rewrite map_length; Lia.lia).
+          rewrite (ListUtil.nth_default_out_of_bounds (m + (m + 0)) pl) by (Lia.lia).
+          unfold NTT_psi2. rewrite Hierarchy.left_identity.
+          rewrite Ring.mul_0_r. rewrite Hierarchy.ring_sub_definition.
+          rewrite Group.inv_id. rewrite Hierarchy.left_identity.
+          rewrite Hierarchy.left_identity, Ring.mul_0_r.
+          rewrite Ring.mul_0_r. reflexivity.
+    Qed.
+
+    Definition NTT_psi_layer_list (i: nat) (l: list F): list F :=
+      fold_left_chunked (Nat.pow 2 (n - i))
+        (fun k l chunk =>
+           l ++ NTT_psi2_list chunk (Nat.pow 2 (n - S i)) (F.inv (F.pow zeta (List.nth_default 0%N (cyclotomic_decompose (S i)) (2 * k)))))
+        l [].
+
+    Lemma NTT_psi_layer_list_length:
+      forall i l, length (NTT_psi_layer_list i l) = length l.
+    Proof.
+      intros i l. unfold NTT_psi_layer_list.
+      unfold fold_left_chunked.
+      set (f := (fun (acc : list F) '(i0, chunk) => acc ++ _)).
+      assert (forall x acc, length (fold_left f x acc) = length acc + list_sum (map (fun y => length (snd y)) x))%nat as IH.
+      { induction x; [simpl; Lia.lia|].
+        simpl. intros. rewrite IHx. destruct a; unfold f; cbn [fst snd].
+        rewrite app_length. assert (length (NTT_psi2_list _ _ _) = length l0) as ->; [|Lia.lia].
+        unfold NTT_psi2_list. apply ListUtil.fold_left_invariant; [reflexivity|].
+        intros. repeat (rewrite ListUtil.length_set_nth). auto. }
+      rewrite IH. unfold enumerate.
+      rewrite <- (map_map snd), ListUtil.map_snd_combine.
+      rewrite seq_length, firstn_all, <- concat_length, concat_chunk.
+      simpl; Lia.lia.
+    Qed.
+
+    Lemma NTT_psi_layer_list_map_mul c i l:
+      NTT_psi_layer_list i (map (F.mul c) l) = map (F.mul c) (NTT_psi_layer_list i l).
+    Proof.
+      unfold NTT_psi_layer_list, fold_left_chunked.
+      rewrite chunk_map by (apply NatUtil.pow_nonzero; Lia.lia).
+      unfold enumerate. rewrite ListUtil.combine_map_r.
+      rewrite ListUtil.fold_left_map.
+      repeat rewrite map_length.
+      rewrite <- ListUtil.eq_flat_map_fold_left.
+      rewrite (ListUtil.fold_left_ext _ _ _ (fun (acc : list F) z => acc ++ NTT_psi2_list (snd z) (Nat.pow 2 (n - S i)) (F.inv (zeta ^ nth_default 0%N (cyclotomic_decompose (S i)) (2 * (fst z)))))) by (intros x y; destruct y; reflexivity).
+      rewrite <- ListUtil.eq_flat_map_fold_left.
+      rewrite ListUtil.map_flat_map.
+      apply flat_map_ext. destruct a as [k chunk]. cbn [fst snd].
+      unfold NTT_psi2_list.
+      set (f := fun (l0 : list F) (i0 : nat) => _).
+      revert chunk. induction (seq 0 (Nat.pow 2 (n - S i))).
+      - reflexivity.
+      - cbn [fold_left]. intros.
+        rewrite <- IHl0. f_equal.
+        unfold f.
+        apply nth_error_ext. intro j.
+        rewrite nth_error_map.
+        repeat rewrite ListUtil.nth_set_nth.
+        repeat rewrite ListUtil.set_nth_nth_default_full.
+        repeat rewrite ListUtil.length_set_nth.
+        repeat rewrite map_length.
+        destruct (PeanoNat.Nat.eq_dec j (a + Nat.pow 2 (n - S i))).
+        { destruct (Compare_dec.lt_dec j (length chunk)); [|reflexivity].
+          cbn [option_map]. destruct (Compare_dec.lt_dec (a + Nat.pow 2 (n - S i)) (length chunk)); [|repeat rewrite Ring.mul_0_r; reflexivity].
+          rewrite NatUtil.eq_nat_dec_refl.
+          rewrite Hierarchy.associative, (Hierarchy.commutative c (F.inv _)).
+          rewrite <- Hierarchy.associative.
+          rewrite (Hierarchy.left_distributive c).
+          repeat rewrite <- (ListUtil.map_nth_default_always (F.mul c)).
+          rewrite Ring.mul_0_r. reflexivity. }
+        destruct (PeanoNat.Nat.eq_dec j a).
+        { destruct (Compare_dec.lt_dec j (length chunk)); [|reflexivity].
+          cbn [option_map].
+          rewrite (Hierarchy.left_distributive c).
+          repeat rewrite <- (ListUtil.map_nth_default_always (F.mul c)).
+          rewrite Ring.mul_0_r. reflexivity. }
+        apply nth_error_map.
+    Qed.
+
+    Lemma NTT_psi_layer_list_spec (i: nat) (pl: list P):
+      (S i <= N.to_nat km1)%nat ->
+      Forall2 (fun p q => Peq p (Pmod p q)) pl (cyclotomic_decomposition n (S i)) ->
+      Forall2 Peq (List.map (fun x => Pmul (Pconst (F.of_Z _ 2)) x) (NTT_psi_layer_aux i pl)) (List.map of_list (chunk (Nat.pow 2 (n - i)) (NTT_psi_layer_list i (concat (List.map (fun p => to_list (Nat.pow 2 (n - S i)) p) pl))))).
+    Proof.
+      intros Hi HF.
+      assert (Hnz: forall k, Nat.pow 2 k <> 0%nat) by (intros; apply NatUtil.pow_nonzero; Lia.lia).
+      assert (HF': Forall (fun l : list F => length l = Nat.pow 2 (n - S i)) (map (fun p : P => to_list (Nat.pow 2 (n - S i)) p) pl)).
+      { apply Forall_map. apply Forall_forall.
+        intros. apply to_list_length. }
+      unfold NTT_psi_layer_aux. rewrite <- ListUtil.eq_flat_map_fold_left.
+      apply Forall2_nth_error_iff. split.
+      - rewrite map_length.
+        erewrite flat_map_const_length; [|simpl; reflexivity].
+        rewrite seq_length, PeanoNat.Nat.mul_1_l.
+        rewrite map_length, length_chunk; [|apply Hnz].
+        rewrite NTT_psi_layer_list_length.
+        erewrite length_concat_same_length; eauto.
+        rewrite map_length.
+        rewrite (Forall2_length HF), cyclotomic_decomposition_length.
+        rewrite <- PeanoNat.Nat.pow_add_r.
+        assert (S i + (n - S i) = i + (n - i))%nat as -> by Lia.lia.
+        rewrite PeanoNat.Nat.pow_add_r, Nat.div_up_exact; [reflexivity|].
+        apply Hnz.
+      - intros k v1 v2 Hv1 Hv2.
+        rewrite nth_error_map in Hv1.
+        destruct (nth_error (flat_map (fun y : nat => [NTT_psi2 (Nat.pow 2 (n - S i)) (zeta ^ nth_default 0%N (cyclotomic_decompose (S i)) (2 * y)) (nth_default Pzero pl (2 * y)) (nth_default Pzero pl (2 * y + 1))]) (seq 0 (Nat.pow 2 i))) k) as [v1'|] eqn:Hv1'; [|simpl in Hv1; congruence].
+        apply (flat_map_constant_nth_error 1%nat) in Hv1'; [|reflexivity].
+        rewrite PeanoNat.Nat.div_1_r in Hv1'.
+        destruct Hv1' as [k1 [Hk1 Hv1']].
+        rewrite ListUtil.nth_error_seq, PeanoNat.Nat.add_0_l in Hk1.
+        destruct (Compare_dec.lt_dec k (Nat.pow 2 i)) as [Hklt|]; [|congruence].
+        inversion Hk1; subst k1; clear Hk1.
+        rewrite PeanoNat.Nat.mod_1_r in Hv1'. cbn [nth_error] in Hv1'.
+        assert (v1 = Pmul (Pconst (F.of_Z q (Zpos 2))) (NTT_psi2 (Nat.pow 2 (n - S i)) (zeta ^ nth_default 0%N (cyclotomic_decompose (S i)) (2 * k)) (nth_default Pzero pl (2 * k)) (nth_default Pzero pl (2 * k + 1)))) by (rewrite <- Hv1' in Hv1; cbn [option_map] in Hv1; congruence); subst v1; clear Hv1 Hv1'.
+        rewrite nth_error_map in Hv2.
+        rewrite nth_error_chunk in Hv2.
+        2: apply Hnz.
+        2:{ rewrite NTT_psi_layer_list_length, (length_concat_same_length (Nat.pow 2 (n - S i))), map_length.
+            2: apply Forall_map, Forall_forall; intros; rewrite to_list_length; reflexivity.
+            rewrite (Forall2_length HF), cyclotomic_decomposition_length.
+            rewrite <- PeanoNat.Nat.pow_add_r.
+            assert (S i + (n - S i) = i + (n - i))%nat as -> by Lia.lia.
+            rewrite PeanoNat.Nat.pow_add_r, Nat.div_up_exact; auto. }
+        simpl in Hv2. unfold NTT_psi_layer_list in Hv2.
+        unfold fold_left_chunked in Hv2.
+        assert (Hlen: length (concat (map (fun p : P => to_list (Nat.pow 2 (n - S i)) p) pl)) = (Nat.pow 2 (n - i) * Nat.pow 2 i)%nat).
+        { rewrite (length_concat_same_length (Nat.pow 2 (n - S i))).
+          - rewrite map_length, (Forall2_length HF), cyclotomic_decomposition_length.
+            do 2 rewrite <- PeanoNat.Nat.pow_add_r.
+            f_equal; Lia.lia.
+          - apply Forall_map, Forall_forall.
+            intros; rewrite to_list_length; reflexivity. }
+        rewrite (ListUtil.fold_left_ext _ _ _ (fun acc ic => acc ++ NTT_psi2_list (snd ic) (Nat.pow 2 (n - S i)) (F.inv (zeta ^ nth_default 0%N (cyclotomic_decompose (S i)) (2 * fst ic))))) in Hv2.
+        2: intros x y; destruct y; reflexivity.
+        rewrite <- ListUtil.eq_flat_map_fold_left in Hv2.
+        rewrite skipn_flat_map_constant_length in Hv2.
+        2:{ intros x Hx. destruct x as [kx lx].
+            unfold enumerate in Hx. apply in_combine_r in Hx.
+            generalize (Forall_chunk_length_eq (Nat.pow 2 (n - i)) _ (concat (map (fun p : P => to_list (Nat.pow 2 (n - S i)) p) pl)) Hlen).
+            intro HFF.
+            apply (Forall_In HFF) in Hx.
+            rewrite <- Hx. cbn [fst snd].
+            unfold NTT_psi2_list. apply ListUtil.fold_left_invariant; auto.
+            intros. repeat rewrite ListUtil.length_set_nth; auto. }
+        unfold enumerate in Hv2. rewrite ListUtil.skipn_combine, skipn_seq_step in Hv2.
+        rewrite PeanoNat.Nat.add_0_l in Hv2.
+        rewrite length_chunk, Hlen in Hv2; auto.
+        rewrite (PeanoNat.Nat.mul_comm (Nat.pow 2 (n - i)) (Nat.pow 2 i)) in Hv2.
+        rewrite Nat.div_up_exact in Hv2; auto.
+        rewrite skipn_chunk in Hv2; auto.
+        replace (n - i)%nat with (S (n - S i))%nat in Hv2 at 3 by Lia.lia.
+        rewrite PeanoNat.Nat.pow_succ_r', PeanoNat.Nat.mul_assoc, (PeanoNat.Nat.mul_comm k 2) in Hv2.
+        rewrite skipn_concat_same_length in Hv2; [|apply Forall_map, Forall_forall; intros; apply to_list_length].
+        rewrite skipn_map in Hv2.
+        assert (XX: exists p1 p2 pl', skipn (2 * k) pl = p1::p2::pl').
+        { generalize (skipn_length (2 * k) pl).
+          rewrite (Forall2_length HF), cyclotomic_decomposition_length, PeanoNat.Nat.pow_succ_r'. intro X.
+          assert (length (skipn (2 * k) pl) >= 2)%nat as Y by Lia.lia.
+          destruct (skipn (2 * k) pl); [simpl in Y; Lia.lia|].
+          destruct l; [simpl in Y; Lia.lia|].
+          do 3 eexists; reflexivity. }
+        destruct XX as [p1 [p2 [pl' XX]]].
+        rewrite XX in Hv2. cbn [map concat] in Hv2.
+        rewrite app_assoc, chunk_app_chunk in Hv2; auto.
+        2: rewrite app_length, to_list_length, to_list_length.
+        2: assert (n - i = S (n - S i))%nat as -> by Lia.lia; rewrite PeanoNat.Nat.pow_succ_r'; Lia.lia.
+        replace (Nat.pow 2 i - k)%nat with (S (Nat.pred (Nat.pow 2 i - k)))%nat in Hv2 by Lia.lia.
+        rewrite <- cons_seq in Hv2. cbn [combine flat_map] in Hv2.
+        rewrite firstn_app_l in Hv2.
+        2:{ unfold NTT_psi2_list; simpl; apply ListUtil.fold_left_invariant.
+            - rewrite app_length, to_list_length, to_list_length.
+              assert (n - i = S (n - S i))%nat as -> by Lia.lia; rewrite PeanoNat.Nat.pow_succ_r'; Lia.lia.
+            - intros. repeat rewrite ListUtil.length_set_nth. auto. }
+        cbn [fst snd] in Hv2.
+        assert (v2 = of_list (NTT_psi2_list (to_list (Nat.pow 2 (n - S i)) p1 ++ to_list (Nat.pow 2 (n - S i)) p2) (Nat.pow 2 (n - S i)) (F.inv (zeta ^ nth_default 0%N (cyclotomic_decompose (S i)) (2 * k))))) by congruence; subst v2; clear Hv2.
+        assert (F.of_Z _ (Zpos 2) = F.one + F.one) as ->.
+        { unfold F.one. rewrite <- F.of_Z_add. apply F.eq_of_Z_iff. f_equal. }
+        assert (nth_default Pzero pl (2 * k) = p1 /\ nth_default Pzero pl (2 * k + 1) = p2) as [<- <-].
+        { replace (2 * k)%nat with (2 * k + 0)%nat at 1 by Lia.lia.
+          do 2 rewrite <- ListUtil.nth_default_skipn.
+          rewrite XX. split; reflexivity. }
+        apply (NTT_base_psi_unpacked_list_spec (poly_ops:=poly_ops)).
+        + generalize (Hnz (n - S i)%nat); Lia.lia.
+        + apply zeta_pow_nz.
+        + unfold measure.
+          rewrite (Polynomial.peq_proper_degree (poly_defs:=poly_defs) _ _ (proj1 (ListUtil.Forall2_forall_iff (fun p q0 : P => Peq p (Pmod p q0)) _ _ Pzero Pzero ltac:(apply (Forall2_length HF))) HF (2 * k)%nat ltac:(rewrite (Forall2_length HF), cyclotomic_decomposition_length, PeanoNat.Nat.pow_succ_r'; Lia.lia))).
+          assert (ZZ: forall x, In x (cyclotomic_decomposition n (S i)) -> degree x = Some (Nat.pow 2 (n - S i))%nat).
+          { intros x Hx. unfold cyclotomic_decomposition in Hx.
+            apply in_map_iff in Hx. destruct Hx as [y [Hy Hyz]]. subst x.
+            apply Polynomial.posicyclic_degree.
+            generalize (Hnz (n - S i)%nat); Lia.lia. }
+          generalize (ListUtil.nth_default_preserves_properties_length_dep (fun x => degree x = Some (Nat.pow 2 (n - S i)))%nat (cyclotomic_decomposition n (S i)) (2 * k)%nat Pzero ltac:(intros; apply ZZ; auto) ltac:(rewrite cyclotomic_decomposition_length, PeanoNat.Nat.pow_succ_r'; Lia.lia)).
+          intro Q. assert (QQ: not (Peq (nth_default Pzero (cyclotomic_decomposition n (S i)) (2 * k)) Pzero)).
+          { intro EE. rewrite (Polynomial.peq_proper_degree _ _ EE), degree_zero in Q; congruence. }
+          generalize (Pmod_degree_lt (poly_ops:=poly_ops) (nth_default Pzero pl (2 * k)) (nth_default Pzero (cyclotomic_decomposition n (S i)) (2 * k)) QQ).
+          unfold degree_lt. rewrite Q. cbn [convert]. Lia.lia.
+        + unfold measure.
+          rewrite (Polynomial.peq_proper_degree (poly_defs:=poly_defs) _ _ (proj1 (ListUtil.Forall2_forall_iff (fun p q0 : P => Peq p (Pmod p q0)) _ _ Pzero Pzero ltac:(apply (Forall2_length HF))) HF (2 * k + 1)%nat ltac:(rewrite (Forall2_length HF), cyclotomic_decomposition_length, PeanoNat.Nat.pow_succ_r'; Lia.lia))).
+          assert (ZZ: forall x, In x (cyclotomic_decomposition n (S i)) -> degree x = Some (Nat.pow 2 (n - S i))%nat).
+          { intros x Hx. unfold cyclotomic_decomposition in Hx.
+            apply in_map_iff in Hx. destruct Hx as [y [Hy Hyz]]. subst x.
+            apply Polynomial.posicyclic_degree.
+            generalize (Hnz (n - S i)%nat); Lia.lia. }
+          generalize (ListUtil.nth_default_preserves_properties_length_dep (fun x => degree x = Some (Nat.pow 2 (n - S i)))%nat (cyclotomic_decomposition n (S i)) (2 * k + 1)%nat Pzero ltac:(intros; apply ZZ; auto) ltac:(rewrite cyclotomic_decomposition_length, PeanoNat.Nat.pow_succ_r'; Lia.lia)).
+          intro Q. assert (QQ: not (Peq (nth_default Pzero (cyclotomic_decomposition n (S i)) (2 * k + 1)) Pzero)).
+          { intro EE. rewrite (Polynomial.peq_proper_degree _ _ EE), degree_zero in Q; congruence. }
+          generalize (Pmod_degree_lt (poly_ops:=poly_ops) (nth_default Pzero pl (2 * k + 1)) (nth_default Pzero (cyclotomic_decomposition n (S i)) (2 * k + 1)) QQ).
+          unfold degree_lt. rewrite Q. cbn [convert]. Lia.lia.
+    Qed.
+
+    Program Definition NTT_psi_layer (i: nat) (Hle: S i <= N.to_nat km1) (pl: Pquotl (cyclotomic_decomposition n (S i))): Pquotl (cyclotomic_decomposition n i) :=
+      NTT_psi_layer_aux i (proj1_sig pl).
+    Next Obligation.
+      (* Coq ate the hypothesis :( *)
+      assert (Hkm1: zeta ^ (N.pow 2 km1) = F.opp 1).
+      { unfold F.pow, F.opp, F.of_Z. apply ModularArithmeticPre.exist_reduced_eq.
+        exact H0. }
+      unfold NTT_psi_layer_aux.
+      clear H0. rewrite <- ListUtil.eq_flat_map_fold_left.
+      apply Forall2_nth_error_iff.
+      erewrite flat_map_constant_length; [|simpl; reflexivity].
+      rewrite PeanoNat.Nat.mul_1_r, seq_length, cyclotomic_decomposition_length.
+      split; [reflexivity|].
+      intros. eapply flat_map_constant_nth_error in H; [|simpl; reflexivity].
+      rewrite PeanoNat.Nat.mod_1_r in H. cbn [nth_error] in H.
+      destruct H as [y [HA HB]]. inversion HB; subst v1; clear HB.
+      rewrite PeanoNat.Nat.div_1_r in HA.
+      rewrite ListUtil.nth_error_seq in HA. destruct (Compare_dec.lt_dec k (Nat.pow 2 i)) as [Hlt|]; try congruence.
+      rewrite PeanoNat.Nat.add_0_l in HA; inversion HA; subst y; clear HA.
+      assert (2 * k + 1 < Nat.pow 2 (S i))%nat as Hlt' by (rewrite PeanoNat.Nat.pow_succ_r'; Lia.lia).
+      generalize (@ListUtil.nth_error_value_eq_nth_default _ _ _ _ H0 Pzero). intro Hx; subst v2.
+      set (m := nth_default 0%N (cyclotomic_decompose i) k).
+      assert (Hm': exists m', nth_error (cyclotomic_decompose i) k = Some m') by (apply ListUtil.nth_error_length_exists_value; rewrite cyclotomic_decompose_length; Lia.lia).
+      destruct Hm' as [m' Hm].
+      assert (m = m') by (apply ListUtil.nth_error_value_eq_nth_default; auto). subst m'.
+      generalize (cyclotomic_decompose_S_nth_error _ Hle _ _ Hm). intros [HA [HB HC]].
+      unfold cyclotomic_decomposition. erewrite ListUtil.map_nth_default by (rewrite cyclotomic_decompose_length; Lia.lia).
+      instantiate (1 := 0%N). rewrite (ListUtil.nth_error_value_eq_nth_default _ _ _ Hm).
+      generalize (ListUtil.nth_error_value_eq_nth_default _ _ _ HA 0%N).
+      intro X; cbn in X; rewrite X. clear X.
+      assert (Hp1: nth_error (cyclotomic_decomposition n (S i)) (2 * k) = Some (posicyclic (Nat.pow 2 (n - S i)) (zeta ^ (m / 2)%N))).
+      { unfold cyclotomic_decomposition. rewrite nth_error_map, HA. reflexivity. }
+      assert (Hp2: nth_error (cyclotomic_decomposition n (S i)) (2 * k + 1) = Some (posicyclic (Nat.pow 2 (n - S i)) (zeta ^ (2 ^ km1 + m / 2)%N))).
+      { unfold cyclotomic_decomposition. rewrite nth_error_map, HB. reflexivity. }
+      generalize (cyclotomic_decomposition_S _ Hle k _ _ Hp1 Hp2). intros [Hcoprime [p [Hp Hmul]]].
+      rewrite <- neg_zeta_power_eq in Hmul.
+      rewrite Polynomial.posicyclic_opp in Hmul.
+      rewrite <- Polynomial.posicyclic_decomposition in Hmul.
+      assert (Hxy: Peq (nth_default Pzero (proj1_sig pl) (k + (k + 0))) (Pmod (nth_default Pzero (proj1_sig pl) (k + (k + 0))) (posicyclic (Nat.pow 2 (n - S i)) (zeta ^ (m / 2)))) /\ Peq (nth_default Pzero (proj1_sig pl) (k + (k + 0) + 1)) (Pmod (nth_default Pzero (proj1_sig pl) (k + (k + 0) + 1)) (posicyclic (Nat.pow 2 (n - S i)) (zeta ^ (2 ^ km1 + m / 2))))).
+      { destruct pl as [pl Hpl]; simpl.
+        apply Forall2_nth_error_iff in Hpl.
+        destruct Hpl as [Hpl1 Hpl2]. rewrite cyclotomic_decomposition_length in Hpl1.
+        split; eapply Hpl2; try (apply ListUtil.nth_error_Some_nth_default; Lia.lia); [exact Hp1|exact Hp2]. }
+      destruct Hxy as [Hx Hy].
+      rewrite <- neg_zeta_power_eq in Hy.
+      set (x := exist (fun p => Peq p (Pmod p _)) (nth_default Pzero (proj1_sig pl) (k + (k + 0))) Hx).
+      assert (X:Peq (Pmod (nth_default Pzero (proj1_sig pl) (k + (k + 0) + 1)) (posicyclic (Nat.pow 2 (n - S i)) (F.opp (zeta ^ (m / 2))))) (Pmod (nth_default Pzero (proj1_sig pl) (k + (k + 0) + 1)) (negacyclic (Nat.pow 2 (n - S i)) ((zeta ^ (m / 2)))))) by (apply Polynomial.peq_mod_proper; [reflexivity|apply Polynomial.posicyclic_opp]).
+      rewrite X in Hy. clear X.
+      set (y := exist (fun p => Peq p (Pmod p _)) (nth_default Pzero (proj1_sig pl) (k + (k + 0) + 1)) Hy).
+      generalize (Polynomial.NTT_base_psi_obligation_1 (poly_defs:=poly_defs) (Nat.pow 2 (n - S i)) (zeta ^ (m / 2)%N) _ _ _ ltac:(generalize (NatUtil.pow_nonzero 2 (n - S i) ltac:(Lia.lia)); Lia.lia) ltac:(apply zeta_pow_nz) ltac:(reflexivity) ltac:(reflexivity) ltac:(reflexivity) (x, y)).
+      unfold x, y; simpl. intro X. etransitivity; eauto.
+      apply Polynomial.peq_mod_proper; [reflexivity|].
+      rewrite <- F.pow_add_r.
+      assert (Nat.pow 2 (n - S i) + (Nat.pow 2 (n - S i) + 0) = Nat.pow 2 (n - i))%nat as -> by (assert (n - i = S (n - S i))%nat as -> by Lia.lia; rewrite PeanoNat.Nat.pow_succ_r'; Lia.lia).
+      assert (m / 2 + m / 2 = m)%N as -> by Lia.lia. reflexivity.
+    Qed.
+
+    (* This does not compute well *)
+    (* Program Fixpoint NTT_psi (i: nat) (Hle: i <= N.to_nat km1) (pl: Pquotl (cyclotomic_decomposition n i)): Pquotl (cyclotomic_decomposition n 0%nat) := *)
+    (*   match i with *)
+    (*   | O => pl *)
+    (*   | S i => (NTT_psi i ltac:(Lia.lia) (NTT_psi_layer i Hle pl)) *)
+    (*   end. *)
+    (* Next Obligation. destruct pl as [pl Hpl]. simpl. exact Hpl. Qed. *)
+    (* Next Obligation. destruct pl as [pl Hpl]. simpl. exact Hpl. Qed. *)
+
+    (* Goal forall (Hle: (0 <= N.to_nat km1)%nat)pl, NTT_psi 0%nat Hle pl = pl. intros. Fail reflexivity. *)
+
+    Fixpoint NTT_psi_aux (i: nat) (pl: list P): list P :=
+      match i with
+      | O => pl
+      | S i => NTT_psi_aux i (NTT_psi_layer_aux i pl)
+      end.
+
+    Local Instance NTT_psi_aux_proper_peq {i:nat}:
+      Proper (Forall2 Peq ==> Forall2 Peq) (NTT_psi_aux i).
+    Proof.
+      induction i; intros pl1 pl2 Heq; simpl; [assumption|].
+      apply IHi. apply NTT_psi_layer_aux_proper_peq. assumption.
+    Qed.
+
+    Lemma NTT_psi_aux_const_mul (i: nat) (c:F) (pl: list P):
+      Forall2 Peq
+        (NTT_psi_aux i (map (fun p => Pmul (Pconst c) p) pl))
+        (map (fun p => Pmul (Pconst c) p) (NTT_psi_aux i pl)).
+    Proof.
+      revert pl. induction i; [reflexivity|].
+      intros pl; simpl. rewrite <- IHi.
+      apply NTT_psi_aux_proper_peq.
+      apply NTT_psi_layer_aux_const_mul.
+    Qed.
+
+    Lemma mul_const_of_list (c: F) (l: list F):
+      Peq (Pmul (Pconst c) (of_list l)) (of_list (List.map (F.mul c) l)).
+    Proof.
+      intro i. unfold of_list.
+      rewrite mul_const_coeff_l, coeff_bigop, coeff_bigop.
+      rewrite map_length. rewrite bigop_l_distr.
+      apply bigop_ext_eq. intros k Hk.
+      do 2 rewrite mul_const_coeff_l.
+      apply in_seq in Hk.
+      erewrite ListUtil.map_nth_default by Lia.lia.
+      rewrite Hierarchy.associative. reflexivity.
+    Qed.
+
+    Lemma of_list_inj (l1 l2: list F) (Heq: length l1 = length l2):
+      Peq (of_list l1) (of_list l2) -> l1 = l2.
+    Proof.
+      unfold of_list; intro.
+      apply nth_error_ext_samelength; auto.
+      intros i Hi. generalize (H i).
+      do 2 rewrite Polynomial.Pdecompose_coeff.
+      rewrite <- Heq. destruct (Decidable.dec_lt_nat i (length l1)) as [_|]; [|Lia.lia].
+      rewrite (ListUtil.nth_error_Some_nth_default i 0 l1 Hi).
+      rewrite (ListUtil.nth_error_Some_nth_default i 0 l2 ltac:(rewrite <- Heq; apply Hi)).
+      congruence.
+    Qed.
+
+    Fixpoint NTT_psi_list_no_div (i: nat) (l: list F): list F :=
+      match i with
+      | O => l
+      | S i => NTT_psi_list_no_div i (NTT_psi_layer_list i l)
+      end.
+
+    Lemma NTT_psi_list_no_div_length (i: nat) (l: list F):
+      length (NTT_psi_list_no_div i l) = length l.
+    Proof.
+      revert l; induction i; [reflexivity|]; intros.
+      simpl. rewrite IHi, NTT_psi_layer_list_length. reflexivity.
+    Qed.
+
+    Lemma NTT_psi_list_no_div_map_mul c i l:
+      NTT_psi_list_no_div i (map (F.mul c) l) = map (F.mul c) (NTT_psi_list_no_div i l).
+    Proof.
+      revert l; induction i; [reflexivity|].
+      simpl. intro. rewrite NTT_psi_layer_list_map_mul.
+      rewrite IHi. reflexivity.
+    Qed.
+
+    Lemma NTT_psi_list_no_div_spec:
+      forall (i: nat) (pl: list P),
+        (i <= N.to_nat km1)%nat ->
+        Forall2 (fun p q : P => Peq p (Pmod p q)) pl (cyclotomic_decomposition n i) ->
+        Forall2 Peq
+          (map (fun x : P => Pmul (Pconst (F.of_Z q (Zpower.two_power_nat i))) x) (NTT_psi_aux i pl))
+          (map of_list
+             (chunk (Nat.pow 2 n)
+                (NTT_psi_list_no_div i
+                   (concat (map (fun p : P => to_list (Nat.pow 2 (n - i)) p) pl))))).
+    Proof.
+      induction i; intros pl Hi HF.
+      - cbn [NTT_psi_aux NTT_psi_list_no_div].
+        rewrite PeanoNat.Nat.sub_0_r.
+        assert (Zpower.two_power_nat 0%nat = BinInt.Z.one) as -> by reflexivity.
+        assert (Forall2 Peq (map _ pl) pl) as ->.
+        { apply Forall2_nth_error_iff.
+          split; [apply map_length|].
+          intros k v1 v2 Hv1 Hv2.
+          rewrite nth_error_map, Hv2 in Hv1.
+          simpl in Hv1. inversion Hv1; subst v1; clear Hv1.
+          rewrite const_one_definition. apply Hierarchy.left_identity. }
+        rewrite chunk_concat, map_map.
+        2: apply NatUtil.pow_nonzero; Lia.lia.
+        2: apply Forall_forall; intros x Hx; apply in_map_iff in Hx.
+        2: destruct Hx as [y [<- Hx]]; apply to_list_length.
+        apply Forall2_nth_error_iff.
+        split; [rewrite map_length; reflexivity|].
+        intros k v1 v2 Hv1 Hv2.
+        rewrite nth_error_map, Hv1 in Hv2. cbn in Hv2.
+        inversion Hv2; subst v2.
+        symmetry. apply Polynomial.of_list_to_list.
+        cbv [cyclotomic_decomposition cyclotomic_decompose map] in HF.
+        rewrite PeanoNat.Nat.sub_0_r, Hkm1 in HF.
+        generalize (Forall2_length HF); cbn [length]. intro Hpl1.
+        destruct pl; [cbn in Hpl1; congruence|].
+        destruct pl; [|cbn in Hpl1; congruence].
+        rewrite nth_error_cons in Hv1.
+        destruct k; [|rewrite nth_error_nil in Hv1; congruence].
+        assert (v1 = p) as -> by congruence.
+        apply Forall2_cons_iff in HF. destruct HF as [Heq HF].
+        rewrite (Polynomial.peq_proper_degree _ _ Heq).
+        erewrite <- (Polynomial.posicyclic_degree (poly_ops:=poly_ops)) by (generalize (NatUtil.pow_nonzero 2 n ltac:(Lia.lia)); Lia.lia).
+        apply Polynomial.Pmod_degree_lt.
+        intro T.
+        generalize (Polynomial.posicyclic_degree (poly_ops:=poly_ops) (Nat.pow 2 n) (F.opp 1) ltac:(generalize (NatUtil.pow_nonzero 2 n ltac:(Lia.lia)); Lia.lia)).
+        rewrite (Polynomial.peq_proper_degree _ _ T), degree_zero.
+        congruence.
+      - simpl.
+        destruct (NTT_psi_layer i Hi (exist _ pl HF)) as [pl' HF'] eqn:Heq.
+        simpl in Heq. apply EqdepFacts.eq_sig_fst in Heq.
+        cbn [proj1_sig] in Heq. subst pl'.
+        generalize (IHi _ ltac:(Lia.lia) HF'). intro IH.
+        rewrite Zpower.two_power_nat_S, F.of_Z_mul.
+        assert (Forall2 Peq (map (fun x => Pmul (Pconst (F.of_Z q (Zpos 2))) x) (map (fun x => Pmul (Pconst (F.of_Z q (Zpower.two_power_nat i))) x) (NTT_psi_aux i (NTT_psi_layer_aux i pl)))) (map (fun x : P => Pmul (Pconst (F.of_Z q (Zpos 2) * F.of_Z q (Zpower.two_power_nat i))) x) (NTT_psi_aux i (NTT_psi_layer_aux i pl)))) as <-.
+        { rewrite map_map. apply Forall2_nth_error_iff.
+          split; [repeat rewrite map_length; reflexivity|].
+          intros k v1 v2 Hv1 Hv2.
+          rewrite nth_error_map in Hv1, Hv2.
+          destruct (nth_error (NTT_psi_aux i (NTT_psi_layer_aux i pl)) k); [|simpl in Hv1; congruence].
+          simpl in Hv1, Hv2. inversion Hv1; inversion Hv2; subst v1; subst v2.
+          rewrite <- Polynomial.const_mul_const.
+          rewrite Hierarchy.associative. reflexivity. }
+        generalize (NTT_psi_layer_list_spec i pl Hi HF). intro IH2.
+        etransitivity; [apply (Forall2_map _ _ _ IH); [intros x1 x2 Hx; rewrite Hx; reflexivity]|].
+        transitivity (map of_list (map (map (F.mul (F.of_Z q (Zpos 2)))) (chunk (Nat.pow 2 n) (NTT_psi_list_no_div i (concat (map (fun p : P => to_list (Nat.pow 2 (n - i)) p) (NTT_psi_layer_aux i pl))))))).
+        { rewrite map_map. etransitivity; [eapply Forall2_map_in; intros; apply mul_const_of_list|].
+          rewrite <- map_map. reflexivity. }
+        rewrite <- chunk_map by (apply NatUtil.pow_nonzero; Lia.lia).
+        rewrite <- NTT_psi_list_no_div_map_mul.
+        rewrite concat_map.
+        assert (concat (map _ _) = NTT_psi_layer_list i (concat (map (fun p : P => to_list (Nat.pow 2 (n - S i)) p) pl))) as ->; [|reflexivity].
+        generalize (Forall2_map (to_list (Nat.pow 2 (n - i))) _ _ IH2 peq_proper_to_list).
+        assert (map (to_list (Nat.pow 2 (n - i))) (map of_list _) = chunk (Nat.pow 2 (n - i)) (NTT_psi_layer_list i (concat (map (fun p : P => to_list (Nat.pow 2 (n - S i)) p) pl)))) as ->.
+        { rewrite map_map. eapply map_ext_id.
+          intros x Hx. apply to_list_of_list.
+          eapply (Forall_In (P := fun x => length x = Nat.pow 2 (n - i))); [|apply Hx].
+          apply (Forall_chunk_length_eq (Nat.pow 2 (n - i)) (Nat.pow 2 i)%nat (NTT_psi_layer_list i (concat (map (fun p : P => to_list (Nat.pow 2 (n - S i)) p) pl)))).
+          rewrite NTT_psi_layer_list_length, (length_concat_same_length (Nat.pow 2 (n - S i))), map_length, (Forall2_length HF), cyclotomic_decomposition_length.
+          2: apply Forall_map, Forall_forall; intros; apply to_list_length.
+          do 2 rewrite <- PeanoNat.Nat.pow_add_r. f_equal. Lia.lia. }
+        intro X. rewrite <- (concat_chunk (Nat.pow 2 (n - i)) (NTT_psi_layer_list i _)).
+        f_equal.
+        assert (chunk _ _ = (map (to_list (Nat.pow 2 (n - i))) (map (fun x : P => Pmul (Pconst (F.of_Z q (Zpos 2))) x) (NTT_psi_layer_aux i pl)))) as ->.
+        { apply Forall2_nth_error_iff in X. destruct X as [X1 X2].
+          apply nth_error_ext_samelength; auto.
+          intros j Hj. destruct (ListUtil.nth_error_length_exists_value _ _ Hj) as [? Y1].
+          rewrite Y1. rewrite <- X1 in Hj.
+          destruct (ListUtil.nth_error_length_exists_value _ _ Hj) as [? Y2].
+          rewrite Y2. f_equal. symmetry. eapply X2; eauto. }
+        do 2 rewrite map_map. apply map_ext_in. intros p Hp.
+        apply of_list_inj.
+        { rewrite map_length, to_list_length, to_list_length. reflexivity. }
+        rewrite <- mul_const_of_list.
+        assert (degree_lt (degree p) (Some (Nat.pow 2 (n - i)))).
+        { destruct (In_nth_error _ _ Hp) as [j Hj].
+          apply Forall2_nth_error_iff in HF'. destruct HF' as [HF1 HF2].
+          generalize (nth_error_Some_bound_index _ _ _ Hj). intro Hjj.
+          rewrite HF1 in Hjj. destruct (ListUtil.nth_error_length_exists_value _ _ Hjj) as [qq Hqq].
+          generalize (HF2 _ _ _ Hj Hqq). intro Hpmod.
+          rewrite (Polynomial.peq_proper_degree _ _ Hpmod).
+          assert (Some (Nat.pow 2 (n - i)) = degree qq) as DD.
+          { unfold cyclotomic_decomposition in Hqq. rewrite nth_error_map in Hqq.
+            destruct (nth_error (cyclotomic_decompose i) j) as [nn|] eqn:Hnn; simpl in Hqq; [|congruence].
+            inversion Hqq. symmetry. apply posicyclic_degree.
+            generalize (NatUtil.pow_nonzero 2 (n - i) ltac:(Lia.lia)); Lia.lia. }
+          rewrite DD. apply Polynomial.Pmod_degree_lt.
+          intro T. rewrite (Polynomial.peq_proper_degree _ _ T), degree_zero in DD.
+          congruence. }
+        rewrite of_list_to_list; auto.
+        rewrite of_list_to_list; [reflexivity|].
+        rewrite mul_degree_eq, degree_const.
+        destruct (F.eq_dec (F.of_Z q (Zpos 2)) 0) as [He|Hne]; [|rewrite degree_add_0_l; auto].
+        generalize (char_ge_3 2%positive ltac:(simpl; Lia.lia)); simpl.
+        unfold F.zero, F.one. repeat rewrite <- F.of_Z_add.
+        assert (Z0 + Zpos 1 + Zpos 1 = Zpos 2)%Z as -> by Lia.lia.
+        intro Hne. elim Hne. apply He.
+    Qed.
+
+    Definition NTT_psi_list (i: nat) (l: list F): list F :=
+      map (fun c => F.div c (F.of_Z _ (Zpower.two_power_nat i))) (NTT_psi_list_no_div i l).
+
+    Lemma NTT_psi_list_spec:
+      forall (i: nat) (pl: list P),
+        (i <= N.to_nat km1)%nat ->
+        Forall2 (fun p q : P => Peq p (Pmod p q)) pl (cyclotomic_decomposition n i) ->
+        Forall2 Peq
+          (NTT_psi_aux i pl)
+          (map of_list
+             (chunk (Nat.pow 2 n)
+                (NTT_psi_list i
+                   (concat (map (fun p : P => to_list (Nat.pow 2 (n - i)) p) pl))))).
+    Proof.
+      intros i pl Hi HF.
+      generalize (NTT_psi_list_no_div_spec i pl Hi HF). intro HF2.
+      unfold NTT_psi_list.
+      rewrite chunk_map; [|generalize (NatUtil.pow_nonzero 2 n ltac:(Lia.lia)); Lia.lia].
+      rewrite map_map.
+      assert (Forall2 Peq (map _ _) (map (fun p => (Pmul (Pconst (1 / F.of_Z q (Zpower.two_power_nat i))) p)) (map (fun l => of_list l) (chunk (Nat.pow 2 n) (NTT_psi_list_no_div i (concat (map (fun p : P => to_list (Nat.pow 2 (n - i)) p) pl))))))) as ->.
+      { rewrite map_map. eapply Forall2_map_in. intros x Hx.
+        symmetry. rewrite mul_const_of_list.
+        erewrite map_ext; [reflexivity|]. intros; simpl.
+        do 2 rewrite Hierarchy.field_div_definition.
+        rewrite Hierarchy.commutative, Hierarchy.associative, Hierarchy.right_identity.
+        reflexivity. }
+      eapply (@Forall2_map _ _ Peq Peq _ _ (fun p : P => Pmul (Pconst (1 / F.of_Z q (Zpower.two_power_nat i))) p)) in HF2.
+      2: intros p1 p2 Hpeq; rewrite Hpeq; reflexivity.
+      rewrite map_map in HF2.
+      etransitivity; eauto.
+      apply Forall2_nth_error_iff. rewrite map_length. split; [reflexivity|].
+      intros k v1 v2 Hv1 Hv2.
+      rewrite nth_error_map, Hv1 in Hv2. simpl in Hv2. inversion Hv2; clear Hv2.
+      rewrite Hierarchy.associative, const_mul_const, Hierarchy.field_div_definition, Hierarchy.left_identity.
+      rewrite Hierarchy.left_multiplicative_inverse, const_one_definition, Hierarchy.left_identity; [reflexivity|].
+      intro X. unfold F.zero in X. apply F.eq_of_Z_iff in X.
+      rewrite Zdiv.Zmod_0_l, Zpower.two_power_nat_equiv in X.
+      apply Zmod_divide in X; [|congruence].
+      clear -X prime_q char_ge_3. (* Prove that q does not divide 2^i *)
+      induction i.
+      { simpl in X. apply BinInt.Z.divide_1_r_nonneg in X; [|Lia.lia].
+        inversion X; subst q. apply not_prime_1. auto. }
+      { rewrite Znat.Nat2Z.inj_succ in X.
+        rewrite BinInt.Z.pow_succ_r in X by Lia.lia.
+        apply (prime_mult _ prime_q) in X. destruct X as [X|X]; auto.
+        apply (prime_div_prime _ _ prime_q prime_2) in X.
+        inversion X; subst q.
+        generalize (char_ge_3 2%positive ltac:(simpl; Lia.lia)); simpl.
+        unfold F.zero, F.one. repeat rewrite <- F.of_Z_add.
+        assert (Z0 + Zpos 1 + Zpos 1 = Zpos 2)%Z as -> by Lia.lia.
+        intro Y. apply Y. apply F.eq_of_Z_iff.
+        rewrite Zdiv.Zmod_0_l, Zdiv.Z_mod_same by Lia.lia.
+        reflexivity. }
+    Qed.
+
+    Program Definition NTT_psi (i: nat) (Hle: i <= N.to_nat km1) (pl: Pquotl (cyclotomic_decomposition n i)): Pquotl (cyclotomic_decomposition n 0%nat) :=
+      NTT_psi_aux i (proj1_sig pl).
+    Next Obligation.
+      assert (Hkm1: zeta ^ (N.pow 2 km1) = F.opp 1).
+      { unfold F.pow, F.opp, F.of_Z. apply ModularArithmeticPre.exist_reduced_eq.
+        exact H0. }
+      induction i.
+      - destruct pl as [pl Hpl]. simpl. assumption.
+      - simpl. specialize (IHi ltac:(Lia.lia)).
+        assert (NTT_psi_layer_aux i (proj1_sig pl) = proj1_sig (NTT_psi_layer i Hle pl)) as -> by reflexivity.
+        apply IHi.
+    Qed.
+
+    Lemma NTT_psi_0 (Hle: 0%nat <= N.to_nat km1) pl:
+      Polynomial.eql (NTT_psi 0%nat Hle pl) pl.
+    Proof.
+      destruct pl as [pl Hpl]; unfold Polynomial.eql; simpl.
+      apply Forall2_nth_error_iff. split; [reflexivity|].
+      intros k v1 v2 Hv1 Hv2. rewrite Hv2 in Hv1; inversion Hv1; subst v2; reflexivity.
+    Qed.
+
+    Lemma NTT_psi_S (i: nat) (Hle: S i <= N.to_nat km1) pl:
+      forall (Hle': i <= N.to_nat km1),
+        Polynomial.eql (NTT_psi (S i) Hle pl) (NTT_psi i Hle' (NTT_psi_layer i Hle pl)).
+    Proof.
+      intros; destruct pl as [pl Hpl].
+      unfold Polynomial.eql; simpl.
+      apply Forall2_nth_error_iff. split; [reflexivity|].
+      intros k v1 v2 Hv1 Hv2. rewrite Hv2 in Hv1; inversion Hv1; subst v2; reflexivity.
+    Qed.
+
+    Local Instance eql_NTT_psi_layer_proper: forall i Hle, Proper (Polynomial.eql ==> Polynomial.eql) (NTT_psi_layer i Hle).
+    Proof.
+      intros; intros p1 p2 Heq.
+      unfold Polynomial.eql in *.
+      destruct p1 as [p1 Hp1]. destruct p2 as [p2 Hp2]; simpl in *.
+      unfold NTT_psi_layer_aux. repeat rewrite <- ListUtil.eq_flat_map_fold_left.
+      apply Forall2_nth_error_iff.
+      repeat rewrite (flat_map_constant_length (c:=1%nat)) by reflexivity.
+      split; [reflexivity|].
+      intros k v1 v2 Hv1 Hv2.
+      apply (@flat_map_constant_nth_error _ _ 1%nat) in Hv1; [|reflexivity].
+      apply (@flat_map_constant_nth_error _ _ 1%nat) in Hv2; [|reflexivity].
+      rewrite PeanoNat.Nat.div_1_r in Hv1, Hv2.
+      rewrite PeanoNat.Nat.mod_1_r in Hv1, Hv2. simpl in Hv1, Hv2.
+      destruct Hv1 as [kk [Hkk Hv1]]. rewrite Hkk in Hv2.
+      destruct Hv2 as [kk' [Hkk' Hv2]]. inversion Hkk'; subst kk'; clear Hkk'.
+      inversion Hv1; subst v1; clear Hv1.
+      inversion Hv2; subst v2; clear Hv2.
+      unfold NTT_psi2. assert (kk + (kk + 0) = 2 * kk :> _)%nat as -> by Lia.lia.
+      assert (Hlp1: (length p1 = Nat.pow 2 (S i) :> _)%nat) by (rewrite <- (cyclotomic_decomposition_length n); eapply Forall2_length; eauto).
+      assert (Hkklt: (kk < Nat.pow 2 i)%nat) by (rewrite ListUtil.nth_error_seq in Hkk; destruct (Compare_dec.lt_dec k (Nat.pow 2 i)); [|congruence]; inversion Hkk; subst kk; Lia.lia).
+      assert (Hkk2: (2 * kk < length p1)%nat) by (rewrite Hlp1, PeanoNat.Nat.pow_succ_r'; Lia.lia).
+      assert (Hkk2': (2 * kk + 1 < length p1)%nat) by (rewrite Hlp1, PeanoNat.Nat.pow_succ_r'; Lia.lia).
+      rewrite (proj1 (ListUtil.Forall2_forall_iff Peq p1 p2 Pzero Pzero ltac:(eapply Forall2_length; eauto)) Heq _ Hkk2).
+      rewrite (proj1 (ListUtil.Forall2_forall_iff Peq p1 p2 Pzero Pzero ltac:(eapply Forall2_length; eauto)) Heq _ Hkk2').
+      reflexivity.
+    Qed.
+
+    Local Instance eql_NTT_psi_proper: forall i Hle, Proper (Polynomial.eql ==> Polynomial.eql) (NTT_psi i Hle).
+    Proof.
+      induction i; intros; intros p1 p2 Heq.
+      - repeat rewrite NTT_psi_0. auto.
+      - repeat rewrite NTT_psi_S. apply (IHi ltac:(Lia.lia)).
+        rewrite Heq. reflexivity.
+    Qed.
+
+    Local Instance eql_NTT_phi_layer_proper: forall i, Proper (Polynomial.eql ==> Polynomial.eql) (NTT_phi_layer i).
+    Proof.
+      intros; intros p1 p2 Heq.
+      unfold Polynomial.eql in *.
+      destruct p1 as [p1 Hp1]. destruct p2 as [p2 Hp2]; simpl in *.
+      unfold NTT_phi_layer_aux.
+      repeat rewrite <- ListUtil.eq_flat_map_fold_left.
+      apply Forall2_nth_error_iff.
+      repeat rewrite (flat_map_constant_length (c:=2%nat)) by reflexivity.
+      split; [reflexivity|].
+      intros k v1 v2 Hv1 Hv2.
+      apply (@flat_map_constant_nth_error _ _ 2%nat) in Hv1; [|reflexivity].
+      apply (@flat_map_constant_nth_error _ _ 2%nat) in Hv2; [|reflexivity].
+      destruct Hv1 as [kk [Hkk Hv1]]. rewrite Hkk in Hv2.
+      destruct Hv2 as [kk' [Hkk' Hv2]]. inversion Hkk'; subst kk'; clear Hkk'.
+      rewrite ListUtil.nth_error_seq in Hkk.
+      rewrite PeanoNat.Nat.add_0_l in Hkk.
+      destruct (Compare_dec.lt_dec (PeanoNat.Nat.div k 2) (Nat.pow 2 i)) as [Hdivklt|]; [|congruence].
+      assert (Hkkeq: kk = PeanoNat.Nat.div k 2) by congruence. clear Hkk.
+      assert (HPP: Peq (nth_default Pzero p1 kk) (nth_default Pzero p2 kk)).
+      { apply Forall2_nth_error_iff in Heq. destruct Heq as [Hl Heq].
+        apply (Heq kk); apply ListUtil.nth_error_Some_nth_default; [rewrite (Forall2_length Hp1)|rewrite (Forall2_length Hp2)]; rewrite cyclotomic_decomposition_length; Lia.lia. }
+      assert (Hr: (PeanoNat.Nat.modulo k 2 = 0 \/ PeanoNat.Nat.modulo k 2 = 1)%nat).
+      { generalize (PeanoNat.Nat.mod_upper_bound k 2 ltac:(Lia.lia)). Lia.lia. }
+      destruct Hr as [Hr|Hr]; rewrite Hr in *; cbn [nth_error] in *;
+      inversion Hv1; subst v1; inversion Hv2; subst v2; apply (Polynomial.peq_mod_proper _ _ HPP); reflexivity.
+    Qed.
+
+    Local Instance eql_NTT_phi_proper: forall i, Proper (Polynomial.eql ==> Polynomial.eql) (NTT_phi i).
+    Proof.
+      induction i; intros; intros p1 p2 Heq.
+      - repeat rewrite NTT_phi_0. auto.
+      - repeat rewrite NTT_phi_S. apply eql_NTT_phi_layer_proper.
+        apply IHi. apply Heq.
+    Qed.
+
+    Lemma NTT_psi_phi_layer (i: nat) (Hle: S i <= N.to_nat km1) pl:
+      Polynomial.eql (NTT_psi_layer i Hle (NTT_phi_layer i pl)) pl.
+    Proof.
+      unfold Polynomial.eql, Polynomial.to_pl.
+      destruct pl as [pl Hpl]. simpl. unfold NTT_phi_layer_aux.
+      rewrite <- ListUtil.eq_flat_map_fold_left.
+      unfold NTT_psi_layer_aux. rewrite <- ListUtil.eq_flat_map_fold_left.
+      apply Forall2_nth_error_iff. split.
+      - rewrite (flat_map_constant_length (c:=1%nat)); [|reflexivity].
+        rewrite seq_length, PeanoNat.Nat.mul_1_r.
+        apply Forall2_length in Hpl. rewrite Hpl.
+        symmetry; apply cyclotomic_decomposition_length.
+      - intros k p1 p Hp1 Hp.
+        apply (flat_map_constant_nth_error 1%nat) in Hp1; [|reflexivity].
+        destruct Hp1 as [y [Hy Hp1]].
+        rewrite PeanoNat.Nat.div_1_r in Hy.
+        rewrite ListUtil.nth_error_seq in Hy.
+        destruct (Compare_dec.lt_dec k (Nat.pow 2 i)) as [Hlt|_]; [|congruence].
+        destruct (ListUtil.nth_error_length_exists_value k (cyclotomic_decomposition n i) ltac:(rewrite cyclotomic_decomposition_length; Lia.lia)) as [p' Hp'].
+        assert (Hpp: Peq p (Pmod p p')).
+        { apply Forall2_nth_error_iff in Hpl. destruct Hpl as [_ Hpl]. eapply Hpl; eauto. }
+        rewrite PeanoNat.Nat.add_0_l in Hy. inversion Hy; subst y; clear Hy.
+        rewrite PeanoNat.Nat.mod_1_r in Hp1; simpl in Hp1.
+        inversion Hp1; subst p1; clear Hp1.
+        set (m := flat_map _ (seq _ _)).
+        assert (Hmlength: (length m = 2 * Nat.pow 2 i)%nat).
+        { unfold m; rewrite (flat_map_constant_length (c:=2%nat)); [|reflexivity].
+          rewrite seq_length. Lia.lia. }
+        set (p1 := nth_default Pzero m (k + (k + 0))).
+        set (p2 := nth_default Pzero m (k + (k + 0) + 1)).
+        assert (Hp1: nth_error m (k + (k + 0)) = Some p1).
+        { apply ListUtil.nth_error_Some_nth_default.
+          rewrite Hmlength; Lia.lia. }
+        assert (Hp2: nth_error m (k + (k + 0) + 1) = Some p2).
+        { apply ListUtil.nth_error_Some_nth_default.
+          rewrite Hmlength; Lia.lia. }
+        apply (flat_map_constant_nth_error 2%nat) in Hp1; [|reflexivity].
+        apply (flat_map_constant_nth_error 2%nat) in Hp2; [|reflexivity].
+        assert (k + (k + 0) + 1 = 2 * k + 1)%nat as H2k1 by Lia.lia.
+        rewrite H2k1 in *. clear H2k1.
+        assert (k + (k + 0) = 2 * k + 0)%nat as H2k by Lia.lia.
+        rewrite H2k in *. clear H2k.
+        assert (PeanoNat.Nat.div (2 * k + 0) 2 = k) as Hdiv2 by (symmetry; eapply PeanoNat.Nat.div_unique; [|reflexivity]; Lia.lia).
+        rewrite Hdiv2 in *. clear Hdiv2.
+        assert (PeanoNat.Nat.div (2 * k + 1) 2 = k) as Hdiv2 by (symmetry; eapply PeanoNat.Nat.div_unique; [|reflexivity]; Lia.lia).
+        rewrite Hdiv2 in *. clear Hdiv2.
+        assert (PeanoNat.Nat.modulo (2 * k + 0) 2 = 0)%nat as Hmod2 by (symmetry; eapply PeanoNat.Nat.mod_unique; [|reflexivity]; Lia.lia).
+        rewrite Hmod2 in *. clear Hmod2.
+        assert (PeanoNat.Nat.modulo (2 * k + 1) 2 = 1)%nat as Hmod2 by (symmetry; eapply PeanoNat.Nat.mod_unique; [|reflexivity]; Lia.lia).
+        rewrite Hmod2 in *. clear Hmod2.
+        cbn [nth_error] in Hp1, Hp2.
+        destruct Hp1 as [k1 [Hk1 Hp1]].
+        destruct Hp2 as [k2 [Hk2 Hp2]].
+        rewrite ListUtil.nth_error_seq in Hk1, Hk2.
+        rewrite PeanoNat.Nat.add_0_l in Hk1, Hk2.
+        destruct (Compare_dec.lt_dec k (Nat.pow 2 i)) as [_|_]; [|congruence].
+        inversion Hk1; subst k1; clear Hk1.
+        inversion Hk2; subst k2; clear Hk2.
+        assert (nth_default Pzero pl k = p) as Hpeq by (apply ListUtil.nth_error_value_eq_nth_default; auto); rewrite Hpeq in *; clear Hpeq.
+        generalize Hp'. unfold cyclotomic_decomposition. rewrite nth_error_map.
+        destruct (nth_error (cyclotomic_decompose i) k) as [x|] eqn:Hx; [|simpl; congruence].
+        destruct (cyclotomic_decompose_S_nth_error i Hle k x Hx) as [Hx0 [Hx1 Hxx]].
+        assert (nth_default _ _ _ = x / 2)%N as -> by (apply ListUtil.nth_error_value_eq_nth_default; rewrite PeanoNat.Nat.add_0_r; apply Hx0).
+        intro Z. simpl in Z; inversion Z; subst p'; clear Z.
+        assert (Z: nth_default Pzero (cyclotomic_decomposition n (S i)) (k + (k + 0)) = posicyclic (Nat.pow 2 (n - (S i))) (zeta ^ (x/2))).
+        { apply ListUtil.nth_error_value_eq_nth_default.
+          unfold cyclotomic_decomposition. rewrite nth_error_map.
+          cbn [Nat.mul] in Hx0. rewrite Hx0. simpl. reflexivity. }
+        rewrite Z in *; clear Z.
+        assert (Z: nth_default Pzero (cyclotomic_decomposition n (S i)) (k + (k + 0) + 1) = posicyclic (Nat.pow 2 (n - (S i))) (zeta ^ (2^km1 + x/2))).
+        { apply ListUtil.nth_error_value_eq_nth_default.
+          unfold cyclotomic_decomposition. rewrite nth_error_map.
+          cbn [Nat.mul] in Hx1. rewrite Hx1. simpl. reflexivity. }
+        rewrite Z in *; clear Z.
+        set (d1 := (posicyclic (Nat.pow 2 (n - S i)) (zeta ^ (x / 2)))).
+        set (d2 := (posicyclic (Nat.pow 2 (n - S i)) (zeta ^ (2 ^ km1 + x / 2)))).
+        assert (Hd2: Peq d2 (negacyclic (Nat.pow 2 (n - S i)) (zeta ^ (x / 2)))).
+        { unfold d2. rewrite <- neg_zeta_power_eq, Polynomial.posicyclic_opp. reflexivity. }
+        set (pmul := (posicyclic (Nat.pow 2 (n - i)) (zeta ^ x))).
+        assert (coprime d1 d2 /\ Peq pmul (Pmul d1 d2)) as [Hcoprime Hpmul].
+        { destruct (cyclotomic_decomposition_S i Hle k d1 d2 ltac:(unfold cyclotomic_decomposition; rewrite nth_error_map, Hx0; reflexivity) ltac:(unfold cyclotomic_decomposition; rewrite nth_error_map, Hx1; reflexivity)) as [HA HB].
+          split; auto. destruct HB as [pp [HB1 HB2]]. rewrite <- HB2.
+          unfold cyclotomic_decomposition in HB1. rewrite nth_error_map, Hx in HB1.
+          simpl in HB1. unfold pmul; congruence. }
+        assert (Hngt0 : Nat.pow 2 (n - S i) > 0) by (generalize (NatUtil.pow_nonzero 2 (n - S i) ltac:(Lia.lia)); Lia.lia).
+        assert (Hanz : zeta ^ (x / 2) <> 0) by (apply zeta_pow_nz).
+        replace (Nat.pow 2 (n - i)) with (2 * Nat.pow 2 (n - S i))%nat in Hpp by (rewrite <- PeanoNat.Nat.pow_succ_r'; f_equal; Lia.lia).
+        rewrite Hxx, <- F.pow_pow_l, F.pow_2_r, F.pow_mul_l in Hpp.
+        generalize (Polynomial.NTT_base_psi_phi_id (poly_defs:=poly_defs) (Nat.pow 2 (n - S i)) (zeta ^(x / 2)) _ _ _ Hngt0 Hanz ltac:(reflexivity) ltac:(reflexivity) ltac:(reflexivity) (exist _ p Hpp)).
+        unfold Polynomial.eq1, Polynomial.to_P. simpl.
+        inversion Hp1; inversion Hp2.
+        intro X. etransitivity; eauto.
+        apply Polynomial.peq_NTT_base_psi_unpacked_proper; [reflexivity|].
+        apply Polynomial.peq_mod_proper; [reflexivity|].
+        fold d2. apply Hd2.
+    Qed.
+
+    Lemma NTT_psi_layer_inj (i: nat) (Hle: (S i <= N.to_nat km1)):
+      forall (a b : Pquotl (cyclotomic_decomposition n (S i))),
+        Polynomial.eql (NTT_psi_layer i Hle a) (NTT_psi_layer i Hle b) <->
+        Polynomial.eql a b.
+    Proof.
+      intros a b. split.
+      - destruct a as [a Ha]. destruct b as [b Hb].
+        unfold Polynomial.eql; simpl.
+        unfold NTT_psi_layer_aux.
+        repeat rewrite <- ListUtil.eq_flat_map_fold_left.
+        do 2 rewrite Forall2_nth_error_iff.
+        rewrite (flat_map_constant_length (c:=1%nat)) by reflexivity.
+        rewrite (flat_map_constant_length (c:=1%nat)) by reflexivity.
+        intros [_ HH].
+        rewrite (Forall2_length Ha), (Forall2_length Hb).
+        split; [reflexivity|]. intros k v1 v2 Hv1 Hv2.
+        set (k1 := PeanoNat.Nat.div k 2).
+        set (r1 := PeanoNat.Nat.modulo k 2).
+        assert (Hkeq: (k = 2 * k1 + r1)%nat) by (rewrite (PeanoNat.Nat.Div0.div_mod k 2); reflexivity).
+        set (k' := (2 * k1 + (1 - r1))%nat).
+        assert (Hr1: (r1 = 0 \/ r1 = 1)%nat).
+        { generalize (PeanoNat.Nat.mod_upper_bound k 2 ltac:(Lia.lia)). Lia.lia. }
+        assert (Hk1': k1 = PeanoNat.Nat.div k' 2).
+        { eapply PeanoNat.Nat.div_unique; [|reflexivity]. Lia.lia. }
+        assert (Hr1': PeanoNat.Nat.modulo k' 2 = (1 - r1)%nat).
+        { symmetry; eapply PeanoNat.Nat.mod_unique; [|reflexivity]. Lia.lia. }
+        apply Forall2_nth_error_iff in Ha.
+        destruct Ha as [Hal Ha].
+        apply Forall2_nth_error_iff in Hb.
+        destruct Hb as [Hbl Hb].
+        assert (Hklt: (k < 2 * Nat.pow 2 i)) by (apply ListUtil.nth_error_value_length in Hv1; rewrite Hal, cyclotomic_decomposition_length, PeanoNat.Nat.pow_succ_r' in Hv1; Lia.lia).
+        assert (Hklt1: (k1 < Nat.pow 2 i)) by Lia.lia.
+        destruct (ListUtil.nth_error_length_exists_value k1 (cyclotomic_decomposition n i) ltac:(rewrite cyclotomic_decomposition_length; Lia.lia)) as [p Hpeq].
+        destruct (ListUtil.nth_error_length_exists_value k (cyclotomic_decomposition n (S i)) ltac:(rewrite cyclotomic_decomposition_length, PeanoNat.Nat.pow_succ_r'; Lia.lia)) as [p1 Hpeq1].
+        destruct (ListUtil.nth_error_length_exists_value k' (cyclotomic_decomposition n (S i)) ltac:(rewrite cyclotomic_decomposition_length, PeanoNat.Nat.pow_succ_r'; Lia.lia)) as [p2 Hpeq2].
+        assert (HX: exists k,
+                   Peq (if (Decidable.dec_eq_nat r1 0) then p1 else p2)
+                     (posicyclic (Nat.pow 2 (n - S i)) (zeta^k)) /\
+                     Peq (if (Decidable.dec_eq_nat r1 0) then p2 else p1)
+                       (negacyclic (Nat.pow 2 (n - S i)) (zeta^k)) /\
+                     Peq p (posicyclic (2 * Nat.pow 2 (n - S i)) (zeta^k * zeta^k))).
+        { generalize (cyclotomic_decomposition_S_chunks2 i Hle).
+          intros Hchunks. apply Forall2_nth_error_iff in Hchunks.
+          destruct Hchunks as [Hlchunks Hchunks].
+          assert (exists ll, nth_error (chunks2 (cyclotomic_decomposition n (S i))) k1 = Some ll) as [ll Hll].
+          { generalize (chunks2_nth_error (cyclotomic_decomposition n (S i)) k).
+            fold k1. rewrite Hpeq1. destruct (nth_error (chunks2 _) k1); simpl; [|congruence].
+            exists l; reflexivity. }
+          destruct (Hchunks k1 _ _ Hpeq Hll) as [p1' [p2' [Hlleq [Hco [Hpmul X]]]]]; subst ll.
+          rewrite (chunks2_nth_error) in Hpeq1, Hpeq2.
+          fold k1 in Hpeq1. rewrite <- Hk1' in Hpeq2. rewrite Hll in Hpeq1, Hpeq2.
+          cbn [Option.bind] in Hpeq1, Hpeq2.
+          fold r1 in Hpeq1. rewrite Hr1' in Hpeq2.
+          assert (Y: p1' = (if (Decidable.dec_eq_nat r1 0) then p1 else p2) /\ (p2' = if (Decidable.dec_eq_nat r1 0) then p2 else p1)) by (destruct Hr1 as [Hr1|Hr1]; rewrite Hr1 in Hpeq1, Hpeq2; simpl in Hpeq1, Hpeq2; destruct (Decidable.dec_eq_nat r1 0); try Lia.lia; split; congruence).
+          destruct Y; subst p1'; subst p2'.
+          destruct X as [kk [HA [HB HC]]].
+          exists kk. destruct (Decidable.dec_eq_nat r1 0); repeat split; assumption. }
+        destruct HX as [x [Hpdef1 [Hpdef2 Hpmul]]].
+        destruct (ListUtil.nth_error_length_exists_value k' a ltac:(rewrite Hal, cyclotomic_decomposition_length, PeanoNat.Nat.pow_succ_r'; Lia.lia)) as [u1 Hu1].
+        destruct (ListUtil.nth_error_length_exists_value k' b ltac:(rewrite Hbl, cyclotomic_decomposition_length, PeanoNat.Nat.pow_succ_r'; Lia.lia)) as [u2 Hu2].
+        generalize (Ha _ _ _ Hv1 Hpeq1). intros Hvp1.
+        generalize (Hb _ _ _ Hv2 Hpeq1). intros Hvp2.
+        generalize (Ha _ _ _ Hu1 Hpeq2). intros Hup1.
+        generalize (Hb _ _ _ Hu2 Hpeq2). intros Hup2.
+        assert (Hvu1: Peq (if Decidable.dec_eq_nat r1 0 then v1 else u1) (Pmod (if Decidable.dec_eq_nat r1 0 then v1 else u1) (if Decidable.dec_eq_nat r1 0 then p1 else p2))) by (destruct (Decidable.dec_eq_nat r1 0); auto).
+        assert (Hvu2: Peq (if Decidable.dec_eq_nat r1 0 then v2 else u2) (Pmod (if Decidable.dec_eq_nat r1 0 then v2 else u2) (if Decidable.dec_eq_nat r1 0 then p1 else p2))) by (destruct (Decidable.dec_eq_nat r1 0); auto).
+        assert (Huv1: Peq (if Decidable.dec_eq_nat r1 0 then u1 else v1) (Pmod (if Decidable.dec_eq_nat r1 0 then u1 else v1) (if Decidable.dec_eq_nat r1 0 then p2 else p1))) by (destruct (Decidable.dec_eq_nat r1 0); auto).
+        assert (Huv2: Peq (if Decidable.dec_eq_nat r1 0 then u2 else v2) (Pmod (if Decidable.dec_eq_nat r1 0 then u2 else v2) (if Decidable.dec_eq_nat r1 0 then p2 else p1))) by (destruct (Decidable.dec_eq_nat r1 0); auto).
+        generalize (proj1 (Polynomial.NTT_base_psi_inj_aux(poly_defs:=poly_defs) (Nat.pow 2 (n - S i)) (zeta ^ x) p _ _ ltac:(generalize (NatUtil.pow_nonzero 2 (n - S i) ltac:(Lia.lia)); Lia.lia) (zeta_pow_nz _) Hpmul Hpdef1 Hpdef2 _ Hvu1 _ Hvu2 _ Huv1 _ Huv2)).
+        intro AA.
+        set (ma := (flat_map (fun y : nat => [NTT_psi2 (Nat.pow 2 (n - S i)) (zeta ^ nth_default 0%N (cyclotomic_decompose (S i)) (2 * y)) (nth_default Pzero a (2 * y)) (nth_default Pzero a (2 * y + 1))]) (seq 0 (Nat.pow 2 i)))).
+        set (mb := (flat_map (fun y : nat => [NTT_psi2 (Nat.pow 2 (n - S i)) (zeta ^ nth_default 0%N (cyclotomic_decompose (S i)) (2 * y)) (nth_default Pzero b (2 * y)) (nth_default Pzero b (2 * y + 1))]) (seq 0 (Nat.pow 2 i)))).
+        generalize (ListUtil.nth_error_length_exists_value k1 ma ltac:(unfold ma; rewrite (flat_map_constant_length (c:=1%nat)), seq_length by reflexivity; Lia.lia)).
+        intros [x1 Hx1].
+        generalize (ListUtil.nth_error_length_exists_value k1 mb ltac:(unfold mb; rewrite (flat_map_constant_length (c:=1%nat)), seq_length by reflexivity; Lia.lia)).
+        intros [x2 Hx2].
+        generalize (HH _ _ _ Hx1 Hx2). intros Hxx.
+        eapply (@flat_map_constant_nth_error _ _ 1%nat) in Hx1; [|reflexivity].
+        eapply (@flat_map_constant_nth_error _ _ 1%nat) in Hx2; [|reflexivity].
+        rewrite PeanoNat.Nat.div_1_r, PeanoNat.Nat.mod_1_r in Hx1.
+        rewrite PeanoNat.Nat.div_1_r, PeanoNat.Nat.mod_1_r in Hx2.
+        cbn [nth_error] in Hx1, Hx2.
+        rewrite ListUtil.nth_error_seq in Hx1, Hx2.
+        rewrite PeanoNat.Nat.add_0_l in Hx1, Hx2.
+        destruct (Compare_dec.lt_dec k1 (Nat.pow 2 i)) as [_|]; [|contradiction].
+        destruct Hx1 as [kk [Hkk Hx1]].
+        inversion Hkk; subst kk; clear Hkk.
+        destruct Hx2 as [kk [Hkk Hx2]].
+        inversion Hkk; subst kk; clear Hkk.
+        assert (Hx: zeta ^ nth_default 0%N (cyclotomic_decompose (S i)) (2 * k1) = zeta ^ x).
+        { assert (2 * k1 = if (Decidable.dec_eq_nat r1 0) then k else k')%nat as -> by (destruct (Decidable.dec_eq_nat r1 0); destruct Hr1; Lia.lia).
+          unfold cyclotomic_decomposition in Hpeq1, Hpeq2.
+          rewrite nth_error_map in Hpeq1, Hpeq2.
+          destruct (nth_error (cyclotomic_decompose (S i)) k) as [xk|] eqn:Hxk; simpl in Hpeq1; [|congruence].
+          destruct (nth_error (cyclotomic_decompose (S i)) k') as [xk'|] eqn:Hxk'; simpl in Hpeq2; [|congruence].
+          assert (nth_default 0%N (cyclotomic_decompose (S i)) (if Decidable.dec_eq_nat r1 0 then k else k') = if Decidable.dec_eq_nat r1 0 then xk else xk') as -> by (destruct (Decidable.dec_eq_nat r1 0); apply ListUtil.nth_error_value_eq_nth_default; auto).
+          assert (p1 = (posicyclic (Nat.pow 2 (n - S i)) (zeta ^ xk))) by congruence. subst p1.
+          assert (p2 = (posicyclic (Nat.pow 2 (n - S i)) (zeta ^ xk'))) by congruence; subst p2.
+          destruct (Decidable.dec_eq_nat r1 0).
+          - generalize (Hpdef1 0%nat).
+            unfold posicyclic. intro X.
+            repeat rewrite (Polynomial.sub_definition (base _)) in X.
+            rewrite Polynomial.base_definition, Polynomial.const_definition, Polynomial.const_definition in X.
+            generalize (NatUtil.pow_nonzero 2 (n - S i) ltac:(Lia.lia)); intro; destruct (Decidable.dec_eq_nat (Nat.pow 2 (n - S i)) 0); try Lia.lia.
+            rewrite Hierarchy.ring_sub_definition, Hierarchy.left_identity in X.
+            rewrite Hierarchy.ring_sub_definition, Hierarchy.left_identity in X.
+            apply Group.inv_bijective. auto.
+          - generalize (Hpdef1 0%nat).
+            unfold posicyclic. intro X.
+            repeat rewrite (Polynomial.sub_definition (base _)) in X.
+            rewrite Polynomial.base_definition, Polynomial.const_definition, Polynomial.const_definition in X.
+            generalize (NatUtil.pow_nonzero 2 (n - S i) ltac:(Lia.lia)); intro; destruct (Decidable.dec_eq_nat (Nat.pow 2 (n - S i)) 0); try Lia.lia.
+            rewrite Hierarchy.ring_sub_definition, Hierarchy.left_identity in X.
+            rewrite Hierarchy.ring_sub_definition, Hierarchy.left_identity in X.
+            apply Group.inv_bijective. auto. }
+        rewrite Hx in *.
+        replace (2 * k1 + 1)%nat with (if Decidable.dec_eq_nat r1 0 then k' else k)%nat in Hx1, Hx2 by (destruct (Decidable.dec_eq_nat r1 0); Lia.lia).
+        replace (2 * k1)%nat with (if Decidable.dec_eq_nat r1 0 then k else k')%nat in Hx1, Hx2 by (destruct (Decidable.dec_eq_nat r1 0); Lia.lia).
+        destruct (Decidable.dec_eq_nat r1 0); apply AA.
+        + do 2 (erewrite ListUtil.nth_error_value_eq_nth_default in Hx1; [|eassumption]).
+          do 2 (erewrite ListUtil.nth_error_value_eq_nth_default in Hx2; [|eassumption]).
+          congruence.
+        + do 2 (erewrite ListUtil.nth_error_value_eq_nth_default in Hx1; [|eassumption]).
+          do 2 (erewrite ListUtil.nth_error_value_eq_nth_default in Hx2; [|eassumption]).
+          congruence.
+      - intros Heq. rewrite Heq. reflexivity.
+    Qed.
+
+    Lemma NTT_phi_psi_layer (i: nat) (Hle: S i <= N.to_nat km1) pl:
+      Polynomial.eql (NTT_phi_layer i (NTT_psi_layer i Hle pl)) pl.
+    Proof.
+      apply (proj1 (NTT_psi_layer_inj i Hle _ _)).
+      rewrite NTT_psi_phi_layer. reflexivity.
+    Qed.
+
+    Lemma NTT_psi_phi (i: nat) (Hle: i <= N.to_nat km1) pl:
+      Polynomial.eql (NTT_psi i Hle (NTT_phi i pl)) pl.
+    Proof.
+      induction i.
+      - rewrite NTT_phi_0. apply NTT_psi_0.
+      - assert (Hle': i <= N.to_nat km1) by Lia.lia.
+        rewrite (NTT_psi_S i Hle _ Hle'), NTT_phi_S.
+        rewrite NTT_psi_phi_layer. apply IHi.
+    Qed.
+
+    Lemma NTT_phi_psi (i: nat) (Hle: i <= N.to_nat km1) pl:
+      Polynomial.eql (NTT_phi i (NTT_psi i Hle pl)) pl.
+    Proof.
+      induction i.
+      - rewrite NTT_phi_0. apply NTT_psi_0.
+      - assert (Hle': i <= N.to_nat km1) by Lia.lia.
+        rewrite (NTT_psi_S _ Hle _ Hle'). rewrite NTT_phi_S.
+        rewrite IHi. apply NTT_phi_psi_layer.
+    Qed.
+
+    Lemma NTT_phi_layer_opp (i: nat) (Hle: i <= N.to_nat km1):
+      forall a : Pquotl (cyclotomic_decomposition n i),
+        Polynomial.eql (NTT_phi_layer i (Polynomial.oppl a)) (Polynomial.oppl (NTT_phi_layer i a)).
+    Proof.
+      intros a. destruct a as [a Ha].
+      unfold Polynomial.eql; simpl. unfold NTT_phi_layer_aux.
+      do 2 rewrite <- ListUtil.eq_flat_map_fold_left.
+      rewrite ListUtil.map_flat_map.
+      apply Forall2_flat_map; [reflexivity|].
+      intros k Hk. cbn [map].
+      apply in_seq in Hk.
+      repeat rewrite (ListUtil.map_nth_default _ _ _ _ Pzero) by (rewrite (Forall2_length Ha), cyclotomic_decomposition_length; Lia.lia).
+      repeat constructor; rewrite <- (Polynomial.Pmod_opp (poly_defs:=poly_defs)); apply (Polynomial.peq_mod_proper); try reflexivity.
+    Qed.
+
+    Lemma NTT_phi_layer_add (i: nat) (Hle: i <= N.to_nat km1):
+      forall a b : Pquotl (cyclotomic_decomposition n i),
+        Polynomial.eql (NTT_phi_layer i (Polynomial.addl a b))
+          (Polynomial.addl (NTT_phi_layer i a) (NTT_phi_layer i b)).
+    Proof.
+      intros a b. destruct a as [a Ha]. destruct b as [b Hb].
+      unfold Polynomial.eql; simpl. unfold NTT_phi_layer_aux.
+      repeat rewrite <- ListUtil.eq_flat_map_fold_left.
+      rewrite flat_map_map2 by reflexivity. simpl.
+      apply Forall2_flat_map; [reflexivity|].
+      intros k Hk. apply in_seq in Hk. rewrite PeanoNat.Nat.add_0_l in Hk.
+      repeat constructor; rewrite <- (Polynomial.Pmod_distr); apply Polynomial.peq_mod_proper; try reflexivity; rewrite (ListUtil.nth_default_map2 _ _ _ _ _ Pzero Pzero), (Forall2_length Ha), (Forall2_length Hb), PeanoNat.Nat.min_id, cyclotomic_decomposition_length; destruct (Compare_dec.lt_dec _ _); try Lia.lia; reflexivity.
+    Qed.
+
+    Lemma NTT_phi_layer_sub (i: nat) (Hle: i <= N.to_nat km1):
+      forall a b : Pquotl (cyclotomic_decomposition n i),
+        Polynomial.eql (NTT_phi_layer i (Polynomial.subl a b))
+          (Polynomial.subl (NTT_phi_layer i a) (NTT_phi_layer i b)).
+    Proof.
+      intros a b. rewrite Hierarchy.ring_sub_definition.
+      rewrite (@Hierarchy.ring_sub_definition _ _ _ _ _ _ _ _ (Polynomial.PquotlRing (poly_defs:=poly_defs) (field:=field) (ql:=cyclotomic_decomposition n (S i))).(Hierarchy.commutative_ring_ring)).
+      rewrite NTT_phi_layer_add, NTT_phi_layer_opp by Lia.lia.
+      reflexivity.
+    Qed.
+
+    Lemma NTT_phi_layer_mul (i: nat) (Hle: S i <= N.to_nat km1):
+      forall a b : Pquotl (cyclotomic_decomposition n i),
+        Polynomial.eql (NTT_phi_layer i (Polynomial.mull a b))
+          (Polynomial.mull (NTT_phi_layer i a) (NTT_phi_layer i b)).
+    Proof.
+      intros a b. destruct a as [a Ha]. destruct b as [b Hb].
+      unfold Polynomial.eql; simpl. unfold NTT_phi_layer_aux.
+      repeat rewrite <- ListUtil.eq_flat_map_fold_left.
+      rewrite flat_map_map2 by reflexivity. cbn [ListUtil.List.map2].
+      unfold cyclotomic_decomposition at 9. cbn [cyclotomic_decompose].
+      rewrite ListUtil.map_flat_map. simpl.
+      assert (cyclotomic_decompose i = map (fun k => nth_default 0%N (cyclotomic_decompose i) k) (seq 0 (Nat.pow 2 i))) as Hgen.
+      { apply nth_error_ext; intros.
+        rewrite nth_error_map, ListUtil.nth_error_seq.
+        destruct (Compare_dec.lt_dec _ _); simpl.
+        - apply ListUtil.nth_error_Some_nth_default.
+          rewrite cyclotomic_decompose_length. Lia.lia.
+        - apply ListUtil.nth_error_length_error.
+          rewrite cyclotomic_decompose_length. Lia.lia. }
+      rewrite Hgen, ListUtil.flat_map_map.
+      rewrite flat_map_map2 by reflexivity. simpl.
+      apply Forall2_flat_map; [reflexivity|].
+      intros x Hx. apply in_seq in Hx.
+      rewrite (ListUtil.nth_default_map2 _ _ _ _ _ Pzero Pzero).
+      rewrite ListUtil.map2_length, (Forall2_length Ha), (Forall2_length Hb), PeanoNat.Nat.min_id, PeanoNat.Nat.min_id, cyclotomic_decomposition_length.
+      destruct (Compare_dec.lt_dec x (Nat.pow 2 i)) as [_|]; [|Lia.lia].
+      rewrite (ListUtil.nth_default_map2 _ _ _ _ _ Pzero Pzero).
+      rewrite (Forall2_length Ha), (Forall2_length Hb), PeanoNat.Nat.min_id, cyclotomic_decomposition_length.
+      destruct (Compare_dec.lt_dec x (Nat.pow 2 i)) as [_|]; [|Lia.lia].
+      assert (x + (x + 0) = 2 * x)%nat as -> by Lia.lia.
+      assert (Hdiv1: PeanoNat.Nat.div (2 * x) 2 = x) by (symmetry; apply (PeanoNat.Nat.div_unique _ _ _ O); Lia.lia).
+      assert (Hdiv2: PeanoNat.Nat.div (2 * x + 1) 2 = x) by (symmetry; apply (PeanoNat.Nat.div_unique _ _ _ 1); Lia.lia).
+      assert (Hmod1: (PeanoNat.Nat.modulo (2 * x) 2 = 0)%nat) by (symmetry; apply (PeanoNat.Nat.mod_unique _ _ x O); Lia.lia).
+      assert (Hmod2: (PeanoNat.Nat.modulo (2 * x + 1) 2 = 1)%nat) by (symmetry; apply (PeanoNat.Nat.mod_unique _ _ x 1); Lia.lia).
+      generalize (proj1 (ListUtil.Forall2_forall_iff _ _ _ Pzero Pzero (Forall2_length Ha)) Ha x ltac:(rewrite (Forall2_length Ha), cyclotomic_decomposition_length; Lia.lia)); intro Hax.
+      unfold cyclotomic_decomposition in Hax. erewrite (ListUtil.map_nth_default _ _ _ _ 0%N) in Hax by (rewrite cyclotomic_decompose_length; Lia.lia).
+      generalize (proj1 (ListUtil.Forall2_forall_iff _ _ _ Pzero Pzero (Forall2_length Hb)) Hb x ltac:(rewrite (Forall2_length Hb), cyclotomic_decomposition_length; Lia.lia)); intro Hbx.
+      unfold cyclotomic_decomposition in Hbx. erewrite (ListUtil.map_nth_default _ _ _ _ 0%N) in Hbx by (rewrite cyclotomic_decompose_length; Lia.lia).
+      assert (nth_default Pzero (cyclotomic_decomposition n (S i)) (2 * x) = posicyclic (Nat.pow 2 (n - S i)) (zeta ^ (nth_default 0%N (cyclotomic_decompose i) x / 2)) /\ (nth_default Pzero (cyclotomic_decomposition n (S i)) (2 * x + 1)) = (posicyclic (Nat.pow 2 (n - S i)) (zeta ^ (2 ^ km1 + nth_default 0%N (cyclotomic_decompose i) x / 2)))) as [-> ->].
+      { unfold cyclotomic_decomposition. cbn [cyclotomic_decompose].
+        rewrite ListUtil.map_flat_map.
+        assert (flat_map _ (cyclotomic_decompose i) = flat_map _ (map _ (seq _ _))) as -> by (rewrite Hgen; reflexivity).
+        rewrite ListUtil.flat_map_map. cbn [map].
+        split; apply ListUtil.nth_error_value_eq_nth_default;
+        match goal with
+        | |- nth_error ?m ?j = _ =>
+            generalize (ListUtil.nth_error_length_exists_value j m ltac:(rewrite (flat_map_constant_length (c:=2%nat)), seq_length by reflexivity; Lia.lia))
+        end;
+        intros [y Hy]; rewrite Hy;
+        (apply (@flat_map_constant_nth_error _ _ 2%nat) in Hy; [|reflexivity]);
+        [rewrite Hdiv1, Hmod1 in Hy|rewrite Hdiv2, Hmod2 in Hy];
+        cbn [nth_error] in Hy;
+        rewrite ListUtil.nth_error_seq, PeanoNat.Nat.add_0_l in Hy;
+        (destruct (Compare_dec.lt_dec x (Nat.pow 2 i)) as [_|]; [|Lia.lia]);
+        destruct Hy as [y' [Hy' Hy]]; inversion Hy'; subst y'; clear Hy'; congruence. }
+      assert (nth_default Pzero (cyclotomic_decomposition n i) x = posicyclic (Nat.pow 2 (n - i)) (zeta ^ (nth_default 0%N (cyclotomic_decompose i) x))) as ->.
+      { unfold cyclotomic_decomposition.
+        erewrite ListUtil.map_nth_default; [reflexivity|].
+        rewrite cyclotomic_decompose_length; Lia.lia. }
+      set (p := (posicyclic (Nat.pow 2 (n - i)) (zeta ^ nth_default 0%N (cyclotomic_decompose i) x))).
+      set (p1 := (posicyclic (Nat.pow 2 (n - S i)) (zeta ^ (nth_default 0%N (cyclotomic_decompose i) x / 2)))).
+      set (p2 := (posicyclic (Nat.pow 2 (n - S i)) (zeta ^ (2 ^ km1 + nth_default 0%N (cyclotomic_decompose i) x / 2)))).
+      assert (Hpeq : Peq p (posicyclic (2 * Nat.pow 2 (n - S i)) (zeta ^ (nth_default 0%N (cyclotomic_decompose i) x / 2) * zeta ^ (nth_default 0%N (cyclotomic_decompose i) x / 2)))).
+      { rewrite <- PeanoNat.Nat.pow_succ_r'.
+        assert (S (n - S i) = n - i)%nat as -> by Lia.lia.
+        rewrite <- F.pow_add_r.
+        assert ((nth_default 0%N (cyclotomic_decompose i) x / 2) + (nth_default 0%N (cyclotomic_decompose i) x / 2) = 2 * (nth_default 0%N (cyclotomic_decompose i) x / 2))%N as -> by Lia.lia.
+        rewrite <- (proj2 (N.Div0.div_exact (nth_default 0%N (cyclotomic_decompose i) x) 2)); [reflexivity|].
+        apply N.Div0.mod_divides.
+        assert (Hin: (In (nth_default 0%N (cyclotomic_decompose i) x) (cyclotomic_decompose i))) by (eapply nth_error_In; apply ListUtil.nth_error_Some_nth_default; rewrite cyclotomic_decompose_length; Lia.lia).
+        generalize (cyclotomic_decompose_mod i ltac:(Lia.lia) (nth_default 0%N (cyclotomic_decompose i) x) Hin); intros [HA _].
+        apply N.Div0.mod_divides in HA.
+        destruct HA as [d HA]. rewrite HA.
+        assert (km1 - N.of_nat i = N.succ (km1 - N.of_nat (S i)))%N as -> by Lia.lia.
+        rewrite N.pow_succ_r'. exists (2 ^ (km1 - N.of_nat (S i)) * d)%N. Lia.lia. }
+      assert (Hpeq1 : Peq p1 (posicyclic (Nat.pow 2 (n - S i)) (zeta ^ (nth_default 0%N (cyclotomic_decompose i) x / 2)))) by reflexivity.
+      assert (Hpeq2 : Peq p2 (negacyclic (Nat.pow 2 (n - S i)) (zeta ^ (nth_default 0%N (cyclotomic_decompose i) x / 2)))).
+      { rewrite <- Polynomial.posicyclic_opp.
+        rewrite neg_zeta_power_eq. reflexivity. }
+      destruct (Polynomial.NTT_ring_isomorphism2 (poly_defs:=poly_defs) (Nat.pow 2 (n - S i)) (zeta ^ (nth_default 0%N (cyclotomic_decompose i) x / 2)) p p1 p2 ltac:(generalize (NatUtil.pow_nonzero 2 (n - S i) ltac:(Lia.lia)); Lia.lia) ltac:(apply zeta_pow_nz) Hpeq Hpeq1 Hpeq2) as [_ [hom1 hom2]].
+      generalize (hom1.(Ring.homomorphism_mul) (exist _ (nth_default Pzero a x) Hax) (exist _ (nth_default Pzero b x) Hbx)).
+      unfold Polynomial.EQ2, Polynomial.eq1; simpl. intros [XA XB].
+      repeat constructor; [apply XA|apply XB].
+    Qed.
+
+    Lemma NTT_layer_homomorphism (i: nat) (Hle: S i <= N.to_nat km1):
+      @Ring.is_homomorphism
+        (Pquotl (cyclotomic_decomposition n (S i)))
+        Polynomial.eql Polynomial.onel Polynomial.addl Polynomial.mull
+        (Pquotl (cyclotomic_decomposition n i))
+        Polynomial.eql Polynomial.onel Polynomial.addl Polynomial.mull
+        (NTT_psi_layer i Hle) /\
+      @Ring.is_homomorphism
+        (Pquotl (cyclotomic_decomposition n i))
+        Polynomial.eql Polynomial.onel Polynomial.addl Polynomial.mull
+        (Pquotl (cyclotomic_decomposition n (S i)))
+        Polynomial.eql Polynomial.onel Polynomial.addl Polynomial.mull
+        (NTT_phi_layer i).
+    Proof.
+      eapply Ring.ring_by_isomorphism.
+      - apply NTT_phi_psi_layer.
+      - intros a b. split; intros HEQ.
+        + rewrite <- (NTT_psi_phi_layer i Hle a), <- (NTT_psi_phi_layer i Hle b).
+          apply NTT_psi_layer_inj; auto.
+        + rewrite HEQ. reflexivity.
+      - instantiate (1:=Polynomial.zerol).
+        unfold Polynomial.eql; simpl. unfold NTT_phi_layer_aux.
+        rewrite <- ListUtil.eq_flat_map_fold_left.
+        apply Forall2_nth_error_iff.
+        rewrite (flat_map_constant_length (c:=2%nat)); [|reflexivity].
+        rewrite repeat_length, seq_length, cyclotomic_decomposition_length, PeanoNat.Nat.pow_succ_r'.
+        split; [Lia.lia|].
+        intros k v1 v2 Hv1 Hv2. apply ListUtil.nth_error_repeat in Hv2.
+        subst v2. apply (@flat_map_constant_nth_error _ _ 2%nat) in Hv1; [|reflexivity].
+        destruct Hv1 as [k' [Hk' Hv1]].
+        assert (Hp: nth_default Pzero (repeat Pzero (length (cyclotomic_decomposition n i))) k' = Pzero).
+        { rewrite ListUtil.nth_default_repeat.
+          destruct (Decidable.dec _); reflexivity. }
+        rewrite Hp in Hv1.
+        generalize (NatUtil.mod_bound_lt k 2 ltac:(Lia.lia)). intro Hklt.
+        destruct (PeanoNat.Nat.modulo k 2); [simpl in Hv1; inversion Hv1; subst v1; rewrite Polynomial.Pmod_0_l; reflexivity|].
+        destruct n0; [|Lia.lia].
+        simpl in Hv1; inversion Hv1; subst v1; rewrite Polynomial.Pmod_0_l; reflexivity.
+      - generalize (Polynomial.of_pl_obligation_1 (poly_defs:=poly_defs) (ql:=cyclotomic_decomposition n i) (repeat Pone (length (cyclotomic_decomposition n i))) (repeat_length Pone (length _))). intro HF.
+        generalize (Polynomial.of_pl_obligation_1 (poly_defs:=poly_defs) (ql:=cyclotomic_decomposition n (S i)) (repeat Pone (length (cyclotomic_decomposition n (S i)))) (repeat_length Pone (length _))). intro HFS.
+        unfold Polynomial.eql. simpl. unfold NTT_phi_layer_aux.
+        rewrite <- ListUtil.eq_flat_map_fold_left.
+        apply Forall2_nth_error_iff.
+        rewrite (flat_map_constant_length (c:=2%nat)); [|reflexivity].
+        rewrite ListUtil.map2_length, seq_length, repeat_length, PeanoNat.Nat.min_id, cyclotomic_decomposition_length, PeanoNat.Nat.pow_succ_r'.
+        split; [Lia.lia|].
+        intros k v1 v2 Hv1 Hv2. apply (@flat_map_constant_nth_error _ _ 2%nat) in Hv1; [|reflexivity].
+        destruct Hv1 as [kk [Hkk Hv1]].
+        rewrite ListUtil.nth_error_seq, PeanoNat.Nat.add_0_l in Hkk.
+        destruct (Compare_dec.lt_dec (PeanoNat.Nat.div k 2) (Nat.pow 2 i)) as [Hkklt|]; [|congruence].
+        generalize (ListUtil.nth_error_value_length _ _ _ _ Hv2).
+        rewrite ListUtil.map2_length, repeat_length, cyclotomic_decomposition_length, PeanoNat.Nat.pow_succ_r', PeanoNat.Nat.min_id. intro Hklt.
+        assert (Peq v2 Pone) as ->.
+        { generalize (nth_error_repeat Pone Hklt). intro Hrepeat.
+          generalize (ListUtil.nth_error_length_exists_value k (cyclotomic_decomposition n (S i)) ltac:(rewrite cyclotomic_decomposition_length, PeanoNat.Nat.pow_succ_r'; Lia.lia)). intros [x Hx].
+          rewrite (nth_error_map2 _ _ _ k _ _ Hrepeat Hx) in Hv2.
+          inversion Hv2; subst v2. rewrite Polynomial.Pmod_small; [reflexivity|].
+          rewrite (Polynomial.degree_one (poly_defs:=poly_defs)).
+          rewrite (cyclotomic_decomposition_degree _ Hle _ _ Hx).
+          cbv [Polynomial.degree_lt Polynomial.convert].
+          generalize (NatUtil.pow_nonzero 2 (n - S i) ltac:(Lia.lia)). Lia.lia. }
+        assert (Peq v1 Pone) as ->; [|reflexivity].
+        assert (Hv1eq: v1 = Pmod (nth_default Pzero (ListUtil.List.map2 (fun p q0 : P => Pmod p q0) (repeat Pone (length (cyclotomic_decomposition n i))) (cyclotomic_decomposition n i)) kk) (nth_default Pzero (cyclotomic_decomposition n (S i)) (kk + (kk + 0))) \/ v1 = Pmod (nth_default Pzero (ListUtil.List.map2 (fun p q0 : P => Pmod p q0) (repeat Pone (length (cyclotomic_decomposition n i))) (cyclotomic_decomposition n i)) kk) (nth_default Pzero (cyclotomic_decomposition n (S i)) (kk + (kk + 0) + 1))) by (destruct (PeanoNat.Nat.modulo k 2) as [|n']; [simpl in Hv1; inversion Hv1; subst v1; auto|destruct n' as [|n']; simpl in Hv1; [inversion Hv1; subst v1; auto|rewrite nth_error_nil in Hv1; congruence]]).
+        assert (Hone: Peq (nth_default Pzero (ListUtil.List.map2 (fun p q0 : P => Pmod p q0) (repeat Pone (length (cyclotomic_decomposition n i))) (cyclotomic_decomposition n i)) kk) Pone).
+        { assert (kk = PeanoNat.Nat.div k 2) as Hkkeq by congruence.
+          rewrite <- Hkkeq in *. rewrite cyclotomic_decomposition_length.
+          generalize (nth_error_repeat Pone Hkklt). intro Hrepeat.
+          generalize (ListUtil.nth_error_length_exists_value kk (cyclotomic_decomposition n i) ltac:(rewrite cyclotomic_decomposition_length; Lia.lia)). intros [x Hx].
+          erewrite ListUtil.nth_error_value_eq_nth_default; [|eapply nth_error_map2; eauto].
+          rewrite Polynomial.Pmod_small; [reflexivity|].
+          rewrite (Polynomial.degree_one (poly_defs:=poly_defs)).
+          rewrite (cyclotomic_decomposition_degree i ltac:(Lia.lia) _ _ Hx).
+          cbv [Polynomial.degree_lt Polynomial.convert].
+          generalize (NatUtil.pow_nonzero 2 (n - i) ltac:(Lia.lia)). Lia.lia. }
+        replace (kk + (kk + 0))%nat with (2 * kk)%nat in Hv1eq by Lia.lia.
+        assert (Hkklt2: (2 * kk + 1 < 2 * Nat.pow 2 i)).
+        { assert (kk = PeanoNat.Nat.div k 2) by congruence. Lia.lia. }
+        generalize (ListUtil.nth_error_length_exists_value (2 * kk) (cyclotomic_decomposition n (S i)) ltac:(rewrite cyclotomic_decomposition_length, PeanoNat.Nat.pow_succ_r'; Lia.lia)). intros [x1 Hx1].
+        generalize (ListUtil.nth_error_length_exists_value (2 * kk + 1) (cyclotomic_decomposition n (S i)) ltac:(rewrite cyclotomic_decomposition_length, PeanoNat.Nat.pow_succ_r'; Lia.lia)). intros [x2 Hx2].
+        rewrite (ListUtil.nth_error_value_eq_nth_default _ _ _ Hx1), (ListUtil.nth_error_value_eq_nth_default _ _ _ Hx2) in Hv1eq.
+        destruct Hv1eq; subst v1; rewrite Polynomial.Pmod_small; try apply Hone; [rewrite (cyclotomic_decomposition_degree (S i) ltac:(Lia.lia) _ _ Hx1)|rewrite (cyclotomic_decomposition_degree (S i) ltac:(Lia.lia) _ _ Hx2)]; rewrite (Polynomial.peq_proper_degree (poly_defs:=poly_defs) _ _ Hone), (Polynomial.degree_one (poly_defs:=poly_defs)); cbv [Polynomial.degree_lt Polynomial.convert]; generalize (NatUtil.pow_nonzero 2 (n - S i) ltac:(Lia.lia)); Lia.lia.
+      - apply NTT_phi_layer_opp. Lia.lia.
+      - apply NTT_phi_layer_add. Lia.lia.
+      - apply NTT_phi_layer_sub. Lia.lia.
+      - apply NTT_phi_layer_mul. Lia.lia.
+    Qed.
+
+    Local Instance NTT_psi_layer_homomorphism (i: nat) (Hle: S i <= N.to_nat km1):
+      @Ring.is_homomorphism
+        (Pquotl (cyclotomic_decomposition n (S i)))
+        Polynomial.eql Polynomial.onel Polynomial.addl Polynomial.mull
+        (Pquotl (cyclotomic_decomposition n i))
+        Polynomial.eql Polynomial.onel Polynomial.addl Polynomial.mull
+        (NTT_psi_layer i Hle).
+    Proof. apply NTT_layer_homomorphism. Qed.
+
+    Local Instance NTT_phi_layer_homomorphism (i: nat) (Hle: S i <= N.to_nat km1):
+      @Ring.is_homomorphism
+        (Pquotl (cyclotomic_decomposition n i))
+        Polynomial.eql Polynomial.onel Polynomial.addl Polynomial.mull
+        (Pquotl (cyclotomic_decomposition n (S i)))
+        Polynomial.eql Polynomial.onel Polynomial.addl Polynomial.mull
+        (NTT_phi_layer i).
+    Proof. apply NTT_layer_homomorphism; auto. Qed.
+
+    Theorem NTT_homomorphism (i: nat) (Hle: i <= N.to_nat km1):
+      @Ring.is_homomorphism
+        (Pquotl (cyclotomic_decomposition n i))
+        Polynomial.eql Polynomial.onel Polynomial.addl Polynomial.mull
+        (Pquotl (cyclotomic_decomposition n 0%nat))
+        Polynomial.eql Polynomial.onel Polynomial.addl Polynomial.mull
+        (NTT_psi i Hle) /\
+      @Ring.is_homomorphism
+        (Pquotl (cyclotomic_decomposition n 0%nat))
+        Polynomial.eql Polynomial.onel Polynomial.addl Polynomial.mull
+        (Pquotl (cyclotomic_decomposition n i))
+        Polynomial.eql Polynomial.onel Polynomial.addl Polynomial.mull
+        (NTT_phi i).
+    Proof.
+      induction i.
+      - split; constructor.
+        + constructor; [|apply eql_NTT_psi_proper].
+          intros a b. repeat rewrite (NTT_psi_0). reflexivity.
+        + intros a b. repeat rewrite (NTT_psi_0). reflexivity.
+        + rewrite (NTT_psi_0). reflexivity.
+        + constructor; [|apply eql_NTT_phi_proper].
+          intros a b. reflexivity.
+        + intros a b. reflexivity.
+        + reflexivity.
+      - assert (Hle': i <= N.to_nat km1) by Lia.lia.
+        specialize (IHi Hle').
+        split; [destruct IHi as [[Hpsi_add Hpsi_mul Hpsi_one] _]|destruct IHi as [_ [Hphi_add Hphi_mul Hphi_one]]]; constructor.
+        + constructor; [|apply eql_NTT_psi_proper].
+          intros a b. do 3 rewrite (NTT_psi_S _ _ _ Hle').
+          rewrite <- Monoid.homomorphism, (NTT_psi_layer_homomorphism i Hle).(Ring.homomorphism_is_homomorphism).(Monoid.homomorphism).
+          reflexivity.
+        + intros a b. do 3 rewrite (NTT_psi_S _ _ _ Hle').
+          rewrite <- Hpsi_mul, (NTT_psi_layer_homomorphism i Hle).(Ring.homomorphism_mul).
+          reflexivity.
+        + rewrite (NTT_psi_S _ _ _ Hle').
+          rewrite (NTT_psi_layer_homomorphism i Hle).(Ring.homomorphism_one).
+          apply Hpsi_one.
+        + constructor; [|apply eql_NTT_phi_proper].
+          intros a b. do 3 rewrite NTT_phi_S.
+          rewrite <- (NTT_phi_layer_homomorphism i Hle).(Ring.homomorphism_is_homomorphism).(Monoid.homomorphism), <- Monoid.homomorphism.
+          reflexivity.
+        + intros a b. do 3 rewrite NTT_phi_S.
+          rewrite <- (NTT_phi_layer_homomorphism i Hle).(Ring.homomorphism_mul), <- Hphi_mul.
+          reflexivity.
+        + rewrite NTT_phi_S, Hphi_one, (NTT_phi_layer_homomorphism i Hle).(Ring.homomorphism_one).
+          reflexivity.
+    Qed.
+
+  End NTT.
+
+End CyclotomicDecomposition.
+
+Section SanityCheck.
+  Local Definition bitrev (n: nat) (i: N): N :=
+    let fix aux k := match k with
+                     | O => if N.testbit i 0%N then N.setbit 0%N (N.of_nat (n - 1)%nat) else 0%N
+                     | S k' => if N.testbit i (N.of_nat k) then N.setbit (aux k') (N.of_nat (n - 1 - k)%nat)%N else aux k'
+                     end in
+    aux (n - 1)%nat.
+
+  Local Notation bitrev8 := (bitrev 8%nat). (* Dilithium *)
+  Local Notation bitrev7 := (bitrev 7%nat). (* Kyber *)
+
+  (* Making sure the decomposition returns the same order expected by ML-DSA
+     aka Dilithium *)
+  (* See Section 7.5 of https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.204.pdf *)
+  Local Lemma dilithium_ok:
+    (@cyclotomic_decompose 8%N 8%nat) = List.map (fun k => (2 * (bitrev8 (N.of_nat k)) + 1)%N) (seq 0 256%nat).
+  Proof. reflexivity. Qed.
+
+  (* Making sure the decomposition returns the same order expected by ML-KEM
+     aka Kyber *)
+  (* See Section 4.3 of https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.203.pdf *)
+  Local Lemma kyber_ok:
+    (@cyclotomic_decompose 7%N 7%nat) = List.map (fun k => (2 * (bitrev7 (N.of_nat k)) + 1)%N) (seq 0 128%nat).
+  Proof. reflexivity. Qed.
+End SanityCheck.

--- a/src/NTT/CyclotomicDecomposition.v
+++ b/src/NTT/CyclotomicDecomposition.v
@@ -12,6 +12,13 @@ Require Import coqutil.Datatypes.List.
 
 Section Utils.
   (* These should be moved to ListUtil ? Maybe ? *)
+  Lemma nth_error_cons {A: Type} (x: A) xs n:
+    nth_error (x :: xs) n = match n with
+                           | O => Some x
+                           | S n => nth_error xs n
+                           end.
+  Proof. destruct n; reflexivity. Qed.
+
   Lemma fold_right_eq_ext {A B: Type} {eq: A->A->Prop}
     `{RelationClasses.Equivalence A eq}
     (f g: B -> A -> A) (v: A) (xs: list B):
@@ -35,7 +42,7 @@ Section Utils.
       apply Hl in Hz. apply ListUtil.length0_nil in Hz.
       rewrite Hz in Hzz. elim (in_nil Hzz). }
     induction l; intros Hl k x Hx; simpl in Hx.
-    - rewrite nth_error_nil in Hx; inversion Hx.
+    - rewrite ListUtil.nth_error_nil_error in Hx; inversion Hx.
     - rewrite ListUtil.nth_error_app, Hl in Hx; [|apply in_eq].
       destruct (Compare_dec.lt_dec k c).
       + rewrite PeanoNat.Nat.div_small, PeanoNat.Nat.mod_small by Lia.lia.
@@ -110,7 +117,7 @@ Section Utils.
     split.
     - intros; split; [eapply Forall2_length; eauto|].
       induction H; intros.
-      + rewrite nth_error_nil in H; congruence.
+      + rewrite ListUtil.nth_error_nil_error in H; congruence.
       + destruct k; simpl in *.
         * inversion H1; inversion H2; subst x; subst y; auto.
         * eapply IHForall2; eauto.
@@ -226,9 +233,9 @@ Section Utils.
     assert (IH: forall n (xs: list A), (length xs <= n) -> forall k : nat, nth_error xs k = Option.bind (nth_error (chunks2 xs) (PeanoNat.Nat.div k 2)) (fun chunk : list A => nth_error chunk (PeanoNat.Nat.modulo k 2))).
     { induction n; intros xs Hxs k.
       - destruct xs; simpl in Hxs; [|Lia.lia].
-        simpl. repeat rewrite nth_error_nil. reflexivity.
+        simpl. repeat rewrite ListUtil.nth_error_nil_error. reflexivity.
       - rewrite (PeanoNat.Nat.Div0.div_mod k 2) at 1.
-        destruct (@Decidable.dec_eq_list_nil_r _ xs) as [->|Hnn]; [simpl; repeat rewrite nth_error_nil; reflexivity|].
+        destruct (@Decidable.dec_eq_list_nil_r _ xs) as [->|Hnn]; [simpl; repeat rewrite ListUtil.nth_error_nil_error; reflexivity|].
         rewrite chunks2_cons; auto. rewrite nth_error_cons.
         assert (length xs = 1 \/ 2 <= length xs)%nat as [He|Hle] by (destruct xs; simpl in *; [congruence|]; Lia.lia).
         + rewrite skipn_all2 by Lia.lia. cbn [chunks2].
@@ -238,7 +245,7 @@ Section Utils.
           assert (S (S k) = k + 2)%nat as -> by Lia.lia.
           rewrite NatUtil.div_minus by Lia.lia.
           rewrite (ListUtil.nth_error_length_error _ (2 * _ + _)%nat [a]) by (simpl; Lia.lia).
-          rewrite PeanoNat.Nat.add_1_r, nth_error_nil. reflexivity.
+          rewrite PeanoNat.Nat.add_1_r, ListUtil.nth_error_nil_error. reflexivity.
         + destruct k; [simpl; destruct xs; reflexivity|].
           destruct k; [simpl; destruct xs; [reflexivity|destruct xs; reflexivity]|].
           assert (S (S k) = k + 2)%nat as -> by Lia.lia.
@@ -1712,7 +1719,7 @@ Section CyclotomicDecomposition.
         destruct pl; [cbn in Hpl1; congruence|].
         destruct pl; [|cbn in Hpl1; congruence].
         rewrite nth_error_cons in Hv1.
-        destruct k; [|rewrite nth_error_nil in Hv1; congruence].
+        destruct k; [|rewrite ListUtil.nth_error_nil_error in Hv1; congruence].
         assert (v1 = p) as -> by congruence.
         apply Forall2_cons_iff in HF. destruct HF as [Heq HF].
         rewrite (Polynomial.peq_proper_degree _ _ Heq).
@@ -2390,7 +2397,7 @@ Section CyclotomicDecomposition.
           cbv [Polynomial.degree_lt Polynomial.convert].
           generalize (NatUtil.pow_nonzero 2 (n - S i) ltac:(Lia.lia)). Lia.lia. }
         assert (Peq v1 Pone) as ->; [|reflexivity].
-        assert (Hv1eq: v1 = Pmod (nth_default Pzero (ListUtil.List.map2 (fun p q0 : P => Pmod p q0) (repeat Pone (length (cyclotomic_decomposition n i))) (cyclotomic_decomposition n i)) kk) (nth_default Pzero (cyclotomic_decomposition n (S i)) (kk + (kk + 0))) \/ v1 = Pmod (nth_default Pzero (ListUtil.List.map2 (fun p q0 : P => Pmod p q0) (repeat Pone (length (cyclotomic_decomposition n i))) (cyclotomic_decomposition n i)) kk) (nth_default Pzero (cyclotomic_decomposition n (S i)) (kk + (kk + 0) + 1))) by (destruct (PeanoNat.Nat.modulo k 2) as [|n']; [simpl in Hv1; inversion Hv1; subst v1; auto|destruct n' as [|n']; simpl in Hv1; [inversion Hv1; subst v1; auto|rewrite nth_error_nil in Hv1; congruence]]).
+        assert (Hv1eq: v1 = Pmod (nth_default Pzero (ListUtil.List.map2 (fun p q0 : P => Pmod p q0) (repeat Pone (length (cyclotomic_decomposition n i))) (cyclotomic_decomposition n i)) kk) (nth_default Pzero (cyclotomic_decomposition n (S i)) (kk + (kk + 0))) \/ v1 = Pmod (nth_default Pzero (ListUtil.List.map2 (fun p q0 : P => Pmod p q0) (repeat Pone (length (cyclotomic_decomposition n i))) (cyclotomic_decomposition n i)) kk) (nth_default Pzero (cyclotomic_decomposition n (S i)) (kk + (kk + 0) + 1))) by (destruct (PeanoNat.Nat.modulo k 2) as [|n']; [simpl in Hv1; inversion Hv1; subst v1; auto|destruct n' as [|n']; simpl in Hv1; [inversion Hv1; subst v1; auto|rewrite ListUtil.nth_error_nil_error in Hv1; congruence]]).
         assert (Hone: Peq (nth_default Pzero (ListUtil.List.map2 (fun p q0 : P => Pmod p q0) (repeat Pone (length (cyclotomic_decomposition n i))) (cyclotomic_decomposition n i)) kk) Pone).
         { assert (kk = PeanoNat.Nat.div k 2) as Hkkeq by congruence.
           rewrite <- Hkkeq in *. rewrite cyclotomic_decomposition_length.

--- a/src/NTT/MLDSA.v
+++ b/src/NTT/MLDSA.v
@@ -1,0 +1,202 @@
+Require Import Coq.ZArith.ZArith.
+Require Import Crypto.Spec.ModularArithmetic.
+Require Import Crypto.NTT.CyclotomicDecomposition.
+Require Import Crypto.NTT.BedrockNTT.
+Require Import Crypto.NTT.RupicolaMontgomeryArithmetic.
+Require Import bedrock2.BasicC64Semantics.
+Require Import Rupicola.Lib.Api.
+From Coqprime.PrimalityTest Require Import Pocklington PocklingtonCertificat.
+
+Section MLDSA.
+  Local Notation q := 8380417%positive.
+  Local Notation F := (F q).
+  Local Notation zeta := (F.of_Z q 1753%Z).
+  Local Notation n := 8%nat.
+  Local Notation km1 := 8%nat.
+  Local Notation add := "mldsa_felem_montgomery_add".
+  Local Notation sub := "mldsa_felem_montgomery_sub".
+  Local Notation mul := "mldsa_felem_montgomery_mul".
+  Local Notation from_montgomery := "mldsa_from_montgomery".
+  Local Notation to_montgomery := "mldsa_to_montgomery".
+
+  Local Notation mldsa_make_zetas := (@make_zetas q zeta).
+
+  (* Sanity check *)
+  Lemma mldsa_prime_q: prime (Z.pos q).
+  Proof.
+    apply (Pocklington_refl
+             (Pock_certif 8380417 5 ((2,13)::nil)%positive 1)
+             ((Proof_certif 2 prime_2) ::
+                nil)).
+    native_cast_no_check (refl_equal true).
+  Qed.
+
+  (* ζ^0 to ζ^256 *)
+  Definition mldsa_zetas_256 :=
+    [1%Z; 1753; 3073009; 6757063; 3602218; 4234153; 5801164; 3994671; 5010068;
+     8352605; 1528066; 5346675; 3415069; 2998219; 1356448; 6195333; 7778734;
+     1182243; 2508980; 6903432; 394148; 3747250; 7062739; 3105558; 5152541;
+     6695264; 4213992; 3980599; 5483103; 7921677; 348812; 8077412; 5178923;
+     2660408; 4183372; 586241; 5269599; 2387513; 3482206; 3363542; 4855975;
+     6400920; 7814814; 5767564; 3756790; 7025525; 4912752; 5365997; 3764867;
+     4423672; 2811291; 507927; 2071829; 3195676; 3901472; 860144; 7737789; 4829411;
+     1736313; 1665318; 2917338; 2039144; 4561790; 1900052; 3765607; 5720892;
+     5744944; 6006015; 2740543; 2192938; 5989328; 7009900; 2663378; 1009365;
+     1148858; 2647994; 7562881; 8291116; 2683270; 2358373; 2682288; 636927;
+     1937570; 2491325; 1095468; 1239911; 3035980; 508145; 2453983; 2678278;
+     1987814; 6764887; 556856; 4040196; 1011223; 4405932; 5234739; 8321269;
+     5258977; 527981; 3704823; 8111961; 7080401; 545376; 676590; 4423473; 2462444;
+     749577; 6663429; 7070156; 7727142; 2926054; 557458; 5095502; 7270901; 7655613;
+     3241972; 1254190; 2925816; 140244; 2815639; 8129971; 5130263; 1163598;
+     3345963; 7561656; 6143691; 1054478; 4808194; 6444997; 1277625; 2105286;
+     3182878; 6607829; 1787943; 8368538; 4317364; 822541; 482649; 8041997; 1759347;
+     141835; 5604662; 3123762; 3542485; 87208; 2028118; 1994046; 928749; 2296099;
+     2461387; 7277073; 1714295; 4969849; 4892034; 2569011; 3192354; 6458423;
+     8052569; 3531229; 5496691; 6600190; 5157610; 7200804; 2101410; 4768667;
+     4197502; 214880; 7946292; 1596822; 169688; 4148469; 6444618; 613238; 2312838;
+     6663603; 7375178; 6084020; 5396636; 7192532; 4361428; 2642980; 7153756;
+     3430436; 4795319; 635956; 235407; 2028038; 1853806; 6500539; 6458164; 7598542;
+     3761513; 6924527; 3852015; 6346610; 4793971; 6653329; 6125690; 3020393;
+     6705802; 5926272; 5418153; 3009748; 4805951; 2513018; 5601629; 6187330;
+     2129892; 4415111; 4564692; 6987258; 4874037; 4541938; 621164; 7826699;
+     1460718; 4611469; 5183169; 1723229; 3870317; 4908348; 6026202; 4606686;
+     5178987; 2772600; 8106357; 5637006; 1159875; 5199961; 6018354; 7609976;
+     7044481; 4620952; 5046034; 4357667; 4430364; 6161950; 7921254; 7987710;
+     7159240; 4663471; 4158088; 6545891; 2156050; 8368000; 3374250; 6866265;
+     2283733; 5925040; 3258457; 5011144; 1858416; 6201452; 1744507; 7648983;
+     -1].
+
+  Lemma mldsa_zetas_256_spec:
+    mldsa_make_zetas 256 = List.map (F.of_Z _) mldsa_zetas_256.
+  Proof.
+    pose (list_eq_strong := fix list_eq_strong A B (eqx: A -> B -> Prop) x y :=
+            match x with
+            | nil => match y with
+                    | nil => True
+                    | _ => False
+                    end
+            | x0::x1 => match y with
+                       | nil => False
+                       | y0::y1 => eqx x0 y0 /\ (eqx x0 y0 -> list_eq_strong A B eqx x1 y1)
+                       end
+            end).
+    assert (Hstrong: forall A B eq x y, list_eq_strong A B eq x y -> @ListUtil.list_eq A B eq x y).
+    { induction x; simpl; auto.
+      intros; destruct y; auto. destruct H; split; auto. }
+    apply ListUtil.list_eq_to_leq, Hstrong.
+    split; [reflexivity|intro H].
+    repeat (split; [rewrite H; rewrite <- ModularArithmeticTheorems.F.of_Z_mul; apply ModularArithmeticTheorems.F.eq_of_Z_iff; reflexivity|clear H; intro H]).
+    reflexivity.
+  Qed.
+
+  (* Sanity check ζ^(2^km1) = -1 *)
+  Lemma mldsa_zeta_km1_ok:
+    F.pow zeta (N.of_nat (Nat.pow 2 km1)) = F.of_Z _ (-1).
+  Proof.
+    assert (Nat.pow 2 km1 = 256)%nat as -> by reflexivity.
+    generalize (@make_zetas_spec q zeta 256%nat 256%nat ltac:(reflexivity)).
+    rewrite mldsa_zetas_256_spec. intro X.
+    unfold mldsa_zetas_256 in X. cbv [List.map nth_error] in X.
+    congruence.
+  Qed.
+
+  Definition mldsa_zetas := List.map (fun k => nth_default 0%F (List.map (F.of_Z q) mldsa_zetas_256) (N.to_nat k)) (@zeta_powers (N.of_nat km1) km1).
+
+  Lemma mldsa_zetas_correct:
+    mldsa_zetas = List.map (fun k => F.pow zeta k) (@zeta_powers (N.of_nat km1) km1).
+  Proof.
+    unfold mldsa_zetas. rewrite <- mldsa_zetas_256_spec.
+    apply nth_error_ext. intros.
+    do 2 rewrite ListUtil.nth_error_map.
+    destruct (nth_error (zeta_powers km1) i) as [k|] eqn:Hk; [|reflexivity].
+    cbn [option_map].
+    assert (N.to_nat k <= 256)%nat as Hk'.
+    { cbv in Hk. do 256 (destruct i as [|i]; [simpl in Hk; inversion Hk; subst k; Lia.lia|]).
+      destruct i; congruence. }
+    apply (@make_zetas_spec q zeta) in Hk'.
+    rewrite (ListUtil.nth_error_value_eq_nth_default _ _ _ Hk').
+    rewrite Nnat.N2Nat.id. reflexivity.
+  Qed.
+
+  Definition mldsa_c: F := F.of_Z _ 8347681.
+
+  Lemma mldsa_c_correct:
+    mldsa_c = F.inv (F.of_Z q (two_power_nat km1)).
+  Proof.
+    apply ModularArithmeticTheorems.F.eq_to_Z_iff.
+    reflexivity.
+  Qed.
+
+  Definition mldsa_ntt := @br2_ntt 64 (Naive.word _) q n km1 mldsa_zetas (F_to_Z (width:=64)) add sub mul.
+  Definition mldsa_inverse_ntt := @br2_ntt_inverse 64 (Naive.word _) q n km1 mldsa_c mldsa_zetas (F_to_Z (width:=64)) add sub mul.
+
+  Definition mldsa_from_montgomery := @from_montgomery_br2fn 64 (Naive.word _) q.
+  Definition mldsa_to_montgomery := @to_montgomery_br2fn1 64 (Naive.word _) q.
+  Definition mldsa_felem_add := @add_br2fn 64 (Naive.word _) q.
+  Definition mldsa_felem_sub := @sub_br2fn 64 (Naive.word _) q.
+  Definition mldsa_felem_mul := @mul_br2fn1 64 (Naive.word _) q.
+
+  Definition mldsa_funcs :=
+    [ ("mldsa_ntt", mldsa_ntt)
+    ; ("mldsa_inverse_ntt", mldsa_inverse_ntt)
+    ; (from_montgomery, mldsa_from_montgomery)
+    ; (to_montgomery, mldsa_to_montgomery)
+    ; (add, mldsa_felem_add)
+    ; (sub, mldsa_felem_sub)
+    ; (mul, mldsa_felem_mul)
+    ].
+
+  Lemma q_small: 3 <= Zpos q < 2 ^ 64.
+  Proof. cbn. Lia.lia. Qed.
+
+  Lemma mldsa_felem_add_ok:
+    @spec_of_add _ _ _ _ _ _ _ _ q q_small mldsa_prime_q add (map.of_list mldsa_funcs).
+  Proof.
+    apply (add_br2fn_ok (modulus_pos:=q) (modulus_small:=q_small) (modulus_prime:=mldsa_prime_q)).
+    - cbn. Lia.lia.
+    - reflexivity.
+  Qed.
+
+  Lemma mldsa_felem_sub_ok:
+    @spec_of_sub _ _ _ _ _ _ _ _ q q_small mldsa_prime_q sub (map.of_list mldsa_funcs).
+  Proof.
+    apply (sub_br2fn_ok (modulus_pos:=q) (modulus_small:=q_small) (modulus_prime:=mldsa_prime_q)).
+    - cbn. Lia.lia.
+    - reflexivity.
+  Qed.
+
+  Lemma mldsa_felem_mul_ok:
+    @spec_of_mul _ _ _ _ _ _ _ _ q q_small mldsa_prime_q mul (map.of_list mldsa_funcs).
+  Proof.
+    apply (mul_br2fn_ok1 (modulus_pos:=q) (modulus_small:=q_small) (modulus_prime:=mldsa_prime_q)).
+    - cbn. Lia.lia.
+    - reflexivity.
+  Qed.
+
+  Lemma mldsa_ntt_ok:
+    @spec_of_ntt _ _ _ _ _ _ "mldsa_ntt" q n km1 mldsa_zetas (feval (modulus_small:=q_small) (modulus_prime:=mldsa_prime_q)) (map.of_list mldsa_funcs).
+  Proof.
+    eapply br2_ntt_ok.
+    3-6: cbn; Lia.lia.
+    - apply F.zero.
+    - eapply feval_ok.
+    - reflexivity.
+    - apply mldsa_felem_mul_ok.
+    - apply mldsa_felem_sub_ok.
+    - apply mldsa_felem_add_ok.
+  Qed.
+
+  Lemma mldsa_inverse_ntt_ok:
+    @spec_of_ntt_inverse _ _ _ _ _ _ "mldsa_inverse_ntt" q n km1 mldsa_c mldsa_zetas (feval (modulus_small:=q_small) (modulus_prime:=mldsa_prime_q)) (map.of_list mldsa_funcs).
+  Proof.
+    eapply br2_ntt_inverse_ok.
+    2-5: cbn; Lia.lia.
+    - eapply feval_ok.
+    - reflexivity.
+    - apply mldsa_felem_mul_ok.
+    - apply mldsa_felem_sub_ok.
+    - apply mldsa_felem_add_ok.
+  Qed.
+
+  (* Eval compute in ToCString.c_module mldsa_funcs. *)
+End MLDSA.

--- a/src/NTT/MLKEM.v
+++ b/src/NTT/MLKEM.v
@@ -1,0 +1,196 @@
+Require Import Coq.ZArith.ZArith.
+Require Import Crypto.Spec.ModularArithmetic.
+Require Import Crypto.NTT.CyclotomicDecomposition.
+Require Import Crypto.NTT.BedrockNTT.
+Require Import Crypto.NTT.RupicolaBarrettReduction.
+Require Import bedrock2.BasicC64Semantics.
+Require Import Rupicola.Lib.Api.
+From Coqprime.PrimalityTest Require Import Pocklington PocklingtonCertificat.
+
+Section MLKEM.
+  Local Notation q := 3329%positive.
+  Local Notation F := (F q).
+  Local Notation zeta := (F.of_Z q 17%Z).
+  Local Notation n := 8%nat.
+  Local Notation km1 := 7%nat.
+  Local Notation add := "mlkem_felem_add".
+  Local Notation sub := "mlkem_felem_sub".
+  Local Notation mul := "mlkem_felem_mul".
+  Local Notation reduce := "mlkem_barrett_reduce".
+  Local Notation reduce_small := "mlkem_barrett_reduce_small".
+
+  Local Notation mlkem_make_zetas := (@make_zetas q zeta).
+
+  (* Sanity check *)
+  Lemma mlkem_prime_q: prime (Z.pos q).
+  Proof.
+    apply (Pocklington_refl
+             (Pock_certif 3329 3 ((2,8)::nil)%positive 1)
+             ((Proof_certif 2 prime_2) ::
+                nil)).
+    native_cast_no_check (refl_equal true).
+  Qed.
+
+  (* ζ^0 to ζ^128 *)
+  Definition mlkem_zetas_128 :=
+    [1%Z; 17; 289; 1584; 296; 1703; 2319; 2804; 1062; 1409; 650; 1063; 1426; 939;
+     2647; 1722; 2642; 1637; 1197; 375; 3046; 1847; 1438; 1143; 2786; 756; 2865;
+     2099; 2393; 733; 2474; 2110; 2580; 583; 3253; 2037; 1339; 2789; 807; 403; 193;
+     3281; 2513; 2773; 535; 2437; 1481; 1874; 1897; 2288; 2277; 2090; 2240; 1461;
+     1534; 2775; 569; 3015; 1320; 2466; 1974; 268; 1227; 885; 1729; 2761; 331;
+     2298; 2447; 1651; 1435; 1092; 1919; 2662; 1977; 319; 2094; 2308; 2617; 1212;
+     630; 723; 2304; 2549; 56; 952; 2868; 2150; 3260; 2156; 33; 561; 2879; 2337;
+     3110; 2935; 3289; 2649; 1756; 3220; 1476; 1789; 452; 1026; 797; 233; 632; 757;
+     2882; 2388; 648; 1029; 848; 1100; 2055; 1645; 1333; 2687; 2402; 886; 1746;
+     3050; 1915; 2594; 821; 641; 910; 2154; -1].
+
+  Lemma mlkem_zetas_128_spec:
+    mlkem_make_zetas 128 = List.map (F.of_Z _) mlkem_zetas_128.
+  Proof.
+    pose (list_eq_strong := fix list_eq_strong A B (eqx: A -> B -> Prop) x y :=
+            match x with
+            | nil => match y with
+                    | nil => True
+                    | _ => False
+                    end
+            | x0::x1 => match y with
+                       | nil => False
+                       | y0::y1 => eqx x0 y0 /\ (eqx x0 y0 -> list_eq_strong A B eqx x1 y1)
+                       end
+            end).
+    assert (Hstrong: forall A B eq x y, list_eq_strong A B eq x y -> @ListUtil.list_eq A B eq x y).
+    { induction x; simpl; auto.
+      intros; destruct y; auto. destruct H; split; auto. }
+    apply ListUtil.list_eq_to_leq, Hstrong.
+    split; [reflexivity|intro H].
+    repeat (split; [rewrite H; rewrite <- ModularArithmeticTheorems.F.of_Z_mul; apply ModularArithmeticTheorems.F.eq_of_Z_iff; reflexivity|clear H; intro H]).
+    reflexivity.
+  Qed.
+
+  (* Sanity check ζ^(2^km1) = -1 *)
+  Lemma mlkem_zeta_km1_ok:
+    F.pow zeta (N.of_nat (Nat.pow 2 km1)) = F.of_Z _ (-1).
+  Proof.
+    assert (Nat.pow 2 7 = 128)%nat as -> by reflexivity.
+    generalize (@make_zetas_spec q zeta 128%nat 128%nat ltac:(reflexivity)).
+    rewrite mlkem_zetas_128_spec. intro X.
+    unfold mlkem_zetas_128 in X. cbv [List.map nth_error] in X.
+    congruence.
+  Qed.
+
+  Definition mlkem_zetas := List.map (fun k => nth_default 0%F (List.map (F.of_Z q) mlkem_zetas_128) (N.to_nat k)) (@zeta_powers (N.of_nat km1) km1).
+
+  Lemma mlkem_zetas_correct:
+    mlkem_zetas = List.map (fun k => F.pow zeta k) (@zeta_powers (N.of_nat km1) km1).
+  Proof.
+    unfold mlkem_zetas. rewrite <- mlkem_zetas_128_spec.
+    apply nth_error_ext. intros.
+    do 2 rewrite ListUtil.nth_error_map.
+    destruct (nth_error (zeta_powers km1) i) as [k|] eqn:Hk; [|reflexivity].
+    cbn [option_map].
+    assert (N.to_nat k <= 128)%nat as Hk'.
+    { cbv in Hk. do 128 (destruct i as [|i]; [simpl in Hk; inversion Hk; subst k; Lia.lia|]).
+      destruct i; cbn in Hk; congruence. }
+    apply (@make_zetas_spec q zeta) in Hk'.
+    rewrite (ListUtil.nth_error_value_eq_nth_default _ _ _ Hk').
+    rewrite Nnat.N2Nat.id. reflexivity.
+  Qed.
+
+  Definition mlkem_c: F := F.of_Z _ 3303.
+
+  Lemma mlkem_c_correct:
+    mlkem_c = F.inv (F.of_Z q (two_power_nat km1)).
+  Proof.
+    apply ModularArithmeticTheorems.F.eq_to_Z_iff.
+    reflexivity.
+  Qed.
+
+  Definition mlkem_ntt := @br2_ntt 64 (Naive.word _) q n km1 mlkem_zetas F_to_Z add sub mul.
+  Definition mlkem_inverse_ntt := @br2_ntt_inverse 64 (Naive.word _) q n km1 mlkem_c mlkem_zetas F_to_Z add sub mul.
+
+  Definition mlkem_barrett_reduce_small := @reduce_small_br2fn 64 (Naive.word _) q.
+  Definition mlkem_barrett_reduce := @reduce_br2fn 64 (Naive.word _) q.
+  Definition mlkem_felem_add := @add_br2fn reduce_small.
+  Definition mlkem_felem_sub := @sub_br2fn q reduce_small.
+  Definition mlkem_felem_mul := @mul_br2fn reduce.
+
+  Definition mlkem_funcs :=
+    [ ("mlkem_ntt", mlkem_ntt)
+    ; ("mlkem_inverse_ntt", mlkem_inverse_ntt)
+    ; (reduce_small, mlkem_barrett_reduce_small)
+    ; (reduce, mlkem_barrett_reduce)
+    ; (add, mlkem_felem_add)
+    ; (sub, mlkem_felem_sub)
+    ; (mul, mlkem_felem_mul)
+    ].
+
+  Lemma mlkem_reduce_small_ok:
+    @spec_of_reduce_small _ _ _ _ _ _ q reduce_small (map.of_list mlkem_funcs).
+  Proof.
+    apply (reduce_small_br2fn_ok (modulus_pos:=q) (modulus_prime:=mlkem_prime_q) (modulus_not_2:=ltac:(Lia.lia))); auto.
+    - cbv. reflexivity.
+    - exact I.
+  Qed.
+
+  Lemma mlkem_felem_add_ok:
+    @spec_of_add _ _ _ _ _ _ _ q add (map.of_list mlkem_funcs).
+  Proof.
+    apply (add_br2fn_ok (modulus_pos:=q) (modulus_not_2:=ltac:(Lia.lia)) (reduce_small_name:=reduce_small)).
+    - compute. reflexivity.
+    - reflexivity.
+    - apply mlkem_reduce_small_ok.
+  Qed.
+
+  Lemma mlkem_felem_sub_ok:
+    @spec_of_sub _ _ _ _ _ _ _ q sub (map.of_list mlkem_funcs).
+  Proof.
+    apply (sub_br2fn_ok (modulus_pos:=q) (modulus_not_2:=ltac:(Lia.lia)) (reduce_small_name:=reduce_small)).
+    - compute. reflexivity.
+    - reflexivity.
+    - apply mlkem_reduce_small_ok.
+  Qed.
+
+  Lemma mlkem_reduce_ok:
+    @spec_of_reduce _ _ _ _ _ _ q reduce (map.of_list mlkem_funcs).
+  Proof.
+    apply (reduce_br2fn_ok (modulus_pos:=q) (modulus_prime:=mlkem_prime_q) (modulus_not_2:=ltac:(Lia.lia))); auto.
+    - cbv. reflexivity.
+    - exact I.
+  Qed.
+
+  Lemma mlkem_felem_mul_ok:
+    @spec_of_mul _ _ _ _ _ _ _ q mul (map.of_list mlkem_funcs).
+  Proof.
+    apply (mul_br2fn_ok (modulus_pos:=q) (modulus_prime:=mlkem_prime_q) (modulus_not_2:=ltac:(Lia.lia)) (reduce_name:=reduce)); try reflexivity.
+    apply mlkem_reduce_ok.
+  Qed.
+
+  Lemma mlkem_ntt_ok:
+    @spec_of_ntt _ _ _ _ _ _ "mlkem_ntt" q n km1 mlkem_zetas feval (map.of_list mlkem_funcs).
+  Proof.
+    eapply br2_ntt_ok.
+    3-6: cbn; try Lia.lia.
+    - apply F.zero.
+    - eapply feval_ok. compute. reflexivity.
+    - reflexivity.
+    - apply mlkem_felem_mul_ok.
+    - apply mlkem_felem_sub_ok.
+    - apply mlkem_felem_add_ok.
+      Unshelve. Lia.lia.
+  Qed.
+
+  Lemma mlkem_inverse_ntt_ok:
+    @spec_of_ntt_inverse _ _ _ _ _ _ "mlkem_inverse_ntt" q n km1 mlkem_c mlkem_zetas feval (map.of_list mlkem_funcs).
+  Proof.
+    eapply br2_ntt_inverse_ok.
+    2-5: cbn; Lia.lia.
+    - eapply feval_ok. compute. reflexivity.
+    - reflexivity.
+    - apply mlkem_felem_mul_ok.
+    - apply mlkem_felem_sub_ok.
+    - apply mlkem_felem_add_ok.
+      Unshelve. Lia.lia.
+  Qed.
+
+  (* Eval compute in ToCString.c_module mlkem_funcs. *)
+End MLKEM.

--- a/src/NTT/Polynomial.v
+++ b/src/NTT/Polynomial.v
@@ -1,0 +1,3625 @@
+From Coq Require Import List Permutation.
+From Coq Require Program.Tactics Program.Wf.
+From Coq.Classes Require Import Morphisms.
+From Crypto.Util Require Import Decidable ListUtil.
+From Crypto.Algebra Require Import Hierarchy Ring Field.
+
+Section Permutation_fold_right.
+  (* TODO: move to ListUtil *)
+  Lemma fold_right_permutation {A B} (R:B->B->Prop) `{RelationClasses.Equivalence B R}
+    (f:A->B->B) (b: B) `{Hf : forall x, Morphisms.Proper (Morphisms.respectful R R) (f x)} (l1 l2: list A):
+    (forall j1 a1 j2 a2 b,
+        j1 <> j2 -> nth_error l1 j1 = Some a1 -> nth_error l1 j2 = Some a2 ->
+        R (f a1 (f a2 b)) (f a2 (f a1 b))) ->
+    Permutation l1 l2 -> R (fold_right f b l1) (fold_right f b l2).
+  Proof.
+    intros Hf'. induction 1.
+    - simpl. reflexivity.
+    - simpl. rewrite IHPermutation; [reflexivity|].
+      intros. apply (Hf' (S j1) _ (S j2)); auto.
+    - simpl. apply (Hf' O _ (S O)); auto.
+    - etransitivity.
+      + apply IHPermutation1, Hf'.
+      + apply IHPermutation2. intros j1 a1 j2 a2 b' ? ? ?.
+        destruct (proj1 (Permutation_nth_error _ _) H0_) as (Hlen & g & Hinj & Hg).
+        apply (Hf' (g j1) _ (g j2)); try rewrite <- Hg; auto.
+  Qed.
+End Permutation_fold_right.
+Section NoDup.
+  (* TODO: move to ListUtil *)
+  Lemma NoDup_app {A} (l1 l2: list A):
+    NoDup (l1 ++ l2) <-> NoDup l1 /\ (forall x, In x l1 -> ~ In x l2) /\ NoDup l2.
+  Proof.
+    induction l1; simpl.
+    - split; intros.
+      + split; [apply NoDup_nil|].
+        split; auto.
+      + destruct H as (? & ? & ?); auto.
+    - split; intros.
+      + inversion H; subst; clear H.
+        apply IHl1 in H3. destruct H3 as (? & ? & ?).
+        split; [apply NoDup_cons; auto; intro; apply H2; apply in_app_iff; left; auto|].
+        split; auto.
+        intros. destruct H3 as [<-|?]; [|apply H0; auto].
+        intro; apply H2. apply in_app_iff; right; auto.
+      + destruct H as (Hl1 & Hin & Hl2).
+        inversion Hl1; subst; clear Hl1.
+        apply NoDup_cons; [|apply IHl1; repeat split; auto].
+        intro X. apply in_app_iff in X. destruct X; [elim H1; auto|].
+        eapply Hin; eauto.
+  Qed.
+  Lemma NoDup_map {A B} (l: list A) (f: A -> B):
+    (forall x y, In x l -> In y l -> f x = f y -> x = y) ->
+    NoDup l ->
+    NoDup (map f l).
+  Proof.
+    intro Hinj. induction 1; [apply NoDup_nil|].
+    simpl. apply NoDup_cons.
+    - intro Hin. apply in_map_iff in Hin.
+      destruct Hin as (y & Heq & Hin).
+      apply H. rewrite (Hinj x y); auto.
+      left; auto. right; auto.
+    - apply IHNoDup. intros; apply Hinj; auto; right; auto.
+  Qed.
+End NoDup.
+
+Section Bigop.
+  Context {A:Type} {eq:A->A->Prop} {op:A->A->A} {id:A} {inv:A->A} {group: @commutative_group A eq op id inv}.
+
+  Local Infix "=" := eq : type_scope. Local Notation "a <> b" := (not (a = b)) : type_scope.
+
+  (* Iteratively apply op over a sequence indexed by a list of indices of some type I *)
+  Definition bigop {I} (idx: list I) (f: I -> A) :=
+    List.fold_right (fun i x => op (f i) x) id idx.
+
+  Lemma bigop_ext_eq {I} (idx: list I) (f g: I -> A):
+    (forall i, In i idx -> f i = g i) ->
+    bigop idx f = bigop idx g.
+  Proof.
+    induction idx; [reflexivity|].
+    intros Hi; simpl.
+    rewrite (Hi a) by (left; reflexivity).
+    rewrite IHidx; [reflexivity|].
+    intros; apply Hi; right; auto.
+  Qed.
+
+  Lemma bigop_index_change {I I'} (idx: list I) (f: I' -> A) (phi: I -> I'):
+    bigop (List.map phi idx) f = bigop idx (fun i => f (phi i)).
+  Proof.
+    induction idx; [reflexivity|].
+    simpl. rewrite IHidx. reflexivity.
+  Qed.
+
+  Lemma bigop_index_change_inj {I I'} (idx: list I) (f: I -> A)
+    (phi: I -> I') (psi: I' -> I)
+    (Hinj: forall i, List.In i idx -> psi (phi i) = i :> I):
+    bigop idx f = bigop (List.map phi idx) (fun i => f (psi i)).
+  Proof.
+    rewrite bigop_index_change. apply bigop_ext_eq.
+    intros; rewrite Hinj by assumption; reflexivity.
+  Qed.
+
+  Lemma bigop_shift a b len f:
+    bigop (seq a len) f = bigop (seq (a + b) len) (fun i => (f (i - b))).
+  Proof.
+    assert (seq (a + b) len = map (fun i => i + b) (seq a len) :> _) as ->.
+    { induction b.
+      - rewrite PeanoNat.Nat.add_0_r.
+        rewrite (map_ext _ Datatypes.id); [|intros; rewrite PeanoNat.Nat.add_0_r; reflexivity].
+        rewrite map_id. reflexivity.
+      - assert (a + S b = S (a + b) :> _) as -> by Lia.lia.
+        rewrite <- seq_shift, IHb, map_map.
+        apply map_ext. intros; Lia.lia. }
+    rewrite bigop_index_change.
+    apply bigop_ext_eq; intros.
+    assert (i + b - b = i :> _) as -> by Lia.lia. reflexivity.
+  Qed.
+
+  Lemma bigop_nil {I} (f: I -> A):
+    bigop nil f = id.
+  Proof. reflexivity. Qed.
+
+  Lemma bigop_app {I} (f: I -> A) idx1 idx2:
+    bigop (idx1 ++ idx2) f = op (bigop idx1 f) (bigop idx2 f).
+  Proof.
+    induction idx1; simpl.
+    - symmetry; apply left_identity.
+    - rewrite IHidx1. apply associative.
+  Qed.
+
+  Lemma bigop_cons {I} (f: I -> A) i idx:
+    bigop (i::idx) f = op (f i) (bigop idx f).
+  Proof. reflexivity. Qed.
+
+  Lemma bigop_same_index {I} (f g: I -> A) idx:
+    op (bigop idx f) (bigop idx g) = bigop idx (fun i => op (f i) (g i)).
+  Proof.
+    induction idx; simpl; [apply left_identity|].
+    rewrite <- IHidx. repeat rewrite associative.
+    rewrite <- (associative _ _ (g a)).
+    rewrite (commutative _ (g a)).
+    rewrite associative. reflexivity.
+  Qed.
+
+  Lemma bigop_permutation {I} (f: I -> A) idx1 idx2:
+    Permutation idx1 idx2 ->
+    bigop idx1 f = bigop idx2 f.
+  Proof.
+    intros. unfold bigop. apply fold_right_permutation; auto; try typeclasses eauto.
+    - intros. intros a b Heq. rewrite Heq; reflexivity.
+    - intros. rewrite (associative (f a1)), (commutative (f a1)), <- (associative (f a2)).
+      reflexivity.
+  Qed.
+
+  Lemma bigop_rev {I} (f: I -> A) idx:
+    bigop (rev idx) f = bigop idx f.
+  Proof. symmetry; apply bigop_permutation, Permutation_rev. Qed.
+
+  Lemma bigop_flatten {I I'} (idx: list I) (idx': I -> list I') (f: I -> I' -> A):
+    bigop idx (fun i => bigop (idx' i) (fun j => f i j)) =
+    bigop (flat_map (fun i => List.map (fun j => (i, j)) (idx' i)) idx) (fun '(i, j) => f i j).
+  Proof.
+    induction idx; [reflexivity|].
+    simpl. rewrite bigop_app.
+    rewrite IHidx.
+    assert ((bigop (idx' a) (fun j : I' => f a j)) = (bigop (map (fun j : I' => (a, j)) (idx' a)) (fun '(i, j) => f i j))) as ->; [|reflexivity].
+    clear IHidx. induction (idx' a); [reflexivity|].
+    simpl. rewrite IHl. reflexivity.
+  Qed.
+
+  Lemma bigop_flatten_index_char {I I'} (idx: list I) (idx': I -> list I'):
+    forall i j, In (i, j) (flat_map (fun i => List.map (fun j => (i, j)) (idx' i)) idx) <-> (In i idx /\ In j (idx' i)).
+  Proof.
+    intros i j; split; [intros H|intros [HA HB]].
+    - apply in_flat_map in H. destruct H as (x & Hin & Hinm).
+      apply in_map_iff in Hinm. destruct Hinm as (? & Heq & ?).
+      inversion Heq; subst; clear Heq; split; auto.
+    - apply in_flat_map.
+      exists i. split; auto. apply in_map; auto.
+  Qed.
+
+  Lemma bigop_inv {I} (idx: list I) f:
+    inv (bigop idx f) = bigop idx (fun i => inv (f i)).
+  Proof.
+    induction idx; simpl;[apply Group.inv_id|].
+    rewrite <- IHidx, Group.inv_op, commutative. reflexivity.
+  Qed.
+
+  Context {one:A}{sub mul:A->A->A}{ring:@ring A eq id one inv op sub mul}.
+
+  Lemma bigop_const {I} (idx: list I) (a:A):
+    bigop idx (fun _ => a) = mul (bigop idx (fun _ => one)) a.
+  Proof.
+    induction idx; simpl; [rewrite mul_0_l; reflexivity|].
+    rewrite IHidx. rewrite right_distributive.
+    rewrite left_identity. reflexivity.
+  Qed.
+
+  Lemma bigop_l_distr {I} (idx: list I) (a: A) (f: I->A):
+    mul a (bigop idx f) = bigop idx (fun i => mul a (f i)).
+  Proof.
+    induction idx; simpl.
+    - apply mul_0_r.
+    - rewrite left_distributive, IHidx. reflexivity.
+  Qed.
+
+  Lemma bigop_r_distr {I} (idx: list I) (a: A) (f: I->A):
+    mul (bigop idx f) a = bigop idx (fun i => mul (f i) a).
+  Proof.
+    induction idx; simpl.
+    - apply mul_0_l.
+    - rewrite right_distributive, IHidx. reflexivity.
+  Qed.
+
+  Lemma bigop_widen {I} (f: I -> A) idx1 idx2:
+    (forall i, In i idx2 -> f i = id) ->
+     bigop idx1 f = bigop (idx1 ++ idx2) f.
+  Proof.
+    intros Hi. rewrite bigop_app.
+    rewrite (bigop_ext_eq idx2 _ (fun _ => id) Hi).
+    rewrite bigop_const, mul_0_r, right_identity.
+    reflexivity.
+  Qed.
+End Bigop.
+
+Section Polynomial.
+  (* We define univariate polynomials with coefficients defined over a commutative ring. *)
+  Context {F:Type}{Feq:F->F->Prop}{Fzero Fone:F}{Fopp:F->F}{Fadd Fsub Fmul:F->F->F}
+    {cring:@commutative_ring F Feq Fzero Fone Fopp Fadd Fsub Fmul}
+    {Feq_dec:DecidableRel Feq}.
+
+  Local Infix "=" := Feq : type_scope. Local Notation "a <> b" := (not (a = b)) : type_scope.
+  Local Notation "0" := Fzero. Local Notation "1" := Fone.
+  Local Infix "+" := Fadd. Local Infix "-" := Fsub.
+  Local Infix "*" := Fmul.
+
+  Class polynomial_ops {P: Type} :=
+    {
+      Pzero: P;
+      Pone: P;
+      coeff: P -> nat -> F;
+      degree: P -> option nat;
+      Popp: P -> P;
+      Padd: P -> P -> P;
+      Psub: P -> P -> P;
+      Pmul: P -> P -> P;
+      base: nat -> P;
+      Pconst: F -> P
+    }.
+
+  Definition Peq {P} `{@polynomial_ops P} (p1 p2: P): Prop :=
+    forall k, coeff p1 k = coeff p2 k.
+
+  Definition mul_coeff (f1 f2: nat -> F) (n: nat): F :=
+    @bigop _ Fadd Fzero _ (List.seq 0%nat (S n)) (fun i => f1 i * f2 (n - i)%nat).
+
+  Context {P} {Poly_ops: @polynomial_ops P}.
+
+  Class is_zero_definition :=
+    { zero_definition : forall k, coeff Pzero k = 0 }.
+  Class is_one_definition :=
+    { one_definition : forall k, coeff Pone k = match k with O => 1 | _ => 0 end }.
+  Class is_degree_definition :=
+    { degree_definition : forall p, match degree p with
+                               | None => forall k, coeff p k = 0
+                               | Some n => coeff p n <> 0 /\ forall k, k > n -> coeff p k = 0
+                               end }.
+  Class is_opp_definition :=
+    { opp_definition : forall p k, coeff (Popp p) k = Fopp (coeff p k) }.
+  Class is_add_definition :=
+    { add_definition : forall p1 p2 k, coeff (Padd p1 p2) k = coeff p1 k + coeff p2 k }.
+  Class is_sub_definition :=
+    { sub_definition : forall p1 p2 k, coeff (Psub p1 p2) k = coeff p1 k - coeff p2 k }.
+  Class is_mul_definition :=
+    { mul_definition : forall p1 p2 k, coeff (Pmul p1 p2) k = mul_coeff (coeff p1) (coeff p2) k }.
+  Class is_base_definition :=
+    { base_definition: forall n k, coeff (base n) k = if dec_eq_nat n k then 1 else 0 }.
+  Class is_const_definition :=
+    { const_definition: forall c k, coeff (Pconst c) k = match k with 0%nat => c | _ => 0 end }.
+
+  Class polynomial_defs :=
+    {
+      polynomial_is_zero_definition: is_zero_definition;
+      polynomial_is_one_definition: is_one_definition;
+      polynomial_is_degree_definition : is_degree_definition;
+      polynomial_is_opp_definition: is_opp_definition;
+      polynomial_is_add_definition: is_add_definition;
+      polynomial_is_sub_definition: is_sub_definition;
+      polynomial_is_mul_definition: is_mul_definition;
+      polynomial_is_base_definition: is_base_definition;
+      polynomial_is_const_definition: is_const_definition;
+    }.
+
+  Global Existing Instance polynomial_is_zero_definition.
+  Global Existing Instance polynomial_is_one_definition.
+  Global Existing Instance polynomial_is_degree_definition.
+  Global Existing Instance polynomial_is_opp_definition.
+  Global Existing Instance polynomial_is_add_definition.
+  Global Existing Instance polynomial_is_sub_definition.
+  Global Existing Instance polynomial_is_mul_definition.
+  Global Existing Instance polynomial_is_base_definition.
+  Global Existing Instance polynomial_is_const_definition.
+
+End Polynomial.
+
+Section Theorems.
+  Context {F:Type}{Feq:F->F->Prop}{Fzero Fone:F}{Fopp:F->F}{Fadd Fsub Fmul:F->F->F}
+    {cring:@commutative_ring F Feq Fzero Fone Fopp Fadd Fsub Fmul}
+    {Feq_dec:DecidableRel Feq}.
+
+  Local Infix "=" := Feq : type_scope. Local Notation "a <> b" := (not (a = b)) : type_scope.
+  Local Notation "0" := Fzero. Local Notation "1" := Fone.
+  Local Infix "+" := Fadd. Local Infix "-" := Fsub.
+  Local Infix "*" := Fmul.
+
+  Context {P} {poly_ops: @polynomial_ops F P} {poly_defs: @polynomial_defs F Feq Fzero Fone Fopp Fadd Fsub Fmul P poly_ops}.
+
+  Local Notation Peq := (@Peq F Feq P poly_ops).
+  Local Notation mul_coeff := (@mul_coeff F Fzero Fadd Fmul).
+
+  Definition lead_coeff p: F :=
+    match degree p with
+    | None => 0
+    | Some n => coeff p n
+    end.
+
+  Definition is_monic p: Prop :=
+    lead_coeff p = 1.
+
+  Section Degree.
+    Definition convert (x: option nat): nat := match x with None => 0%nat | Some n => S n end.
+    Definition measure p := convert (degree p).
+    Lemma measure_definition p k:
+      (measure p <= k)%nat ->
+      coeff p k = 0.
+    Proof.
+      generalize (degree_definition p); unfold measure, convert.
+      destruct (degree p); [intros [A B] Hle|intros A Hle].
+      - apply B; Lia.lia.
+      - apply A.
+    Qed.
+    Definition degree_le (d1 d2: option nat): Prop := (convert d1 <= convert d2)%nat.
+    Global Instance degree_le_dec: DecidableRel degree_le := fun x y => dec_le_nat (convert x) (convert y).
+    Global Instance degree_le_preorder: PreOrder degree_le.
+    Proof. constructor; intro; unfold degree_le; intros; [|etransitivity]; eauto. Qed.
+    Definition degree_lt (d1 d2: option nat): Prop := (convert d1 < convert d2)%nat.
+    Global Instance degree_lt_dec: DecidableRel degree_lt := fun x y => dec_lt_nat (convert x) (convert y).
+    Global Instance degree_lt_strorder: StrictOrder degree_lt.
+    Proof. constructor; intro; unfold degree_lt; intro; simpl; Lia.lia. Qed.
+    Definition degree_max (d1 d2: option nat): option nat :=
+      if degree_lt_dec d1 d2 then d2 else d1.
+    Definition degree_add (d1 d2: option nat): option nat :=
+      Option.map2 Nat.add d1 d2.
+    Lemma degree_add_0_l d:
+      degree_add (Some 0%nat) d = d :> _.
+    Proof. destruct d; reflexivity. Qed.
+    Lemma degree_add_0_r d:
+      degree_add d (Some 0%nat) = d :> _.
+    Proof. destruct d; simpl; [rewrite <- plus_n_O|]; reflexivity. Qed.
+    Lemma degree_max_lub:
+      forall x y z, degree_le x z -> degree_le y z -> degree_le (degree_max x y) z.
+    Proof.
+      unfold degree_le, degree_max, degree_lt_dec, convert.
+      intros. destruct x, y, z; destruct (dec_lt_nat _ _); Lia.lia.
+    Qed.
+    Lemma degree_max_lub_lt:
+      forall x y z, degree_lt x z -> degree_lt y z -> degree_lt (degree_max x y) z.
+    Proof.
+      unfold degree_lt, degree_max, degree_lt_dec, convert.
+      intros. destruct x, y, z; simpl in *; try Lia.lia.
+      destruct (dec_lt_nat _ _); Lia.lia.
+    Qed.
+    Lemma degree_le_lt_trans:
+      forall x y z, degree_le x y -> degree_lt y z -> degree_lt x z.
+    Proof. unfold degree_le, degree_lt, convert; intros; destruct x, y, z; Lia.lia. Qed.
+    Lemma degree_lt_le_trans:
+      forall x y z, degree_lt x y -> degree_le y z -> degree_lt x z.
+    Proof. unfold degree_le, degree_lt, convert; intros; destruct x, y, z; Lia.lia. Qed.
+    Lemma degree_lt_add_mono_l p q r (Hr: r <> None :> _):
+      degree_lt p q ->
+      degree_lt (degree_add r p) (degree_add r q).
+    Proof. destruct p, q, r; unfold degree_lt; simpl; try Lia.lia; congruence. Qed.
+    Lemma degree_char:
+      forall p n,
+        coeff p n <> 0 ->
+        (forall k, k > n -> coeff p k = 0) ->
+        degree p = Some n :> _.
+    Proof.
+      intros p n HA HB.
+      generalize (degree_definition p); intro HC.
+      destruct (degree p) as [np|] eqn:Hp; [|rewrite HC in HA; elim HA; reflexivity].
+      destruct HC as (HC1 & HC2).
+      assert (n = np :> _ \/ n < np \/ np < n) as [<- | [Hn | Hn]] by Lia.lia; auto.
+      - rewrite HB in HC1 by Lia.lia. elim HC1; reflexivity.
+      - rewrite HC2 in HA by Lia.lia. elim HA; reflexivity.
+    Qed.
+    Global Instance peq_proper_degree: Proper (Peq ==> eq) degree.
+    Proof.
+      intros p1 p2 Heq.
+      generalize (degree_definition p1); intro Hp1.
+      generalize (degree_definition p2); intro Hp2.
+      destruct (degree p1) eqn:Heq1.
+      - destruct Hp1 as (Hp1 & Hp1').
+        symmetry; apply degree_char.
+        + rewrite <- (Heq n). assumption.
+        + intros k Hk. rewrite <- (Heq k). apply Hp1'; auto.
+      - destruct (degree p2) eqn:Heq2.
+        + destruct Hp2 as (Hp2 & Hp2').
+          elim Hp2. rewrite <- (Heq n). apply Hp1.
+        + reflexivity.
+    Qed.
+    Lemma degree_zero:
+      degree Pzero = None :> _.
+    Proof.
+      generalize (degree_definition Pzero); destruct (degree Pzero) eqn:Hz; [|reflexivity].
+      rewrite zero_definition. intros (A & B); elim A; reflexivity.
+    Qed.
+    Lemma zero_degree p:
+      degree p = None :> _ -> Peq p Pzero.
+    Proof.
+      intro A; generalize (degree_definition p); rewrite A.
+      intros B k; rewrite B, zero_definition; reflexivity.
+    Qed.
+    Lemma degree_max_id d:
+      degree_max d d = d :> _.
+    Proof.
+      unfold degree_max. destruct (degree_lt_dec d d) as [H|H]; [|reflexivity].
+      apply StrictOrder_Irreflexive in H. tauto.
+    Qed.
+    Lemma opp_degree:
+      forall p, degree p = degree (Popp p) :> _.
+    Proof.
+      intros. generalize (degree_definition p); intro Hp.
+      destruct (degree p) eqn:Heq.
+      - destruct Hp as (Hp1 & Hp2).
+        symmetry; apply degree_char.
+        + rewrite opp_definition. intro Hx.
+          apply Hp1. apply Group.inv_id_iff; auto.
+        + intros k Hk. rewrite opp_definition.
+          rewrite Hp2; auto.
+          apply Group.inv_id.
+      - generalize (degree_definition (Popp p)); intro Hp'.
+        destruct (degree (Popp p)) eqn:Heq'; [|reflexivity].
+        destruct Hp' as (Hp' & _).
+        elim Hp'.
+        rewrite opp_definition, Hp. apply Group.inv_id.
+    Qed.
+    Lemma add_degree:
+      forall p1 p2, degree_le (degree (Padd p1 p2)) (degree_max (degree p1) (degree p2)).
+    Proof.
+      intros. generalize (degree_definition p1); intro Hp1.
+      generalize (degree_definition p2); intro Hp2.
+      generalize (degree_definition (Padd p1 p2)); intro Hadd.
+      destruct (degree p1), (degree p2), (degree (Padd p1 p2)); simpl; unfold degree_max, degree_le, degree_lt_dec, convert; destruct (dec_lt_nat _ _); simpl; try Lia.lia; rewrite add_definition in Hadd; destruct Hadd as (Hadd1 & Hadd2).
+      - destruct Hp1 as (Hp1 & Hp1').
+        destruct Hp2 as (Hp2 & Hp2').
+        destruct (dec_le_nat n1 n0); [Lia.lia|].
+        assert (Hin1: coeff p1 n1 = 0) by (apply Hp1'; Lia.lia).
+        assert (Hin2: coeff p2 n1 = 0) by (apply Hp2'; Lia.lia).
+        rewrite Hin1, Hin2 in Hadd1.
+        elim Hadd1. apply left_identity.
+      - destruct Hp1 as (Hp1 & Hp1').
+        destruct Hp2 as (Hp2 & Hp2').
+        destruct (dec_le_nat n1 n); [Lia.lia|].
+        assert (Hin1: coeff p1 n1 = 0) by (apply Hp1'; Lia.lia).
+        assert (Hin2: coeff p2 n1 = 0) by (apply Hp2'; Lia.lia).
+        rewrite Hin1, Hin2 in Hadd1.
+        elim Hadd1. apply left_identity.
+      - destruct Hp1 as (Hp1 & Hp1').
+        rewrite Hp2, right_identity in Hadd1.
+        destruct (dec_le_nat n0 n); [Lia.lia|].
+        elim Hadd1. apply Hp1'. Lia.lia.
+      - destruct Hp2 as (Hp2 & Hp2').
+        rewrite Hp1, left_identity in Hadd1.
+        destruct (dec_le_nat n0 n); [Lia.lia|].
+        elim Hadd1. apply Hp2'. Lia.lia.
+      - elim Hadd1. rewrite Hp1, Hp2. apply left_identity.
+    Qed.
+    Lemma sub_degree:
+      forall p1 p2, degree_le (degree (Psub p1 p2)) (degree_max (degree p1) (degree p2)).
+    Proof.
+      intros; assert (Peq (Psub p1 p2) (Padd p1 (Popp p2))) as ->.
+      - intro k. rewrite sub_definition, add_definition, opp_definition.
+        apply cring.(commutative_ring_ring).(ring_sub_definition).
+      - rewrite (opp_degree p2).
+        apply add_degree.
+    Qed.
+    Lemma mul_coeff_hi p1 p2 n1 n2
+      (Hp1: degree p1 = Some n1 :> _) (Hp2: degree p2 = Some n2 :> _):
+      coeff (Pmul p1 p2) (n1 + n2)%nat = coeff p1 n1 * coeff p2 n2 /\
+      (forall k : nat, k > (n1 + n2)%nat -> coeff (Pmul p1 p2) k = 0).
+    Proof.
+      generalize (degree_definition p1); rewrite Hp1; intros (Hd1 & Hd1').
+      generalize (degree_definition p2); rewrite Hp2; intros (Hd2 & Hd2').
+      split; intros; rewrite mul_definition; unfold mul_coeff.
+      1: assert (S (n1 + n2) = S n1 + n2 :> nat)%nat as -> by Lia.lia.
+      2: assert (S k = S n1 + (n2 + (k - (n1 + n2))) :> nat)%nat as -> by Lia.lia.
+      all: rewrite seq_app, seq_S; repeat rewrite bigop_app.
+      all: rewrite (bigop_ext_eq (seq 0 n1) _ (fun _ => 0)) by (intros i Hi; rewrite in_seq in Hi; rewrite Hd2' by Lia.lia; apply mul_0_r).
+      all: rewrite bigop_const; rewrite mul_0_r, left_identity.
+      all: rewrite (bigop_ext_eq (seq _ _) _ (fun _ => 0)) by (intros i Hi; rewrite in_seq in Hi; rewrite Hd1' by Lia.lia; apply mul_0_l).
+      all: rewrite bigop_const; rewrite mul_0_r, right_identity.
+      all: simpl; rewrite right_identity.
+      1: assert (n1 + n2 - n1 = n2 :> nat)%nat as -> by Lia.lia.
+      2: rewrite Hd2' by Lia.lia; rewrite mul_0_r.
+      all: reflexivity.
+    Qed.
+    (* We only have equality when we are in an integral domain, as it is otherwise possible that lead_coeff p * lead_coeff q = 0 *)
+    Lemma mul_degree_le:
+      forall p1 p2, degree_le (degree (Pmul p1 p2)) (degree_add (degree p1) (degree p2)).
+    Proof.
+      intros. generalize (degree_definition p1); intro Hp1.
+      generalize (degree_definition p2); intro Hp2.
+      generalize (degree_definition (Pmul p1 p2)); intro Hmul.
+      destruct (degree p1) eqn:H1.
+      2:{ simpl. destruct (degree (Pmul p1 p2)); simpl; [|reflexivity].
+          rewrite mul_definition in Hmul. destruct Hmul as (Hmul1 & Hmul2).
+          elim Hmul1. unfold mul_coeff.
+          rewrite (bigop_ext_eq _ _ (fun _ => 0)) by (intros; rewrite Hp1; apply mul_0_l).
+          rewrite bigop_const. apply mul_0_r. }
+      destruct (degree p2) eqn:H2.
+      2:{ simpl. destruct (degree (Pmul p1 p2)); simpl; [|reflexivity].
+          rewrite mul_definition in Hmul. destruct Hmul as (Hmul1 & Hmul2).
+          elim Hmul1. unfold mul_coeff.
+          rewrite (bigop_ext_eq _ _ (fun _ => 0)) by (intros; rewrite Hp2; apply mul_0_r).
+          rewrite bigop_const. apply mul_0_r. }
+      destruct (degree (Pmul p1 p2)) eqn:Hp; unfold degree_le, convert; simpl; [|Lia.lia].
+      destruct Hmul as (Hmul1 & Hmul2).
+      destruct (mul_coeff_hi p1 p2 _ _ H1 H2) as (_ & HA).
+      destruct (dec_le_nat n1 (n + n0)%nat); try Lia.lia.
+      elim Hmul1. apply HA; Lia.lia.
+    Qed.
+    Lemma mul_degree_eq `{HID: @Hierarchy.integral_domain F Feq Fzero Fone Fopp Fadd Fsub Fmul}:
+      forall p1 p2, degree (Pmul p1 p2) = degree_add (degree p1) (degree p2) :> _.
+    Proof.
+      intros. generalize (mul_degree_le p1 p2). intro Hmul_le.
+      destruct (degree p1) eqn:Hp1.
+      2:{ destruct (degree (Pmul p1 p2)); simpl in *; [|reflexivity].
+          unfold degree_le in *. simpl in *; Lia.lia. }
+      destruct (degree p2) eqn:Hp2.
+      2:{ destruct (degree (Pmul p1 p2)); simpl in *; [|reflexivity].
+          unfold degree_le in *. simpl in *; Lia.lia. }
+      simpl. generalize (mul_coeff_hi _ _ _ _ Hp1 Hp2). intros (Hmul1 & Hmul2).
+      generalize (degree_definition p1); rewrite Hp1. intros (Hp1n & Heq1).
+      generalize (degree_definition p2); rewrite Hp2. intros (Hp2n & Heq2).
+      destruct (Feq_dec (coeff (Pmul p1 p2) (n + n0)) 0).
+      { rewrite Hmul1 in f. apply zero_product_zero_factor in f.
+        destruct f; tauto. }
+      apply degree_char; auto.
+    Qed.
+    Lemma degree_one `{Hznone: @is_zero_neq_one F Feq Fzero Fone}:
+      degree Pone = Some 0%nat :> _.
+    Proof.
+      apply degree_char.
+      - rewrite one_definition. symmetry; apply zero_neq_one.
+      - intros; rewrite one_definition. destruct k; [Lia.lia|reflexivity].
+    Qed.
+    Lemma is_monic_degree:
+      forall p, is_monic p ->
+           if (Feq_dec 0 1) then degree p = None :> _ else exists n, degree p = Some n :> _.
+    Proof.
+      intros p H. unfold is_monic, lead_coeff in H.
+      generalize (degree_definition p); intros Hp.
+      destruct (degree p).
+      - rewrite H in Hp. destruct Hp as [Hznone Hp].
+        destruct (Feq_dec 0 1); [elim Hznone; symmetry; auto| eauto].
+      - destruct (Feq_dec 0 1); [reflexivity| contradiction].
+    Qed.
+  End Degree.
+
+  Global Instance peq_proper_lead_coeff:
+    Proper (Peq ==> Feq) lead_coeff.
+  Proof.
+    intros p p' Hp. unfold lead_coeff.
+    rewrite Hp. destruct (degree p'); [|reflexivity].
+    rewrite (Hp n). reflexivity.
+  Qed.
+
+  Global Instance peq_proper_is_monic:
+    Proper (Peq ==> iff) is_monic.
+  Proof.
+    intros p1 p2 Hp; unfold is_monic.
+    rewrite Hp. reflexivity.
+  Qed.
+
+  Global Instance Peq_dec: DecidableRel Peq.
+  Proof.
+    intros p q. generalize (degree_definition p); intros Hp.
+    generalize (degree_definition q); intros Hq.
+    destruct (degree p) as [np|] eqn:Heqp.
+    - destruct (degree q) as [nq|] eqn:Heqq.
+      + destruct (dec_eq_nat np nq).
+        * subst np. destruct Hp as (Hp1 & Hp2).
+          destruct Hq as (Hq1 & Hq2).
+          set (check := fix loop n := match n with O => O | S n' => if Feq_dec (coeff p n') (coeff q n') then loop n' else n end).
+          assert (Hcheck: forall n, match check n with
+                               | O => forall k, (k < n)%nat -> coeff p k = coeff q k
+                               | S n' => coeff p n' <> coeff q n' end).
+          { clear. induction n.
+            - simpl; intros. Lia.lia.
+            - simpl. destruct (Feq_dec (coeff p n) (coeff q n)); auto.
+              destruct (check n) eqn:Hn; auto.
+              intros. destruct (dec_eq_nat k n); [subst k; auto|].
+              apply IHn; Lia.lia. }
+          specialize (Hcheck (S nq)); destruct (check (S nq)).
+          { left. intro k. destruct (dec_lt_nat k (S nq)); [apply Hcheck; auto|].
+            rewrite Hp2, Hq2 by Lia.lia. reflexivity. }
+          { right. intro eq. apply Hcheck. apply eq. }
+        * right. intro Heq. rewrite Heq in Heqp.
+          rewrite Heqp in Heqq. apply n; congruence.
+      + right. intro Heq. rewrite Heq in Heqp.
+        rewrite Heqp in Heqq. congruence.
+    - destruct (degree q) as [nq|] eqn:Heqq.
+      + right. intro Heq. rewrite Heq in Heqp.
+        rewrite Heqp in Heqq. congruence.
+      + left. intro k; rewrite Hp, Hq. reflexivity.
+  Qed.
+
+  Section Pmul.
+    Lemma mul_coeff_comm:
+      forall f1 f2 n, mul_coeff f1 f2 n = mul_coeff f2 f1 n.
+    Proof.
+      intros. unfold mul_coeff.
+      rewrite (bigop_index_change_inj _ _ (fun i => (n - i)%nat) (fun i => (n - i)%nat)).
+      2: { intros i Hi. apply in_seq in Hi. Lia.lia. }
+      rewrite (bigop_ext_eq _ _ (fun i : nat => f2 i * f1 (n - i)%nat)).
+      2: { intros i Hi. apply in_map_iff in Hi.
+           destruct Hi as (j & Hj & Hi).
+           apply in_seq in Hi.
+           assert (n - (n - i) = i :> nat)%nat as -> by Lia.lia.
+           apply commutative_ring_is_commutative. }
+      apply bigop_permutation.
+      apply Permutation_nth with (d := (fun i : nat => (n - i)%nat) 0%nat).
+      rewrite map_length, seq_length; split; [reflexivity|].
+      exists (fun i => (n - i)%nat).
+      split; [intro; Lia.lia|].
+      split; [red; intros; Lia.lia|].
+      intros. rewrite map_nth. do 2 rewrite seq_nth by Lia.lia.
+      Lia.lia.
+    Qed.
+
+    Lemma mul_coeff_left_identity f:
+      forall n, mul_coeff (coeff Pone) f n = f n.
+    Proof.
+      unfold mul_coeff; simpl; intros.
+      assert (n - 0 = n :> nat)%nat as -> by Lia.lia.
+      rewrite one_definition, left_identity.
+      rewrite bigop_ext_eq with (g := fun _ => 0).
+      2:{ intros i Hi. apply in_seq in Hi.
+          rewrite one_definition. destruct i; [Lia.lia|].
+          apply mul_0_l. }
+      assert (bigop (seq 1 n) (fun _ : nat => 0) = 0) as ->; [|apply right_identity].
+      rewrite bigop_const, mul_0_r. reflexivity.
+    Qed.
+
+    Lemma mul_coeff_right_identity f:
+      forall n, mul_coeff f (coeff Pone) n = f n.
+    Proof.
+      intros. rewrite mul_coeff_comm.
+      apply mul_coeff_left_identity.
+    Qed.
+
+    Lemma mul_coeff_assoc:
+      forall f1 f2 f3 n, mul_coeff f1 (mul_coeff f2 f3) n = mul_coeff (mul_coeff f1 f2) f3 n.
+    Proof.
+      intros. unfold mul_coeff.
+      rewrite (bigop_ext_eq _ (fun i : nat => f1 i * bigop (seq 0 (S (n - i))) (fun i0 : nat => f2 i0 * f3 (n - i - i0)%nat)) (fun i : nat => @bigop _ Fadd Fzero _ (seq 0 (S (n - i))) (fun i0 : nat => f1 i * f2 i0 * f3 (n - i - i0)%nat))).
+      2: { intros. rewrite bigop_l_distr; apply bigop_ext_eq.
+           intros. apply associative. }
+      rewrite (bigop_ext_eq _ (fun i : nat => bigop (seq 0 (S i)) (fun i0 : nat => f1 i0 * f2 (i - i0)%nat) * f3 (n - i)%nat) (fun i : nat => @bigop _ Fadd Fzero _ (seq 0 (S i)) (fun i0 : nat => f1 i0 * f2 (i - i0)%nat  * f3 (n - i)%nat))).
+      2: { intros. rewrite bigop_r_distr; reflexivity. }
+      do 2 rewrite bigop_flatten.
+      assert (Hnd: forall f, NoDup (flat_map (fun i : nat => map (fun j : nat => (i, j)) (seq 0 (f i))) (seq 0 (S n)))).
+      { intro f; induction n.
+        - simpl. rewrite app_nil_r.
+          apply NoDup_map; [|apply seq_NoDup].
+          intros ? ? ? ? Heq; inversion Heq; subst; reflexivity.
+        - rewrite seq_S, flat_map_app.
+          apply NoDup_app. split; auto.
+          split.
+          + intros. destruct x as (i & j).
+            apply bigop_flatten_index_char in H.
+            destruct H as (Hi & Hj). apply in_seq in Hi, Hj.
+            intro H. apply bigop_flatten_index_char in H.
+            destruct H as (Hi' & _).
+            apply in_inv in Hi'. destruct Hi' as [H|H]; [Lia.lia|eapply in_nil; eauto].
+          + cbn [flat_map]. rewrite app_nil_r.
+            apply NoDup_map; [|apply seq_NoDup].
+            intros. inversion H1; subst; reflexivity. }
+      generalize (bigop_flatten_index_char (seq 0%nat (S n)) (fun i => seq 0%nat (S i))). intro Hin1.
+      generalize (bigop_flatten_index_char (seq 0%nat (S n)) (fun i => seq 0%nat (S (n - i)%nat))). intro Hin2.
+      set (psi := (fun '(i, j) => (i + j, i)%nat)).
+      set (phi := (fun '(i, j) => (j, i - j)%nat)).
+      erewrite (bigop_index_change_inj _ (fun '(i, j) => f1 j * f2 (i - j)%nat * f3 (n - i)%nat) phi psi).
+      2: { intros. destruct i as (i & j). simpl.
+           f_equal. apply Hin1 in H.
+           destruct H as [HA HB]. apply in_seq in HA, HB.
+           Lia.lia. }
+      rewrite (bigop_ext_eq _ (fun i : nat * nat => let '(i0, j) := psi i in f1 j * f2 (i0 - j)%nat * f3 (n - i0)%nat) (fun '(i, j) => f1 i * f2 j * f3 (n - i - j)%nat)).
+      2: { intros; destruct i; simpl.
+           apply in_map_iff in H. destruct H as (? & Hphi & Hi).
+           destruct x; simpl in Hphi.
+           inversion Hphi; subst; clear Hphi.
+           apply Hin1 in Hi.
+           destruct Hi as [Hi1 Hi2]. apply in_seq in Hi1, Hi2.
+           assert ((n0 + (n2 - n0) - n0)%nat = (n2 - n0)%nat :> nat) as -> by Lia.lia.
+           assert ((n - (n0 + (n2 - n0)))%nat = (n - n0 - (n2 - n0))%nat :> nat) as -> by Lia.lia.
+           reflexivity. }
+      generalize (in_map_iff phi (flat_map (fun i : nat => map (fun j : nat => (i, j)) (seq 0 (S i))) (seq 0 (S n)))). intro Hin1'.
+      apply bigop_permutation. apply NoDup_Permutation.
+      { apply Hnd. }
+      { apply NoDup_map.
+        - intros x y Hx Hy Heq.
+          destruct x as (x1 & y1). destruct y as (x2 & y2).
+          apply Hin1 in Hx, Hy.
+          destruct Hx as (Hx1 & Hx2).
+          destruct Hy as (Hy1 & Hy2).
+          apply in_seq in Hx1, Hx2, Hy1, Hy2.
+          inversion Heq; subst; clear Heq.
+          f_equal. Lia.lia.
+        - apply Hnd. }
+      { intro x. destruct x as (i & j).
+        split; intro H.
+        - apply Hin2 in H.
+          destruct H as [HA HB]. apply in_seq in HA, HB.
+          apply Hin1'. exists (psi (i, j)).
+          split; [simpl; f_equal; Lia.lia|].
+          apply Hin1. split; apply in_seq; Lia.lia.
+        - apply Hin1' in H. apply Hin2.
+          destruct H as (x & Heq & H). destruct x as (i' & j').
+          inversion Heq; subst; clear Heq.
+          apply Hin1 in H. destruct H as [HA HB]; apply in_seq in HA, HB.
+          split; apply in_seq; Lia.lia. }
+    Qed.
+    Lemma is_monic_mul `{Hznone: @is_zero_neq_one F Feq Fzero Fone}:
+      forall p q, is_monic p -> is_monic q -> is_monic (Pmul p q).
+    Proof.
+      intros p q Hp Hq. unfold is_monic, lead_coeff.
+      unfold is_monic, lead_coeff in Hp, Hq.
+      destruct (degree p) as [np|] eqn:Hnp; [|apply zero_neq_one in Hp; elim Hp].
+      destruct (degree q) as [nq|] eqn:Hnq; [|apply zero_neq_one in Hq; elim Hq].
+      generalize (mul_coeff_hi _ _ _ _ Hnp Hnq).
+      rewrite Hp, Hq, left_identity. intros [X Y].
+      rewrite (degree_char (Pmul p q) (np + nq)%nat ltac:(rewrite X; symmetry; apply zero_neq_one) Y).
+      apply X.
+    Qed.
+  End Pmul.
+
+  Global Instance polynomial_group:
+    @commutative_group P Peq Padd Pzero Popp.
+  Proof.
+    repeat constructor.
+    - unfold Peq; intros; repeat rewrite add_definition.
+      apply associative.
+    - unfold Peq; intros; rewrite add_definition, zero_definition.
+      apply left_identity.
+    - unfold Peq; intros; rewrite add_definition, zero_definition.
+      apply right_identity.
+    - intros p1 p1' Heq1 p2 p2' Heq2.
+      unfold Peq in *; intros; simpl.
+      repeat rewrite add_definition.
+      rewrite Heq1, Heq2. reflexivity.
+    - intros p k. reflexivity.
+    - intros p1 p2 Heq k. rewrite (Heq k). reflexivity.
+    - intros p1 p2 p3 Heq1 Heq2 k.
+      rewrite (Heq1 k). apply Heq2.
+    - intros p k. rewrite add_definition, opp_definition, zero_definition.
+      apply left_inverse.
+    - intros p k. rewrite add_definition, opp_definition, zero_definition.
+      apply right_inverse.
+    - intros p1 p2 Heq k.
+      repeat rewrite opp_definition. rewrite (Heq k). reflexivity.
+    - intros p1 p2 k. repeat rewrite add_definition.
+      apply commutative.
+  Qed.
+
+  Global Instance polynomial_ring:
+    @commutative_ring P Peq Pzero Pone Popp Padd Psub Pmul.
+  Proof.
+    constructor.
+    - constructor.
+      + apply polynomial_group.
+      + constructor; [..|apply (@monoid_Equivalence _ _ _ _ (@group_monoid _ _ _ _ _ (commutative_group_group polynomial_group)))]; repeat constructor.
+        * unfold Peq; intros p1 p2 p3 k.
+          repeat rewrite mul_definition.
+          unfold mul_coeff.
+          rewrite (bigop_ext_eq _ (fun i : nat => coeff p1 i * coeff (Pmul p2 p3) (k - i)) (fun i : nat => coeff p1 i * (mul_coeff (coeff p2) (coeff p3)) (k - i))) by (intros; rewrite mul_definition; reflexivity).
+          rewrite (bigop_ext_eq _ (fun i : nat => coeff (Pmul p1 p2) i * coeff p3 (k - i)) (fun i : nat => mul_coeff (coeff p1) (coeff p2) i * coeff p3 (k - i))) by (intros; rewrite mul_definition; reflexivity).
+          apply mul_coeff_assoc.
+        * intros p k. rewrite mul_definition.
+          apply mul_coeff_left_identity.
+        * intros p k. rewrite mul_definition.
+          apply mul_coeff_right_identity.
+        * intros p1 p1' Heq1 p2 p2' Heq2 k.
+          repeat rewrite mul_definition.
+          apply bigop_ext_eq; intros. rewrite (Heq1 _), (Heq2 _); reflexivity.
+      + constructor. intros p1 p2 p3 k.
+        rewrite mul_definition. rewrite add_definition.
+        repeat rewrite mul_definition.
+        unfold mul_coeff. rewrite bigop_same_index. apply bigop_ext_eq.
+        intros; rewrite add_definition.  apply left_distributive.
+      + constructor. intros p1 p2 p3 k.
+        rewrite mul_definition. rewrite add_definition.
+        repeat rewrite mul_definition.
+        unfold mul_coeff. rewrite bigop_same_index. apply bigop_ext_eq.
+        intros; rewrite add_definition. apply right_distributive.
+      + intros p1 p2 k. rewrite sub_definition, add_definition, opp_definition.
+        apply ring_sub_definition.
+      + intros p1 p1' Heq1 p2 p2' Heq2 k.
+        repeat rewrite mul_definition.
+        unfold mul_coeff. apply bigop_ext_eq; intros.
+        rewrite (Heq1 _), (Heq2 _); reflexivity.
+      + intros p1 p1' Heq1 p2 p2' Heq2 k.
+        repeat rewrite sub_definition. rewrite (Heq1 k), (Heq2 k). reflexivity.
+    - constructor. intros p1 p2 k.
+      repeat rewrite mul_definition. apply mul_coeff_comm.
+  Qed.
+  Global Instance polynomial_integral_domain `{HID: @Hierarchy.integral_domain F Feq Fzero Fone Fopp Fadd Fsub Fmul}:
+    @Hierarchy.integral_domain P Peq Pzero Pone Popp Padd Psub Pmul.
+  Proof.
+    econstructor.
+    - apply polynomial_ring.
+    - constructor; intros.
+      generalize (mul_degree_eq x y); rewrite H, degree_zero.
+      destruct (degree x) as [nx|] eqn:Hnx; [|apply zero_degree in Hnx; auto].
+      destruct (degree y) as [ny|] eqn:Hny; [|apply zero_degree in Hny; auto].
+      simpl; congruence.
+    - constructor. intro H.
+      generalize (H O); rewrite one_definition, zero_definition.
+      intro X. apply zero_neq_one; auto.
+  Qed.
+  Section Base.
+    Lemma mul_base_coeff:
+      forall p n k, coeff (Pmul p (base n)) k = if dec_lt_nat k n then 0 else coeff p (k - n)%nat.
+    Proof.
+      intros. rewrite (@commutative _ _ _ (@commutative_ring_is_commutative _ _ _ _ _ _ _ _ (polynomial_ring)) _ _ k), mul_definition.
+      unfold mul_coeff. destruct (dec_lt_nat k n).
+      - rewrite (bigop_ext_eq _ _ (fun _ => 0)).
+        + rewrite bigop_const. apply mul_0_r.
+        + intros. rewrite base_definition.
+          apply in_seq in H.
+          destruct (dec_eq_nat n i); [Lia.lia|].
+          apply mul_0_l.
+      - assert (S k = S n + (k - n) :> nat)%nat as -> by Lia.lia.
+        rewrite seq_app, bigop_app, seq_S, bigop_app.
+        rewrite (bigop_ext_eq (seq 0 n) _ (fun _ => 0)).
+        2: { intros i Hi; apply in_seq in Hi; rewrite base_definition.
+             destruct (dec_eq_nat n i); [Lia.lia|].
+             apply mul_0_l. }
+        rewrite bigop_const, mul_0_r, left_identity.
+        rewrite (bigop_ext_eq (seq _ _) _ (fun _ => 0)).
+        2: { intros i Hi; apply in_seq in Hi; rewrite base_definition.
+             destruct (dec_eq_nat n i); [Lia.lia|].
+             apply mul_0_l. }
+        rewrite bigop_const, mul_0_r, right_identity.
+        simpl. rewrite base_definition, right_identity.
+        destruct (dec_eq_nat n n); [|Lia.lia].
+        apply left_identity.
+    Qed.
+    Lemma degree_base `{Hznone: @is_zero_neq_one F Feq Fzero Fone}:
+      forall n, degree (base n) = Some n :> _.
+    Proof.
+      intros. apply degree_char.
+      - rewrite base_definition.
+        destruct (dec_eq_nat _ _); [|congruence].
+        symmetry; apply zero_neq_one.
+      - intros; rewrite base_definition.
+        destruct (dec_eq_nat n k); [Lia.lia|reflexivity].
+    Qed.
+    Lemma is_monic_base n:
+      is_monic (base n).
+    Proof.
+      unfold is_monic, lead_coeff.
+      destruct (Feq_dec 1 0).
+      - destruct (degree (base n)) eqn:Hn; [|rewrite f; reflexivity].
+        rewrite base_definition. destruct (dec_eq_nat n n0); [reflexivity|].
+        rewrite f; reflexivity.
+      - rewrite (degree_char (base n) n); intros.
+        all: rewrite base_definition.
+        1-2: destruct (dec_eq_nat _ _); [|congruence].
+        reflexivity. assumption.
+        destruct (dec_eq_nat n k); [Lia.lia|reflexivity].
+    Qed.
+    Lemma base_0_one:
+      Peq (base 0%nat) Pone.
+    Proof.
+      intros k. rewrite base_definition, one_definition.
+      destruct k; [destruct (dec_eq_nat _ _); [|congruence]; reflexivity|].
+      destruct (dec_eq_nat 0 (S k)); [Lia.lia|reflexivity].
+    Qed.
+    Lemma base_mul_base n1 n2:
+      Peq (Pmul (base n1) (base n2)) (base (n1 + n2)%nat).
+    Proof.
+      intro k. rewrite base_definition, mul_base_coeff.
+      destruct (dec_lt_nat k n2); [destruct (dec_eq_nat (n1 + n2)%nat k); [Lia.lia|reflexivity]|].
+      rewrite base_definition.
+      destruct (dec_eq_nat n1 (k - n2)%nat); destruct (dec_eq_nat (n1 + n2)%nat k); try Lia.lia; reflexivity.
+    Qed.
+    Lemma base_not_zero `{Hznone: @is_zero_neq_one F Feq Fzero Fone} n:
+      not (Peq (base n) Pzero).
+    Proof.
+      intro Heq.
+      generalize (Heq n). rewrite zero_definition, base_definition.
+      destruct (dec_eq_nat _ _); [|congruence]. intro; apply zero_neq_one; symmetry; auto.
+    Qed.
+  End Base.
+  Section Pconst.
+    Global Instance eq_proper_const:
+      Proper (Feq ==> Peq) Pconst.
+    Proof.
+      intros x y Heq k. do 2 rewrite const_definition.
+      destruct k; auto; reflexivity.
+    Qed.
+
+    Lemma const_zero_definition:
+      Peq (Pconst 0) Pzero.
+    Proof.
+      intros k; rewrite zero_definition, const_definition.
+      destruct k; reflexivity.
+    Qed.
+    Lemma const_one_definition:
+      Peq (Pconst 1) Pone.
+    Proof.
+      intros k; rewrite one_definition, const_definition.
+      destruct k; reflexivity.
+    Qed.
+    Lemma mul_const_coeff_l c p:
+      forall k,
+        coeff (Pmul (Pconst c) p) k = c * (coeff p k).
+    Proof.
+      intros k; rewrite mul_definition.
+      unfold mul_coeff. simpl.
+      assert (k - 0 = k :> _)%nat as -> by Lia.lia.
+      rewrite const_definition.
+      rewrite (bigop_ext_eq _ _ (fun _ => 0)).
+      - rewrite bigop_const. rewrite mul_0_r.
+        apply right_identity.
+      - intros i Hi. apply in_seq in Hi.
+        rewrite const_definition; destruct i; [Lia.lia|].
+        apply mul_0_l.
+    Qed.
+    Lemma mul_const_coeff_r c p:
+      forall k,
+        coeff (Pmul p (Pconst c)) k = c * (coeff p k).
+    Proof.
+      intros k; rewrite mul_definition.
+      unfold mul_coeff. rewrite seq_S, bigop_app. simpl.
+      assert (k - k = 0 :> _)%nat as -> by Lia.lia.
+      rewrite const_definition, right_identity.
+      rewrite (bigop_ext_eq _ _ (fun _ => 0)).
+      - rewrite bigop_const. rewrite mul_0_r.
+        rewrite left_identity, commutative. reflexivity.
+      - intros i Hi. apply in_seq in Hi.
+        destruct k; [Lia.lia|].
+        rewrite const_definition; destruct i.
+        + assert (S k - 0 = S k :> _)%nat as -> by Lia.lia.
+          apply mul_0_r.
+        + assert (S k - S i = S (k - S i) :> _)%nat as -> by Lia.lia.
+          apply mul_0_r.
+    Qed.
+    Lemma mul_const_base_coeff:
+      forall c n k,
+        coeff (Pmul (Pconst c) (base n)) k = if dec_eq_nat n k then c else 0.
+    Proof.
+      intros c n k. rewrite mul_const_coeff_l.
+      rewrite base_definition. destruct (dec_eq_nat n k).
+      - apply right_identity.
+      - apply mul_0_r.
+    Qed.
+    Lemma mul_const_base_degree:
+      forall c n,
+        degree (Pmul (Pconst c) (base n)) = (if Feq_dec c 0 then None else Some n) :> _.
+    Proof.
+      intros. destruct (Feq_dec c 0).
+      - assert (Peq Pzero (Pmul _ _)) as <-; [|apply degree_zero].
+        intro k. rewrite mul_const_base_coeff, zero_definition.
+        destruct (dec_eq_nat n k); symmetry; [apply f|reflexivity].
+      - apply degree_char; [|intros k Hk]; rewrite mul_const_base_coeff.
+        + destruct (dec_eq_nat _ _); [|congruence]; auto.
+        + destruct (dec_eq_nat n k); [Lia.lia|reflexivity].
+    Qed.
+    Lemma degree_const n:
+      (degree (Pconst n) = (if Feq_dec n 0 then None else Some 0%nat) :> _).
+    Proof.
+      destruct (Feq_dec n 0) as [->|Hnez].
+      - rewrite const_zero_definition; apply degree_zero.
+      - apply degree_char; [rewrite const_definition; auto|].
+        intros; rewrite const_definition; destruct k; [Lia.lia|reflexivity].
+    Qed.
+    Lemma degree_0_const p:
+      (degree p = Some 0%nat :> _) ->
+      Peq p (Pconst (coeff p 0%nat)).
+    Proof.
+      intros Hdegp. generalize (degree_definition p); rewrite Hdegp.
+      intros [Hpne Heq] k.
+      rewrite const_definition.
+      destruct k; [reflexivity|].
+      apply Heq; Lia.lia.
+    Qed.
+    Lemma const_add_const c1 c2:
+      Peq (Padd (Pconst c1) (Pconst c2)) (Pconst (c1 + c2)).
+    Proof.
+      intro k. rewrite const_definition, add_definition, const_definition, const_definition.
+      destruct k; [reflexivity|apply left_identity].
+    Qed.
+    Lemma opp_const c:
+      Peq (Popp (Pconst c)) (Pconst (Fopp c)).
+    Proof.
+      intro k. rewrite opp_definition, const_definition, const_definition.
+      destruct k; [reflexivity|apply Group.inv_id].
+    Qed.
+    Lemma const_sub_const c1 c2:
+      Peq (Psub (Pconst c1) (Pconst c2)) (Pconst (c1 - c2)).
+    Proof.
+      rewrite ring_sub_definition, opp_const, const_add_const, <- ring_sub_definition.
+      reflexivity.
+    Qed.
+    Lemma const_mul_const c1 c2:
+      Peq (Pmul (Pconst c1) (Pconst c2)) (Pconst (c1 * c2)).
+    Proof.
+      intro k. rewrite const_definition, mul_const_coeff_l, const_definition.
+      destruct k; [reflexivity|apply mul_0_r].
+    Qed.
+  End Pconst.
+  Section DivMod.
+    Context {Finv: F -> F}{Fdiv: F -> F -> F}
+      {field: @field F Feq Fzero Fone Fopp Fadd Fsub Fmul Finv Fdiv}.
+    (* Assume a field for simplicity in order to define euclidean division *)
+    (* A pseudo euclidean division exists for rings https://math.stackexchange.com/questions/116029/why-polynomial-division-algorithm-works-for-x-a-or-any-monic-polynomial/116037#116037 *)
+    Local Infix "/" := Fdiv.
+
+    (* Invariant: measure p ≤ n *)
+    Fixpoint Pdivmod_rec p q n :=
+      match n with
+      | O => (Pzero, Pzero)
+      | S n' => match degree p with
+               | None => (Pzero, Pzero)
+               | Some np => match degree q with
+                          | None => (Pzero, p)
+                          | Some nq => if dec_lt_nat np nq then (Pzero, p)
+                                     else
+                                       let a := lead_coeff p in
+                                       let b := lead_coeff q in
+                                       let '(d, r) := Pdivmod_rec (Psub p (Pmul (Pmul (Pconst (a/b)) (base (np - nq)%nat)) q)) q n' in
+                                       (Padd (Pmul (Pconst (a/b)) (base (np - nq)%nat)) d, r)
+                          end
+               end
+      end.
+
+    Definition Pdivmod p q :=
+      Pdivmod_rec p q (measure p).
+
+    Definition Pdiv p q :=
+      fst (Pdivmod p q).
+
+    Definition Pmod p q :=
+      snd (Pdivmod p q).
+
+    Definition Pdivides p q :=
+      Peq (Pmod q p) Pzero.
+
+    Global Instance peq_divmod_rec_proper n: Proper (Peq ==> Peq ==> (fun a b => Peq (fst a) (fst b) /\ Peq (snd a) (snd b))) (fun a b => Pdivmod_rec a b n).
+    Proof.
+      induction n; intros p1 p1' Hp1 p2 p2' Hp2.
+      - simpl; split; reflexivity.
+      - cbn [Pdivmod_rec]. rewrite Hp1.
+        destruct (degree p1') eqn:Hp1'; [|split; reflexivity].
+        rewrite Hp2; destruct (degree p2') eqn:Hp2'; [|split; simpl; auto; reflexivity].
+        destruct (dec_lt_nat n0 n1); [simpl; split; auto; reflexivity|].
+        rewrite (surjective_pairing (Pdivmod_rec (Psub p1 _) _ n)).
+        rewrite (surjective_pairing (Pdivmod_rec (Psub p1' _) _ n)). simpl.
+        assert (Heq: Peq (Psub p1 (Pmul (Pmul (Pconst (lead_coeff p1 / lead_coeff p2)) (base (n0 - n1))) p2)) (Psub p1' (Pmul (Pmul (Pconst (lead_coeff p1' / lead_coeff p2')) (base (n0 - n1))) p2'))) by (rewrite Hp1, Hp2; reflexivity).
+        generalize (IHn _ _ Heq _ _ Hp2). intros [U V].
+        simpl; split.
+        + rewrite U, Hp1, Hp2. reflexivity.
+        + rewrite V. reflexivity.
+    Qed.
+
+    Global Instance peq_divmod_proper: Proper (Peq ==> Peq ==> (fun a b => Peq (fst a) (fst b) /\ Peq (snd a) (snd b))) Pdivmod.
+    Proof.
+      intros p1 p1' Hp1 p2 p2' Hp2.
+      unfold Pdivmod. assert (measure p1 = measure p1' :> _) as -> by (unfold measure; rewrite Hp1; reflexivity).
+      apply peq_divmod_rec_proper; auto.
+    Qed.
+
+    Global Instance peq_div_proper: Proper (Peq ==> Peq ==> Peq) Pdiv.
+    Proof.
+      intros p1 p1' Hp1 p2 p2' Hp2.
+      unfold Pdiv. apply peq_divmod_proper; auto.
+    Qed.
+
+    Global Instance peq_mod_proper: Proper (Peq ==> Peq ==> Peq) Pmod.
+    Proof.
+      intros p1 p1' Hp1 p2 p2' Hp2.
+      unfold Pdiv. apply peq_divmod_proper; auto.
+    Qed.
+
+    Global Instance peq_divides_proper: Proper (Peq ==> Peq ==> iff) Pdivides.
+    Proof.
+      intros p1 p1' Hp1 p2 p2' Hp2.
+      unfold Pdivides. rewrite Hp1, Hp2. reflexivity.
+    Qed.
+
+    Lemma Pdivmod_eq p q:
+      Pdivmod p q = (Pdiv p q, Pmod p q) :> _.
+    Proof. apply surjective_pairing. Qed.
+
+    Lemma Pdivmod_rec_spec q:
+      not (Peq q Pzero) ->
+      forall n p,
+        (measure p <= n)%nat ->
+        let '(d, r) := Pdivmod_rec p q n in
+        Peq p (Padd (Pmul d q) r) /\ degree_lt (degree r) (degree q).
+    Proof.
+      intro H. assert (Hlt: degree_lt (None) (degree q)) by (destruct (degree q) as [nq|] eqn:Y; cbv; try Lia.lia; apply zero_degree in Y; contradiction).
+      induction n; intros.
+      - unfold Pdivmod_rec.
+        rewrite mul_0_l, left_identity, degree_zero.
+        split; auto. apply zero_degree.
+        unfold measure, convert in H0; destruct (degree p); [Lia.lia|reflexivity].
+      - generalize (degree_definition p).
+        destruct (degree p) as [np|] eqn:Hp; [intros (Hp1 & Hp2)|intros Hp1].
+        2: { simpl. rewrite Hp, mul_0_l, left_identity, degree_zero.
+             split; auto. apply zero_degree; auto. }
+        cbn [Pdivmod_rec]; rewrite Hp.
+        generalize (degree_definition q).
+        destruct (degree q) as [nq|] eqn:Hqeq; [intros (Hq1 & Hq2)|apply StrictOrder_Irreflexive in Hlt; tauto].
+        unfold measure, convert in H0; rewrite Hp in H0.
+        destruct (dec_lt_nat np nq).
+        + rewrite mul_0_l, left_identity, Hp; simpl; split; [reflexivity|]; cbv; Lia.lia.
+        + rewrite (surjective_pairing (Pdivmod_rec _ q n)).
+          assert (Hle: (measure (Psub p (Pmul (Pmul (Pconst (lead_coeff p / lead_coeff q)) (base (np - nq))) q)) <= n)%nat).
+          { unfold measure. destruct (degree (Psub _ _)) as [ns|] eqn:Hs; [|cbv; Lia.lia].
+            generalize (sub_degree p (Pmul (Pmul (Pconst (lead_coeff p / lead_coeff q)) (base (np - nq))) q)).
+            rewrite Hs, Hp. intro X.
+            generalize (mul_degree_eq (Pmul (Pconst (lead_coeff p / lead_coeff q)) (base (np - nq))) q).
+            rewrite Hqeq, mul_const_base_degree.
+            destruct (Feq_dec (lead_coeff p / lead_coeff q) 0) as [He|Hn].
+            { rewrite field_div_definition in He.
+              apply is_mul_nonzero_nonzero in He.
+              unfold lead_coeff in He; rewrite Hp, Hqeq in He.
+              destruct He as [He|He]; [contradiction|].
+              generalize (right_multiplicative_inverse (coeff q nq) Hq1).
+              rewrite He, mul_0_r. intro Hx. elim (zero_neq_one Hx). }
+            simpl. assert (np - nq + nq = np :> _)%nat as -> by Lia.lia.
+            intro Y. rewrite Y in X. simpl in X. rewrite degree_max_id in X.
+            cbv in X.
+            assert (ns < np \/ ns = np :> _)%nat as [Hns| ->] by Lia.lia; [Lia.lia|].
+            generalize (degree_definition (Psub p (Pmul (Pmul (Pconst (lead_coeff p / lead_coeff q)) (base (np - nq))) q))); rewrite Hs; intros (U&V).
+            elim U.
+            rewrite sub_definition, mul_definition.
+            unfold mul_coeff.
+            rewrite (bigop_ext_eq _ _ (fun i => (if dec_eq_nat (np - nq)%nat i then (coeff p np) / (coeff q nq) else 0) * coeff q (np - i)%nat)).
+            2:{ intros i Hi. rewrite mul_const_base_coeff.
+                unfold lead_coeff; rewrite Hp, Hqeq. reflexivity. }
+            assert (S np = S (np - nq) + nq :> _)%nat as -> by Lia.lia.
+            rewrite seq_add, seq_S, bigop_app, bigop_app.
+            rewrite (bigop_ext_eq (seq 0 _) _ (fun _ => 0)).
+            2:{ intros i Hi. apply in_seq in Hi.
+                destruct (dec_eq_nat (np - nq)%nat i); [Lia.lia|].
+                apply mul_0_l. }
+            rewrite bigop_const, mul_0_r, left_identity.
+            rewrite (bigop_ext_eq (seq _ _) _ (fun _ => 0)).
+            2:{ intros i Hi. apply in_seq in Hi.
+                destruct (dec_eq_nat (np - nq)%nat i); [Lia.lia|].
+                apply mul_0_l. }
+            rewrite bigop_const, mul_0_r, right_identity.
+            simpl. rewrite right_identity.
+            destruct (dec_eq_nat _ _); [|congruence].
+            assert (np - _ = nq :> nat)%nat as -> by Lia.lia.
+            rewrite field_div_definition, <-associative, left_multiplicative_inverse, right_identity, ring_sub_definition, right_inverse; auto.
+            reflexivity. }
+          generalize (IHn _ Hle).
+          rewrite (surjective_pairing (Pdivmod_rec _ q n)); cbn [fst snd].
+          intros (X & Y). split; [|exact Y].
+          rewrite (right_distributive), <- associative, <- X.
+          rewrite ring_sub_definition, commutative, <- associative, left_inverse, right_identity.
+          reflexivity.
+    Qed.
+
+    Lemma Pdiv_0_l q:
+      Peq (Pdiv Pzero q) Pzero.
+    Proof. unfold Pdiv, Pdivmod, Pdivmod_rec, measure. rewrite degree_zero. reflexivity. Qed.
+
+    Lemma Pdiv_0_r p:
+      Peq (Pdiv p Pzero) Pzero.
+    Proof.
+      unfold Pdiv, Pdivmod, Pdivmod_rec, measure, convert.
+      destruct (degree p) as [n|] eqn:Hp; [|reflexivity].
+      rewrite Hp, degree_zero. reflexivity.
+    Qed.
+
+    Lemma Pmod_0_l q:
+      Peq (Pmod Pzero q) Pzero.
+    Proof. unfold Pmod, Pdivmod, Pdivmod_rec, measure, convert; rewrite degree_zero. reflexivity. Qed.
+
+    Lemma Pmod_0_r p:
+      Peq (Pmod p Pzero) p.
+    Proof.
+      unfold Pmod, Pdivmod, Pdivmod_rec, measure, convert.
+      destruct (degree p) as [n|] eqn:Hp.
+      - rewrite Hp, degree_zero. reflexivity.
+      - symmetry. apply zero_degree. auto.
+    Qed.
+
+    Lemma Pdivmod_eq_spec p q:
+      Peq p (Padd (Pmul (Pdiv p q) q) (Pmod p q)).
+    Proof.
+      destruct (Peq_dec q Pzero) as [->|Hn].
+      - rewrite Pmod_0_r, Pdiv_0_r, mul_0_l, left_identity. reflexivity.
+      - generalize (Pdivmod_rec_spec q Hn (measure p) p ltac:(reflexivity)).
+        rewrite (surjective_pairing (Pdivmod_rec p q _)); intros [X Y].
+        unfold Pdiv, Pmod, Pdivmod. auto.
+    Qed.
+
+    Lemma Pdivmod_spec p q (Hn: not (Peq q Pzero)):
+      Peq p (Padd (Pmul (Pdiv p q) q) (Pmod p q))
+      /\ degree_lt (degree (Pmod p q)) (degree q).
+    Proof.
+      generalize (Pdivmod_rec_spec q Hn (measure p) p ltac:(reflexivity)).
+      rewrite (surjective_pairing (Pdivmod_rec p q _)); intros [X Y].
+      unfold Pdiv, Pmod, Pdivmod. auto.
+    Qed.
+
+    Lemma Pmod_degree_lt p q (Hn: not (Peq q Pzero)):
+      degree_lt (degree (Pmod p q)) (degree q).
+    Proof. apply Pdivmod_spec; auto. Qed.
+
+    Lemma Pmod_1_r p:
+      Peq (Pmod p Pone) Pzero.
+    Proof.
+      assert (Hn: not (Peq Pone Pzero)) by (intro X; generalize (degree_one); rewrite X, degree_zero; inversion 1).
+      generalize (Pmod_degree_lt p Pone Hn). rewrite degree_one.
+      destruct (degree (Pmod p Pone)) as [n|] eqn:Hdeg; cbv; [Lia.lia|].
+      intro; apply zero_degree; auto.
+    Qed.
+
+    Lemma Pdiv_1_r p:
+      Peq (Pdiv p Pone) p.
+    Proof.
+      generalize (Pdivmod_eq_spec p Pone).
+      rewrite Pmod_1_r. rewrite right_identity, right_identity.
+      symmetry; auto.
+    Qed.
+
+    Lemma Pdivides_0_r p:
+      Pdivides p Pzero.
+    Proof. apply Pmod_0_l. Qed.
+
+    Lemma Pdivides_1_l p:
+      Pdivides Pone p.
+    Proof. apply Pmod_1_r. Qed.
+
+    Lemma Pdivmod_eq_iff p q (Hn: not (Peq q Pzero)):
+      forall d r, Peq p (Padd (Pmul d q) r) ->
+             degree_lt (degree r) (degree q) ->
+             Peq d (Pdiv p q) /\ Peq r (Pmod p q).
+    Proof.
+      intros. generalize (Pdivmod_spec p q Hn); intros (X & Y).
+      assert (Z: Peq (Pmul (Psub d (Pdiv p q)) q) (Psub (Pmod p q) r)).
+      { assert (Peq r (Psub p (Pmul d q))) as -> by (rewrite H, ring_sub_definition, commutative, associative, left_inverse, left_identity; reflexivity).
+        assert (Peq (Pmod p q) (Psub p (Pmul (Pdiv p q) q))) as -> by (rewrite X at 2; rewrite ring_sub_definition, commutative, associative, left_inverse, left_identity; reflexivity).
+        repeat rewrite ring_sub_definition.
+        rewrite Group.inv_op, Group.inv_inv, <- mul_opp_l.
+        rewrite <- (commutative (Popp p)), (commutative p).
+        rewrite <- associative, (associative p), right_inverse, left_identity, <- right_distributive, (commutative d).
+        reflexivity. }
+      assert (W: degree_lt (degree (Psub (Pmod p q) r)) (degree q)).
+      { eapply degree_le_lt_trans; [apply (sub_degree (Pmod p q) r)|].
+        apply degree_max_lub_lt; auto. }
+      rewrite <- Z in W.
+      generalize (mul_degree_eq (Psub d (Pdiv p q)) q). intro U.
+      rewrite U in W.
+      destruct (degree q) as [nq|] eqn:Hq; [|apply zero_degree in Hq; contradiction].
+      destruct (degree (Psub d (Pdiv p q))) as [n|] eqn:Hx; [cbv -[Nat.add] in W; Lia.lia|apply zero_degree in Hx; rewrite Hx, mul_0_l in Z].
+      split.
+      - rewrite <- (right_identity (Pdiv _ _)), <- Hx, ring_sub_definition, (commutative d), associative, right_inverse, left_identity. reflexivity.
+      - rewrite <- (right_identity r), Z, ring_sub_definition, (commutative (Pmod _ _)), associative, right_inverse, left_identity. reflexivity.
+    Qed.
+
+    Lemma Pmod_opp p q:
+      Peq (Pmod (Popp p) q) (Popp (Pmod p q)).
+    Proof.
+      destruct (Peq_dec q Pzero) as [->|Hqnz]; [rewrite Pmod_0_r, Pmod_0_r; reflexivity|].
+      symmetry. assert (HA: Peq (Popp p) (Padd (Pmul (Popp (Pdiv p q)) q) (Popp (Pmod p q)))).
+      { rewrite (Pdivmod_eq_spec p q) at 1.
+        rewrite Group.inv_op, commutative.
+        rewrite <- mul_opp_l. reflexivity. }
+      apply (proj2 (Pdivmod_eq_iff (Popp p) q Hqnz _ _ HA ltac:(rewrite <- opp_degree; apply Pmod_degree_lt; auto))).
+    Qed.
+
+    Lemma Pdiv_same p (Hn: not (Peq p Pzero)):
+      Peq (Pdiv p p) Pone.
+    Proof.
+      assert (Hlt: degree_lt (degree Pzero) (degree p)) by (destruct (degree p) as [np|] eqn:Hp; [rewrite degree_zero; cbv; auto; Lia.lia|apply zero_degree in Hp; contradiction]).
+      generalize (Pdivmod_eq_iff p p Hn Pone Pzero ltac:(rewrite left_identity, right_identity; reflexivity) Hlt).
+      intros [A B]; symmetry; assumption.
+    Qed.
+
+    Lemma Pmod_same p:
+      Peq (Pmod p p) Pzero.
+    Proof.
+      destruct (Peq_dec p Pzero) as [->|Hn]; [apply Pmod_0_l|].
+      assert (Hlt: degree_lt (degree Pzero) (degree p)) by (destruct (degree p) as [np|] eqn:Hp; [rewrite degree_zero; cbv; Lia.lia|apply zero_degree in Hp; contradiction]).
+      generalize (Pdivmod_eq_iff p p Hn Pone Pzero ltac:(rewrite left_identity, right_identity; reflexivity) Hlt).
+      intros [A B]; symmetry; assumption.
+    Qed.
+
+    Lemma Pdiv_mul_r p q (Hn: not (Peq q Pzero)):
+      Peq (Pdiv (Pmul p q) q) p.
+    Proof.
+      assert (Hlt: degree_lt (degree Pzero) (degree q)) by (destruct (degree q) as [np|] eqn:Hp; [rewrite degree_zero; cbv; Lia.lia|apply zero_degree in Hp; contradiction]).
+      generalize (Pdivmod_eq_iff (Pmul p q) q Hn p Pzero ltac:(rewrite right_identity; reflexivity) Hlt).
+      intros [A B]; symmetry; assumption.
+    Qed.
+
+    Lemma Pdiv_mul_l q p (Hn: not (Peq q Pzero)):
+      Peq (Pdiv (Pmul q p) q) p.
+    Proof. rewrite commutative. apply Pdiv_mul_r. auto. Qed.
+
+    Lemma Pdivmod_distr p q d:
+      Peq (Pdiv (Padd p q) d) (Padd (Pdiv p d) (Pdiv q d)) /\
+      Peq (Pmod (Padd p q) d) (Padd (Pmod p d) (Pmod q d)).
+    Proof.
+      destruct (Peq_dec d Pzero) as [->|Hdnz].
+      - repeat rewrite Pdiv_0_r, Pmod_0_r.
+        rewrite left_identity; split; reflexivity.
+      - edestruct (Pdivmod_eq_iff (Padd p q) d Hdnz) as [<- <-]; [| |split; reflexivity].
+        + rewrite (Pdivmod_eq_spec p d) at 1.
+          rewrite (Pdivmod_eq_spec q d) at 1.
+          rewrite <- (associative (Pmul _ _) (Pmod _ _) (Padd _ _)).
+          rewrite (associative (Pmod _ _)).
+          rewrite (commutative (Pmod _ _)).
+          rewrite <- associative, associative, right_distributive.
+          reflexivity.
+        + generalize (add_degree (Pmod p d) (Pmod q d)).
+          generalize (Pmod_degree_lt p d Hdnz).
+          generalize (Pmod_degree_lt q d Hdnz). intros.
+          destruct (degree d) as [nd|] eqn:Hd; [|elim Hdnz; apply zero_degree; auto].
+          destruct (degree (Pmod p d)); destruct (degree (Pmod q d)); destruct ((degree (Padd (Pmod p d) (Pmod q d)))); cbv -[degree_lt_dec] in *; destruct (degree_lt_dec _ _); Lia.lia.
+    Qed.
+
+    Lemma Pdiv_distr p q d:
+      Peq (Pdiv (Padd p q) d) (Padd (Pdiv p d) (Pdiv q d)).
+    Proof. apply Pdivmod_distr. Qed.
+
+    Lemma Pmod_distr p q d:
+      Peq (Pmod (Padd p q) d) (Padd (Pmod p d) (Pmod q d)).
+    Proof. apply Pdivmod_distr. Qed.
+
+    Lemma Pmod_mul p q:
+      Peq (Pmod (Pmul p q) q) Pzero.
+    Proof.
+      destruct (Peq_dec q Pzero) as [->|Hn]; [rewrite mul_0_r; apply Pmod_0_l|].
+      assert (Hlt: degree_lt (degree Pzero) (degree q)) by (destruct (degree q) as [np|] eqn:Hp; [rewrite degree_zero; cbv; Lia.lia|apply zero_degree in Hp; contradiction]).
+      generalize (Pdivmod_eq_iff (Pmul p q) q Hn p Pzero ltac:(rewrite right_identity; reflexivity) Hlt).
+      intros [A B]; symmetry; assumption.
+    Qed.
+
+    Lemma Pmod_mod_eq p q:
+      Peq (Pmod (Pmod p q) q) (Pmod p q).
+    Proof.
+      destruct (Peq_dec q Pzero) as [->|Hn]; [repeat rewrite Pmod_0_r; reflexivity|].
+      generalize (Pdivmod_eq_iff (Pmod p q) q Hn Pzero (Pmod p q) ltac:(rewrite mul_0_l, left_identity; reflexivity) ltac:(apply Pmod_degree_lt; auto)).
+      intros [A B]; symmetry; assumption.
+    Qed.
+
+    Lemma Pmod_small p q:
+      degree_lt (degree p) (degree q) ->
+      Peq (Pmod p q) p.
+    Proof.
+      intro Hlt. destruct (Peq_dec q Pzero) as [->|Hn]; [rewrite Pmod_0_r; reflexivity|].
+      generalize (Pdivmod_eq_iff p q Hn Pzero p ltac:(rewrite mul_0_l, left_identity; reflexivity) Hlt).
+      intros [A B]; symmetry; assumption.
+    Qed.
+
+    Lemma Pmul_mod_idemp_l p1 p2 q:
+      Peq (Pmod (Pmul (Pmod p1 q) p2) q) (Pmod (Pmul p1 p2) q).
+    Proof.
+      destruct (Peq_dec q Pzero) as [->|Hn]; [repeat rewrite Pmod_0_r; reflexivity|].
+      generalize (Pdivmod_spec p1 q Hn); intros [A1 B1].
+      generalize (Pdivmod_spec (Pmul p1 p2) q Hn); intros [A B].
+      set (d1 := Pdiv p1 q). set (d := Pdiv (Pmul p1 p2) q).
+      fold d1 in A1; fold d in A.
+      assert (A1': Peq (Psub p1 (Pmul d1 q)) (Pmod p1 q)) by (rewrite A1 at 1; rewrite ring_sub_definition, (commutative (Pmul _ _)), <- associative, right_inverse, right_identity; reflexivity).
+      assert (A': Peq (Psub (Pmul p1 p2) (Pmul d q)) (Pmod (Pmul p1 p2) q)) by (rewrite A at 1; rewrite ring_sub_definition, (commutative (Pmul _ _)), <- associative, right_inverse, right_identity; reflexivity).
+      assert (X: Peq (Pmul (Pmod p1 q) p2) (Padd (Pmul (Psub d (Pmul d1 p2)) q) (Pmod (Pmul p1 p2) q))).
+      { rewrite <- A1', <- A', (right_distributive q).
+        repeat rewrite ring_sub_definition.
+        rewrite (commutative (Pmul d q)), <- (commutative (Popp (Pmul d q))).
+        rewrite associative, <- (associative (Popp (Pmul (Pmul d1 p2) q))).
+        rewrite right_inverse, right_identity.
+        rewrite <- (associative d1), (commutative p2), associative, <- (mul_opp_l (Pmul d1 q)).
+        rewrite <- right_distributive, (commutative p1). reflexivity. }
+      generalize (Pdivmod_eq_iff (Pmul (Pmod p1 q) p2) q Hn (Psub d (Pmul d1 p2)) (Pmod (Pmul p1 p2) q) X B).
+      intros [U V]; symmetry; assumption.
+    Qed.
+
+    Lemma Pmul_mod_idemp_r p1 p2 q:
+      Peq (Pmod (Pmul p1 (Pmod p2 q)) q) (Pmod (Pmul p1 p2) q).
+    Proof.
+      rewrite (commutative p1 p2), <- (Pmul_mod_idemp_l p2 p1 q).
+      rewrite (commutative p1). reflexivity.
+    Qed.
+
+    Lemma Pmul_mod_idemp p1 p2 q:
+      Peq (Pmod (Pmul (Pmod p1 q) (Pmod p2 q)) q) (Pmod (Pmul p1 p2) q).
+    Proof. rewrite Pmul_mod_idemp_l, Pmul_mod_idemp_r. reflexivity. Qed.
+
+    Lemma Pmul_mod_distr_l p1 p2 q:
+      Peq (Pmod (Pmul q p1) (Pmul q p2)) (Pmul q (Pmod p1 p2)).
+    Proof.
+      destruct (Peq_dec p2 Pzero) as [->|Hnp2].
+      - rewrite mul_0_r, Pmod_0_r, Pmod_0_r. reflexivity.
+      - generalize (Pdivmod_spec p1 p2 Hnp2). intros [A B].
+        destruct (Peq_dec q Pzero) as [->|Hnq].
+        + rewrite mul_0_l, mul_0_l, Pmod_0_l, mul_0_l. reflexivity.
+        + symmetry. eapply (proj2 (Pdivmod_eq_iff (Pmul q p1) (Pmul q p2) _ (Pdiv p1 p2) _ _ _)). Unshelve.
+          * intro X. apply zero_product_zero_factor in X.
+            destruct X; contradiction.
+          * rewrite A at 1. rewrite left_distributive.
+            rewrite (associative q), (commutative q), <-associative.
+            reflexivity.
+          * repeat rewrite mul_degree_eq.
+            apply degree_lt_add_mono_l; auto.
+            intro X; apply zero_degree in X; congruence.
+    Qed.
+
+    Lemma Pmul_mod_distr_r p1 p2 q:
+      Peq (Pmod (Pmul p1 q) (Pmul p2 q)) (Pmul (Pmod p1 p2) q).
+    Proof.
+      repeat rewrite <- (commutative q).
+      apply Pmul_mod_distr_l.
+    Qed.
+
+    Lemma Pmod_add_l p q r:
+      Peq (Pmod (Padd (Pmul p q) r) q) (Pmod r q).
+    Proof.
+      destruct (Peq_dec q Pzero) as [->|Hn]; [rewrite mul_0_r, left_identity; reflexivity|].
+      symmetry.
+      eapply (proj2 (Pdivmod_eq_iff (Padd (Pmul p q) r) q Hn (Padd p (Pdiv r q)) (Pmod r q) _ _)).
+      Unshelve.
+      - generalize (Pdivmod_spec r q Hn); intros [A B].
+        rewrite A at 1. rewrite associative, <- right_distributive.
+        reflexivity.
+      - apply Pmod_degree_lt; auto.
+    Qed.
+
+    Lemma Pmod_add_r p q r:
+      Peq (Pmod (Padd r (Pmul p q)) q) (Pmod r q).
+    Proof. rewrite (commutative r). apply Pmod_add_l. Qed.
+
+    Lemma Padd_mod_idemp_l p1 p2 q:
+      Peq (Pmod (Padd (Pmod p1 q) p2) q) (Pmod (Padd p1 p2) q).
+    Proof.
+      destruct (Peq_dec q Pzero) as [->|Hn]; [repeat rewrite Pmod_0_r; reflexivity|].
+      generalize (Pdivmod_spec p1 q Hn); intros [A B].
+      assert (Peq (Pmod p1 q) (Psub p1 (Pmul (Pdiv p1 q) q))) as ->.
+      { rewrite A at 2. rewrite ring_sub_definition, (commutative (Pmul _ _)), <- associative, right_inverse, right_identity. reflexivity. }
+      rewrite ring_sub_definition, <- mul_opp_l, (commutative p1), <- associative.
+      apply Pmod_add_l.
+    Qed.
+
+    Lemma Padd_mod_idemp_r p1 p2 q:
+      Peq (Pmod (Padd p1 (Pmod p2 q)) q) (Pmod (Padd p1 p2) q).
+    Proof.
+      rewrite (commutative p1 p2), <- (Padd_mod_idemp_l p2 p1).
+      rewrite (commutative p1). reflexivity.
+    Qed.
+
+    Lemma Padd_mod_idemp p1 p2 q:
+      Peq (Pmod (Padd (Pmod p1 q) (Pmod p2 q)) q) (Pmod (Padd p1 p2) q).
+    Proof. rewrite Padd_mod_idemp_l, Padd_mod_idemp_r. reflexivity. Qed.
+
+    Lemma Pmod_mul_mod_l x p1 p2:
+      Peq (Pmod (Pmod x (Pmul p1 p2)) p1) (Pmod x p1).
+    Proof.
+      assert (HA: Peq (Pmod x (Pmul p1 p2)) (Psub x (Pmul (Pdiv x (Pmul p1 p2)) (Pmul p1 p2)))); [|rewrite HA at 1].
+      { rewrite (Pdivmod_eq_spec x (Pmul p1 p2)) at 2.
+        rewrite ring_sub_definition, (commutative _ (Pmod _ _)), <- associative, right_inverse, right_identity. reflexivity. }
+      rewrite ring_sub_definition, <- mul_opp_l, (commutative p1 p2), Pmod_distr, (associative _ p2 p1), Pmod_mul, right_identity. reflexivity.
+    Qed.
+
+    Lemma Pmod_mul_mod_r x p1 p2:
+      Peq (Pmod (Pmod x (Pmul p1 p2)) p2) (Pmod x p2).
+    Proof. rewrite (commutative p1 p2). apply Pmod_mul_mod_l. Qed.
+
+    Lemma Pdivides_iff a b:
+      Pdivides a b <-> exists c, Peq b (Pmul c a).
+    Proof.
+      split; [intro Hdiv|intros [c Heq]].
+      - exists (Pdiv b a). rewrite <- (right_identity (Pmul _ _)).
+        unfold Pdivides in Hdiv. rewrite <- Hdiv.
+        apply Pdivmod_eq_spec.
+      - rewrite <- (right_identity (Pmul _ _)) in Heq.
+        destruct (Peq_dec a Pzero) as [He|Hn]; [rewrite Heq, He, mul_0_r, right_identity; apply Pdivides_0_r|].
+        apply Pdivmod_eq_iff in Heq; auto.
+        + unfold Pdivides; symmetry. apply Heq.
+        + rewrite degree_zero. destruct (degree a) as [|] eqn:Ha; [cbv; Lia.lia|elim Hn; apply zero_degree; auto].
+    Qed.
+
+    Lemma Pmul_div_l a b c (Hc: Pdivides c a):
+      Peq (Pmul (Pdiv a c) b) (Pdiv (Pmul a b) c).
+    Proof.
+      destruct (Peq_dec c Pzero) as [->|Hcnz]; [rewrite Pdiv_0_r, Pdiv_0_r, mul_0_l; reflexivity|].
+      apply Pdivides_iff in Hc. destruct Hc as [k Hc].
+      rewrite Hc. rewrite Pdiv_mul_r; auto.
+      rewrite <- associative, (commutative c), associative.
+      rewrite Pdiv_mul_r; auto. reflexivity.
+    Qed.
+
+    Lemma Pmul_div_r a b c (Hc: Pdivides c b):
+      Peq (Pmul a (Pdiv b c)) (Pdiv (Pmul a b) c).
+    Proof.
+      destruct (Peq_dec c Pzero) as [->|Hcnz]; [rewrite Pdiv_0_r, Pdiv_0_r, mul_0_r; reflexivity|].
+      apply Pdivides_iff in Hc. destruct Hc as [k Hc].
+      rewrite Hc. rewrite Pdiv_mul_r; auto.
+      rewrite associative, Pdiv_mul_r; auto. reflexivity.
+    Qed.
+
+    Lemma Pdivides_trans a b c:
+      Pdivides a b -> Pdivides b c -> Pdivides a c.
+    Proof.
+      repeat rewrite Pdivides_iff.
+      intros [c1 A] [c2 B]. rewrite A, associative in B.
+      eauto.
+    Qed.
+
+    Lemma Pdivides_opp a b:
+      Pdivides a b -> Pdivides a (Popp b).
+    Proof.
+      repeat rewrite Pdivides_iff.
+      intros (c & Heq). exists (Popp c). rewrite Heq, mul_opp_l.
+      reflexivity.
+    Qed.
+
+    Lemma Pdivides_add x a b:
+      Pdivides x a -> Pdivides x b -> Pdivides x (Padd a b).
+    Proof.
+      repeat rewrite Pdivides_iff. intros (ca & Ha) (cb & Hb).
+      exists (Padd ca cb). rewrite Ha, Hb, right_distributive. reflexivity.
+    Qed.
+
+    Lemma Pdivides_sub x a b:
+      Pdivides x a -> Pdivides x b -> Pdivides x (Psub a b).
+    Proof.
+      rewrite ring_sub_definition; intros.
+      apply Pdivides_add; auto. apply Pdivides_opp; auto.
+    Qed.
+
+    Lemma Pdivides_mul_l x a b:
+      Pdivides x a -> Pdivides x (Pmul a b).
+    Proof.
+      repeat rewrite Pdivides_iff; intros (c & Ha).
+      exists (Pmul c b). rewrite Ha. rewrite <- associative, (commutative x b), associative.
+      reflexivity.
+    Qed.
+
+    Lemma Pdivides_mul_r x a b:
+      Pdivides x b -> Pdivides x (Pmul a b).
+    Proof. rewrite commutative. apply Pdivides_mul_l. Qed.
+
+    Lemma Pdivides_mod x a b:
+      Pdivides x a -> Pdivides x b -> Pdivides x (Pmod a b).
+    Proof.
+      intros Ha Hb. generalize (Pdivmod_eq_spec a b); intro Heq.
+      assert (Peq (Pmod a b) (Psub a (Pmul (Pdiv a b) b))) as ->; [|apply Pdivides_sub; auto; apply Pdivides_mul_r; auto].
+      rewrite Heq at 2. rewrite ring_sub_definition.
+      rewrite <- associative, (commutative (Pmod _ _)), associative, right_inverse, left_identity.
+      reflexivity.
+    Qed.
+
+    (* Extended euclidean algorithm for Bezout's coefficients *)
+    Definition Pegcd p q :=
+      let fix egcd_rec n p' q' :=
+        match n with
+        | O => (Pone, Pzero)
+        | S n' => if Peq_dec q' Pzero then (Pone, Pzero) else
+                   let '(u, v) := egcd_rec n' q' (Pmod p' q') in
+                   (v, Psub u (Pmul v (Pdiv p' q')))
+        end
+      in egcd_rec (measure q) p q.
+
+    Definition Pgcd p q :=
+      (* Invariant measure q' <= n *)
+      let fix gcd_rec n p' q' :=
+        match n with
+        | O => p'
+        | S n' => if Peq_dec q' Pzero then p' else gcd_rec n' q' (Pmod p' q')
+        end
+      in gcd_rec (measure q) p q.
+
+    Global Instance peq_egcd_proper: Proper (Peq ==> Peq ==> (fun x y => Peq (fst x) (fst y) /\ Peq (snd x) (snd y))) Pegcd.
+    Proof.
+      pose (egcd_rec := (fix egcd_rec n p' q' :=
+        match n with
+        | O => (Pone, Pzero)
+        | S n' => if Peq_dec q' Pzero then (Pone, Pzero) else
+                   let '(u, v) := egcd_rec n' q' (Pmod p' q') in
+                   (v, Psub u (Pmul v (Pdiv p' q')))
+        end)).
+      assert (IH: forall n, Proper (Peq ==> Peq ==> (fun x y => Peq (fst x) (fst y) /\ Peq (snd x) (snd y))) (egcd_rec n)).
+      { induction n; intros p1 p1' Hp1 p2 p2' Hp2; simpl; [split; reflexivity|].
+        destruct (Peq_dec p2 Pzero); destruct (Peq_dec p2' Pzero); try rewrite Hp1 in *; try rewrite Hp2 in *; simpl; try (split; reflexivity); try contradiction.
+        rewrite (surjective_pairing (egcd_rec n p2 _)).
+        rewrite (surjective_pairing (egcd_rec n p2' _)).
+        simpl. generalize (IHn p2 p2' Hp2 (Pmod p1 p2) (Pmod p1' p2') ltac:(rewrite Hp1, Hp2; reflexivity)); intros [A B].
+        rewrite A, B, Hp1, Hp2. split; reflexivity. }
+      intros p1 p1' Hp1 p2 p2' Hp2.
+      unfold Pegcd. unfold measure. assert (degree p2 = degree p2' :> _) as -> by (rewrite Hp2; reflexivity).
+      apply IH; auto.
+    Qed.
+
+    Global Instance peq_egcd_proper1: Proper (Peq ==> Peq ==> (fun x y => Peq (fst x) (fst y))) Pegcd.
+    Proof. intros p1 p1' Hp1 p2 p2' Hp2. apply (proj1 (peq_egcd_proper _ _ Hp1 _ _ Hp2)). Qed.
+
+    Global Instance peq_egcd_proper2: Proper (Peq ==> Peq ==> (fun x y => Peq (snd x) (snd y))) Pegcd.
+    Proof. intros p1 p1' Hp1 p2 p2' Hp2. apply (proj2 (peq_egcd_proper _ _ Hp1 _ _ Hp2)). Qed.
+
+    Global Instance peq_gcd_proper: Proper (Peq ==> Peq ==> Peq) Pgcd.
+    Proof.
+      pose (gcd_rec := (fix gcd_rec (n : nat) (p' q' : P) {struct n} : P :=
+        match n with
+        | 0%nat => p'
+        | S n' => if Peq_dec q' Pzero then p' else gcd_rec n' q' (Pmod p' q')
+        end)).
+      assert (IHn: forall n, Proper (Peq ==> Peq ==> Peq) (gcd_rec n)).
+      { induction n; intros p1 p1' Hp1 p2 p2' Hp2; simpl; auto.
+        destruct (Peq_dec p2 Pzero); destruct (Peq_dec p2' Pzero); try rewrite Hp1 in *; try rewrite Hp2 in *; try reflexivity; try contradiction. }
+      intros p1 p1' Hp1 p2 p2' Hp2.
+      unfold Pgcd. unfold measure. rewrite Hp2 at 1.
+      apply IHn; auto.
+    Qed.
+
+    Lemma Pegcd_0_r p:
+      Peq (fst (Pegcd p Pzero)) Pone /\ Peq (snd (Pegcd p Pzero)) Pzero.
+    Proof.
+      unfold Pegcd; unfold measure; rewrite degree_zero; simpl.
+      split; reflexivity.
+    Qed.
+
+    Lemma Pegcd_0_l p:
+      Peq (fst (Pegcd Pzero p)) (if Peq_dec p Pzero then Pone else Pzero) /\ Peq (snd (Pegcd Pzero p)) (if Peq_dec p Pzero then Pzero else Pone).
+    Proof.
+      unfold Pegcd. unfold measure; destruct (degree p) as [np|] eqn:Hp.
+      - simpl. destruct (Peq_dec p Pzero) as [He|Hne]; [rewrite He, degree_zero in Hp; congruence|].
+        destruct np; simpl; [rewrite mul_0_l, ring_sub_definition, Group.inv_id, right_identity; split; reflexivity|].
+        destruct (Peq_dec (Pmod Pzero p) Pzero) as [He|Hn]; simpl; [rewrite mul_0_l, ring_sub_definition, Group.inv_id, right_identity; split; reflexivity|].
+        rewrite Pmod_0_l in Hn; elim Hn; reflexivity.
+      - simpl. apply zero_degree in Hp.
+        destruct (Peq_dec p Pzero); [|contradiction].
+        split; reflexivity.
+    Qed.
+
+    Lemma Pgcd_0_r p:
+      Peq (Pgcd p Pzero) p.
+    Proof. unfold Pgcd. unfold measure; rewrite degree_zero. reflexivity. Qed.
+
+    Lemma Pgcd_0_l p:
+      Peq (Pgcd Pzero p) p.
+    Proof.
+      unfold Pgcd. unfold measure; destruct (degree p) as [np|] eqn:Hp.
+      - simpl; destruct (Peq_dec p Pzero) as [He|Hne]; [rewrite He, degree_zero in Hp; congruence|].
+        destruct np; simpl; [reflexivity|].
+        destruct (Peq_dec (Pmod Pzero p) Pzero) as [He|Hn]; [reflexivity|].
+        destruct np; [rewrite Pmod_0_l in Hn; elim Hn; reflexivity|].
+        destruct (Peq_dec (Pmod p (Pmod Pzero p)) Pzero) as [He|_]; [rewrite Pmod_0_l, Pmod_0_r in He; contradiction|].
+        destruct np; [rewrite Pmod_0_l, Pmod_0_r; reflexivity|].
+        destruct (Peq_dec (Pmod (Pmod Pzero p) (Pmod p (Pmod Pzero p))) Pzero) as [|HX]; [|elim HX]; rewrite Pmod_0_l, Pmod_0_r; [| rewrite Pmod_0_l]; reflexivity.
+      - symmetry; apply zero_degree; auto.
+    Qed.
+
+    Lemma Pgcd_mod p q:
+      Peq (Pgcd p q) (Pgcd q (Pmod p q)).
+    Proof.
+      pose (gcd_rec := (fix gcd_rec (n : nat) (p' q' : P) {struct n} : P :=
+        match n with
+        | 0%nat => p'
+        | S n' => if Peq_dec q' Pzero then p' else gcd_rec n' q' (Pmod p' q')
+        end)).
+      assert (IH: forall n1 n2 p q, (measure q <= n1 <= n2)%nat -> Peq (gcd_rec n1 p q) (gcd_rec n2 p q)).
+      { clear p q. induction n1; simpl; intros n2 p q (Hle1 & Hle2).
+        - unfold measure, convert in Hle1; destruct (degree q) as [nq|] eqn:Hq; [Lia.lia|].
+          apply zero_degree in Hq.
+          destruct n2; [reflexivity|].
+          simpl. destruct (Peq_dec q Pzero); [reflexivity|contradiction].
+        - destruct n2; [Lia.lia|]; simpl.
+          destruct (Peq_dec q Pzero) as [|Hn]; [reflexivity|].
+          generalize (Pmod_degree_lt p q Hn); intro Hlt.
+          apply IHn1; try Lia.lia. unfold measure, convert in *.
+          destruct (degree (Pmod p q)) as [|] eqn:Hm; [|Lia.lia].
+          destruct (degree q) as [nq|] eqn:Hq; cbv in Hlt; Lia.lia. }
+      destruct (Peq_dec q Pzero) as [->|Hqnz]; [rewrite Pgcd_0_l, Pgcd_0_r, Pmod_0_r; reflexivity|].
+      unfold Pgcd. destruct (measure q) eqn:Hq.
+      - unfold measure in Hq; destruct (degree q) as [|] eqn:Hqq; [inversion Hq|apply zero_degree in Hqq; contradiction].
+      - destruct (Peq_dec q Pzero) as [|_]; [contradiction|].
+        generalize (Pmod_degree_lt p q Hqnz). intro Hlt.
+        unfold measure in Hq; destruct (degree q) as [|] eqn:Hqq; [|apply zero_degree in Hqq; contradiction].
+        inversion Hq; subst n0; clear Hq.
+        assert (Hle: (measure (Pmod p q) <= n)%nat) by (unfold measure, convert; destruct (degree (Pmod p q)) as [npq|] eqn:Hpq; cbv in Hlt; Lia.lia).
+        fold gcd_rec.
+        rewrite (IH (measure (Pmod p q)) n q (Pmod p q) ltac:(Lia.lia)).
+        reflexivity.
+    Qed.
+
+    Lemma Pgcd_same p:
+      Peq (Pgcd p p) p.
+    Proof. rewrite Pgcd_mod, Pmod_same, Pgcd_0_r. reflexivity. Qed.
+
+    Lemma Pgcd_divides_lr:
+      forall p q, Pdivides (Pgcd p q) p /\ Pdivides (Pgcd p q) q.
+    Proof.
+      assert (IH: forall n p q, measure p <= n -> measure q <= n -> Pdivides (Pgcd p q) p /\ Pdivides (Pgcd p q) q).
+      { induction n; intros p q Hp Hq.
+        - unfold measure in Hp, Hq.
+          destruct (degree p) as [|] eqn:Hpz; [inversion Hp|].
+          destruct (degree q) as [|] eqn:Hqz; [inversion Hq|].
+          apply zero_degree in Hpz, Hqz.
+          rewrite Hpz, Hqz; unfold Pdivides.
+          rewrite Pmod_0_l; split; reflexivity.
+        - assert ((measure p <= n /\ measure q <= n) \/ (measure p = S n :> _ \/ measure q = S n :> _))%nat as [[Hlep Hleq] | Hnle] by Lia.lia.
+          + apply IHn; auto.
+          + destruct (Peq_dec p Pzero) as [->|Hnpz]; [unfold Pdivides; rewrite Pmod_0_l, Pgcd_0_l, Pmod_same; split; reflexivity|].
+            destruct (Peq_dec q Pzero) as [->|Hnqz]; [unfold Pdivides; rewrite Pmod_0_l, Pgcd_0_r, Pmod_same; split; reflexivity|].
+            assert (Hmod1: (measure (Pmod p q) <= n)%nat).
+            { generalize (Pmod_degree_lt p q Hnqz); intros Hmod1.
+              unfold measure, convert; destruct (degree (Pmod p q)) as [nm|]; [|Lia.lia].
+              unfold measure, convert in Hq; destruct (degree q) as [nq|] eqn:Hqq; [|elim Hnqz; apply zero_degree; auto].
+              cbv in Hmod1; Lia.lia. }
+            rewrite Pgcd_mod.
+            destruct (Peq_dec (Pmod p q) Pzero) as [He|Hmodnz].
+            * unfold Pdivides. rewrite He, Pgcd_0_r, Pmod_same.
+              split; [auto|reflexivity].
+            * rewrite Pgcd_mod.
+              assert (Hmod2: (measure (Pmod q (Pmod p q)) <= n)%nat).
+              { generalize (Pmod_degree_lt q (Pmod p q) Hmodnz). intros Hmod2.
+                unfold measure, convert; destruct (degree (Pmod q (Pmod p q))) as [nm|]; [|Lia.lia].
+                unfold measure, convert in Hmod1; destruct (degree (Pmod p q)) as [nq|] eqn:Hqq; [|elim Hmodnz; apply zero_degree; auto].
+                cbv in Hmod2; Lia.lia. }
+              generalize (IHn _ _ Hmod1 Hmod2).
+              rewrite <- Pgcd_mod, <- Pgcd_mod.
+              intros [A B].
+              apply Pdivides_iff in A, B.
+              destruct A as [c1 A]; destruct B as [c2 B].
+              assert (exists cq, Peq q (Pmul cq (Pgcd p q))) as [cq C].
+              { eexists. rewrite (Pdivmod_eq_spec q (Pmod p q)) at 1; rewrite B.
+                rewrite A at 2. rewrite associative, <- right_distributive.
+                reflexivity. }
+              split; apply Pdivides_iff; eauto.
+              { eexists. rewrite (Pdivmod_eq_spec p q) at 1.
+                rewrite A. rewrite C at 2.
+                rewrite associative, <- right_distributive.
+                reflexivity. } }
+      intros p q. apply (IH (measure p + measure q)%nat p q); Lia.lia.
+    Qed.
+
+    Lemma Pgcd_divides_l p q:
+      Pdivides (Pgcd p q) p.
+    Proof. apply Pgcd_divides_lr. Qed.
+
+    Lemma Pgcd_divides_r p q:
+      Pdivides (Pgcd p q) q.
+    Proof. apply Pgcd_divides_lr. Qed.
+
+    Lemma Pgcd_eq_0_l p q:
+      Peq (Pgcd p q) Pzero -> Peq p Pzero.
+    Proof.
+      intros A; generalize (Pgcd_divides_l p q); rewrite Pdivides_iff.
+      intros [c B]. rewrite A, mul_0_r in B. auto.
+    Qed.
+
+    Lemma Pgcd_eq_0_r p q:
+      Peq (Pgcd p q) Pzero -> Peq q Pzero.
+    Proof.
+      intros A; generalize (Pgcd_divides_r p q); rewrite Pdivides_iff.
+      intros [c B]. rewrite A, mul_0_r in B. auto.
+    Qed.
+
+    Lemma Pgcd_greatest:
+      forall p q s,
+        Pdivides s p ->
+        Pdivides s q ->
+        Pdivides s (Pgcd p q).
+    Proof.
+      assert (IH: forall n p q s, (measure p + measure q <= n)%nat -> Pdivides s p -> Pdivides s q -> Pdivides s (Pgcd p q)).
+      { induction n; intros p q s Hpq Hdivp Hdivq.
+        - assert (measure p <= 0 /\ measure q <= 0) as [Hpn Hqn] by Lia.lia.
+          unfold measure, convert in Hpn, Hqn.
+          destruct (degree p) as [|] eqn:Hpz; [inversion Hpn|].
+          destruct (degree q) as [|] eqn:Hqz; [inversion Hqn|].
+          apply zero_degree in Hpz, Hqz.
+          rewrite Hpz, Hqz, Pgcd_0_l. apply Pdivides_0_r.
+        - destruct (Peq_dec p Pzero) as [->|Hpnz]; [rewrite Pgcd_0_l; auto|].
+          destruct (Peq_dec q Pzero) as [->|Hqnz]; [rewrite Pgcd_0_r; auto|].
+          destruct (degree p) as [np|] eqn:Hp; [|elim Hpnz; apply zero_degree; auto].
+          destruct (degree q) as [nq|] eqn:Hq; [|elim Hqnz; apply zero_degree; auto].
+          destruct (degree_lt_dec (degree p) (degree q)) as [Hlt|Hnlt].
+          + assert (Peq (Pgcd p q) (Pgcd q p)) as -> by (rewrite (Pgcd_mod p q), Pmod_small; auto; reflexivity).
+            rewrite Pgcd_mod. generalize (Pdivides_mod s q p Hdivq Hdivp); intro Hdivm.
+            apply IHn; auto.
+            generalize (Pmod_degree_lt q p Hpnz); intro X.
+            unfold measure, convert in *.
+            rewrite Hp in *; rewrite Hq in *; simpl in *.
+            destruct (degree (Pmod q p)) as [nm|] eqn:Hmm; cbv in X, Hlt; Lia.lia.
+          + rewrite Pgcd_mod. generalize (Pdivides_mod s p q Hdivp Hdivq); intro Hdivm.
+            apply IHn; auto.
+            generalize (Pmod_degree_lt p q Hqnz); intro X.
+            unfold measure, convert in *.
+            rewrite Hp in *; rewrite Hq in *; simpl in *.
+            destruct (degree (Pmod p q)) as [nm|] eqn:Hmm; cbv in X, Hnlt; Lia.lia. }
+      intros; apply (IH (measure p + measure q)%nat); auto; Lia.lia.
+    Qed.
+
+    Lemma Pegcd_mod:
+      forall p q, not (Peq q Pzero) ->
+             Peq (fst (Pegcd p q)) (snd (Pegcd q (Pmod p q))) /\
+             Peq (snd (Pegcd p q)) (Psub (fst (Pegcd q (Pmod p q))) (Pmul (snd (Pegcd q (Pmod p q))) (Pdiv p q))).
+    Proof.
+      pose (egcd_rec := (fix egcd_rec n p' q' :=
+        match n with
+        | O => (Pone, Pzero)
+        | S n' => if Peq_dec q' Pzero then (Pone, Pzero) else
+                   let '(u, v) := egcd_rec n' q' (Pmod p' q') in
+                   (v, Psub u (Pmul v (Pdiv p' q')))
+        end)).
+      assert (IH: forall n n' p q, (measure q <= n)%nat -> (measure q <= n')%nat -> Peq (fst (Pegcd p q)) (fst (egcd_rec n' p q)) /\ Peq (snd (Pegcd p q)) (snd (egcd_rec n' p q))).
+      { induction n; intros n' p q Hle Hle'.
+        - unfold measure, convert in Hle.
+          destruct (degree q) as [|] eqn:Hqz; [Lia.lia|].
+          apply zero_degree in Hqz.
+          destruct (peq_egcd_proper _ p ltac:(reflexivity) _ _ Hqz) as [-> ->].
+          destruct (Pegcd_0_r p) as [-> ->].
+          destruct n'; simpl; [split; reflexivity|].
+          destruct (Peq_dec q Pzero) as [_|]; [|contradiction].
+          simpl. split; reflexivity.
+        - destruct (Peq_dec q Pzero) as [Hqz|Hqnz].
+          + destruct (peq_egcd_proper _ p ltac:(reflexivity) _ _ Hqz) as [-> ->].
+            destruct (Pegcd_0_r p) as [-> ->].
+            simpl; destruct (Peq_dec q Pzero) as [_|]; [|contradiction].
+            destruct n'; simpl; [split; reflexivity|].
+            destruct (Peq_dec q Pzero) as [_|]; [|contradiction].
+            simpl; split; reflexivity.
+          + generalize (Pmod_degree_lt p q Hqnz). intro Hlt.
+            destruct (degree q) as [nq|] eqn:Hq; [|elim Hqnz; apply zero_degree; auto].
+            destruct n'; [unfold measure, convert in Hle'; rewrite Hq in Hle'; Lia.lia|].
+            unfold Pegcd; fold egcd_rec.
+            unfold measure; rewrite Hq. simpl.
+            destruct (Peq_dec q Pzero) as [|_]; [contradiction|].
+            rewrite (surjective_pairing (egcd_rec n' _ _)).
+            rewrite (surjective_pairing (egcd_rec nq _ _)).
+            assert (Hn: (measure (Pmod p q) <= n)%nat) by (unfold measure, convert in *; rewrite Hq in *; destruct (degree (Pmod p q)); cbv in *; Lia.lia).
+            assert (Hn': (measure (Pmod p q) <= n')%nat) by (unfold measure, convert in *; rewrite Hq in *; destruct (degree (Pmod p q)); cbv in *; Lia.lia).
+            assert (Hnq: (measure (Pmod p q) <= nq)%nat) by (unfold measure, convert in *; rewrite Hq in *; destruct (degree (Pmod p q)); cbv in *; Lia.lia).
+            simpl. destruct (IHn n' q _ Hn Hn') as [<- <-].
+            simpl. destruct (IHn nq q _ Hn Hnq) as [<- <-].
+            split; reflexivity. }
+      intros p q Hqnz. unfold Pegcd; fold egcd_rec.
+      destruct (IH _ _ q (Pmod p q) ltac:(reflexivity) ltac:(reflexivity)) as [<- <-].
+      destruct (degree q) as [nq|] eqn:Hq; [|elim Hqnz; apply zero_degree; auto].
+      unfold measure; rewrite Hq; simpl.
+      destruct (Peq_dec q Pzero) as [|_]; [contradiction|].
+      rewrite (surjective_pairing (egcd_rec _ _ _)). simpl.
+      generalize (Pmod_degree_lt p q Hqnz). intro Hlt.
+      assert (Hle: (measure (Pmod p q) <= nq)%nat) by (unfold measure, convert in *; rewrite Hq in *; destruct (degree (Pmod p q)); cbv in *; Lia.lia).
+      destruct (IH _ _ q _ ltac:(reflexivity) Hle) as [<- <-].
+      split; reflexivity.
+    Qed.
+
+    (* We do not generally have equality here as we do not enforce the GCD
+       to be monic *)
+    Lemma Pgcd_comm p q:
+      Pdivides (Pgcd p q) (Pgcd q p) /\ Pdivides (Pgcd q p) (Pgcd p q).
+    Proof. split; apply Pgcd_greatest; apply Pgcd_divides_lr. Qed.
+
+    Lemma Pegcd_bezout:
+      forall p q, Peq (Padd (Pmul (fst (Pegcd p q)) p) (Pmul (snd (Pegcd p q)) q)) (Pgcd p q).
+    Proof.
+      assert (IH: forall n p q, (measure q <= n)%nat -> Peq (Padd (Pmul (fst (Pegcd p q)) p) (Pmul (snd (Pegcd p q)) q)) (Pgcd p q)).
+      { induction n; intros p q Hle.
+        - unfold measure in *.
+          destruct (degree q) eqn:Hqz; [inversion Hle|].
+          apply zero_degree in Hqz.
+          destruct (peq_egcd_proper p _ ltac:(reflexivity) _ _ Hqz) as [-> ->].
+          destruct (Pegcd_0_r p) as [-> ->].
+          rewrite mul_0_l, left_identity, right_identity.
+          rewrite Hqz, Pgcd_0_r. reflexivity.
+        - destruct (Peq_dec q Pzero) as [Hqz|Hqnz].
+          { destruct (peq_egcd_proper p _ ltac:(reflexivity) _ _ Hqz) as [-> ->].
+            destruct (Pegcd_0_r p) as [-> ->].
+            rewrite Hqz, Pgcd_0_r, mul_0_l, left_identity, right_identity; reflexivity. }
+          destruct (degree q) as [nq|] eqn:Hq; [|elim Hqnz; apply zero_degree; auto].
+          generalize (Pmod_degree_lt p q Hqnz). intro Hlt.
+          assert (Hn: (measure (Pmod p q) <= n)%nat) by (unfold measure, convert in *; rewrite Hq in *; destruct (degree (Pmod p q)); cbv in *; Lia.lia).
+          rewrite Pgcd_mod.
+          rewrite <- (IHn q _ Hn).
+          destruct (Pegcd_mod p q Hqnz) as [-> ->].
+          assert (Heq: Peq (Pmod p q) (Psub p (Pmul (Pdiv p q) q))) by (rewrite (Pdivmod_eq_spec p q) at 2; rewrite ring_sub_definition, <- associative, (commutative (Pmod _ _)), associative, right_inverse, left_identity; reflexivity).
+          rewrite Heq at 6.
+          clear Heq.
+          rewrite ring_sub_definition, ring_sub_definition, right_distributive, left_distributive.
+          rewrite associative, associative.
+          rewrite (commutative (Pmul (snd _) _)).
+          rewrite mul_opp_l, mul_opp_r.
+          rewrite associative. reflexivity. }
+      intros p q; apply (IH _ p q ltac:(reflexivity)).
+    Qed.
+
+    Lemma Pgcd_bezout:
+      forall p q, exists u v, Peq (Padd (Pmul u p) (Pmul v q)) (Pgcd p q).
+    Proof.
+      intros p q. eexists; eexists. apply (Pegcd_bezout p q).
+    Qed.
+
+    Lemma Pdivides_degree_zero p q:
+      degree p = Some 0%nat :> _ -> Pdivides p q.
+    Proof.
+      intro Hd0. generalize (degree_0_const _ Hd0).
+      intro Heq. rewrite Heq. apply Pdivides_iff.
+      generalize (degree_definition p); rewrite Hd0.
+      intros [Hnz Hs].
+      exists (Pmul q (Pconst (Finv (coeff p 0)))).
+      intro k. rewrite mul_const_coeff_r, mul_const_coeff_r.
+      rewrite associative, right_multiplicative_inverse; auto.
+      rewrite left_identity. reflexivity.
+    Qed.
+
+    Lemma Pgcd_same_degree p q:
+      degree (Pgcd p q) = degree (Pgcd q p) :> _.
+    Proof.
+      generalize (Pgcd_comm p q); intros [A B].
+      apply Pdivides_iff in A, B.
+      destruct A as [c1 A]. destruct B as [c2 B].
+      generalize (mul_degree_eq c1 (Pgcd p q)); rewrite <- A at 1.
+      generalize (mul_degree_eq c2 (Pgcd q p)); rewrite <- B at 1.
+      intros BB AA. rewrite AA.
+      destruct (degree (Pgcd p q)) as [np|] eqn:Hpq; [|destruct (degree c1); simpl; reflexivity].
+      destruct (degree (Pgcd q p)) as [nq|] eqn:Hqp; [|destruct (degree c2); simpl in BB; congruence].
+      destruct (degree c1) as [nc1|] eqn:Hc1; [|simpl in AA; congruence].
+      destruct (degree c2) as [nc2|] eqn:Hc2; [|simpl in BB; congruence].
+      rewrite BB in AA; simpl in AA. inversion AA.
+      assert (nc1 = 0%nat :> _ /\ nc2 = 0%nat :> _) as [-> ->] by Lia.lia.
+      simpl. reflexivity.
+    Qed.
+
+    Lemma Pdivides_gcd p q:
+      Pdivides q p -> Peq (Pgcd p q) q.
+    Proof.
+      unfold Pdivides; intro A.
+      rewrite Pgcd_mod, A, Pgcd_0_r.
+      reflexivity.
+    Qed.
+
+    Definition coprime p q :=
+      degree (Pgcd p q) = Some 0%nat :> _.
+
+    Global Instance peq_proper_coprime: Proper (Peq ==> Peq ==> iff) coprime.
+    Proof.
+      intros p1 p1' Heq1 p2 p2' Heq2.
+      unfold coprime. rewrite Heq1, Heq2. reflexivity.
+    Qed.
+
+    Lemma coprime_comm p q:
+      coprime p q <-> coprime q p.
+    Proof. unfold coprime; rewrite Pgcd_same_degree. reflexivity. Qed.
+
+    Lemma Pegcd_bezout_coprime p q:
+      coprime p q -> Peq (Padd (Pmul (Pdiv (fst (Pegcd p q)) (Pgcd p q)) p) (Pmul (Pdiv (snd (Pegcd p q)) (Pgcd p q)) q)) Pone.
+    Proof.
+      intro Hcoprime. generalize (Pegcd_bezout p q). intro Heq.
+      pose (u := (fst (Pegcd p q))). pose (v := (snd (Pegcd p q))).
+      generalize (Pdivides_degree_zero (Pgcd p q) u Hcoprime). intro Hu.
+      generalize (Pdivides_degree_zero (Pgcd p q) v Hcoprime). intro Hv.
+      assert (Hnz: not (Peq (Pgcd p q) Pzero)) by (intro He; unfold coprime in Hcoprime; rewrite He, degree_zero in Hcoprime; congruence).
+      rewrite <- (Pdiv_same (Pgcd p q) Hnz).
+      rewrite Pmul_div_l, Pmul_div_l by assumption.
+      rewrite <- Pdiv_distr. rewrite Heq. reflexivity.
+    Qed.
+
+    Lemma Bezout_coprime p q:
+      coprime p q -> exists u v, Peq (Padd (Pmul u p) (Pmul v q)) Pone.
+    Proof.
+      intro Hcoprime. eexists; eexists.
+      apply Pegcd_bezout_coprime; auto.
+    Qed.
+
+    Lemma gauss_divides_r d p q:
+      coprime d p -> Pdivides d (Pmul p q) -> Pdivides d q.
+    Proof.
+      intros Hcoprime Hdiv.
+      destruct (Bezout_coprime d p Hcoprime) as (u & v & Heq).
+      apply Pdivides_iff. apply Pdivides_iff in Hdiv.
+      destruct Hdiv as (kpq & Hdiv).
+      exists (Padd (Pmul q u) (Pmul v kpq)).
+      transitivity (Pmul q Pone); [symmetry; apply right_identity|].
+      rewrite <- Heq. rewrite left_distributive.
+      rewrite (associative q v), (commutative q v), <- (associative v q), (commutative q p), Hdiv.
+      rewrite right_distributive, associative, associative.
+      reflexivity.
+    Qed.
+
+    Lemma gauss_divides_l d p q:
+      coprime d p -> Pdivides d (Pmul q p) -> Pdivides d q.
+    Proof. rewrite commutative. apply gauss_divides_r. Qed.
+
+    Lemma coprime_divides p1 p2 q:
+      coprime p1 p2 -> Pdivides p1 q -> Pdivides p2 q -> Pdivides (Pmul p1 p2) q.
+    Proof.
+      intros Hco Hdiv1 Hdiv2.
+      apply Pdivides_iff in Hdiv2.
+      destruct Hdiv2 as (c2 & Hdiv2).
+      rewrite Hdiv2 in Hdiv1.
+      generalize (gauss_divides_l _ _ _ Hco Hdiv1). intros Hdiv.
+      apply Pdivides_iff in Hdiv. destruct Hdiv as (c & Hdiv).
+      rewrite Hdiv in Hdiv2. rewrite Hdiv2.
+      apply Pdivides_iff.
+      exists c. rewrite associative. reflexivity.
+    Qed.
+
+    Lemma coprime_mul_r p q1 q2:
+      coprime p q1 -> coprime p q2 -> coprime p (Pmul q1 q2).
+    Proof.
+      unfold coprime; intros A B.
+      generalize (Pgcd_divides_lr p (Pmul q1 q2)); intros [C1 C2].
+      assert (D: coprime (Pgcd p (Pmul q1 q2)) q1).
+      { unfold coprime. generalize (Pgcd_divides_lr (Pgcd p (Pmul q1 q2)) q1); intros [D1 D2].
+        generalize (Pdivides_trans _ _ _ D1 C1). intro E.
+        generalize (Pgcd_greatest _ _ _ E D2). intro G.
+        apply Pdivides_iff in G. destruct G as [c G].
+        rewrite G, mul_degree_eq in A.
+        destruct (degree c) as [nc|]; [|simpl in A; congruence].
+        destruct (degree (Pgcd (Pgcd p (Pmul q1 q2)) q1)) as [n|]; simpl in A; [|congruence].
+        inversion A; f_equal. Lia.lia. }
+      generalize (gauss_divides_r _ q1 q2 D C2).
+      intro E. generalize (Pgcd_greatest _ _ _ C1 E). intro G.
+      apply Pdivides_iff in G. destruct G as [c G].
+      rewrite G, mul_degree_eq in B.
+      destruct (degree c) as [nc|]; [|simpl in B; congruence].
+      destruct (degree (Pgcd p (Pmul q1 q2))) as [n|]; simpl in B; [|congruence].
+      inversion B; f_equal; Lia.lia.
+    Qed.
+
+    Lemma coprime_mul_l q1 q2 p:
+      coprime q1 p -> coprime q2 p -> coprime (Pmul q1 q2) p.
+    Proof.
+      intros A B. apply coprime_comm. apply coprime_mul_r; apply coprime_comm; auto.
+    Qed.
+  End DivMod.
+  Section Decomposition.
+    Context {Finv: F -> F}{Fdiv: F -> F -> F}
+      {field: @field F Feq Fzero Fone Fopp Fadd Fsub Fmul Finv Fdiv}.
+
+    Local Notation Pdivmod := (@Pdivmod Fdiv).
+    Local Notation Pdiv := (@Pdiv Fdiv).
+    Local Notation Pmod := (@Pmod Fdiv).
+
+    (* Show that base is actually a base system for polynomials *)
+    (* p = Σ p_i X^i *)
+    Definition Pdecompose (p: P): P :=
+      @bigop _ Padd Pzero _ (seq 0 (measure p)) (fun k => Pmul (Pconst (coeff p k)) (base k)).
+
+    Lemma coeff_bigop n c:
+      forall i, coeff (@bigop _ Padd Pzero _ (seq 0 n) (fun k => Pmul (Pconst (c k)) (base k))) i = @bigop F Fadd Fzero _ (seq 0 n) (fun k => coeff (Pmul (Pconst (c k )) (base k)) i).
+    Proof.
+      induction n; intros; [simpl; apply zero_definition|].
+      rewrite seq_S, (@bigop_app F) by typeclasses eauto.
+      rewrite <- IHn; simpl.
+      etransitivity; [generalize ((bigop_app (fun k : nat => Pmul (Pconst (c k)) (base k)) (seq 0 n) (n::nil)) i); eauto|].
+      rewrite add_definition; simpl.
+      rewrite add_definition, zero_definition; reflexivity.
+    Qed.
+
+    Global Instance peq_proper_decompose: Proper (Peq ==> Peq) Pdecompose.
+    Proof.
+      intros p1 p2 Heq. unfold Pdecompose.
+      assert (measure p1 = measure p2 :> _) as -> by (unfold measure; rewrite Heq; reflexivity).
+      apply bigop_ext_eq; intros i Hi.
+      rewrite (Heq i). reflexivity.
+    Qed.
+
+    Lemma Pdecompose_add p1 p2:
+      Peq (Pdecompose (Padd p1 p2)) (Padd (Pdecompose p1) (Pdecompose p2)).
+    Proof.
+      pose (n := max (measure p1) (measure p2)).
+      assert (exists n1, n = measure p1 + n1 :> _)%nat as [n1 Hn1] by (exists (n - measure p1)%nat; Lia.lia).
+      assert (exists n2, n = measure p2 + n2 :> _)%nat as [n2 Hn2] by (exists (n - measure p2)%nat; Lia.lia).
+      assert (Hn: measure (Padd p1 p2) <= n).
+      { generalize (add_degree p1 p2). unfold measure, convert in *.
+        destruct (degree (Padd p1 p2)); destruct (degree p1); destruct (degree p2); cbv -[degree_lt_dec Nat.max] in *; destruct (degree_lt_dec _ _); try Lia.lia. }
+      assert (exists nn, n = measure (Padd p1 p2) + nn :> _)%nat as [nn Hnn] by (exists (n - (measure (Padd p1 p2)))%nat; Lia.lia).
+      assert (Hlt: forall p k, (measure p <= k)%nat -> coeff p k = 0).
+      { intros p k Hk. unfold measure, convert in Hk.
+        generalize (degree_definition p). destruct (degree p); auto.
+        intros [X Y]; apply Y; Lia.lia. }
+      unfold Pdecompose.
+      rewrite (bigop_widen _ (seq 0 (measure p1)) (seq (measure p1) n1)) by (intros i Hi k; apply in_seq in Hi; rewrite mul_const_base_coeff, zero_definition; destruct (dec_eq_nat i k); [apply Hlt; Lia.lia|reflexivity]).
+      rewrite <- seq_add, <- Hn1.
+      rewrite (bigop_widen _ (seq 0 (measure p2)) (seq (measure p2) n2)) by (intros i Hi k; apply in_seq in Hi; rewrite mul_const_base_coeff, zero_definition; destruct (dec_eq_nat i k); [apply Hlt; Lia.lia|reflexivity]).
+      rewrite <- seq_add, <- Hn2.
+      rewrite (bigop_widen _ (seq 0 (measure (Padd p1 p2))) (seq (measure (Padd p1 p2)) nn)) by (intros i Hi k; apply in_seq in Hi; rewrite mul_const_base_coeff, zero_definition; destruct (dec_eq_nat i k); [apply Hlt; Lia.lia|reflexivity]).
+      rewrite <- seq_add, <- Hnn.
+      rewrite bigop_same_index. apply bigop_ext_eq.
+      intros i Hi. rewrite <- right_distributive, const_add_const, add_definition.
+      reflexivity.
+    Qed.
+
+    Lemma Pdecompose_eq:
+      forall p, Peq p (Pdecompose p).
+    Proof.
+      assert (IH: forall n p, (measure p <= n)%nat -> Peq p (Pdecompose p)).
+      { induction n; intros p Hm.
+        - unfold Pdecompose. assert (measure p = 0 :> _)%nat as -> by Lia.lia.
+          simpl. unfold measure, convert in Hm.
+          destruct (degree p) as [np|] eqn:Hnp; [Lia.lia|apply zero_degree; auto].
+        - assert (measure p <= n \/ measure p = S n :> _)%nat as [A|A] by Lia.lia.
+          + apply IHn; auto.
+          + unfold measure, convert in A. destruct (degree p) as [np|] eqn:Hnp; [|congruence].
+            inversion A; subst np; clear A.
+            generalize (Pmod_degree_lt p (base n) (base_not_zero n)); intro Hlt.
+            rewrite degree_base in Hlt.
+            assert (Hm': (measure (Pmod p (base n)) <= n)%nat).
+            { unfold measure, convert.
+              destruct (degree (Pmod p (base n))); cbv in Hlt; Lia.lia. }
+            assert (Heq': Peq p (Padd (Pmul (Pconst (coeff p n)) (base n)) (Pmod p (base n)))).
+            { intro k. rewrite add_definition, mul_const_base_coeff.
+              assert (k < n \/ k >= n)%nat as [Hk_lt|Hk_ge] by Lia.lia.
+              - destruct (dec_eq_nat n k); [Lia.lia|].
+                rewrite left_identity, (Pdivmod_eq_spec p (base n) k), add_definition, mul_definition.
+                assert (mul_coeff (coeff (Pdiv p (base n))) (coeff (base n)) k = 0) as ->; [|rewrite left_identity; reflexivity].
+                unfold mul_coeff. rewrite (bigop_ext_eq _ _ (fun _ => 0)); [rewrite bigop_const; rewrite mul_0_r; reflexivity|].
+                intros i Hin; apply in_seq in Hin.
+                rewrite base_definition.
+                destruct (dec_eq_nat n (k - i)); [Lia.lia|].
+                apply mul_0_r.
+              - assert (coeff (Pmod p (base n)) k = 0) as ->.
+                { generalize (degree_definition (Pmod p (base n))).
+                  destruct (degree (Pmod p (base n))); cbv in Hlt; auto.
+                  intros [X Y]; apply Y; Lia.lia. }
+                rewrite right_identity.
+                destruct (dec_eq_nat n k); [subst k; reflexivity|].
+                generalize (degree_definition p); rewrite Hnp; intros [X Y].
+                apply Y; Lia.lia. }
+            rewrite Heq', Pdecompose_add, <- (IHn _ Hm').
+            assert (Peq (Pdecompose _) (Pmul (Pconst (coeff p n)) (base n))) as ->; [|reflexivity].
+            unfold Pdecompose.
+            assert (measure _ = S n :> _) as ->.
+            { unfold measure. rewrite mul_degree_eq, degree_base, degree_const.
+              destruct (Feq_dec (coeff p n) 0); simpl; [|Lia.lia].
+              generalize (degree_definition p); rewrite Hnp.
+              intros [X Y]; contradiction. }
+            rewrite seq_S, bigop_app; simpl.
+            rewrite (bigop_ext_eq _ _ (fun _ => Pzero)).
+            2: { intros i Hi. apply in_seq in Hi. intro k.
+                 rewrite zero_definition, mul_definition.
+                 unfold mul_coeff.
+                 rewrite (bigop_ext_eq _ _ (fun _ => 0)); [rewrite bigop_const, mul_0_r; reflexivity|].
+                 intros j Hj. rewrite base_definition, const_definition.
+                 destruct j; [|apply mul_0_l].
+                 rewrite mul_const_base_coeff.
+                 destruct (dec_eq_nat n i); [|apply mul_0_l].
+                 destruct (dec_eq_nat i (k - 0)%nat); Lia.lia. }
+            rewrite bigop_const, mul_0_r, left_identity, right_identity.
+            intro k. rewrite mul_const_base_coeff.
+            rewrite (mul_const_base_coeff (coeff p n) n k).
+            destruct (dec_eq_nat n k); [|reflexivity].
+            rewrite mul_const_base_coeff.
+            destruct (dec_eq_nat _ _); [|congruence]. reflexivity. }
+      intros; eapply IH. reflexivity.
+    Qed.
+
+    Lemma Pdecompose_coeff n c:
+      forall i, coeff (@bigop _ Padd Pzero _ (seq 0 n) (fun k => Pmul (Pconst (c k)) (base k))) i = if dec_lt_nat i n then c i else 0.
+    Proof.
+      intro i.
+      transitivity (@bigop _ Fadd Fzero _ (seq 0 n) (fun k => coeff (Pmul (Pconst (c k)) (base k)) i)); [apply coeff_bigop|].
+      destruct (dec_lt_nat i n).
+      - assert (n = i + (n - i) :> _)%nat as -> by Lia.lia.
+        rewrite seq_add, bigop_app; simpl.
+        rewrite (bigop_ext_eq (seq 0 _) _ (fun _ => 0)) by (intros j Hj; apply in_seq in Hj; rewrite mul_const_base_coeff; destruct (dec_eq_nat _ _); [Lia.lia|reflexivity]).
+        rewrite bigop_const, mul_0_r, left_identity.
+        assert (n - i = S (pred (n - i)) :> _)%nat as -> by Lia.lia.
+        simpl. rewrite (bigop_ext_eq _ _ (fun _ => 0)) by (intros j Hj; apply in_seq in Hj; rewrite mul_const_base_coeff; destruct (dec_eq_nat _ _); [Lia.lia|reflexivity]).
+        rewrite bigop_const, mul_0_r, right_identity.
+        rewrite mul_const_base_coeff.
+        destruct (dec_eq_nat _ _); [|congruence]. reflexivity.
+      - rewrite (bigop_ext_eq _ _ (fun _ => 0)) by (intros j Hj; apply in_seq in Hj; rewrite mul_const_base_coeff; destruct (dec_eq_nat _ _); [Lia.lia|reflexivity]).
+        rewrite bigop_const, mul_0_r. reflexivity.
+    Qed.
+
+    Lemma degree_cyclotomic n a:
+      degree (Psub (base n) (Pconst a)) = match n with O => if Feq_dec a 1 then None else Some n | S _ => Some n end :> _.
+    Proof.
+      pose (p := Psub (base n) (Pconst a)); fold p.
+      generalize (degree_definition p).
+      destruct (degree p) as [np|] eqn:Hnp; [intros [A1 A2]|intro A].
+      - destruct (dec_eq_nat np n) as [->|Hn].
+        + destruct n; [|reflexivity].
+          unfold p in A1; rewrite sub_definition, base_definition, const_definition in A1.
+          destruct (dec_eq_nat _ _); [|congruence].
+          rewrite ring_sub_definition in A1.
+          destruct (Feq_dec a 1) as [Heq|]; [rewrite Heq in A1|reflexivity].
+          rewrite right_inverse in A1; elim A1; reflexivity.
+        + assert (np < n \/ n < np)%nat as [Hlt|Hlt] by Lia.lia.
+          * generalize (A2 n ltac:(Lia.lia)).
+            unfold p. rewrite sub_definition, base_definition, const_definition.
+            destruct (dec_eq_nat _ _); [|congruence]. destruct n; [Lia.lia|].
+            rewrite ring_sub_definition, Group.inv_id, right_identity.
+            intro X; symmetry in X; elim (zero_neq_one X).
+          * unfold p in A1. rewrite sub_definition, base_definition, const_definition in A1.
+            destruct (dec_eq_nat n np); [Lia.lia|].
+            destruct np; [Lia.lia|].
+            elim A1. rewrite ring_sub_definition, Group.inv_id.
+            apply right_identity.
+      - generalize (A n); destruct n.
+        + unfold p; rewrite sub_definition, base_definition, const_definition.
+          destruct (dec_eq_nat _ _); [|congruence].
+          rewrite ring_sub_definition.
+          intro X; apply Group.inv_unique in X.
+          rewrite Group.inv_inv in X. destruct (Feq_dec a 1) as [|Hn]; [reflexivity|elim Hn; symmetry; assumption].
+        + unfold p; rewrite sub_definition, base_definition, const_definition.
+          destruct (dec_eq_nat _ _); [|congruence].
+          rewrite ring_sub_definition, Group.inv_id, right_identity.
+          intro X; symmetry in X; elim (zero_neq_one X).
+    Qed.
+
+    (* Pmod (Σ p_i) q = Σ (Pmod p_i q) *)
+    Lemma Pmod_bigop {I} (idx: list I) p q:
+      Peq (Pmod (@bigop _ Padd Pzero _ idx p) q) (@bigop _ Padd Pzero _ idx (fun k => Pmod (p k) q)).
+    Proof.
+      induction idx; simpl; [apply Pmod_0_l|].
+      rewrite <- IHidx, Pmod_distr. reflexivity.
+    Qed.
+
+    (* P mod (X^n - a) = Σ_{i=0}^{n - 1} (p_i + a * p_{i+n})X^i when deg(P)<=2n-1*)
+    Lemma Pmod_cyclotomic p n a (Hnpos: (n > 0)%nat) (Hmp: (measure p <= 2 * n)%nat):
+      Peq (Pmod p (Psub (base n) (Pconst a)))
+          (@bigop _ Padd Pzero _ (seq 0 n) (fun k => Pmul (Pconst ((coeff p k) + a * (coeff p (k + n)%nat))) (base k))).
+    Proof.
+      generalize (degree_cyclotomic n a); intro Hna.
+      destruct n as [|n'] eqn:Hneq; [Lia.lia|].
+      destruct (dec_le_nat (measure p) n) as [Hle|Hnle].
+      - assert (Hlt: degree_lt (degree p) (Some n)) by (unfold measure, convert in Hle; destruct (degree p); cbv; auto; Lia.lia).
+        rewrite Hneq, <- Hna in Hlt.
+        rewrite Pmod_small, <- Hneq; auto.
+        assert (n = (measure p) + (n - measure p) :> _)%nat as -> by Lia.lia.
+        rewrite seq_add, bigop_app; simpl.
+        rewrite (bigop_ext_eq (seq (measure p) _) _ (fun _ => Pzero)).
+        2: intros i Hi k; apply in_seq in Hi; rewrite zero_definition, mul_const_base_coeff; destruct (dec_eq_nat i k); [|reflexivity]; rewrite measure_definition, measure_definition, mul_0_r by Lia.lia; apply left_identity.
+        rewrite bigop_const, mul_0_r, right_identity.
+      rewrite (Pdecompose_eq p) at 1. unfold Pdecompose.
+      apply bigop_ext_eq. intros i Hi; apply in_seq in Hi.
+      rewrite (measure_definition p (i + _)) by Lia.lia.
+      rewrite mul_0_r, right_identity. reflexivity.
+      - rewrite <- Hneq in *. rewrite (Pdecompose_eq p). unfold Pdecompose.
+        assert (measure p = n + (measure p - n) :> _)%nat as -> by Lia.lia.
+        rewrite seq_add, bigop_app, Pmod_distr.
+        rewrite (Pmod_bigop (seq 0 n)).
+        rewrite (bigop_ext_eq (seq 0 n) _ (fun k => (Pmul (Pconst (coeff p k)) (base k)))).
+        2: intros i Hi; apply in_seq in Hi; rewrite Pmod_small; [reflexivity|].
+        2: rewrite mul_degree_eq, degree_base, degree_const, Hna.
+        2: destruct (Feq_dec _ 0); cbv; auto; Lia.lia.
+        rewrite (bigop_ext_eq (seq (0 + n)%nat _) _ (fun k => Padd (Pmul (Pmul (Pconst (coeff p k)) (base (k - n)%nat)) (Psub (base n) (Pconst a))) (Pmul (Pconst (a * coeff p ((k - n) + n)%nat)) (base (k - n)%nat)))).
+        2:{ intros i Hi; apply in_seq in Hi.
+            rewrite left_distributive, <- associative, base_mul_base.
+            assert (i - n + n = i :> _)%nat as -> by Lia.lia.
+            rewrite <- (associative (Pconst _)), (commutative (base _)).
+            rewrite (associative (Pconst _)), const_mul_const, (commutative _ a).
+            rewrite ring_sub_definition, <- associative.
+            rewrite left_inverse, right_identity. reflexivity. }
+        rewrite <- bigop_same_index, Pmod_distr.
+        rewrite Pmod_bigop at 1.
+        rewrite (bigop_ext_eq (seq (0 + n)%nat _) (fun k => Pmod _ _) (fun _ => Pzero)) by (intros; apply Pmod_mul).
+        rewrite bigop_const, mul_0_r, left_identity.
+        rewrite <- (bigop_shift 0%nat n (measure p - n)%nat (fun i : nat => Pmul (Pconst (a * coeff p (i + n))) (base i))).
+        rewrite (bigop_widen _ (seq 0 (measure _ - _)%nat) (seq (measure p - n)%nat (2 * n - measure p)%nat)).
+        2:{ intros i Hi k. apply in_seq in Hi.
+            rewrite mul_const_base_coeff, zero_definition.
+            destruct (dec_eq_nat i k); [|reflexivity].
+            rewrite measure_definition by Lia.lia; apply mul_0_r. }
+        rewrite <- seq_app.
+        assert ((measure p - n + (2 * n - measure p)) = n :> _)%nat as -> by Lia.lia.
+        rewrite Pmod_bigop, bigop_same_index.
+        apply bigop_ext_eq; intros i Hi. apply in_seq in Hi.
+        rewrite Pmod_small by (rewrite Hna, mul_degree_eq, degree_base, degree_const; destruct (Feq_dec _ _); cbv; auto; Lia.lia).
+        rewrite <- right_distributive, const_add_const. reflexivity.
+    Qed.
+
+    (* First n coefficients of P *)
+    Definition to_list (n: nat) (p: P): list F :=
+      List.map (coeff p) (seq 0%nat n).
+
+    Definition of_list (l: list F): P :=
+      @bigop _ Padd Pzero _ (seq 0%nat (length l)) (fun k => Pmul (Pconst (nth_default 0 l k)) (base k)).
+
+    Lemma to_list_length (p: P) (n: nat):
+      length (to_list n p) = n :> _.
+    Proof. unfold to_list. rewrite map_length, seq_length. reflexivity. Qed.
+
+    Lemma to_list_nth_default_inbounds (p: P) (n: nat) d:
+      forall k,
+        (k < n)%nat ->
+        nth_default d (to_list n p) k = coeff p k.
+    Proof.
+      intros. unfold to_list.
+      erewrite map_nth_default by (rewrite seq_length; auto).
+      instantiate (1 := 0%nat).
+      rewrite nth_default_seq_inbounds; auto.
+      reflexivity.
+    Qed.
+
+    Lemma of_list_to_list (p: P) (n: nat) (Hlt: degree_lt (degree p) (Some n)):
+      Peq (of_list (to_list n p)) p.
+    Proof.
+      intro k. unfold of_list. rewrite Pdecompose_coeff, to_list_length.
+      generalize (degree_definition p). intro Hp.
+      destruct (degree p) as [np|] eqn:Hpdeg; [destruct Hp as [Hp1 Hp2]|].
+      - cbv in Hlt. destruct (dec_lt_nat k n).
+        + unfold to_list. assert (coeff p (S np) = 0) as <- by (apply Hp2; Lia.lia).
+          rewrite map_nth_default_always, nth_default_seq_inbounds; auto.
+          reflexivity.
+        + symmetry; apply Hp2; Lia.lia.
+      - destruct (dec_lt_nat k n); [|symmetry; apply Hp].
+        unfold to_list. rewrite <- (Hp k), map_nth_default_always, nth_default_seq_inbounds; auto.
+        reflexivity.
+    Qed.
+
+    Definition Pmod_cyclotomic_list (l: list F) (n: nat) (a: F) :=
+      List.fold_left
+        (fun l i =>
+           let tmp := a * (nth_default 0 l (i + n)%nat) in
+           let l' := set_nth (i + n)%nat ((nth_default 0 l i) - tmp) l in
+           set_nth i ((nth_default 0 l i) + tmp) l')
+        (seq 0%nat n)
+        l.
+
+    Lemma Pmod_cyclotomic_list_length l n a:
+      length (Pmod_cyclotomic_list l n a) = length l :> _.
+    Proof.
+      unfold Pmod_cyclotomic_list. apply fold_left_invariant.
+      - reflexivity.
+      - intros. repeat rewrite length_set_nth; auto.
+    Qed.
+
+    Lemma Pmod_cyclotomic_list_nth_default l n a
+      (Hlength: (length l >= 2 * n)%nat):
+      forall d k,
+        nth_default d (Pmod_cyclotomic_list l n a) k =
+          if (dec_lt_nat k n) then
+            let xk := nth_default 0 l k in
+            let xkn := nth_default 0 l (k + n)%nat in
+            xk + (a * xkn)
+          else if (dec_lt_nat k (2 * n)) then
+                 let xk := nth_default 0 l k in
+                 let xkn := nth_default 0 l (k - n)%nat in
+                 xkn - (a * xk)
+               else nth_default d l k.
+    Proof.
+      revert l Hlength. unfold Pmod_cyclotomic_list.
+      set (f := (fun (p: nat) (l : list F) (i : nat) => set_nth i (nth_default 0 l i + a * nth_default 0 l (i + p)) (set_nth (i + p) (nth_default 0 l i - a * nth_default 0 l (i + p)) l))).
+      fold (f n). revert n.
+      assert (IH: forall (n : nat) (p: nat) (l : list F),
+                 (n <= p)%nat ->
+                 (length l >= 2 * p)%nat ->
+                 forall (d : F) (k : nat),
+                   nth_default d (fold_left (f p) (seq 0 n) l) k =
+                     (if dec_lt_nat k n
+                      then nth_default 0 l k + a * nth_default 0 l (k + p)
+                      else
+                        if dec_le_nat p k
+                        then
+                          if dec_lt_nat k (p + n) then
+                            nth_default 0 l (k - p) - a * nth_default 0 l k
+                          else nth_default d l k
+                        else nth_default d l k)).
+      { induction n; intros p l Hp Hl d k.
+        - simpl. rewrite PeanoNat.Nat.add_0_r.
+          destruct (dec_le_nat p k); [|reflexivity].
+          destruct (dec_lt_nat k p); [Lia.lia|]. reflexivity.
+        - rewrite seq_S, PeanoNat.Nat.add_0_l, fold_left_app. cbn [fold_left].
+          assert (Hlength': length (fold_left (f p) (seq 0 n) l) = length l :> _).
+          { apply fold_left_invariant; [reflexivity|].
+            intros. unfold f. repeat rewrite length_set_nth. auto. }
+          unfold f at 1. rewrite set_nth_nth_default_full, length_set_nth, Hlength'.
+          destruct (Compare_dec.lt_dec k (length l)).
+          2: { destruct (dec_lt_nat k (S n)); [Lia.lia|].
+               destruct (dec_le_nat p k); [|rewrite nth_default_out_of_bounds by Lia.lia; reflexivity].
+               destruct (dec_lt_nat k (p + S n)); [Lia.lia|].
+               rewrite nth_default_out_of_bounds by Lia.lia. reflexivity. }
+          destruct (PeanoNat.Nat.eq_dec k n); [subst k|].
+          { destruct (dec_lt_nat n (S n)) as [_|]; [|Lia.lia].
+            rewrite IHn by Lia.lia.
+            destruct (dec_lt_nat n n) as [|_]; [Lia.lia|].
+            destruct (dec_le_nat p n); [Lia.lia|].
+            rewrite IHn by Lia.lia.
+            destruct (dec_lt_nat (n + p) n) as [|_]; [Lia.lia|].
+            destruct (dec_le_nat p (n + p)); [|Lia.lia].
+            destruct (dec_lt_nat (n + p) (p + n)); [Lia.lia|].
+            reflexivity. }
+          rewrite set_nth_nth_default_full, Hlength'.
+          destruct (Compare_dec.lt_dec k (length l)) as [_|]; [|Lia.lia].
+          destruct (PeanoNat.Nat.eq_dec k (n + p)); [subst k|].
+          { destruct (dec_lt_nat (n + p) (S n)); [Lia.lia|].
+            destruct (dec_le_nat p (n + p)); [|Lia.lia].
+            destruct (dec_lt_nat (n + p) (p + S n)); [|Lia.lia].
+            do 2 rewrite IHn by Lia.lia.
+            destruct (dec_lt_nat n n); [Lia.lia|].
+            destruct (dec_le_nat p n); [Lia.lia|].
+            assert (n + p - p = n :> _)%nat as -> by Lia.lia.
+            destruct (dec_lt_nat (n + p) n); [Lia.lia|].
+            destruct (dec_le_nat p (n + p)); [|Lia.lia].
+            destruct (dec_lt_nat (n + p) (p + n)); [Lia.lia|]. reflexivity. }
+          rewrite IHn by Lia.lia. destruct (dec_lt_nat k n).
+          { destruct (dec_lt_nat k (S n)); [|Lia.lia]. reflexivity. }
+          destruct (dec_lt_nat k (S n)); [Lia.lia|].
+          destruct (dec_le_nat p k); [|reflexivity].
+          destruct (dec_lt_nat k (p + n)).
+          { destruct (dec_lt_nat k (p + S n)); [|Lia.lia]. reflexivity. }
+          destruct (dec_lt_nat k (p + S n)); [Lia.lia|]. reflexivity. }
+      intros. rewrite IH by Lia.lia.
+      destruct (dec_lt_nat k n); [reflexivity|].
+      destruct (dec_le_nat n k); [|Lia.lia].
+      assert (2 * n = n + n :> _)%nat as -> by Lia.lia. reflexivity.
+    Qed.
+
+    Lemma Pmod_cyclotomic_list_correct (p: P) (n: nat) (a: F)
+      (Hnpos: (n > 0)%nat) (Hmp: (measure p <= 2 * n)%nat):
+      Peq
+        (Pmod p (Psub (base n) (Pconst a)))
+        (of_list (firstn n (Pmod_cyclotomic_list (to_list (2 * n)%nat p) n a))) /\
+      Peq
+        (Pmod p (Padd (base n) (Pconst a)))
+        (of_list (skipn n (Pmod_cyclotomic_list (to_list (2 * n)%nat p) n a))).
+    Proof.
+      assert (Peq (Padd (base n) (Pconst a)) (Psub (base n) (Pconst (Fopp a)))) as -> by (rewrite ring_sub_definition, opp_const, Group.inv_inv; reflexivity).
+      do 2 (rewrite Pmod_cyclotomic; auto).
+      split.
+      - intro k. unfold of_list. do 2 rewrite Pdecompose_coeff.
+        rewrite firstn_length, Pmod_cyclotomic_list_length, to_list_length.
+        assert (Nat.min n (2 * n) = n :> _) as -> by Lia.lia.
+        destruct (dec_lt_nat k n); [|reflexivity].
+        rewrite nth_default_firstn, Pmod_cyclotomic_list_length, to_list_length.
+        destruct (Compare_dec.le_dec n (2 * n)) as [_|]; [|Lia.lia].
+        destruct (Compare_dec.lt_dec k n); [|Lia.lia].
+        rewrite Pmod_cyclotomic_list_nth_default by (rewrite to_list_length; Lia.lia).
+        destruct (dec_lt_nat k n); [|Lia.lia].
+        cbn zeta. do 2 (rewrite to_list_nth_default_inbounds by Lia.lia).
+        reflexivity.
+      - intro k. unfold of_list. do 2 rewrite Pdecompose_coeff.
+        rewrite skipn_length, Pmod_cyclotomic_list_length, to_list_length.
+        assert (2 * n - n = n :> _)%nat as -> by Lia.lia.
+        destruct (dec_lt_nat k n); [|reflexivity].
+        rewrite nth_default_skipn, Pmod_cyclotomic_list_nth_default by (rewrite to_list_length; Lia.lia).
+        destruct (dec_lt_nat (n + k) n); [Lia.lia|].
+        destruct (dec_lt_nat (n + k) (2 * n)); [|Lia.lia].
+        cbn zeta. assert (n + k - n = k :> _)%nat as -> by Lia.lia.
+        do 2 (rewrite to_list_nth_default_inbounds by Lia.lia).
+        rewrite ring_sub_definition, <- Ring.mul_opp_l.
+        assert (k + n = n + k :> _)%nat as -> by Lia.lia.
+        reflexivity.
+    Qed.
+
+  End Decomposition.
+
+  Section Pquot.
+    Context {Finv: F -> F}{Fdiv: F -> F -> F}
+      {field: @field F Feq Fzero Fone Fopp Fadd Fsub Fmul Finv Fdiv}
+      {char_ge_3: @Ring.char_ge F Feq Fzero Fone Fopp Fadd Fsub Fmul (BinNat.N.succ_pos (BinNat.N.two))}.
+    Local Infix "/" := Fdiv.
+
+    Local Notation Pdivmod := (@Pdivmod Fdiv).
+    Local Notation Pdiv := (@Pdiv Fdiv).
+    Local Notation Pmod := (@Pmod Fdiv).
+    Local Notation Pgcd := (@Pgcd Fdiv).
+    Local Notation Pegcd := (@Pegcd Fdiv).
+    Local Notation Pdivides := (@Pdivides Fdiv).
+    Local Notation coprime := (@coprime Fdiv).
+
+    Definition Pquot (q: P): Type := { p: P | Peq p (Pmod p q) }.
+
+    Section PquotOperations.
+      Definition to_P {q} (p: Pquot q) := proj1_sig p.
+      Context {q: P}.
+      Program Definition of_P (p: P): Pquot q := Pmod p q.
+      Next Obligation. symmetry. apply Pmod_mod_eq. Qed.
+
+      Definition eq1 {q'} (p1: Pquot q) (p2: Pquot q'): Prop :=
+        Peq (to_P p1) (to_P p2).
+      Definition zero: Pquot q := of_P Pzero.
+      Definition one: Pquot q := of_P Pone.
+
+      Definition add (p1 p2: Pquot q): Pquot q :=
+        of_P (Padd (to_P p1) (to_P p2)).
+      Definition mul (p1 p2: Pquot q): Pquot q :=
+        of_P (Pmul (to_P p1) (to_P p2)).
+      Definition opp (p: Pquot q): Pquot q :=
+        of_P (Popp (to_P p)).
+      Definition sub (p1 p2: Pquot q): Pquot q :=
+        add p1 (opp p2).
+
+      Global Instance peq_proper_of_P: Proper (Peq ==> eq1) of_P.
+      Proof. intros x y Heq. unfold eq1; simpl. rewrite Heq. reflexivity. Qed.
+    End PquotOperations.
+    Section PquotRing.
+      Context {q: P}.
+
+      Ltac unwrap_Pquot :=
+        match goal with
+        | |- Proper _ _ => unfold Proper, respectful
+        | |- Reflexive _ => unfold Reflexive
+        | |- Symmetric _ => unfold Symmetric
+        | |- Transitive _ => unfold Transitive
+        | |- _ => idtac end;
+        intros;
+        repeat match goal with | [ x : Pquot _ |- _ ] => destruct x end;
+        lazy iota beta delta [eq1 zero one add mul opp sub of_P to_P proj1_sig] in *.
+      Global Instance PquotRing:
+        @commutative_ring (Pquot q) eq1 zero one opp add sub mul.
+      Proof.
+        repeat constructor; unwrap_Pquot.
+        - rewrite Padd_mod_idemp_l, Padd_mod_idemp_r, associative.
+          reflexivity.
+        - rewrite Pmod_0_l, left_identity.
+          symmetry; assumption.
+        - rewrite Pmod_0_l, right_identity.
+          symmetry; assumption.
+        - rewrite H, H0. reflexivity.
+        - reflexivity.
+        - symmetry; assumption.
+        - etransitivity; eauto.
+        - rewrite Padd_mod_idemp_l, left_inverse. reflexivity.
+        - rewrite Padd_mod_idemp_r, right_inverse. reflexivity.
+        - rewrite H; reflexivity.
+        - rewrite commutative; reflexivity.
+        - rewrite Pmul_mod_idemp_l, Pmul_mod_idemp_r, associative.
+          reflexivity.
+        - rewrite Pmul_mod_idemp_l, left_identity. symmetry; assumption.
+        - rewrite Pmul_mod_idemp_r, right_identity. symmetry; assumption.
+        - rewrite H, H0. reflexivity.
+        - reflexivity.
+        - symmetry; assumption.
+        - etransitivity; eauto.
+        - rewrite Padd_mod_idemp_l, Padd_mod_idemp_r, Pmul_mod_idemp_r, <- left_distributive.
+          reflexivity.
+        - rewrite Padd_mod_idemp_l, Padd_mod_idemp_r, Pmul_mod_idemp_l, <- right_distributive.
+          reflexivity.
+        - reflexivity.
+        - rewrite H, H0. reflexivity.
+        - rewrite H, H0. reflexivity.
+        - rewrite commutative. reflexivity.
+      Qed.
+    End PquotRing.
+    Section PquotSame.
+      Variable (p1 p2: P) (Heq: Peq p1 p2).
+
+      Program Definition phi_same (x: Pquot p1): Pquot p2 := proj1_sig x.
+      Next Obligation. destruct x as [x Hx]; simpl; rewrite <- Heq. assumption. Qed.
+
+      Program Definition psi_same (x: Pquot p2): Pquot p1 := proj1_sig x.
+      Next Obligation. destruct x as [x Hx]; simpl; rewrite Heq. assumption. Qed.
+
+      Lemma Pquot_homomorphism_same:
+        @Ring.is_homomorphism (Pquot p1) eq1 one add mul (Pquot p2) eq1 one add mul phi_same
+        /\ @Ring.is_homomorphism (Pquot p2) eq1 one add mul (Pquot p1) eq1 one add mul psi_same.
+      Proof.
+        apply (Ring.ring_by_isomorphism (zero:=zero) (opp:=opp) (sub:=sub)).
+        - intro a; destruct a as [a Ha]; unfold eq1; simpl; reflexivity.
+        - intros a b; destruct a as [a Ha]; destruct b as [b Hb]; unfold eq1; simpl; reflexivity.
+        - unfold eq1; simpl. rewrite Heq; reflexivity.
+        - unfold eq1; simpl. rewrite Heq; reflexivity.
+        - intro a; destruct a as [a Ha]; unfold eq1; simpl; rewrite Heq; reflexivity.
+        - intros a b; destruct a as [a Ha]; destruct b as [b Hb]; unfold eq1; simpl; rewrite Heq; reflexivity.
+        - intros a b; destruct a as [a Ha]; destruct b as [b Hb]; unfold eq1; simpl; rewrite Heq; reflexivity.
+        - intros a b; destruct a as [a Ha]; destruct b as [b Hb]; unfold eq1; simpl; rewrite Heq; reflexivity.
+      Qed.
+    End PquotSame.
+    Section CRT2.
+      (* Chinese Remainder Theorem (Algebraic form), base case *)
+      Variable (p p1 p2: P) (Hcoprime: coprime p1 p2) (Hp_eq: Peq p (Pmul p1 p2)).
+
+      Definition phi2 (x: Pquot p): (Pquot p1 * Pquot p2) :=
+        (of_P (to_P x), of_P (to_P x)).
+
+      Definition psi2 (xy: Pquot p1 * Pquot p2): Pquot p :=
+        let x := to_P (fst xy) in
+        let y := to_P (snd xy) in
+        let u := fst (Pegcd p1 p2) in
+        let v := snd (Pegcd p1 p2) in
+        of_P (Padd (Pmul y (Pmul (Pdiv u (Pgcd p1 p2)) p1)) (Pmul x (Pmul (Pdiv v (Pgcd p1 p2)) p2))).
+
+      Definition EQ2 (x y: Pquot p1 * Pquot p2) :=
+        eq1 (fst x) (fst y) /\ eq1 (snd x) (snd y).
+
+      Global Instance EQ_proper_psi2: Proper (EQ2 ==> eq1) psi2.
+      Proof.
+        intros x y. unfold EQ2, eq1, psi2; simpl. intros (HEQ1 & HEQ2).
+        destruct x as [x1 x2]. destruct y as [y1 y2].
+        simpl in *.
+        rewrite HEQ1, HEQ2. reflexivity.
+      Qed.
+
+      Global Instance eq_proper_phi2: Proper (eq1 ==> EQ2) phi2.
+      Proof.
+        intros x y. unfold EQ2, eq1, phi2; simpl. intro HEQ.
+        rewrite HEQ; split; reflexivity.
+      Qed.
+
+      Definition ZERO2: Pquot p1 * Pquot p2 := (zero, zero).
+
+      Lemma ZERO_def2: EQ2 (phi2 zero) ZERO2.
+      Proof. unfold phi2, ZERO2, EQ2, eq1; simpl; repeat rewrite Pmod_0_l; split; reflexivity. Qed.
+
+      Definition ONE2: Pquot p1 * Pquot p2 := (one, one).
+
+      Lemma ONE_def2: EQ2 (phi2 one) ONE2.
+      Proof.
+        unfold phi2, ONE2, EQ2, eq1; simpl.
+        rewrite Hp_eq.
+        destruct (Peq_dec p1 Pzero) as [->|Hp1nz].
+        { rewrite mul_0_l, Pmod_0_r, Pmod_0_r.
+          split; reflexivity. }
+        destruct (Peq_dec p2 Pzero) as [->|Hp2nz].
+        { rewrite mul_0_r, Pmod_0_r, Pmod_0_r.
+          split; reflexivity. }
+        destruct (degree p1) as [np1|] eqn:Hp1; [|apply zero_degree in Hp1; contradiction].
+        destruct (degree p2) as [np2|] eqn:Hp2; [|apply zero_degree in Hp2; contradiction].
+        generalize (mul_degree_eq p1 p2); rewrite Hp1, Hp2; simpl. intro Hp12.
+        assert (np1 + np2 = 0%nat :> _ \/ (np1 + np2 > 0))%nat as [He|Hn] by Lia.lia.
+        - assert (np1 = 0 :> _)%nat as He1 by Lia.lia.
+          assert (np2 = 0 :> _)%nat as He2 by Lia.lia.
+          rewrite He1 in Hp1; rewrite He2 in Hp2; rewrite He in Hp12.
+          generalize (Pdivides_degree_zero _ Pone Hp1).
+          generalize (Pdivides_degree_zero _ Pone Hp2).
+          generalize (Pdivides_degree_zero _ Pone Hp12).
+          unfold Pdivides. intros A1 A2 A12.
+          rewrite A1, A2, A12, Pmod_0_l, Pmod_0_l. split; reflexivity.
+        - rewrite (Pmod_small Pone (Pmul p1 p2) ltac:(rewrite degree_one, Hp12; cbv -[Nat.add]; Lia.lia)).
+          split; reflexivity.
+      Qed.
+
+      Definition OPP2 (x: Pquot p1 * Pquot p2): Pquot p1 * Pquot p2 :=
+        (opp (fst x), opp (snd x)).
+
+      Definition ADD2 (x y: Pquot p1 * Pquot p2): Pquot p1 * Pquot p2 :=
+        (add (fst x) (fst y), add (snd x) (snd y)).
+
+      Definition SUB2 (x y: Pquot p1 * Pquot p2): Pquot p1 * Pquot p2 :=
+        (sub (fst x) (fst y), sub (snd x) (snd y)).
+
+      Definition MUL2 (x y: Pquot p1 * Pquot p2): Pquot p1 * Pquot p2 :=
+        (mul (fst x) (fst y), mul (snd x) (snd y)).
+
+      Lemma SUB_def2 x y:
+        EQ2 (SUB2 x y) (ADD2 x (OPP2 y)).
+      Proof.
+        destruct x as [[x1 Hx1] [x2 Hx2]].
+        destruct y as [[y1 Hy1] [y2 Hy2]].
+        unfold EQ2, SUB2, OPP2, eq1; simpl.
+        repeat rewrite Pmod_opp. split; reflexivity.
+      Qed.
+
+      Lemma phi_injective2:
+        forall x y, eq1 (fst (phi2 x)) (fst (phi2 y)) ->
+               eq1 (snd (phi2 x)) (snd (phi2 y)) ->
+               eq1 x y.
+      Proof.
+        intros x y Heq1 Heq2.
+        destruct x, y. unfold phi2, eq1 in *; simpl in *.
+        assert (Hdiv: Pdivides (Pmul p1 p2) (Psub x x0)).
+        { apply coprime_divides; auto.
+          - rewrite (Pdivmod_eq_spec x p1), (Pdivmod_eq_spec x0 p1), ring_sub_definition.
+            rewrite <- Heq1, Group.inv_op.
+            rewrite <- (associative (Pmul _ _) (Pmod _ _)).
+            rewrite (associative (Pmod x p1)).
+            rewrite right_inverse, left_identity.
+            rewrite <- mul_opp_l, <- right_distributive.
+            apply Pdivides_iff. eexists; reflexivity.
+          - rewrite (Pdivmod_eq_spec x p2), (Pdivmod_eq_spec x0 p2), ring_sub_definition.
+            rewrite <- Heq2, Group.inv_op.
+            rewrite <- (associative (Pmul _ _) (Pmod _ _)).
+            rewrite (associative (Pmod x p2)).
+            rewrite right_inverse, left_identity.
+            rewrite <- mul_opp_l, <- right_distributive.
+            apply Pdivides_iff. eexists; reflexivity. }
+        apply sub_zero_iff. apply Pdivides_iff in Hdiv.
+        rewrite Hp_eq in p0, p3.
+        destruct Hdiv as (c & Hdiv).
+        destruct (Peq_dec (Pmul p1 p2) Pzero) as [Hz|Hnz]; [rewrite Hdiv, Hz, mul_0_r; reflexivity|].
+        generalize (Pmod_degree_lt x (Pmul p1 p2) Hnz). rewrite <- p0. intro Hltx0.
+        generalize (Pmod_degree_lt x0 (Pmul p1 p2) Hnz). rewrite <- p3. intro Hltx3.
+        apply IntegralDomain.IntegralDomain.nonzero_product_iff_nonzero_factors in Hnz.
+        destruct Hnz as (Hnz1 & Hnz2).
+        destruct (degree p1) as [np1|] eqn:Hp1; [|apply zero_degree in Hp1; contradiction].
+        destruct (degree p2) as [np2|] eqn:Hp2; [|apply zero_degree in Hp2; contradiction].
+        generalize (mul_degree_eq p1 p2). rewrite Hp1, Hp2; simpl; intro Hp12.
+        assert (Hlt: degree_lt (degree (Psub x x0)) (degree (Pmul p1 p2))).
+        { eapply degree_le_lt_trans; [apply sub_degree|].
+          apply degree_max_lub_lt; eauto. }
+        rewrite Hdiv, (mul_degree_eq c), Hp12 in Hlt.
+        rewrite Hdiv. destruct (degree c) as [nc|] eqn:Hc; [|apply zero_degree in Hc; rewrite Hc, mul_0_l; reflexivity].
+        cbv -[Nat.add] in Hlt. Lia.lia.
+      Qed.
+
+      Lemma psi_phi_id2 x:
+        eq1 (psi2 (phi2 x)) x.
+      Proof.
+        generalize (Pegcd_bezout_coprime _ _ Hcoprime).
+        pose (u := (Pdiv (fst (Pegcd p1 p2)) (Pgcd p1 p2))).
+        pose (v := (Pdiv (snd (Pegcd p1 p2)) (Pgcd p1 p2))).
+        fold u v. intro Huv.
+        assert (Hu: Peq (Pmul u p1) (Psub Pone (Pmul v p2))).
+        { rewrite <- Huv, ring_sub_definition, <- associative, right_inverse.
+          rewrite right_identity; reflexivity. }
+        assert (Hv: Peq (Pmul v p2) (Psub Pone (Pmul u p1))).
+        { rewrite <- Huv, ring_sub_definition, <- associative, (commutative (Pmul v p2)), associative, right_inverse.
+          rewrite left_identity; reflexivity. }
+        destruct x as (x & Hx).
+        pose (a1 := Pmod x p1). pose (a2 := Pmod x p2).
+        destruct (Peq_dec p1 Pzero) as [Hp1|Hp1nz].
+        { unfold eq1; simpl; fold u v.
+          rewrite Hv, Hp1 in *. rewrite Hp_eq.
+          rewrite Pmod_0_r, mul_0_r, mul_0_r, mul_0_l, Pmod_0_r, left_identity.
+          rewrite ring_sub_definition, Group.inv_id, right_identity, right_identity.
+          reflexivity. }
+        destruct (Peq_dec p2 Pzero) as [Hp2|Hp2nz].
+        { unfold eq1; simpl; fold u v.
+          rewrite Hu, Hp2 in *. rewrite Hp_eq.
+          rewrite Pmod_0_r, mul_0_r, mul_0_r, mul_0_r, Pmod_0_r, right_identity.
+          rewrite ring_sub_definition, Group.inv_id, right_identity, right_identity.
+          reflexivity. }
+        destruct (degree p1) as [np1|] eqn:Hp1; [|apply zero_degree in Hp1; contradiction].
+        destruct (degree p2) as [np2|] eqn:Hp2; [|apply zero_degree in Hp2; contradiction].
+        assert (Ha1: degree_lt (degree a1) (degree (Pmul p1 p2))).
+        { generalize (Pmod_degree_lt x p1 Hp1nz); intro.
+          eapply degree_lt_le_trans; eauto.
+          rewrite mul_degree_eq, Hp1, Hp2.
+          cbv -[Nat.add]. Lia.lia. }
+        assert (Ha2: degree_lt (degree a2) (degree (Pmul p1 p2))).
+        { generalize (Pmod_degree_lt x p2 Hp2nz); intro.
+          eapply degree_lt_le_trans; eauto.
+          rewrite mul_degree_eq, Hp1, Hp2.
+          cbv -[Nat.add]. Lia.lia. }
+        apply phi_injective2; unfold eq1; simpl; fold u v.
+        - rewrite Hv. fold a1 a2.
+          assert (Peq (Padd (Pmul a2 (Pmul u p1)) (Pmul a1 (Psub Pone (Pmul u p1)))) (Padd a1 (Pmul (Pmul (Psub a2 a1) u) p1))) as ->.
+          { rewrite ring_sub_definition, (left_distributive a1), right_identity, associative, (commutative _ a1), <- associative, mul_opp_r, <- mul_opp_l, <- right_distributive, <- ring_sub_definition, associative.
+            reflexivity. }
+          rewrite Hp_eq, Pmod_distr, (commutative p1 p2), Pmul_mod_distr_r.
+          rewrite (Pmod_small a1); [|rewrite commutative; assumption].
+          rewrite Pmod_add_r. unfold a1. rewrite Pmod_mod_eq. reflexivity.
+        - rewrite Hu. fold a1 a2.
+          assert (Peq (Padd (Pmul a2 (Psub Pone (Pmul v p2))) (Pmul a1 (Pmul v p2))) (Padd a2 (Pmul (Pmul (Psub a1 a2) v) p2))) as ->.
+          { rewrite ring_sub_definition, (left_distributive a2), right_identity, associative, mul_opp_r, <- mul_opp_l, associative, <- (associative a2), <- right_distributive, <- right_distributive, (commutative _ a1), <- ring_sub_definition.
+            reflexivity. }
+          rewrite Hp_eq, Pmod_distr, Pmul_mod_distr_r.
+          rewrite (Pmod_small a2) by assumption.
+          rewrite Pmod_add_r. unfold a2. rewrite Pmod_mod_eq. reflexivity.
+      Qed.
+
+      Lemma phi_psi_id2 x:
+        EQ2 (phi2 (psi2 x)) x.
+      Proof.
+        destruct x as [[x1 Hx1] [x2 Hx2]]. unfold phi2, psi2, EQ2, eq1; simpl.
+        generalize (Pegcd_bezout_coprime p1 p2 Hcoprime).
+        pose (u := (Pdiv (fst (Pegcd p1 p2)) (Pgcd p1 p2))).
+        pose (v := (Pdiv (snd (Pegcd p1 p2)) (Pgcd p1 p2))).
+        fold u v. intro Huv.
+        assert (Hu: Peq (Pmul u p1) (Psub Pone (Pmul v p2))).
+        { rewrite <- Huv, ring_sub_definition, <- associative, right_inverse.
+          rewrite right_identity; reflexivity. }
+        assert (Hv: Peq (Pmul v p2) (Psub Pone (Pmul u p1))).
+        { rewrite <- Huv, ring_sub_definition, <- associative, (commutative (Pmul v p2)), associative, right_inverse.
+          rewrite left_identity; reflexivity. }
+        destruct (Peq_dec p1 Pzero) as [Hp1|Hp1nz].
+        { rewrite Hv, Hp1 in *. rewrite Hp_eq.
+          rewrite Pmod_0_r, mul_0_r, mul_0_r, mul_0_l, Pmod_0_r, left_identity.
+          rewrite ring_sub_definition, Group.inv_id, right_identity, right_identity.
+          split; [reflexivity|]. unfold coprime in Hcoprime.
+          rewrite Pgcd_0_l in Hcoprime.
+          generalize (Pdivides_degree_zero p2 x1 Hcoprime).
+          unfold Pdivides; intro A; rewrite A, Hx2.
+          symmetry; apply (Pdivides_degree_zero p2 x2 Hcoprime). }
+        destruct (Peq_dec p2 Pzero) as [Hp2|Hp2nz].
+        { unfold eq1; simpl; fold u v.
+          rewrite Hu, Hp2 in *. rewrite Hp_eq.
+          rewrite Pmod_0_r, mul_0_r, mul_0_r, mul_0_r, Pmod_0_r, right_identity.
+          rewrite ring_sub_definition, Group.inv_id, right_identity, right_identity.
+          split; [|reflexivity]. unfold coprime in Hcoprime.
+          rewrite Pgcd_0_r in Hcoprime.
+          generalize (Pdivides_degree_zero p1 x2 Hcoprime).
+          unfold Pdivides; intro A; rewrite A, Hx1.
+          symmetry; apply (Pdivides_degree_zero p1 x1 Hcoprime). }
+        destruct (degree p1) as [np1|] eqn:Hp1; [|apply zero_degree in Hp1; contradiction].
+        destruct (degree p2) as [np2|] eqn:Hp2; [|apply zero_degree in Hp2; contradiction].
+        assert (Ha1: degree_lt (degree x1) (degree (Pmul p1 p2))).
+        { generalize (Pmod_degree_lt x1 p1 Hp1nz); intro.
+          rewrite Hx1. eapply degree_lt_le_trans; eauto.
+          rewrite mul_degree_eq, Hp1, Hp2.
+          cbv -[Nat.add]. Lia.lia. }
+        assert (Ha2: degree_lt (degree x2) (degree (Pmul p1 p2))).
+        { generalize (Pmod_degree_lt x2 p2 Hp2nz); intro.
+          rewrite Hx2. eapply degree_lt_le_trans; eauto.
+          rewrite mul_degree_eq, Hp1, Hp2.
+          cbv -[Nat.add]. Lia.lia. }
+        split; rewrite Pmod_distr.
+        - rewrite Hp_eq, associative, (commutative _ p1), Pmul_mod_distr_l.
+          rewrite Hv, ring_sub_definition, (left_distributive x1), right_identity.
+          rewrite (commutative p1), Pmod_add_l, <- mul_opp_l.
+          rewrite Pmod_distr, (associative x1), (commutative _ p1), Pmul_mod_distr_l, (commutative p1 (Pmod _ _)), Pmod_add_r.
+          rewrite (Pmod_small x1); auto. symmetry; assumption.
+        - rewrite Hp_eq, (associative x1 v), Pmul_mod_distr_r.
+          rewrite Hu, ring_sub_definition, (left_distributive x2), right_identity.
+          rewrite Pmod_add_r, Pmod_distr, <- mul_opp_l.
+          rewrite (associative x2), Pmul_mod_distr_r, Pmod_add_r.
+          rewrite (Pmod_small x2); auto. symmetry; assumption.
+      Qed.
+
+      Lemma psi_EQ2 a b:
+        eq1 (psi2 a) (psi2 b) <-> EQ2 a b.
+      Proof.
+        split; [intro A|intro A; rewrite A; reflexivity].
+        rewrite <- (phi_psi_id2 a), A, phi_psi_id2. reflexivity.
+      Qed.
+
+      Lemma psi_ZERO2:
+        eq1 (psi2 ZERO2) (zero: Pquot p).
+      Proof. rewrite <- ZERO_def2. apply psi_phi_id2. Qed.
+
+      Lemma psi_ONE2:
+        eq1 (psi2 ONE2) (one : Pquot p).
+      Proof. rewrite <- ONE_def2. apply psi_phi_id2. Qed.
+
+      Lemma psi_OPP2 a:
+        eq1 (psi2 (OPP2 a)) (opp (psi2 a)).
+      Proof.
+        destruct a as [[a1 Ha1] [a2 Ha2]]. unfold OPP2, psi2, eq1; simpl.
+        rewrite Pmod_opp, Pmod_opp, mul_opp_l, mul_opp_l, <- Group.inv_op, Pmod_opp, Pmod_opp, Pmod_mod_eq.
+        rewrite <- Ha1, <- Ha2, (commutative (Pmul a1 _)). reflexivity.
+      Qed.
+
+      Lemma psi_ADD2 a b:
+        eq1 (psi2 (ADD2 a b)) (add (psi2 a) (psi2 b)).
+      Proof.
+        destruct a as [[a1 Ha1] [a2 Ha2]].
+        destruct b as [[b1 Hb1] [b2 Hb2]].
+        unfold ADD2, psi2, eq1; simpl.
+        rewrite Hp_eq, (Pmod_distr a1 b1), (Pmod_distr a2 b2), <- (Pmod_distr _ _ (Pmul p1 p2)), Pmod_mod_eq.
+        rewrite <- Ha1, <- Ha2, <- Hb1, <- Hb2.
+        rewrite <- (associative (Pmul a2 _) (Pmul a1 _)), (associative (Pmul a1 _) (Pmul b2 _)), (commutative (Pmul a1 _) (Pmul b2 _)), <- (associative (Pmul b2 _)), <- right_distributive, (associative (Pmul a2 _)), <- right_distributive.
+        reflexivity.
+      Qed.
+
+      Lemma psi_SUB2 a b:
+        eq1 (psi2 (SUB2 a b)) (sub (psi2 a) (psi2 b)).
+      Proof. rewrite ring_sub_definition, SUB_def2, psi_ADD2, psi_OPP2. reflexivity. Qed.
+
+      Lemma psi_MUL2 a b:
+        eq1 (psi2 (MUL2 a b)) (mul (psi2 a) (psi2 b)).
+      Proof.
+        generalize (phi_psi_id2 (MUL2 a b)); intros [A B].
+        generalize (Pegcd_bezout_coprime p1 p2 Hcoprime).
+        pose (u := (Pdiv (fst (Pegcd p1 p2)) (Pgcd p1 p2))).
+        pose (v := (Pdiv (snd (Pegcd p1 p2)) (Pgcd p1 p2))).
+        fold u v. intro Huv.
+        assert (Hu: Peq (Pmul u p1) (Psub Pone (Pmul v p2))).
+        { rewrite <- Huv, ring_sub_definition, <- associative, right_inverse.
+          rewrite right_identity; reflexivity. }
+        assert (Hv: Peq (Pmul v p2) (Psub Pone (Pmul u p1))).
+        { rewrite <- Huv, ring_sub_definition, <- associative, (commutative (Pmul v p2)), associative, right_inverse.
+          rewrite left_identity; reflexivity. }
+        destruct (Peq_dec p1 Pzero) as [Hp1|Hp1nz].
+        { destruct a as [[a1 Ha1] [a2 Ha2]].
+          destruct b as [[b1 Hb1] [b2 Hb2]].
+          unfold MUL2, psi2, eq1; simpl. clear A B.
+          rewrite Hp1, mul_0_r, left_identity in Huv.
+          fold u v. rewrite Hp_eq, Huv, Hp1, mul_0_r, Pmod_0_r, mul_0_r, left_identity, right_identity, mul_0_l, Pmod_0_r, mul_0_r, left_identity, right_identity, Pmod_0_r, mul_0_r, right_identity, left_identity, Pmod_0_r, Pmod_0_r. reflexivity. }
+        destruct (Peq_dec p2 Pzero) as [Hp2|Hp2nz].
+        { destruct a as [[a1 Ha1] [a2 Ha2]].
+          destruct b as [[b1 Hb1] [b2 Hb2]].
+          unfold MUL2, psi2, eq1; simpl. clear A B.
+          rewrite Hp2, mul_0_r, right_identity in Huv.
+          fold u v. rewrite Hp_eq, Huv, Hp2, mul_0_r, Pmod_0_r, mul_0_r, right_identity, right_identity, mul_0_r, Pmod_0_r, right_identity, mul_0_r, right_identity, Pmod_0_r, Pmod_0_r, right_identity, mul_0_r, Pmod_0_r, right_identity. reflexivity. }
+        destruct (degree p1) as [np1|] eqn:Hp1; [|apply zero_degree in Hp1; contradiction].
+        destruct (degree p2) as [np2|] eqn:Hp2; [|apply zero_degree in Hp2; contradiction].
+        destruct a as [[a1 Ha1] [a2 Ha2]].
+        destruct b as [[b1 Hb1] [b2 Hb2]].
+        apply phi_injective2; [rewrite A|rewrite B]; clear A B.
+        - unfold MUL2, psi2, eq1; simpl. fold u v.
+          rewrite Hp_eq, Pmod_mul_mod_l, <- (Pmul_mod_idemp (Pmod _ _) (Pmod _ _) p1).
+          rewrite Pmod_mul_mod_l, Pmod_mul_mod_l.
+          rewrite (associative a2 u), Pmod_add_l.
+          rewrite (associative b2 u), Pmod_add_l.
+          rewrite Hv, ring_sub_definition, (left_distributive a1), (left_distributive b1), right_identity, right_identity, <- mul_opp_l.
+          rewrite (associative a1 (Popp u)), Pmod_add_r.
+          rewrite (associative b1 (Popp u)), Pmod_add_r.
+          rewrite Pmul_mod_idemp. reflexivity.
+        - unfold MUL2, psi2, eq1; simpl. fold u v.
+          rewrite Hp_eq, Pmod_mul_mod_r, <- (Pmul_mod_idemp (Pmod _ _) (Pmod _ _) p2).
+          rewrite Pmod_mul_mod_r, Pmod_mul_mod_r.
+          rewrite (associative a1 v), Pmod_add_r.
+          rewrite (associative b1 v), Pmod_add_r.
+          rewrite Hu, ring_sub_definition, (left_distributive a2), (left_distributive b2), right_identity, right_identity, <- mul_opp_l.
+          rewrite (associative a2 (Popp v)), Pmod_add_r.
+          rewrite (associative b2 (Popp v)), Pmod_add_r.
+          rewrite Pmul_mod_idemp. reflexivity.
+      Qed.
+
+      Lemma CRT_ring_isomorphism2:
+        @ring _ EQ2 ZERO2 ONE2 OPP2 ADD2 SUB2 MUL2
+        /\ @Ring.is_homomorphism _ eq1 one add mul _ EQ2 ONE2 ADD2 MUL2 phi2
+        /\ @Ring.is_homomorphism _ EQ2 ONE2 ADD2 MUL2 _ eq1 one add mul psi2.
+      Proof.
+        apply Ring.ring_by_isomorphism.
+        - apply psi_phi_id2.
+        - apply psi_EQ2.
+        - apply psi_ZERO2.
+        - apply psi_ONE2.
+        - apply psi_OPP2.
+        - apply psi_ADD2.
+        - apply psi_SUB2.
+        - apply psi_MUL2.
+      Qed.
+    End CRT2.
+    Section Negacyclic.
+      (* Negacyclic polynomials X^n + a *)
+      Definition negacyclic (n: nat) (a: F): P := (Padd (base n) (Pconst a)).
+      (* "Posicyclic" polynomials X^n - a *)
+      Definition posicyclic (n: nat) (a: F): P := (Psub (base n) (Pconst a)).
+      Global Instance peq_negacyclic_proper n: Proper (Feq ==> Peq) (negacyclic n).
+      Proof. intros a1 a2 Ha; unfold negacyclic. rewrite Ha. reflexivity. Qed.
+      Global Instance peq_posicyclic_proper n: Proper (Feq ==> Peq) (posicyclic n).
+      Proof. intros a1 a2 Ha; unfold posicyclic. rewrite Ha. reflexivity. Qed.
+      Lemma negacyclic_degree n a (Hngt0: (n > 0)%nat):
+        degree (negacyclic n a) = Some n :> _.
+      Proof.
+        assert (X: coeff (negacyclic n a) n = 1).
+        { unfold negacyclic.
+          rewrite add_definition, base_definition, const_definition.
+          destruct (dec_eq_nat n n); [|congruence]. destruct n; [Lia.lia|].
+          apply right_identity. }
+        generalize (degree_definition (negacyclic n a)).
+        destruct (degree (negacyclic n a)) as [np1|] eqn:Hnp1.
+        - intros [A B]. unfold negacyclic in A.
+          unfold negacyclic in A. rewrite add_definition, base_definition, const_definition in A.
+          destruct (dec_eq_nat n np1); [auto|].
+          destruct np1; [|elim A; apply right_identity].
+          rewrite B in X by Lia.lia. elim (zero_neq_one X).
+        - intros A. rewrite A in X. elim (zero_neq_one X).
+      Qed.
+      Lemma posicyclic_degree n a (Hngt0: (n > 0)%nat):
+        degree (posicyclic n a) = Some n :> _.
+      Proof.
+        assert (X: coeff (posicyclic n a) n = 1).
+        { unfold posicyclic.
+          rewrite sub_definition, base_definition, const_definition.
+          destruct (dec_eq_nat n n); [|congruence]. destruct n; [Lia.lia|].
+          rewrite ring_sub_definition, Group.inv_id.
+          apply right_identity. }
+        generalize (degree_definition (posicyclic n a)).
+        destruct (degree (posicyclic n a)) as [np1|] eqn:Hnp1.
+        - intros [A B]. unfold posicyclic in A.
+          unfold posicyclic in A. rewrite sub_definition, base_definition, const_definition in A.
+          destruct (dec_eq_nat n np1); [auto|].
+          destruct np1; [|elim A; rewrite ring_sub_definition, Group.inv_id; apply right_identity].
+          rewrite B in X by Lia.lia. elim (zero_neq_one X).
+        - intros A. rewrite A in X. elim (zero_neq_one X).
+      Qed.
+      Lemma negacyclic_opp n a:
+        Peq (negacyclic n (Fopp a)) (posicyclic n a).
+      Proof. unfold negacyclic, posicyclic; rewrite ring_sub_definition, opp_const. reflexivity. Qed.
+      Lemma posicyclic_opp n a:
+        Peq (posicyclic n (Fopp a)) (negacyclic n a).
+      Proof. rewrite (peq_negacyclic_proper _ a (Fopp (Fopp a)) ltac:(symmetry; apply Group.inv_inv)), negacyclic_opp. reflexivity. Qed.
+      Lemma posicyclic_decomposition n a:
+        Peq (posicyclic (2 * n)%nat (a * a)) (Pmul (posicyclic n a) (negacyclic n a)).
+      Proof.
+        unfold posicyclic, negacyclic.
+        rewrite right_distributive, left_distributive, left_distributive.
+        rewrite base_mul_base, const_mul_const, (commutative (base n) (Pconst a)).
+        assert (n + n = 2 * n :> _)%nat as -> by Lia.lia.
+        rewrite (ring_sub_definition (Padd _ _)), Group.inv_op.
+        rewrite (associative _ (Popp _)), <- (associative (base _) (Pmul _ _)).
+        rewrite (commutative (Pmul _ _) (Popp _)).
+        rewrite associative, <- associative, right_inverse, right_identity.
+        rewrite <- ring_sub_definition. reflexivity.
+      Qed.
+      Lemma posicyclic_decomposition_coprime n a (Hngt0: (n > 0)%nat) (Hanz: a <> 0):
+        coprime (posicyclic n a) (negacyclic n a).
+      Proof.
+        assert (A: a + a <> 0).
+        { rewrite <- (ring_monoid_mul.(monoid_is_right_identity).(right_identity) a).
+          rewrite <- left_distributive.
+          apply IntegralDomain.IntegralDomain.nonzero_product_iff_nonzero_factors.
+          split; auto.
+          generalize (char_ge_3 (BinPosDef.Pos.of_nat 2%nat) ltac:(simpl; Lia.lia)); simpl.
+          rewrite left_identity; auto. }
+        assert (Hnz: not (Peq (negacyclic n a) Pzero)).
+        { intro X. generalize (negacyclic_degree n a Hngt0).
+          rewrite X, degree_zero. congruence. }
+        assert (Hmod12: Peq (Pmod (posicyclic n a) (negacyclic n a)) (Pconst (Fopp (a + a)))).
+        { symmetry; eapply (Pdivmod_eq_iff (posicyclic n a) (negacyclic n a) Hnz Pone).
+          - rewrite left_identity. unfold negacyclic.
+            rewrite <- associative, const_add_const, Group.inv_op, associative, right_inverse, left_identity, <- opp_const, <- ring_sub_definition.
+            reflexivity.
+          - rewrite degree_const, negacyclic_degree; auto.
+            destruct (Feq_dec (Fopp _) 0); cbv; auto; Lia.lia. }
+        unfold coprime.
+        rewrite Pgcd_mod, Pdivides_gcd; [|apply Pdivides_degree_zero]; rewrite (Hmod12); rewrite degree_const; destruct (Feq_dec (Fopp (a + a)) 0); auto.
+        all: apply (proj1 (Group.inv_id_iff _)) in f; contradiction.
+      Qed.
+    End Negacyclic.
+    Section Cyclotomic_NTT_base.
+      Variable (n: nat) (a: F) (p p1 p2: P).
+      Hypothesis Hngt0: (n > 0)%nat.
+      Hypothesis Hanz: a <> 0.
+      Hypothesis Hpeq: Peq p (posicyclic (2 * n)%nat (a * a)).
+      Hypothesis Hpeq1: Peq p1 (posicyclic n a).
+      Hypothesis Hpeq2: Peq p2 (negacyclic n a).
+
+      Definition NTT_base_psi_unpacked (x y: P): P :=
+        (* (x + y)/2 + (1/2a)(x - y)X^n*)
+        (Padd (Pmul (Pconst (Finv (1 + 1))) (Padd x y)) (Pmul (Pmul (Pconst (Finv (a + a))) (base n)) (Psub x y))).
+
+      Lemma NTT_base_psi_unpacked_alt_eq x y:
+        Peq (Pmul (Pconst (1 + 1)) (NTT_base_psi_unpacked x y)) (Padd (Padd x y) (Pmul (Pmul (Pconst (Finv a)) (base n)) (Psub x y))).
+      Proof.
+        unfold NTT_base_psi_unpacked.
+        repeat rewrite <- (associative (op:=Pmul)). intro k.
+        rewrite add_definition, mul_const_coeff_l, add_definition, mul_const_coeff_l.
+        rewrite add_definition, mul_const_coeff_l, mul_const_coeff_l.
+        assert (Finv (a + a) = Finv (1 + 1) * Finv a) as ->.
+        { symmetry. apply Field.inv_unique.
+          assert (a + a = a * (1 + 1)) as -> by (rewrite left_distributive, right_identity; reflexivity).
+          rewrite <- (associative (Finv (1 + 1))), (associative (Finv a)), left_multiplicative_inverse; auto.
+          rewrite left_identity, left_multiplicative_inverse; [reflexivity|].
+          generalize (char_ge_3 (BinPos.Pos.of_nat 2%nat) ltac:(simpl; Lia.lia)); simpl; rewrite left_identity; auto. }
+        rewrite <- (associative (Finv (1 + 1))), <- left_distributive.
+        rewrite associative, right_multiplicative_inverse, left_identity; [reflexivity|].
+        generalize (char_ge_3 (BinPos.Pos.of_nat 2%nat) ltac:(simpl; Lia.lia)); simpl; rewrite left_identity; auto.
+      Qed.
+
+      Definition NTT_base_psi_unpacked_list (l: list F) (n: nat) (z: F) :=
+        fold_left
+          (fun l i =>
+             let tmp := nth_default 0 l i in
+             let l0 := set_nth i (tmp + nth_default 0 l (i + n)) l in
+             let l1 := set_nth (i + n) (tmp - nth_default 0 l (i + n)) l0 in
+             set_nth (i + n) (z * nth_default 0 l1 (i + n)) l1)
+          (seq 0%nat n) l.
+
+      Lemma NTT_base_psi_unpacked_list_length l k z:
+        length (NTT_base_psi_unpacked_list l k z) = length l :> _.
+      Proof.
+        unfold NTT_base_psi_unpacked_list. apply fold_left_invariant.
+        - reflexivity.
+        - intros. repeat rewrite length_set_nth. auto.
+      Qed.
+
+      Lemma NTT_base_psi_unpacked_list_nth_default (l: list F) (k: nat) (z: F):
+        length l >= 2 * k ->
+        forall (d : F) (i : nat),
+          nth_default d (NTT_base_psi_unpacked_list l k z) i =
+            (if dec_lt_nat i k
+             then
+               let x1 := nth_default 0 l i in
+               let x2 := nth_default 0 l (i + k) in x1 + x2
+             else
+               if dec_lt_nat i (2 * k)
+               then
+                 let x1 := nth_default 0 l (i - k) in
+                 let x2 := nth_default 0 l i in z * (x1 - x2)
+               else nth_default d l i).
+      Proof.
+        unfold NTT_base_psi_unpacked_list.
+        set (f := (fun (p: nat) (l : list F) (i : nat) => set_nth (i + p) (z * nth_default 0 (set_nth (i + p) (nth_default 0 l i - nth_default 0 l (i + p)) (set_nth i (nth_default 0 l i + nth_default 0 l (i + p)) l)) (i + p)) (set_nth (i + p) (nth_default 0 l i - nth_default 0 l (i + p)) (set_nth i (nth_default 0 l i + nth_default 0 l (i + p)) l)))).
+        fold (f k).
+        assert (IH: forall (k : nat) (p: nat) (l : list F),
+                 (k <= p)%nat ->
+                 (length l >= 2 * p)%nat ->
+                 forall (d : F) (i : nat),
+                   nth_default d (fold_left (f p) (seq 0 k) l) i =
+                     (if dec_lt_nat i k
+                      then nth_default 0 l i + nth_default 0 l (i + p)
+                      else
+                        if dec_le_nat p i
+                        then
+                          if dec_lt_nat i (p + k) then
+                            z * (nth_default 0 l (i - p) - nth_default 0 l i)
+                          else nth_default d l i
+                        else nth_default d l i)).
+        { intros xk. induction xk; intros xp xl Hxp Hxl d i.
+          - simpl. destruct (dec_le_nat xp i); [|reflexivity].
+            rewrite PeanoNat.Nat.add_0_r.
+            destruct (dec_lt_nat i xp); [Lia.lia|reflexivity].
+          - rewrite seq_S, fold_left_app, PeanoNat.Nat.add_0_l.
+            cbn [fold_left]. unfold f at 1.
+            assert (Hlength': length (fold_left (f xp) (seq 0 xk) xl) = length xl :> _).
+            { apply fold_left_invariant; [reflexivity|].
+              intros. unfold f. repeat rewrite length_set_nth. auto. }
+            repeat rewrite set_nth_nth_default_full.
+            repeat rewrite length_set_nth, Hlength'.
+            destruct (Compare_dec.lt_dec i (length xl)).
+            2:{ destruct (dec_lt_nat i (S xk)); [Lia.lia|].
+                destruct (dec_le_nat xp i); [|Lia.lia].
+                destruct (dec_lt_nat i (xp + S xk)); [Lia.lia|].
+                rewrite nth_default_out_of_bounds by Lia.lia. reflexivity. }
+            destruct (PeanoNat.Nat.eq_dec i (xk + xp)).
+            { subst i. rewrite NatUtil.eq_nat_dec_refl.
+              destruct (dec_le_nat xp (xk + xp)); [|Lia.lia].
+              destruct (dec_lt_nat (xk + xp) (xp + S xk)); [|Lia.lia].
+              destruct (Compare_dec.lt_dec (xk + xp) (length xl)); [|Lia.lia].
+              destruct (dec_lt_nat (xk + xp) (S xk)); [Lia.lia|].
+              assert (xk + xp - xp = xk :> _)%nat as -> by Lia.lia.
+              do 2 (rewrite IHxk by Lia.lia).
+              destruct (dec_lt_nat xk xk); [Lia.lia|].
+              destruct (dec_lt_nat xk (xp + xk)); [|Lia.lia].
+              destruct (dec_lt_nat (xk + xp) xk); [Lia.lia|].
+              destruct (dec_le_nat xp (xk + xp)); [|Lia.lia].
+              destruct (dec_lt_nat (xk + xp) (xp + xk)); [Lia.lia|].
+              destruct (dec_le_nat xp xk); [Lia.lia|].
+              reflexivity. }
+            destruct (PeanoNat.Nat.eq_dec i xk).
+            { subst i. do 2 (rewrite IHxk by Lia.lia).
+              destruct (dec_lt_nat xk xk) as [|_]; [Lia.lia|].
+              destruct (dec_lt_nat xk (xp + xk)) as [_|]; [|Lia.lia].
+              destruct (dec_lt_nat xk (S xk)) as [_|]; [|Lia.lia].
+              destruct (dec_lt_nat (xk + xp) (xp + xk)) as [|_]; [Lia.lia|].
+              destruct (dec_lt_nat (xk + xp) xk) as [|_]; [Lia.lia|].
+              destruct (dec_le_nat xp xk) as [|_]; [Lia.lia|].
+              destruct (dec_le_nat xp (xk + xp)); reflexivity. }
+            rewrite IHxk by Lia.lia.
+            destruct (dec_lt_nat i xk).
+            { destruct (dec_lt_nat i (S xk)) as [_|]; [|Lia.lia].
+              reflexivity. }
+            destruct (dec_lt_nat i (S xk)) as [|_]; [Lia.lia|].
+            destruct (dec_le_nat xp i); [|reflexivity].
+            destruct (dec_lt_nat i (xp + xk)).
+            { destruct (dec_lt_nat i (xp + S xk)); [|Lia.lia].
+              reflexivity. }
+            destruct (dec_lt_nat i (xp + S xk)); [Lia.lia|]. reflexivity. }
+        intros. rewrite IH by Lia.lia.
+        destruct (dec_lt_nat i k); [reflexivity|].
+        destruct (dec_le_nat k i); [|Lia.lia].
+        assert (k + k = 2 * k :> _)%nat as -> by Lia.lia.
+        reflexivity.
+      Qed.
+
+      Lemma NTT_base_psi_unpacked_list_spec x1 x2:
+        (measure x1 <= n)%nat ->
+        (measure x2 <= n)%nat ->
+        Peq (Pmul (Pconst (1 + 1)) (NTT_base_psi_unpacked x1 x2))
+            (of_list (NTT_base_psi_unpacked_list (to_list n x1 ++ to_list n x2) n (Finv a))).
+      Proof.
+        intros Hx1 Hx2. rewrite NTT_base_psi_unpacked_alt_eq.
+        intro k.
+        rewrite add_definition, add_definition, mul_definition.
+        unfold mul_coeff.
+        rewrite (bigop_ext_eq _ _ (fun i => if dec_eq_nat n i then Finv a * (coeff x1 (k - i) - coeff x2 (k - i)) else 0)).
+        2:{ intros. rewrite mul_const_base_coeff, sub_definition.
+             destruct (dec_eq_nat n i); [reflexivity|].
+             rewrite Ring.mul_0_l. reflexivity. }
+        unfold of_list. rewrite Pdecompose_coeff.
+        rewrite NTT_base_psi_unpacked_list_length, app_length, to_list_length, to_list_length.
+        destruct (dec_lt_nat k (n + n)).
+        2:{ do 2 (rewrite measure_definition by Lia.lia).
+            rewrite left_identity, left_identity.
+            rewrite (bigop_ext_eq _ _ (fun _ => 0)).
+            - rewrite bigop_const, Ring.mul_0_r; reflexivity.
+            - intros i Hi. apply in_seq in Hi.
+              destruct (dec_eq_nat n i); [|reflexivity].
+              subst i. do 2 rewrite measure_definition by Lia.lia.
+              rewrite (proj2 (Ring.sub_zero_iff 0 0)) by reflexivity.
+              rewrite Ring.mul_0_r. reflexivity. }
+        rewrite NTT_base_psi_unpacked_list_nth_default by (rewrite app_length, to_list_length, to_list_length; Lia.lia).
+        destruct (dec_lt_nat k (2 * n)) as [_|]; [|Lia.lia].
+        destruct (dec_lt_nat k n).
+        { cbn zeta. rewrite (bigop_ext_eq _ _ (fun _ => 0)).
+          2:{ intros i Hi. apply in_seq in Hi.
+              destruct (dec_eq_nat n i); [Lia.lia|]. reflexivity. }
+          rewrite bigop_const, Ring.mul_0_r, right_identity.
+          do 2 rewrite nth_default_app.
+          rewrite to_list_length. destruct (Compare_dec.lt_dec k n); [|Lia.lia].
+          destruct (Compare_dec.lt_dec (k + n) n); [Lia.lia|].
+          do 2 (rewrite to_list_nth_default_inbounds by Lia.lia).
+          assert (k + n - n = k :> _)%nat as -> by Lia.lia.
+          reflexivity. }
+        cbn zeta. do 2 rewrite measure_definition by Lia.lia.
+        do 2 rewrite left_identity. do 2 rewrite nth_default_app.
+        rewrite to_list_length. destruct (Compare_dec.lt_dec (k - n) n); [|Lia.lia].
+        destruct (Compare_dec.lt_dec k n); [Lia.lia|].
+        do 2 (rewrite to_list_nth_default_inbounds by Lia.lia).
+        assert (S k = S n + (k - n) :> _)%nat as -> by Lia.lia.
+        rewrite seq_add, bigop_app, seq_S, bigop_app, bigop_cons, bigop_nil.
+        rewrite (bigop_ext_eq _ _ (fun _ => 0)).
+        2:{ intros i Hi. apply in_seq in Hi.
+            destruct (dec_eq_nat n i); [Lia.lia|]. reflexivity. }
+        rewrite bigop_const, Ring.mul_0_r, left_identity.
+        rewrite (bigop_ext_eq _ _ (fun _ => 0)).
+        2:{ intros i Hi. apply in_seq in Hi.
+            destruct (dec_eq_nat n i); [Lia.lia|]. reflexivity. }
+        rewrite bigop_const, Ring.mul_0_r, right_identity, right_identity.
+        destruct (dec_eq_nat n (0 + n)) as [_|]; [|Lia.lia].
+        rewrite PeanoNat.Nat.add_0_l. reflexivity.
+      Qed.
+
+      Global Instance peq_NTT_base_psi_unpacked_proper: Proper (Peq ==> Peq ==> Peq) (NTT_base_psi_unpacked).
+      Proof.
+        intros pp1 pp1' Hp1 pp2 pp2' Hp2. unfold NTT_base_psi_unpacked.
+        rewrite Hp1, Hp2. reflexivity.
+      Qed.
+
+      Program Definition NTT_base_psi (xy: Pquot p1 * Pquot p2) : Pquot p :=
+        NTT_base_psi_unpacked (proj1_sig (fst xy)) (proj1_sig (snd xy)).
+      Next Obligation.
+        assert (degree_p1: degree p1 = Some n :> _) by (rewrite Hpeq1; apply posicyclic_degree; auto).
+        assert (degree_p2: degree p2 = Some n :> _) by (rewrite Hpeq2; apply negacyclic_degree; auto).
+        assert (Hpnz: not (Peq p Pzero)).
+        { rewrite Hpeq; intro X. generalize (posicyclic_degree (2 * n)%nat (a * a) ltac:(Lia.lia)).
+          rewrite X, degree_zero. congruence. }
+        assert (Hpmul: Peq p (Pmul p1 p2)) by (rewrite Hpeq, Hpeq1, Hpeq2; apply posicyclic_decomposition).
+        assert (Hpnz1: not (Peq p1 Pzero)) by (apply (proj1 (IntegralDomain.IntegralDomain.nonzero_product_iff_nonzero_factors p1 p2) ltac:(generalize Hpnz; rewrite Hpmul; auto))).
+        assert (Hpnz2: not (Peq p2 Pzero)) by (apply (proj1 (IntegralDomain.IntegralDomain.nonzero_product_iff_nonzero_factors p1 p2) ltac:(generalize Hpnz; rewrite Hpmul; auto))).
+        unfold NTT_base_psi_unpacked.
+        symmetry; apply Pmod_small.
+        destruct p0 as [x Hx]. destruct p3 as [y Hy]. simpl.
+        rewrite Hpeq, posicyclic_decomposition.
+        rewrite mul_degree_eq, posicyclic_degree, negacyclic_degree; auto.
+        generalize (Pmod_degree_lt x p1 Hpnz1); rewrite <- Hx, degree_p1. intro Hxlt.
+        generalize (Pmod_degree_lt y p2 Hpnz2); rewrite <- Hy, degree_p2. intro Hylt.
+        eapply degree_le_lt_trans; [eapply add_degree|].
+        rewrite mul_degree_eq, mul_degree_eq, mul_degree_eq, degree_const, degree_const, degree_base.
+        assert (H2nz: (1 + 1 <> 0)) by (generalize (char_ge_3 (BinPos.Pos.of_nat 2%nat) ltac:(simpl; Lia.lia)); simpl; rewrite left_identity; auto).
+        destruct (Feq_dec (Finv (1 + 1)) 0) as [He|Hn].
+        { assert (Hzn1: 0 <> 1) by apply zero_neq_one.
+          elim Hzn1. rewrite <- (left_multiplicative_inverse (1 + 1) H2nz).
+          rewrite He, mul_0_l. reflexivity. }
+        assert (H2anz: a + a <> 0).
+        { assert (a + a = a * (1 + 1)) as -> by (rewrite left_distributive, right_identity; reflexivity).
+          apply IntegralDomain.IntegralDomain.nonzero_product_iff_nonzero_factors; auto. }
+        destruct (Feq_dec (Finv (a + a)) 0) as [He|Hn'].
+        { assert (Hzn1: 0 <> 1) by apply zero_neq_one.
+          elim Hzn1. rewrite <- (left_multiplicative_inverse (a + a) H2anz).
+          rewrite He, mul_0_l. reflexivity. }
+        rewrite degree_add_0_l, degree_add_0_l.
+        apply degree_max_lub_lt; [eapply degree_le_lt_trans; [apply add_degree|]; apply degree_max_lub_lt; [destruct (degree x)|destruct (degree y)]; cbv -[Nat.add] in *; Lia.lia|].
+        apply degree_lt_add_mono_l; [congruence|].
+        eapply degree_le_lt_trans; [apply sub_degree|].
+        apply degree_max_lub_lt; auto.
+      Qed.
+
+      Lemma NTT_base_psi_phi_id x:
+        eq1 (NTT_base_psi (phi2 p p1 p2 x)) x.
+      Proof.
+        assert (Hpnz: not (Peq p Pzero)).
+        { rewrite Hpeq; intro X. generalize (posicyclic_degree (2 * n)%nat (a * a) ltac:(Lia.lia)).
+          rewrite X, degree_zero. congruence. }
+        destruct x as [x Hx].
+        unfold phi2, eq1; cbn. unfold NTT_base_psi_unpacked.
+        rewrite Hpeq1, Hpeq2.
+        assert (Hm: (measure x <= 2 * n)%nat).
+        { unfold measure; rewrite Hx.
+          generalize (Pmod_degree_lt x p Hpnz).
+          rewrite Hpeq, posicyclic_degree by Lia.lia.
+          assert (2 * n = S (pred (2 * n)) :> _)%nat as -> by Lia.lia.
+          destruct (degree (Pmod x p)); cbv; auto; Lia.lia. }
+        rewrite (Pdecompose_eq x) at 5.
+        rewrite (Pmod_cyclotomic x n a Hngt0 Hm).
+        unfold negacyclic.
+        rewrite <- (Group.inv_inv a), <- opp_const, <- ring_sub_definition.
+        rewrite (Pmod_cyclotomic x n (Fopp a) Hngt0 Hm).
+        rewrite ring_sub_definition, bigop_inv, bigop_same_index, bigop_same_index.
+        rewrite bigop_l_distr, bigop_l_distr.
+        unfold Pdecompose.
+        rewrite (bigop_ext_eq (seq 0 n) _ (fun k : nat => Pmul (Pconst (coeff x k)) (base k))) at 1.
+        2:{ intros i Hi; apply in_seq in Hi.
+            rewrite <- right_distributive, const_add_const.
+            rewrite mul_opp_l, <- (associative (coeff x i)).
+            rewrite (associative (a * _)), (commutative (a * _)).
+            rewrite <- (associative (coeff x i)), right_inverse, right_identity.
+            rewrite associative, const_mul_const.
+            assert (coeff x i + coeff x i = (1 + 1) * coeff x i) as -> by (rewrite right_distributive, left_identity; reflexivity).
+            rewrite associative, left_multiplicative_inverse.
+            2: generalize (char_ge_3 (BinPosDef.Pos.of_nat 2%nat) ltac:(simpl; Lia.lia)); simpl; rewrite left_identity; auto.
+            rewrite left_identity. reflexivity. }
+        rewrite (bigop_ext_eq (seq 0 n) (fun i => Pmul (Pmul _ _) _) (fun k : nat => Pmul (Pconst (coeff x (k + n))) (base (k + n)))).
+        2:{ intros i Hi; apply in_seq in Hi.
+            rewrite Group.inv_inv, <- mul_opp_l, <- right_distributive.
+            rewrite opp_const, const_add_const, Group.inv_op, <- mul_opp_l.
+            rewrite Group.inv_inv, associative.
+            rewrite <- (associative (Pconst (Finv _))), (commutative (base n)).
+            rewrite associative, const_mul_const, <- associative.
+            rewrite (commutative (base n)), base_mul_base.
+            rewrite associative, <- (associative (coeff x i)), <- right_distributive.
+            rewrite (commutative (coeff x i)), <- (associative (_ * _)), right_inverse.
+            rewrite right_identity, associative, left_multiplicative_inverse, left_identity; [reflexivity|].
+            assert (a + a = a * (1 + 1)) as -> by (rewrite left_distributive, right_identity; reflexivity).
+            intro X; apply zero_product_zero_factor in X.
+            destruct X; [auto|].
+            generalize (char_ge_3 (BinPosDef.Pos.of_nat 2%nat) ltac:(simpl; Lia.lia)); simpl; rewrite left_identity; auto. }
+        rewrite (bigop_shift 0 n n (fun k => Pmul (Pconst (coeff x (k + n)%nat)) (base (k + n)%nat))).
+        rewrite (bigop_ext_eq (seq (0 + n) n) _ (fun k : nat => Pmul (Pconst (coeff x k)) (base k))).
+        2:{ intros i Hi; apply in_seq in Hi.
+            assert (i - n + n = i :> _)%nat as -> by Lia.lia. reflexivity. }
+        rewrite <- bigop_app, <- seq_add.
+        assert (n + n = 2 * n :> _)%nat as -> by Lia.lia.
+        rewrite (bigop_widen _ (seq 0 (measure _)) (seq (0 + measure x)%nat (2 * n - measure x)%nat)).
+        2: intros i Hi k; apply in_seq in Hi; rewrite mul_const_base_coeff, zero_definition; destruct (dec_eq_nat i k); [apply measure_definition; Lia.lia|reflexivity].
+        rewrite <- seq_add. assert (_ + (_ - _) = 2 * n :> _)%nat as -> by Lia.lia.
+        reflexivity.
+      Qed.
+
+      Global Instance EQ_proper_NTT_base_psi: Proper ((EQ2 _ _) ==> eq1) NTT_base_psi.
+      Proof.
+        intros x y. unfold EQ2, eq1, psi2; simpl. unfold NTT_base_psi_unpacked. intros (HEQ1 & HEQ2).
+        destruct x as [x1 x2]. destruct y as [y1 y2].
+        simpl in *.
+        rewrite HEQ1, HEQ2. reflexivity.
+      Qed.
+
+      Lemma NTT_base_psi_is_psi2 x:
+        eq1 (NTT_base_psi x) (psi2 p _ _ x).
+      Proof.
+        assert (Hpmul: Peq p (Pmul p1 p2)) by (rewrite Hpeq, Hpeq1, Hpeq2; apply posicyclic_decomposition).
+        assert (Hco: coprime p1 p2) by (rewrite Hpeq1, Hpeq2; apply (posicyclic_decomposition_coprime n a Hngt0 Hanz)).
+        assert (He: eq1 (NTT_base_psi x) (NTT_base_psi (phi2 p p1 p2 (psi2 p p1 p2 x)))).
+        { rewrite (phi_psi_id2 p p1 p2 Hco Hpmul x) at 1. reflexivity. }
+        generalize (NTT_base_psi_phi_id (psi2 p p1 p2 x)). intro He2.
+        unfold eq1 in *. rewrite He, He2. reflexivity.
+      Qed.
+
+      Lemma NTT_base_psi_inj:
+        forall x y : Pquot p1 * Pquot p2,
+          eq1 (NTT_base_psi x) (NTT_base_psi y) <-> EQ2 p1 p2 x y.
+      Proof.
+        assert (Hpmul: Peq p (Pmul p1 p2)) by (rewrite Hpeq, Hpeq1, Hpeq2; apply posicyclic_decomposition).
+        assert (Hco: coprime p1 p2) by (rewrite Hpeq1, Hpeq2; apply (posicyclic_decomposition_coprime n a Hngt0 Hanz)).
+        intros; rewrite NTT_base_psi_is_psi2, NTT_base_psi_is_psi2.
+        apply (psi_EQ2 _ _ _ Hco Hpmul).
+      Qed.
+
+      Lemma NTT_base_psi_inj_aux:
+        forall x1 (Hx1: Peq x1 (Pmod x1 p1))
+          x2 (Hx2: Peq x2 (Pmod x2 p1))
+          y1 (Hy1: Peq y1 (Pmod y1 p2))
+          y2 (Hy2: Peq y2 (Pmod y2 p2)),
+          Peq (NTT_base_psi_unpacked x1 y1) (NTT_base_psi_unpacked x2 y2) <-> (Peq x1 x2 /\ Peq y1 y2).
+      Proof.
+        intros. apply (NTT_base_psi_inj (exist _ x1 Hx1, exist _ y1 Hy1) (exist _ x2 Hx2, exist _ y2 Hy2)).
+      Qed.
+
+      Lemma NTT_ring_isomorphism2:
+        @ring _ (EQ2 p1 p2) (ZERO2 p1 p2) (ONE2 p1 p2) (OPP2 p1 p2) (ADD2 p1 p2) (SUB2 p1 p2) (MUL2 p1 p2)
+        /\ @Ring.is_homomorphism _ eq1 one add mul _ (EQ2 p1 p2) (ONE2 p1 p2) (ADD2 p1 p2) (MUL2 p1 p2) (phi2 p p1 p2)
+        /\ @Ring.is_homomorphism _ (EQ2 p1 p2) (ONE2 p1 p2) (ADD2 p1 p2) (MUL2 p1 p2) _ eq1 one add mul NTT_base_psi.
+      Proof.
+        assert (Hpmul: Peq p (Pmul p1 p2)) by (rewrite Hpeq, Hpeq1, Hpeq2; apply posicyclic_decomposition).
+        assert (Hco: coprime p1 p2) by (rewrite Hpeq1, Hpeq2; apply (posicyclic_decomposition_coprime n a Hngt0 Hanz)).
+        apply Ring.ring_by_isomorphism.
+        - apply NTT_base_psi_phi_id.
+        - apply NTT_base_psi_inj.
+        - rewrite NTT_base_psi_is_psi2. apply (psi_ZERO2 _ _ _ Hco Hpmul).
+        - rewrite NTT_base_psi_is_psi2. apply (psi_ONE2 _ _ _ Hco Hpmul).
+        - intros; rewrite NTT_base_psi_is_psi2, NTT_base_psi_is_psi2.
+          apply psi_OPP2.
+        - intros; rewrite NTT_base_psi_is_psi2, NTT_base_psi_is_psi2, NTT_base_psi_is_psi2.
+          apply psi_ADD2. apply Hpmul.
+        - intros; rewrite NTT_base_psi_is_psi2, NTT_base_psi_is_psi2, NTT_base_psi_is_psi2.
+          apply psi_SUB2. apply Hpmul.
+        - intros; rewrite NTT_base_psi_is_psi2, NTT_base_psi_is_psi2, NTT_base_psi_is_psi2.
+          apply (psi_MUL2 _ _ _ Hco Hpmul).
+      Qed.
+    End Cyclotomic_NTT_base.
+  End Pquot.
+  Section Pquotl.
+    Context {Finv: F -> F}{Fdiv: F -> F -> F}
+      {field: @field F Feq Fzero Fone Fopp Fadd Fsub Fmul Finv Fdiv}
+      {char_ge_3: @Ring.char_ge F Feq Fzero Fone Fopp Fadd Fsub Fmul (BinNat.N.succ_pos (BinNat.N.two))}.
+    Local Infix "/" := Fdiv.
+
+    Local Notation Pdivmod := (@Pdivmod Fdiv).
+    Local Notation Pdiv := (@Pdiv Fdiv).
+    Local Notation Pmod := (@Pmod Fdiv).
+    Local Notation Pgcd := (@Pgcd Fdiv).
+    Local Notation Pegcd := (@Pegcd Fdiv).
+    Local Notation Pdivides := (@Pdivides Fdiv).
+    Local Notation coprime := (@coprime Fdiv).
+
+    Definition Pquotl (ql: list P): Type := { pl: list P | List.Forall2 (fun p q => Peq p (Pmod p q)) pl ql }.
+
+    Section PquotlOperations.
+      Definition to_pl {ql} (pl: Pquotl ql) := proj1_sig pl.
+
+      Context {ql: list P}.
+      Lemma to_pl_length (pl: Pquotl ql): length (to_pl pl) = length ql :> _.
+      Proof. destruct pl as [pl Hpl]; simpl. eapply Forall2_length; eauto. Qed.
+
+      Program Definition of_pl (pl: list P) (Hpl: length pl = length ql :> _): Pquotl ql :=
+        map2 (fun p q => Pmod p q) pl ql.
+      Next Obligation.
+        revert pl Hpl. induction ql; intros pl Hpl; [destruct pl; simpl in Hpl; try constructor; congruence|].
+        destruct pl; [simpl in Hpl; congruence|].
+        eapply Forall2_cons; [rewrite Pmod_mod_eq; reflexivity|].
+        apply IHl. simpl in Hpl; congruence.
+      Qed.
+
+      Definition eql {ql'} (pl1: Pquotl ql) (pl2: Pquotl ql'): Prop :=
+        List.Forall2 Peq (to_pl pl1) (to_pl pl2).
+
+      Program Definition zerol: Pquotl ql := repeat Pzero (length ql).
+      Next Obligation. induction ql; simpl; constructor; auto. rewrite Pmod_0_l. reflexivity. Qed.
+
+      Lemma nth_error_zerol:
+        forall k, (k < length ql) -> (nth_error (to_pl zerol) k = Some Pzero :> _).
+      Proof. intros. simpl. apply List.nth_error_repeat; auto. Qed.
+
+      Definition onel: Pquotl ql := of_pl (repeat Pone (length ql)) ltac:(apply repeat_length).
+
+      Program Definition addl (p1 p2: Pquotl ql): Pquotl ql :=
+        map2 Padd (to_pl p1) (to_pl p2).
+      Next Obligation.
+        destruct p1 as [p1 Hp1]. destruct p2 as [p2 Hp2].
+        simpl. revert p2 Hp2. induction Hp1.
+        - intros. inversion Hp2. constructor.
+        - intros. destruct p2 as [|z]; inversion Hp2.
+          simpl. constructor; auto.
+          subst. rewrite Pmod_distr, <- H, <- H3. reflexivity.
+      Qed.
+
+      Program Definition mull (p1 p2: Pquotl ql): Pquotl ql :=
+        of_pl (map2 Pmul (to_pl p1) (to_pl p2)) _.
+      Next Obligation. rewrite map2_length, to_pl_length, to_pl_length, PeanoNat.Nat.min_id. reflexivity. Qed.
+
+      Program Definition oppl (pl: Pquotl ql): Pquotl ql :=
+        List.map Popp (to_pl pl).
+      Next Obligation.
+        destruct pl as [pl Hpl]. simpl. induction Hpl; simpl; constructor; auto.
+        rewrite Pmod_opp, <- H. reflexivity.
+      Qed.
+
+      Program Definition subl (p1 p2: Pquotl ql): Pquotl ql :=
+        map2 Psub (to_pl p1) (to_pl p2).
+      Next Obligation.
+        destruct p1 as [p1 Hp1]. destruct p2 as [p2 Hp2].
+        simpl. revert p2 Hp2. induction Hp1.
+        - intros. inversion Hp2. constructor.
+        - intros. destruct p2 as [|z]; inversion Hp2.
+          simpl. constructor; auto.
+          subst. rewrite ring_sub_definition, Pmod_distr, Pmod_opp, <- H, <- H3. reflexivity.
+      Qed.
+    End PquotlOperations.
+    Section Pquotl1.
+      (* Pquotl [q] isomorphic to Pquot q *)
+      Context {q: P}. Local Notation ql := (q::nil).
+      Local Notation Pquot := (@Pquot Fdiv).
+      Program Definition pquot_phi (p: Pquot q): Pquotl ql :=
+        (proj1_sig p)::nil.
+      Next Obligation. destruct p as [p Hp]; simpl. repeat constructor; auto. Qed.
+
+      Program Definition pquot_psi (p: Pquotl ql): Pquot q :=
+        List.hd Pzero (to_pl p).
+      Next Obligation.
+        generalize (to_pl_length p). simpl.
+        destruct p as [p Hp]. simpl in *. inversion Hp; subst.
+        simpl. auto.
+      Qed.
+
+      Lemma Pquotl1_ring_isomorphism:
+        @ring (Pquotl ql) eql zerol onel oppl addl subl mull
+        /\ @Ring.is_homomorphism (Pquot q) eq1 one add mul (Pquotl ql) eql onel addl mull pquot_phi
+        /\ @Ring.is_homomorphism (Pquotl ql) eql onel addl mull (Pquot q) eq1 one add mul pquot_psi.
+      Proof.
+        apply Ring.ring_by_isomorphism.
+        - intros x. destruct x as [x Hx]; unfold eq1; reflexivity.
+        - intros a b. destruct a as [a Ha]; destruct b as [b Hb].
+          unfold eq1, eql; simpl. destruct a as [|x]; inversion Ha; subst.
+          destruct b as [|y]; inversion Hb; subst.
+          inversion H4; inversion H6; subst.
+          simpl. split; intros; [repeat constructor; auto|].
+          inversion H; auto.
+        - unfold pquot_psi, zerol, zero, eq1; simpl; rewrite Pmod_0_l; reflexivity.
+        - unfold pquot_psi, onel, one, eq1; simpl; reflexivity.
+        - intro a. destruct a as [a Ha]; unfold eq1; simpl.
+          inversion Ha; subst. simpl. rewrite Pmod_opp.
+          rewrite H2 at 1. reflexivity.
+        - intros a b. destruct a as [a Ha]; destruct b as [b Hb].
+          unfold eq1; simpl. inversion Ha; subst. inversion Hb; subst; simpl.
+          rewrite H2, H4 at 1. rewrite Pmod_distr. reflexivity.
+        - intros a b. destruct a as [a Ha]; destruct b as [b Hb].
+          unfold eq1; simpl. inversion Ha; subst. inversion Hb; subst; simpl.
+          rewrite Pmod_opp, <- H4, ring_sub_definition.
+          rewrite H2, H4 at 1. rewrite Pmod_distr, Pmod_opp. reflexivity.
+        - intros a b. destruct a as [a Ha]; destruct b as [b Hb].
+          unfold eq1; simpl. inversion Ha; subst. inversion Hb; subst; simpl.
+          reflexivity.
+      Qed.
+
+      Lemma Pquotl1_commutative_ring:
+        @commutative_ring (Pquotl ql) eql zerol onel oppl addl subl mull.
+      Proof.
+        constructor.
+        - apply Pquotl1_ring_isomorphism.
+        - constructor. intros.
+          destruct x as [x Hx]; destruct y as [y Hy].
+          unfold eql; simpl. inversion Hx; inversion Hy; subst.
+          constructor.
+          + rewrite commutative; reflexivity.
+          + inversion H3; inversion H8; simpl. constructor.
+      Qed.
+    End Pquotl1.
+    Section PquotlRing.
+      Context {ql: list P}.
+
+      Global Instance PquotlRing:
+        @commutative_ring (Pquotl ql) eql zerol onel oppl addl subl mull.
+      Proof.
+        split; repeat constructor; intros;
+          match goal with
+          | |- Proper _ _ => unfold Proper, respectful
+          | |- Reflexive _ => unfold Reflexive
+          | |- Symmetric _ => unfold Symmetric
+          | |- Transitive _ => unfold Transitive
+          | |- _ => idtac end;
+          intros; repeat match goal with
+                    | [ x : Pquotl ql  |- _ ] => destruct x as [?a ?A]
+                    | [ H : Forall2 _ ?a ql |- _ ] => revert a H
+                    end;
+          lazy iota beta delta [eql zerol onel addl mull oppl subl] in *; simpl in *.
+        - induction ql; intros.
+          + inversion A; inversion A0; inversion A1; subst; simpl; constructor.
+          + inversion A; inversion A0; inversion A1; subst; simpl; constructor; auto.
+            apply associative.
+        - induction ql; intros.
+          + inversion A; subst; simpl; constructor.
+          + inversion A; subst; simpl; constructor; auto.
+            rewrite left_identity; reflexivity.
+        - induction ql; intros.
+          + inversion A; subst; simpl; constructor.
+          + inversion A; subst; simpl; constructor; auto.
+            rewrite right_identity; reflexivity.
+        - revert H H0; repeat match goal with | [ H : Forall2 _ ?a ql |- _ ] => revert a H end.
+          induction ql; intros.
+          + inversion A; inversion A0; inversion A1; inversion A2; subst; constructor.
+          + inversion A; inversion A0; inversion A1; inversion A2; subst; simpl; constructor; auto; inversion H; inversion H0; subst; auto.
+            rewrite H6, H16; reflexivity.
+        - induction ql; intros.
+          + inversion A; subst; constructor.
+          + inversion A; subst; constructor; auto. reflexivity.
+        - apply Forall2_flip. eapply Forall2_impl; eauto.
+          intros; symmetry; auto.
+        - revert H H0; repeat match goal with | [ H : Forall2 _ ?a ql |- _ ] => revert a H end.
+          induction ql; intros.
+          + inversion A; inversion A0; inversion A1; subst; constructor.
+          + inversion A; inversion A0; inversion A1; subst; simpl; constructor; auto; inversion H; inversion H0; subst; auto.
+            * rewrite H6, H16; reflexivity.
+            * eapply IHl; eauto.
+              clear -field. induction l2; constructor; auto. intro; reflexivity.
+        - induction ql; intros.
+          + inversion A; subst; constructor.
+          + inversion A; subst; simpl; constructor; auto.
+            rewrite left_inverse; reflexivity.
+        - induction ql; intros.
+          + inversion A; subst; constructor.
+          + inversion A; subst; simpl; constructor; auto.
+            rewrite right_inverse; reflexivity.
+        - revert H. revert a A a0 A0. induction ql; intros.
+          + inversion A; inversion A0; subst; constructor.
+          + inversion A; inversion A0; subst; inversion H; subst; constructor; auto.
+            rewrite H5; reflexivity.
+        - induction ql; intros.
+          + inversion A; inversion A0; subst; constructor.
+          + inversion A; inversion A0; subst; simpl; constructor; auto.
+            apply commutative.
+        - induction ql; intros.
+          + inversion A; inversion A0; inversion A1; subst; constructor.
+          + inversion A; inversion A0; inversion A1; subst; simpl; constructor; auto.
+            rewrite Pmul_mod_idemp_l, Pmul_mod_idemp_r, associative.
+            reflexivity.
+        - induction ql; intros.
+          + inversion A; subst; constructor.
+          + inversion A; subst; simpl; constructor; auto.
+            rewrite Pmul_mod_idemp_l, left_identity. symmetry; assumption.
+        - induction ql; intros.
+          + inversion A; subst; constructor.
+          + inversion A; subst; simpl; constructor; auto.
+            rewrite Pmul_mod_idemp_r, right_identity. symmetry; assumption.
+        - revert H H0; repeat match goal with | [ H : Forall2 _ ?a ql |- _ ] => revert a H end.
+          induction ql; intros.
+          + inversion A; inversion A0; inversion A1; inversion A2; subst; constructor.
+          + inversion A; inversion A0; inversion A1; inversion A2; subst; simpl; constructor; auto; inversion H; inversion H0; subst; auto.
+            rewrite H6, H16; reflexivity.
+        - intros a _. induction a; constructor; auto. reflexivity.
+        - apply Forall2_flip. eapply Forall2_impl; eauto. intros; symmetry; auto.
+        - clear A A0 A1. revert H H0. revert a1 a0 a. induction a1; intros; auto.
+          + inversion H; inversion H0; subst; try congruence; constructor.
+          + inversion H; subst.
+            inversion H0; subst; constructor; auto.
+            * rewrite H3; auto.
+            * eapply IHa1; eauto.
+        - induction ql; intros.
+          + inversion A; inversion A0; inversion A1; subst; constructor.
+          + inversion A; inversion A0; inversion A1; subst; simpl; constructor; auto.
+            rewrite <- Pmod_distr, <- left_distributive. reflexivity.
+        - induction ql; intros.
+          + inversion A; inversion A0; inversion A1; subst; constructor.
+          + inversion A; inversion A0; inversion A1; subst; simpl; constructor; auto.
+            rewrite <- Pmod_distr, <- right_distributive. reflexivity.
+        - induction ql; intros.
+          + inversion A; inversion A0; subst; constructor.
+          + inversion A; inversion A0; subst; simpl; constructor; auto.
+            rewrite ring_sub_definition; reflexivity.
+        - revert H H0; repeat match goal with | [ H : Forall2 _ ?a ql |- _ ] => revert a H end.
+          induction ql; intros.
+          + inversion A; inversion A0; inversion A1; inversion A2; subst; constructor.
+          + inversion A; inversion A0; inversion A1; inversion A2; subst; simpl; constructor; auto; inversion H; inversion H0; subst; auto.
+            rewrite H6, H16; reflexivity.
+        - revert H H0; repeat match goal with | [ H : Forall2 _ ?a ql |- _ ] => revert a H end.
+          induction ql; intros.
+          + inversion A; inversion A0; inversion A1; inversion A2; subst; constructor.
+          + inversion A; inversion A0; inversion A1; inversion A2; subst; simpl; constructor; auto; inversion H; inversion H0; subst; auto.
+            rewrite H6, H16; reflexivity.
+        - induction ql; intros.
+          + inversion A; inversion A0; subst; constructor.
+          + inversion A; inversion A0; subst; simpl; constructor; auto.
+            rewrite commutative. reflexivity.
+      Qed.
+    End PquotlRing.
+  End Pquotl.
+End Theorems.

--- a/src/NTT/RupicolaBarrettReduction.v
+++ b/src/NTT/RupicolaBarrettReduction.v
@@ -1,0 +1,368 @@
+Require Import Crypto.Arithmetic.BarrettReduction.Wikipedia.
+Require Import Rupicola.Lib.Api.
+Require Import Rupicola.Lib.Core.
+Require Import Rupicola.Lib.SepLocals.
+Require Import Crypto.Util.ZUtil.ModInv.
+Require Import Crypto.Util.ZUtil.EquivModulo.
+
+Require Import bedrock2.Map.Separation.
+Require Import bedrock2.Map.SeparationLogic.
+Require Import bedrock2.NotationsCustomEntry.
+Require Import bedrock2.ProgramLogic.
+Require Import bedrock2.Scalars.
+Require Import bedrock2.Semantics.
+Require Import bedrock2.Syntax.
+Require Import bedrock2.BasicC32Semantics bedrock2.BasicC64Semantics.
+
+Require Import Crypto.NTT.BedrockNTT.
+Require Import Crypto.Spec.ModularArithmetic.
+
+Section __.
+  Context {width: Z} {BW: Bitwidth width} {word: word.word width}
+    {mem: map.map word Byte.byte} {loc: map.map String.string word}
+    {ext_spec: bedrock2.Semantics.ExtSpec}
+    {word_ok : word.ok word} {map_ok : map.ok mem}
+    {loc_ok : map.ok loc}
+    {ext_spec_ok : Semantics.ext_spec.ok ext_spec}.
+
+  Context {modulus_pos: positive}.
+  Let modulus := Zpos modulus_pos.
+  Context {modulus_prime: Znumtheory.prime modulus}.
+  Context {modulus_not_2: 3 <= modulus}.
+
+  Definition k := Z.log2_up modulus.
+
+  Lemma modulus_lt_pow2k:
+    modulus < Z.pow 2 k.
+  Proof.
+    unfold k. generalize (Z.log2_up_spec modulus ltac:(Lia.lia)). intros Y.
+    assert (modulus = Z.pow 2 (Z.log2_up modulus) \/ modulus < Z.pow 2 (Z.log2_up modulus)) as [Z|?] by Lia.lia; auto.
+    exfalso.
+    generalize (Zpow_facts.prime_power_prime modulus 2 (Z.log2_up modulus) ltac:(apply Z.log2_up_nonneg) modulus_prime Znumtheory.prime_2 ltac:(rewrite <- Z; apply Z.divide_refl)).
+    Lia.lia.
+  Qed.
+
+  Definition m := (4 ^ k / modulus). (* This is precomputed *)
+
+  (* Correct when x < 2 * modulus *)
+  Definition barrett_reduce_small (x: Z): Z :=
+    let/n s := 1 - Z.b2z (Z.ltb x modulus) in
+    let/n r := x - (s * modulus) in
+    r.
+
+  Lemma barrett_reduce_small_correct:
+    forall x, (0 <= x < 2 * modulus) ->
+         barrett_reduce_small x = x mod modulus.
+  Proof.
+    intros. unfold barrett_reduce_small, nlet.
+    generalize (Zlt_cases x modulus); intros.
+    destruct (Z.ltb x modulus).
+    - rewrite Z.sub_0_r. rewrite Z.mod_small by Lia.lia. reflexivity.
+    - rewrite Z.mul_1_l. apply (Zmod_unique _ _ 1); Lia.lia.
+  Qed.
+
+  (* Correct when x < 2^(2k) *)
+  Definition barrett_reduce (x: Z): Z :=
+    let/n q := Z.shiftr (m * x) (2 * k) in
+    let/n r := x - q * modulus in
+    let/n s := 1 - Z.b2z (Z.ltb r modulus) in
+    let/n r := r - (s * modulus) in
+    r.
+
+  Lemma barrett_reduce_correct:
+    forall x, (0 <= x < Z.pow 4 k) ->
+         barrett_reduce x = x mod modulus.
+  Proof.
+    intros. rewrite (barrett_reduction_small modulus x ltac:(Lia.lia) k modulus_lt_pow2k m eq_refl ltac:(Lia.lia) ltac:(Lia.lia) ltac:(Lia.lia)).
+    unfold barrett_reduce, nlet.
+    assert (Hk: 1 < k).
+    { unfold k. apply Z.log2_up_lt_pow2; Lia.lia. }
+    assert ((m * x) / Z.pow 4 k = Z.shiftr (m * x) (2 * k)) as ->.
+    { assert (4 ^ k = 2 ^ (2 * k)) as -> by (rewrite Z.pow_mul_r; f_equal; Lia.lia).
+      rewrite Z.shiftr_div_pow2 by Lia.lia. reflexivity. }
+    generalize (Zlt_cases (x - Z.shiftr (m * x) (2 * k) * modulus) modulus). intros.
+    destruct (Z.ltb (x - Z.shiftr (m * x) (2 * k) * modulus) modulus); simpl.
+    - rewrite Z.sub_0_r. reflexivity.
+    - reflexivity.
+  Qed.
+
+  Context {reduce_small_name reduce_name: string}.
+  Context {add_name sub_name mul_name: string}.
+
+  Instance spec_of_reduce_small : spec_of reduce_small_name :=
+    fnspec! reduce_small_name (X: word) / (x: Z) ~> r,
+    { requires tr mem :=
+        (0 <= x < 2 * modulus) /\
+        X = word.of_Z x;
+      ensures tr' mem' :=
+        tr' = tr /\
+        mem' = mem /\
+        r = word.of_Z (barrett_reduce_small x) }.
+
+  Instance spec_of_reduce : spec_of reduce_name :=
+    fnspec! reduce_name (X: word) / (x: Z) ~> r,
+    { requires tr mem :=
+        (0 <= x < Z.pow 4 k) /\
+        X = word.of_Z x;
+      ensures tr' mem' :=
+        tr' = tr /\
+        mem' = mem /\
+        r = word.of_Z (barrett_reduce x) }.
+
+  Program Definition feval (x: word): option (F modulus_pos) :=
+    if Z_lt_dec (word.unsigned x) modulus then Some (word.unsigned x) else None.
+  Next Obligation.
+    rewrite Z.mod_small; [reflexivity|]. generalize (word.unsigned_range x).
+    Lia.lia.
+  Qed.
+
+  Local Instance F_to_Z: Convertible (F modulus_pos) Z := F.to_Z.
+  Existing Instance F_to_word.
+
+  Lemma feval_is_Some_implies:
+    forall x y, feval x = Some y ->
+           0 <= word.unsigned x < modulus /\ F.to_Z y = word.unsigned x.
+  Proof.
+    intros x y Hx. unfold feval in Hx.
+    generalize (word.unsigned_range x).
+    destruct (Z_lt_dec (word.unsigned x) modulus); [split; [Lia.lia|]|congruence].
+    inversion Hx; subst y; reflexivity.
+  Qed.
+
+  Instance spec_of_add : spec_of add_name := spec_of_add (q:=modulus_pos) (feval:=feval) (add:=add_name).
+  Instance spec_of_sub : spec_of sub_name := spec_of_sub (q:=modulus_pos) (feval:=feval) (sub:=sub_name).
+  Instance spec_of_mul : spec_of mul_name := spec_of_mul (q:=modulus_pos) (feval:=feval) (mul:=mul_name).
+
+  Section VerySmall.
+    Hypothesis k_very_small: 3 * k + 1 < width.
+
+    Lemma modulus_small:
+      2 * modulus < modulus * modulus < 2 ^ width.
+    Proof.
+      split; [apply Z.mul_lt_mono_pos_r; Lia.lia|].
+      generalize (Z.log2_up_spec modulus ltac:(Lia.lia)); intros Hk.
+      generalize (Z.log2_up_nonneg modulus). fold k. intro Hkpos.
+      fold k in Hk. apply (Z.le_lt_trans _ (2 ^ (2 * k))); [|apply Z.pow_lt_mono_r; destruct BW; Lia.lia].
+      rewrite (Z.mul_comm 2), Z.pow_mul_r, Z.pow_2_r by Lia.lia.
+      apply Z.mul_le_mono_nonneg; try Lia.lia.
+    Qed.
+
+    Lemma feval_ok:
+      forall (x: F modulus_pos), feval (cast x) = Some x.
+    Proof.
+      intros. cbv [cast F_to_word F_to_Z feval].
+      pose proof (ModularArithmeticTheorems.F.to_Z_range x ltac:(Lia.lia)) as Hx.
+      pose proof modulus_small as Hsmall.
+      destruct (Z_lt_dec _ _) as [Hlt|Hlt].
+      - f_equal. apply ModularArithmeticTheorems.F.eq_to_Z_iff. cbn.
+        rewrite word.unsigned_of_Z_nowrap; Lia.lia.
+      - rewrite word.unsigned_of_Z_nowrap in Hlt; Lia.lia.
+    Qed.
+
+    Derive reduce_small_br2fn SuchThat
+      (defn! reduce_small_name("x") ~> "r"
+         { reduce_small_br2fn },
+        implements barrett_reduce_small)
+      As reduce_small_br2fn_ok.
+    Proof.
+      compile.
+      eapply expr_compile_Z_b2z.
+      eapply expr_compile_Z_ltb_u.
+      - eapply (expr_compile_var "x"). apply map.get_put_same.
+      - eapply expr_compile_Z_literal.
+      - split; [Lia.lia|].
+        assert (Hk: 1 < k) by (unfold k; apply Z.log2_up_lt_pow2; Lia.lia).
+        pose proof modulus_lt_pow2k. transitivity (2 * 2 ^ k); [Lia.lia|].
+        rewrite <- Z.pow_succ_r by Lia.lia.
+        apply Z.pow_lt_mono_r; Lia.lia.
+      - split; [Lia.lia|]. etransitivity; [apply modulus_lt_pow2k|].
+        assert (Hk: 1 < k) by (unfold k; apply Z.log2_up_lt_pow2; Lia.lia).
+        apply Z.pow_lt_mono_r; Lia.lia.
+    Qed.
+
+    Derive reduce_br2fn SuchThat
+      (defn! reduce_name("x") ~> "r"
+         { reduce_br2fn },
+        implements barrett_reduce)
+      As reduce_br2fn_ok.
+    Proof.
+      assert (Hk: 1 < k) by (unfold k; apply Z.log2_up_lt_pow2; Lia.lia).
+      compile.
+      - assert (0 <= m); [|Lia.lia].
+        unfold m. generalize (Z_div_ge0 (4 ^ k) modulus ltac:(Lia.lia) ltac:(generalize (Z.pow_nonneg 4 k ltac:(Lia.lia)); Lia.lia)).
+        Lia.lia.
+      - assert (4 ^ k <= modulus * 2 ^ (k + 1)).
+        { transitivity (Z.pow 2 (k - 1) * Z.pow 2 (k + 1)).
+          * rewrite <- Z.pow_add_r by Lia.lia.
+            assert (k - 1 + (k + 1) = 2 * k) as -> by Lia.lia.
+            rewrite Z.pow_mul_r by Lia.lia. reflexivity.
+          * apply Z.mul_le_mono_pos_r; [Lia.lia|].
+            generalize (Z.log2_up_spec modulus ltac:(Lia.lia)). unfold k. Lia.lia. }
+        + generalize (Z.div_le_upper_bound (Z.pow 4 k) modulus (Z.pow 2 (k + 1)) ltac:(Lia.lia) ltac:(Lia.lia)).
+          intro. transitivity ((2 ^ (k + 1)) * (4 ^ k)).
+          * unfold m. generalize (Z.pow_nonneg 2 (k + 1) ltac:(Lia.lia)).
+            intro. assert (4 ^ k / modulus < 2 ^ (k + 1) \/ 4 ^ k / modulus = 2 ^ (k + 1)) as [| ->] by Lia.lia.
+            { apply Zmult_lt_compat; auto. split; auto.
+              apply Z_div_nonneg_nonneg; Lia.lia. }
+            { apply Z.mul_lt_mono_pos_l; Lia.lia. }
+          * assert (4 ^ k = 2 ^ (2 * k)) as -> by (rewrite Z.pow_mul_r by Lia.lia; reflexivity).
+            rewrite <- Z.pow_add_r by Lia.lia. apply Z.pow_lt_mono_r; Lia.lia.
+      - Lia.lia.
+      - Lia.lia.
+      - eapply expr_compile_Z_b2z.
+        eapply expr_compile_Z_ltb_u.
+        + eapply (expr_compile_var "r"). apply map.get_put_same.
+        + eapply expr_compile_Z_literal.
+        + unfold v0, v. split.
+          * generalize (qn_small modulus x ltac:(Lia.lia) k modulus_lt_pow2k m eq_refl ltac:(Lia.lia) ltac:(Lia.lia)).
+            assert ((m * x) / Z.pow 4 k = Z.shiftr (m * x) (2 * k)) as ->.
+            { assert (4 ^ k = 2 ^ (2 * k)) as -> by (rewrite Z.pow_mul_r; f_equal; Lia.lia).
+              rewrite Z.shiftr_div_pow2 by Lia.lia. reflexivity. }
+            intros. Lia.lia.
+          * generalize (r_small modulus x ltac:(Lia.lia) k modulus_lt_pow2k m eq_refl ltac:(Lia.lia) ltac:(Lia.lia) ltac:(Lia.lia)).
+            assert ((m * x) / Z.pow 4 k = Z.shiftr (m * x) (2 * k)) as ->.
+            { assert (4 ^ k = 2 ^ (2 * k)) as -> by (rewrite Z.pow_mul_r; f_equal; Lia.lia).
+              rewrite Z.shiftr_div_pow2 by Lia.lia. reflexivity. }
+            intros.
+            transitivity (2 * modulus); auto.
+            transitivity (2 * 2 ^ k); [generalize modulus_lt_pow2k; Lia.lia|].
+            rewrite <- Z.pow_succ_r by Lia.lia. apply Z.pow_lt_mono_r; Lia.lia.
+        + split; try Lia.lia. transitivity (2 ^ k); [apply modulus_lt_pow2k|].
+          apply Z.pow_lt_mono_r; Lia.lia.
+    Qed.
+
+    Definition add_br2fn :=
+      func! (x, y) ~> r {
+          unpack! r = $reduce_small_name(x + y)
+        }.
+
+    Definition sub_br2fn :=
+      func! (x, y) ~> r {
+          unpack! r = $reduce_small_name(x + ($modulus - y))
+        }.
+
+    Definition mul_br2fn :=
+      func! (x, y) ~> r {
+          unpack! r = $reduce_name(x * y)
+        }.
+
+    Lemma add_br2fn_ok:
+      program_logic_goal_for add_br2fn
+        (forall functions : map.rep,
+            map.get functions add_name = Some add_br2fn ->
+            spec_of_reduce_small functions ->
+            spec_of_add functions).
+    Proof.
+      enter add_br2fn. red; intros. red. intros.
+      eapply start_func; eauto.
+      cbv beta match delta [WeakestPrecondition.func].
+      repeat straightline. eexists; split.
+      repeat straightline. eexists; split.
+      unfold l. rewrite map.get_put_diff by congruence. eapply map.get_put_same.
+      repeat straightline. eexists; split; [|repeat straightline].
+      eapply map.get_put_same.
+      straightline_call.
+      { instantiate (1 := word.unsigned x + word.unsigned y).
+        apply feval_is_Some_implies in H1, H2. destruct H1, H2.
+        split; [Lia.lia|]. rewrite word.ring_morph_add.
+        do 2 rewrite word.of_Z_unsigned. reflexivity. }
+      eexists; split; repeat straightline; [reflexivity|].
+      eexists; split; repeat straightline; [apply map.get_put_same|].
+      apply feval_is_Some_implies in H1, H2. destruct H1, H2.
+      rewrite barrett_reduce_small_correct by Lia.lia.
+      pose proof modulus_small as Hsmall.
+      unfold feval. destruct (Z_lt_dec _ _) as [Hlt|Hlt].
+                  - f_equal. apply ModularArithmeticTheorems.F.eq_to_Z_iff.
+                    rewrite ModularArithmeticTheorems.F.to_Z_add. cbn.
+                    rewrite word.unsigned_of_Z_nowrap by Lia.lia.
+                    rewrite H3, H4. reflexivity.
+                  - generalize (Z.mod_pos_bound (word.unsigned x + word.unsigned y) modulus ltac:(Lia.lia)).
+                    rewrite word.unsigned_of_Z_nowrap in Hlt by Lia.lia. Lia.lia.
+    Qed.
+
+    Lemma sub_br2fn_ok:
+      program_logic_goal_for sub_br2fn
+        (forall functions : map.rep,
+            map.get functions sub_name = Some sub_br2fn ->
+            spec_of_reduce_small functions ->
+            spec_of_sub functions).
+    Proof.
+      enter sub_br2fn. red; intros. red. intros.
+      eapply start_func; eauto.
+      cbv beta match delta [WeakestPrecondition.func].
+      repeat straightline. eexists; split.
+      repeat straightline. eexists; split.
+      unfold l. rewrite map.get_put_diff by congruence. eapply map.get_put_same.
+      repeat straightline. eexists; split; [|repeat straightline].
+      eapply map.get_put_same.
+      straightline_call.
+      { instantiate (1 := word.unsigned x + (modulus - word.unsigned y)).
+        apply feval_is_Some_implies in H1, H2. destruct H1, H2.
+        split; [Lia.lia|]. rewrite <- (word.of_Z_unsigned y) at 1.
+        rewrite <- (word.of_Z_unsigned x) at 1.
+        rewrite <- word.ring_morph_sub, <- word.ring_morph_add. reflexivity. }
+      eexists; split; repeat straightline; [reflexivity|].
+      eexists; split; repeat straightline; [apply map.get_put_same|].
+      apply feval_is_Some_implies in H1, H2. destruct H1, H2.
+      rewrite barrett_reduce_small_correct by Lia.lia.
+      pose proof modulus_small as Hsmall.
+      unfold feval. destruct (Z_lt_dec _ _) as [Hlt|Hlt].
+      - f_equal. apply ModularArithmeticTheorems.F.eq_to_Z_iff.
+        rewrite (Hierarchy.ring_sub_definition a b).
+        rewrite ModularArithmeticTheorems.F.to_Z_add, ModularArithmeticTheorems.F.to_Z_opp.
+        rewrite H3, H4. cbv [F.to_Z proj1_sig].
+        rewrite word.unsigned_of_Z_nowrap by Lia.lia.
+        destruct (Z.eq_dec (word.unsigned y) 0) as [->|Hynz].
+        + rewrite Z.sub_0_r, Z.add_0_r.
+          rewrite <- (Z.mul_1_l modulus) at 1.
+          rewrite Modulo.Z.mod_add_full. reflexivity.
+        + f_equal. f_equal. apply (Zmod_unique _ _ (-1)); Lia.lia.
+      - generalize (Z.mod_pos_bound (word.unsigned x + (modulus - word.unsigned y)) modulus ltac:(Lia.lia)).
+        rewrite word.unsigned_of_Z_nowrap in Hlt by Lia.lia. Lia.lia.
+    Qed.
+
+    Lemma mul_br2fn_ok:
+      program_logic_goal_for mul_br2fn
+        (forall functions : map.rep,
+            map.get functions mul_name = Some mul_br2fn ->
+            spec_of_reduce functions ->
+            spec_of_mul functions).
+    Proof.
+      enter mul_br2fn. red; intros. red. intros.
+      eapply start_func; eauto.
+      cbv beta match delta [WeakestPrecondition.func].
+      repeat straightline. eexists; split.
+      repeat straightline. eexists; split.
+      unfold l. rewrite map.get_put_diff by congruence. eapply map.get_put_same.
+      repeat straightline. eexists; split; [|repeat straightline].
+      eapply map.get_put_same.
+      assert (0 <= word.unsigned x * word.unsigned y < 4 ^ k) as Hmul.
+      { apply feval_is_Some_implies in H1, H2. destruct H1, H2.
+        assert (4 = 2 ^ 2) as -> by reflexivity.
+        generalize (Z.log2_up_nonneg modulus); fold k; intro Hkpos.
+        generalize (Z.log2_up_spec modulus ltac:(Lia.lia)). fold k; intro Hk.
+        rewrite <- Z.pow_mul_r, (Z.mul_comm 2), Z.pow_mul_r, Z.pow_2_r by Lia.lia.
+        split; [Lia.lia|].
+        apply (Z.lt_le_trans _ (modulus * modulus)).
+        - apply Z.mul_lt_mono_nonneg; Lia.lia.
+        - apply Z.mul_le_mono_nonneg; Lia.lia. }
+      straightline_call.
+      { instantiate (1 := word.unsigned x * word.unsigned y).
+        split; auto.
+        rewrite word.ring_morph_mul.
+        do 2 rewrite word.of_Z_unsigned. reflexivity. }
+      eexists; split; repeat straightline; [reflexivity|].
+      eexists; split; repeat straightline; [apply map.get_put_same|].
+      apply feval_is_Some_implies in H1, H2. destruct H1, H2.
+      rewrite barrett_reduce_correct by Lia.lia.
+      pose proof modulus_small as Hsmall.
+      unfold feval. destruct (Z_lt_dec _ _) as [Hlt|Hlt].
+      - f_equal. apply ModularArithmeticTheorems.F.eq_to_Z_iff.
+        rewrite ModularArithmeticTheorems.F.to_Z_mul. cbn.
+        rewrite word.unsigned_of_Z_nowrap by Lia.lia.
+        rewrite H3, H4. reflexivity.
+      - generalize (Z.mod_pos_bound (word.unsigned x + word.unsigned y) modulus ltac:(Lia.lia)).
+        rewrite word.unsigned_of_Z_nowrap in Hlt by Lia.lia. Lia.lia.
+    Qed.
+  End VerySmall.
+End __.

--- a/src/NTT/RupicolaMontgomeryArithmetic.v
+++ b/src/NTT/RupicolaMontgomeryArithmetic.v
@@ -1,0 +1,915 @@
+Require Import Rupicola.Lib.Api.
+Require Import Rupicola.Lib.Core.
+Require Import Rupicola.Lib.SepLocals.
+Require Import Crypto.Util.ZUtil.ModInv.
+Require Import Crypto.Util.ZUtil.EquivModulo.
+Require Import Crypto.Arithmetic.MontgomeryReduction.Definition.
+Require Import Crypto.Arithmetic.MontgomeryReduction.Proofs.
+Require Import Crypto.NTT.BedrockNTT.
+Require Import Crypto.Spec.ModularArithmetic.
+
+Section __.
+  Context {width: Z} {BW: Bitwidth width} {word: word.word width}
+    {mem: map.map word Byte.byte} {loc: map.map String.string word}
+    {ext_spec: bedrock2.Semantics.ExtSpec}
+    {word_ok : word.ok word} {map_ok : map.ok mem}
+    {loc_ok : map.ok loc}
+    {ext_spec_ok : Semantics.ext_spec.ok ext_spec}.
+  Context {modulus_pos: positive}.
+  Let modulus := Zpos modulus_pos.
+  Context {modulus_small: 3 <= modulus < 2 ^ width}.
+  Context {modulus_prime: Znumtheory.prime modulus}.
+  Definition r: Z := 2 ^ width.
+  Definition r2: Z := (r * r) mod modulus.
+  Definition r': Z := Z.modinv r modulus.
+  Definition modulus': Z := Z.modinv (-modulus) r.
+
+  Section Utils.
+    (* TODO: turn into a compile lemma and upstream to rupicola ? *)
+    Lemma overflow_bit (a b: word):
+      word.unsigned (@word.b2w _ word (word.ltu (word.add a b) b)) = (word.unsigned a + word.unsigned b) / 2 ^ width.
+    Proof.
+      rewrite word.unsigned_ltu, word.unsigned_add. unfold word.wrap, r.
+      pose proof (word.unsigned_range a) as Ha.
+      pose proof (word.unsigned_range b) as Hb.
+      rewrite word.b2w_if.
+      destruct (Z_lt_dec (word.unsigned a + word.unsigned b) (2 ^ width)) as [Hlt|Hnlt].
+      - rewrite Z.mod_small by Lia.lia.
+        destruct (Z.ltb (word.unsigned a + word.unsigned b) (word.unsigned b)) eqn:Hcond; [apply Z.ltb_lt in Hcond; Lia.lia|].
+        rewrite word.unsigned_of_Z_0. symmetry; apply Zdiv_small. Lia.lia.
+      - rewrite Modulo.Z.mod_small_0_if; [|apply Z.pow_nonzero; destruct BW; Lia.lia|Lia.lia].
+        pose proof (Zle_cases (2 ^ width) (word.unsigned a + word.unsigned b)) as Hle; destruct (_ <=? _); [|Lia.lia].
+        pose proof (Zlt_cases (word.unsigned a + word.unsigned b - 2 ^ width) (word.unsigned b)) as Hlt; destruct (_ <? _); [|Lia.lia].
+        rewrite word.unsigned_of_Z_1.
+        assert (1 <= (word.unsigned a + word.unsigned b) / 2 ^ width < 2); [|Lia.lia].
+        split; [apply Z.div_le_lower_bound|apply Z.div_lt_upper_bound]; Lia.lia.
+    Qed.
+
+    Lemma underflow_bit (a b: word):
+      @word.b2w _ word (word.ltu a (word.sub a b)) = if Z_lt_dec (word.unsigned a) (word.unsigned b) then word.of_Z 1 else word.of_Z 0.
+    Proof.
+      rewrite word.b2w_if, word.unsigned_ltu, word.unsigned_sub. unfold word.wrap, r.
+      pose proof (word.unsigned_range a) as Ha.
+      pose proof (word.unsigned_range b) as Hb.
+      destruct (Z_lt_dec _ _) as [Hlt|Hnlt].
+      - rewrite Modulo.Z.mod_neg_small by Lia.lia.
+        pose proof (Zlt_cases (word.unsigned a) (2 ^ width + (word.unsigned a - word.unsigned b))).
+        destruct (_ <? _); [reflexivity|Lia.lia].
+      - rewrite Z.mod_small by Lia.lia.
+        pose proof (Zlt_cases (word.unsigned a) (word.unsigned a - word.unsigned b)).
+        destruct (_ <? _); [Lia.lia|reflexivity].
+    Qed.
+  End Utils.
+
+  Lemma modulus_nonzero:
+    modulus <> 0.
+  Proof. Lia.lia. Qed.
+
+  Lemma gcd_modulus_r:
+    Z.gcd modulus r = 1.
+  Proof.
+    generalize (Z.gcd_divide_r modulus r); intro Hr.
+    generalize (Z.gcd_divide_l modulus r); intro Hl.
+    generalize (Z.gcd_nonneg modulus r); intro Hn.
+    generalize (Znumtheory.prime_divisors _ modulus_prime _ Hl).
+    intros [? | [? | [? | ?]]]; try Lia.lia.
+    generalize (Zpow_facts.prime_power_prime modulus 2 width ltac:(destruct BW; Lia.lia) modulus_prime Znumtheory.prime_2 ltac:(rewrite <- H; auto)). intro X.
+    subst modulus; Lia.lia.
+  Qed.
+
+  Lemma modulus_correct':
+    Z.equiv_modulo r (modulus * modulus') (-1).
+  Proof.
+    unfold Z.equiv_modulo.
+    assert (modulus = (-1) * (- modulus)) as -> by Lia.lia.
+    rewrite <- Z.mul_assoc, Zmult_mod, (Z.mul_comm (- modulus)).
+    unfold modulus'. rewrite Z.invmod_coprime.
+    - rewrite Z.mul_1_r, Z.mod_mod; [reflexivity|]. unfold r. Lia.lia.
+    - unfold r. Lia.lia.
+    - rewrite Z.gcd_opp_l. apply gcd_modulus_r.
+  Qed.
+
+  Lemma modulus_range':
+    0 <= modulus' < r.
+  Proof.
+    apply Z.modinv_correct.
+    - unfold r. apply Z.pow_pos_nonneg; destruct BW; Lia.lia.
+    - assert (Z.abs _ = modulus) as ->; [|apply gcd_modulus_r].
+      rewrite Z.abs_neq; Lia.lia.
+  Qed.
+
+  Lemma r_correct':
+    Z.equiv_modulo modulus (r * r') 1.
+  Proof.
+    unfold Z.equiv_modulo, r'. rewrite Z.mul_comm.
+    rewrite Z.invmod_coprime, Z.mod_small; try Lia.lia.
+    rewrite Z.gcd_comm. apply gcd_modulus_r.
+  Qed.
+
+  (* Reduces systematically *)
+  Definition montgomery_add (x y: word): word :=
+    let/n res := word.add x y in
+    let/n c := word.b2w (word.ltu (word.of_Z (Z.pred modulus)) res) in
+    let/n res := word.sub res (word.mul c (word.of_Z modulus)) in
+    res.
+
+  Lemma montgomery_add_eq x y (Hx: 0 <= word.unsigned x < modulus) (Hy: 0 <= word.unsigned y <= modulus) (modulus_smaller: 2 * modulus < 2 ^ width):
+    word.unsigned (montgomery_add x y) = if Z_lt_dec (word.unsigned x + word.unsigned y) modulus then word.unsigned x + word.unsigned y else word.unsigned x + word.unsigned y - modulus.
+  Proof.
+    unfold montgomery_add, nlet.
+    pose proof (word.ltu_spec (word.of_Z (Z.pred modulus)) (word.add x y)) as Hltuspec.
+    rewrite word.unsigned_add_nowrap in Hltuspec by Lia.lia.
+    rewrite word.unsigned_of_Z_nowrap in Hltuspec by Lia.lia.
+    rewrite word.unsigned_sub_nowrap.
+    - destruct (Z_lt_dec _ _) as [Hlt|Hnlt].
+      + rewrite word.unsigned_add_nowrap by Lia.lia.
+        rewrite word.b2w_if. destruct (word.ltu _ _); inversion Hltuspec; [Lia.lia|].
+        rewrite word.mul_0_l, word.unsigned_of_Z_0, Z.sub_0_r. reflexivity.
+      + rewrite word.unsigned_mul_nowrap by (rewrite word.b2w_if, word.unsigned_of_Z_nowrap by Lia.lia; destruct (word.ltu _ _); [rewrite word.unsigned_of_Z_1|rewrite word.unsigned_of_Z_0]; Lia.lia).
+        rewrite word.b2w_if. destruct (word.ltu _ _); inversion Hltuspec; [|Lia.lia].
+        rewrite word.unsigned_of_Z_1, Z.mul_1_l.
+        rewrite word.unsigned_of_Z_nowrap by Lia.lia.
+        rewrite word.unsigned_add_nowrap by Lia.lia. reflexivity.
+    - rewrite word.unsigned_add_nowrap by Lia.lia.
+      rewrite word.unsigned_mul_nowrap by (rewrite word.b2w_if, word.unsigned_of_Z_nowrap by Lia.lia; destruct (word.ltu _ _); [rewrite word.unsigned_of_Z_1|rewrite word.unsigned_of_Z_0]; Lia.lia).
+        rewrite word.b2w_if. destruct (word.ltu _ _); inversion Hltuspec; [rewrite word.unsigned_of_Z_1|rewrite word.unsigned_of_Z_0]; rewrite word.unsigned_of_Z_nowrap; Lia.lia.
+  Qed.
+
+  (* Assumes 2 * modulus < 2 ^ width, reduces systematically *)
+  Definition montgomery_sub (x y: word): word :=
+    let/n res := word.sub x y in
+    let/n c := word.b2w (word.ltu x res) in
+    let/n res := word.add res (word.mul c (word.of_Z modulus)) in
+    res.
+
+  Lemma montgomery_sub_eq x y (Hx: 0 <= word.unsigned x < modulus) (Hy: 0 <= word.unsigned y < modulus) (modulus_smaller: 2 * modulus < 2 ^ width):
+    word.unsigned (montgomery_sub x y) = if Z_lt_dec (word.unsigned x) (word.unsigned y) then word.unsigned x + (modulus - word.unsigned y) else word.unsigned x - word.unsigned y.
+  Proof.
+    unfold montgomery_sub, nlet.
+    rewrite underflow_bit. destruct (Z_lt_dec _ _) as [Hlt|Hnlt].
+    - rewrite word.unsigned_add, word.unsigned_sub, word.unsigned_mul_nowrap by (repeat rewrite word.unsigned_of_Z_nowrap; Lia.lia).
+      rewrite word.unsigned_of_Z_1, Z.mul_1_l.
+      rewrite word.unsigned_of_Z_nowrap by Lia.lia.
+      unfold word.wrap.
+      rewrite (Modulo.Z.mod_neg_small (_ - _)) by Lia.lia.
+      assert (2 ^ width + (word.unsigned x - word.unsigned y) + modulus = 2 ^ width + (word.unsigned x + (modulus - word.unsigned y))) as -> by Lia.lia.
+      rewrite <- Zplus_mod_idemp_l, Z.mod_same by Lia.lia.
+      rewrite Z.add_0_l.
+      apply Z.mod_small. Lia.lia.
+    - rewrite word.mul_0_l, word.add_0_r.
+      apply word.unsigned_sub_nowrap. Lia.lia.
+  Qed.
+
+  (* When what needs to be reduced fits in a single word *)
+  Definition montgomery_reduce1 (x: word): word :=
+    let/n m := word.mul x (word.of_Z modulus') in
+    let/n t_hi := word.mulhuu m (word.of_Z modulus) in
+    let/n t_lo := word.mul m (word.of_Z modulus) in
+    let/n carry := word.b2w (word.ltu (word.add x t_lo) t_lo) in
+    let/n t := word.add t_hi carry in
+    let/n c := word.b2w (word.ltu (word.of_Z (Z.pred modulus)) t) in
+    let/n res := word.sub t (word.mul c (word.of_Z modulus)) in
+    res.
+
+  (* When input ≤ modulus * 2 ^ width, assumes 2 * modulus < 2 ^ width *)
+  Definition montgomery_reduce2 (x_hi x_lo: word): word :=
+    let/n m := word.mul x_lo (word.of_Z modulus') in
+    let/n t_hi := word.mulhuu m (word.of_Z modulus) in
+    let/n t_lo := word.mul m (word.of_Z modulus) in
+    let/n carry := word.b2w (word.ltu (word.add x_lo t_lo) t_lo) in
+    let/n t_hi := word.add t_hi carry in
+    let/n t := word.add t_hi x_hi in
+    let/n c := word.b2w (word.ltu (word.of_Z (Z.pred modulus)) t) in
+    let/n res := word.sub t (word.mul c (word.of_Z modulus)) in
+    res.
+
+  (* If modulus² < 2 ^ width *)
+  Definition montgomery_mul1 (x y: word): word :=
+    let/n res := word.mul x y in
+    let/n res := montgomery_reduce1 res in
+    res.
+
+  (* If modulus² ≥ 2 ^ width *)
+  Definition montgomery_mul2 (x y: word): word :=
+    let/n t_hi := word.mulhuu x y in
+    let/n t_lo := word.mul x y in
+    let/n res := montgomery_reduce2 t_hi t_lo in
+    res.
+
+  (* If modulus² < 2 ^ width *)
+  Definition to_montgomery_word1 (x: word): word :=
+    let/n t := word.mul x (word.of_Z r2) in
+    let/n res := montgomery_reduce1 t in
+    res.
+
+  (* If modulus² ≥ 2 ^ width *)
+  Definition to_montgomery_word2 (x: word): word :=
+    let/n t_hi := word.mulhuu x (word.of_Z r2) in
+    let/n t_lo := word.mul x (word.of_Z r2) in
+    let/n res := montgomery_reduce2 t_hi t_lo in
+    res.
+
+  Definition from_montgomery_word (x: word): word :=
+    let/n res := montgomery_reduce1 x in
+    res.
+
+  Local Notation reduce_spec := (@reduce modulus r modulus').
+  Local Notation to_montgomery_spec := (@to_montgomery modulus r modulus').
+  Local Notation from_montgomery_spec := (@from_montgomery modulus r modulus').
+  Local Notation mul_spec := (@MontgomeryReduction.Definition.mul modulus r modulus').
+  Local Notation reduce_spec_correct :=
+    (reduce_correct modulus modulus_nonzero r r' r_correct' modulus' modulus_range' modulus_correct').
+  Local Notation from_to_montgomery_spec_correct :=
+    (from_to_montgomery modulus modulus_nonzero r r' r_correct' modulus' modulus_range' modulus_correct').
+  Local Notation to_from_montgomery_spec_correct :=
+    (to_from_montgomery modulus modulus_nonzero r r' r_correct' modulus' modulus_range' modulus_correct').
+  Local Notation mul_spec_correct :=
+    (mul_correct modulus modulus_nonzero r r' r_correct' modulus' modulus_range' modulus_correct').
+
+  Lemma feval_pre (x: word):
+    (fun z : Z => z = z mod Z.pos modulus_pos) (from_montgomery_spec (word.unsigned x)).
+  Proof.
+    symmetry; apply Z.mod_small.
+    unfold from_montgomery_spec. apply reduce_in_range; try Lia.lia.
+    apply modulus_range'. pose proof (word.unsigned_range x) as Hx.
+    split; [Lia.lia|]. apply Z.lt_le_incl.
+    transitivity r; [unfold r; Lia.lia|].
+    rewrite <- (Z.mul_1_r r) at 1.
+    apply Zmult_lt_compat_l; unfold r; Lia.lia.
+  Qed.
+
+  (* Definition feval (x: word): option (F modulus_pos) := *)
+  (*   Some (exist _ (from_montgomery_spec (word.unsigned x)) (feval_pre x)). *)
+
+  (* Local Instance F_to_Z: Convertible (F modulus_pos) Z := fun x => to_montgomery_spec (F.to_Z x). *)
+
+  (* Existing Instance F_to_word. *)
+
+  (* Lemma feval_ok: *)
+  (*   forall (x: F modulus_pos), feval (cast x) = Some x. *)
+  (* Proof. *)
+  (*   intros. cbv [cast F_to_word F_to_Z feval]. *)
+  (*   f_equal. apply ModularArithmeticTheorems.F.eq_to_Z_iff. cbn. *)
+  (*   pose proof (ModularArithmeticTheorems.F.to_Z_range x ltac:(Lia.lia)) as Hx1. *)
+  (*   assert (Hx2: 0 <= to_montgomery_spec (F.to_Z x) < modulus). *)
+  (*   { unfold to_montgomery_spec. *)
+  (*     apply reduce_in_range; [Lia.lia|apply modulus_range'|]. *)
+  (*     pose proof (Z.mod_pos_bound (r * r) modulus ltac:(Lia.lia)) as Hr2. *)
+  (*     split; try Lia.lia. apply Zmult_le_compat; try Lia.lia. *)
+  (*     apply Z.lt_le_incl. transitivity modulus; unfold modulus, r in *; try Lia.lia. } *)
+  (*   pose proof (from_to_montgomery_spec_correct (F.to_Z x)) as Hx. *)
+  (*   rewrite word.unsigned_of_Z_nowrap; [|Lia.lia]. *)
+  (*   rewrite <- (Z.mod_small (F.to_Z x) modulus Hx1) at 2. *)
+  (*   apply Z.equiv_modulo_mod_small; auto. *)
+  (*   unfold from_montgomery_spec. apply reduce_in_range; [Lia.lia|apply modulus_range'|]. *)
+  (*   split; [|apply Z.lt_le_incl; transitivity modulus]; try Lia.lia. *)
+  (*   unfold r. rewrite <- (Z.mul_1_l modulus) at 1. *)
+  (*   apply Zmult_lt_compat_r; [Lia.lia|]. *)
+  (*   apply Zpow_facts.Zpower_gt_1; [|destruct BW]; Lia.lia. *)
+  (* Qed. *)
+
+  (* Lemma feval_is_Some_implies: *)
+  (*   forall x y, feval x = Some y -> F.to_Z y = (word.unsigned x * r') mod modulus. *)
+  (* Proof. *)
+  (*   intros x y Heq. pose proof (word.unsigned_range x) as Hx. *)
+  (*   unfold feval in Heq. *)
+  (*   inversion Heq; subst y. cbn. *)
+  (*   unfold from_montgomery_spec. *)
+  (*   apply Z.equiv_modulo_mod_small. *)
+  (*   - apply reduce_spec_correct. *)
+  (*   - apply (reduce_in_range _ modulus_nonzero _ _ modulus_range'). *)
+  (*     split; try Lia.lia. rewrite <- (Z.mul_1_r (word.unsigned x)). *)
+  (*     unfold r; apply Zmult_le_compat; Lia.lia. *)
+  (* Qed. *)
+
+  Definition feval (x: word): option (F modulus_pos) :=
+    if (Z_lt_dec (word.unsigned x) modulus) then Some (exist _ (from_montgomery_spec (word.unsigned x)) (feval_pre x)) else None.
+
+  Local Instance F_to_Z: Convertible (F modulus_pos) Z := fun x => to_montgomery_spec (F.to_Z x).
+
+  Existing Instance F_to_word.
+
+  Lemma feval_ok:
+    forall (x: F modulus_pos), feval (cast x) = Some x.
+  Proof.
+    intros. cbv [cast F_to_word F_to_Z feval].
+    pose proof (ModularArithmeticTheorems.F.to_Z_range x ltac:(Lia.lia)) as Hx1.
+    assert (Hx2: 0 <= to_montgomery_spec (F.to_Z x) < modulus).
+    { unfold to_montgomery_spec.
+      apply reduce_in_range; [Lia.lia|apply modulus_range'|].
+      pose proof (Z.mod_pos_bound (r * r) modulus ltac:(Lia.lia)) as Hr2.
+      split; try Lia.lia. apply Zmult_le_compat; try Lia.lia.
+      apply Z.lt_le_incl. transitivity modulus; unfold modulus, r in *; try Lia.lia. }
+    pose proof (from_to_montgomery_spec_correct (F.to_Z x)) as Hx.
+    destruct (Z_lt_dec _ _) as [|Hnlt].
+    2:{ rewrite word.unsigned_of_Z_nowrap in Hnlt; Lia.lia. }
+    f_equal. apply ModularArithmeticTheorems.F.eq_to_Z_iff. cbn.
+    rewrite word.unsigned_of_Z_nowrap; [|Lia.lia].
+    rewrite <- (Z.mod_small (F.to_Z x) modulus Hx1) at 2.
+    apply Z.equiv_modulo_mod_small; auto.
+    unfold from_montgomery_spec. apply reduce_in_range; [Lia.lia|apply modulus_range'|].
+    split; [|apply Z.lt_le_incl; transitivity modulus]; try Lia.lia.
+    unfold r. rewrite <- (Z.mul_1_l modulus) at 1.
+    apply Zmult_lt_compat_r; [Lia.lia|].
+    apply Zpow_facts.Zpower_gt_1; [|destruct BW]; Lia.lia.
+  Qed.
+
+  Lemma feval_is_Some_implies:
+    forall x y, feval x = Some y -> 0 <= word.unsigned x < modulus /\ F.to_Z y = (word.unsigned x * r') mod modulus.
+  Proof.
+    intros x y Heq. pose proof (word.unsigned_range x) as Hx.
+    unfold feval in Heq.
+    destruct (Z_lt_dec _ _); [|congruence]. split; [Lia.lia|].
+    inversion Heq; subst y. cbn.
+    unfold from_montgomery_spec.
+    apply Z.equiv_modulo_mod_small.
+    - apply reduce_spec_correct.
+    - apply (reduce_in_range _ modulus_nonzero _ _ modulus_range').
+      split; try Lia.lia. rewrite <- (Z.mul_1_r (word.unsigned x)).
+      unfold r; apply Zmult_le_compat; Lia.lia.
+  Qed.
+
+  Context {reduce_name: string}.
+  Context {to_montgomery_name from_montgomery_name: string}.
+  Context {add_name sub_name mul_name: string}.
+
+  Instance spec_of_add : spec_of add_name := spec_of_add (q:=modulus_pos) (feval:=feval) (add:=add_name).
+  Instance spec_of_sub : spec_of sub_name := spec_of_sub (q:=modulus_pos) (feval:=feval) (sub:=sub_name).
+  Instance spec_of_mul : spec_of mul_name := spec_of_mul (q:=modulus_pos) (feval:=feval) (mul:=mul_name).
+
+  (* Only used to derive code using Rupicola *)
+  Instance spec_of_add_dummy : spec_of add_name :=
+    fnspec! add_name (X Y: word) ~> res,
+    { requires tr mem :=
+        True;
+      ensures tr' mem' :=
+        tr' = tr /\
+        mem' = mem /\
+        res = montgomery_add X Y }.
+
+  Derive add_br2fn SuchThat
+    (defn! add_name("x", "y") ~> "res"
+       { add_br2fn },
+      implements montgomery_add)
+    As dummy_add_br2fn_ok.
+  Proof. compile. Qed.
+
+  Lemma montgomery_add_correct (modulus_smaller: 2 * modulus < 2 ^ width) x y a b:
+    feval x = Some a ->
+    feval y = Some b ->
+    feval (montgomery_add x y) = Some (a + b)%F.
+  Proof.
+    intros Ha Hb.
+    pose proof (feval_is_Some_implies _ _ Ha) as [Hx Heqa].
+    pose proof (feval_is_Some_implies _ _ Hb) as [Hy Heqb].
+    assert ((word.unsigned (montgomery_add x y)) < modulus) as Hbound.
+    { rewrite montgomery_add_eq by Lia.lia.
+      destruct (Z_lt_dec _ _) as [Hlt|Hnlt]; Lia.lia. }
+    assert (exists ab, feval (montgomery_add x y) = Some ab) as [ab Hab].
+    { unfold feval. destruct (Z_lt_dec _ _) as [_|?]; [|Lia.lia].
+      eexists; reflexivity. }
+    pose proof (feval_is_Some_implies _ _ Hab) as [Hxy Heqab].
+    rewrite Hab. f_equal.
+    apply ModularArithmeticTheorems.F.eq_to_Z_iff. cbn.
+    rewrite montgomery_add_eq in Heqab by Lia.lia.
+    rewrite Heqab, Heqa, Heqb, Z.add_mod_idemp_l, Z.add_mod_idemp_r by congruence.
+    rewrite <- Z.mul_add_distr_r.
+    destruct (Z_lt_dec _ _) as [Hlt|Hnlt]; [reflexivity|].
+    rewrite Z.mul_sub_distr_r.
+    rewrite <- Zminus_mod_idemp_r, ZLib.Z.Z_mod_mult', Z.sub_0_r. reflexivity.
+  Qed.
+
+  Lemma add_br2fn_ok (modulus_smaller: 2 * modulus < 2 ^ width):
+    program_logic_goal_for add_br2fn
+      (forall functions : map.rep,
+          map.get functions add_name = Some add_br2fn ->
+          spec_of_add functions).
+  Proof.
+    red. intros. red. red. red. intros. destruct H0.
+    generalize (dummy_add_br2fn_ok I _ H).
+    intros. eapply Proper_call; [|apply dummy_add_br2fn_ok; auto; exact I].
+    intros ? ? ? ?. destruct H3 as (? & -> & -> & -> & ->).
+    eexists; repeat split; try reflexivity.
+    apply montgomery_add_correct; auto.
+  Qed.
+
+  (* Only used to derive code using Rupicola *)
+  Instance spec_of_sub_dummy : spec_of sub_name :=
+    fnspec! sub_name (X Y: word) ~> res,
+    { requires tr mem :=
+        True;
+      ensures tr' mem' :=
+        tr' = tr /\
+        mem' = mem /\
+        res = montgomery_sub X Y }.
+
+  Derive sub_br2fn SuchThat
+    (defn! sub_name("x", "y") ~> "res"
+       { sub_br2fn },
+      implements montgomery_sub)
+    As dummy_sub_br2fn_ok.
+  Proof. compile. Qed.
+
+  Lemma montgomery_sub_correct (modulus_smaller: 2 * modulus < 2 ^ width) x y a b:
+    feval x = Some a ->
+    feval y = Some b ->
+    feval (montgomery_sub x y) = Some (a - b)%F.
+  Proof.
+    intros Ha Hb.
+    pose proof (feval_is_Some_implies _ _ Ha) as [Hx Heqa].
+    pose proof (feval_is_Some_implies _ _ Hb) as [Hy Heqb].
+    assert ((word.unsigned (montgomery_sub x y)) < modulus) as Hbound.
+    { rewrite montgomery_sub_eq by Lia.lia.
+      destruct (Z_lt_dec _ _) as [Hlt|Hnlt]; Lia.lia. }
+    assert (exists ab, feval (montgomery_sub x y) = Some ab) as [ab Hab].
+    { unfold feval. destruct (Z_lt_dec _ _) as [_|?]; [|Lia.lia].
+      eexists; reflexivity. }
+    pose proof (feval_is_Some_implies _ _ Hab) as [Hxy Heqab].
+    rewrite Hab. f_equal.
+    apply ModularArithmeticTheorems.F.eq_to_Z_iff. cbn.
+    rewrite montgomery_sub_eq in Heqab by Lia.lia.
+    rewrite Heqab, Heqa, Heqb, Z.add_mod_idemp_l, Z.add_mod_idemp_r by congruence.
+    destruct (Z_lt_dec _ _) as [Hlt|Hnlt].
+    - rewrite Z.mul_add_distr_r.
+      rewrite <- Zplus_mod_idemp_r at 1.
+      rewrite <- Zmult_mod_idemp_l.
+      rewrite <- Zminus_mod_idemp_l, Z.mod_same by Lia.lia.
+      rewrite Z.sub_0_l, Zmult_mod_idemp_l.
+      rewrite Zplus_mod_idemp_r, Z.mul_opp_l.
+      repeat rewrite Z.add_opp_r.
+      rewrite Zminus_mod_idemp_r. reflexivity.
+    - rewrite Z.add_opp_r, Zminus_mod_idemp_r.
+      rewrite <- Zmult_minus_distr_r. reflexivity.
+  Qed.
+
+  Lemma sub_br2fn_ok (modulus_smaller: 2 * modulus < 2 ^ width):
+    program_logic_goal_for sub_br2fn
+      (forall functions : map.rep,
+          map.get functions sub_name = Some sub_br2fn ->
+          spec_of_sub functions).
+  Proof.
+    red. intros. red. red. red. intros. destruct H0.
+    generalize (dummy_sub_br2fn_ok I _ H).
+    intros. eapply Proper_call; [|apply dummy_sub_br2fn_ok; auto; exact I].
+    intros ? ? ? ?. destruct H3 as (? & -> & -> & -> & ->).
+    eexists; repeat split; try reflexivity.
+    apply montgomery_sub_correct; auto.
+  Qed.
+
+  Lemma montgomery_reduce_correct1 x (Hx: 0 <= x < 2 ^ width):
+    word.unsigned (montgomery_reduce1 (word.of_Z x)) = reduce_spec x.
+  Proof.
+    pose proof (Z.pow_pos_nonneg 2 width ltac:(Lia.lia) ltac:(destruct BW; Lia.lia)) as ZZ.
+    unfold reduce_spec, prereduce, montgomery_reduce1.
+    rewrite <- word.ring_morph_mul. set (m := word.of_Z (x * modulus')).
+    unfold nlet at 1. repeat rewrite <- word.ring_morph_mul.
+    assert ((x mod r * modulus') mod r = word.unsigned (@word.of_Z _ word (x * modulus'))) as ->.
+    { rewrite word.unsigned_of_Z.
+      rewrite <- PullPush.Z.mul_mod_l. reflexivity. }
+    fold m. set (t_hi := word.mulhuu m (word.of_Z modulus)).
+    set (t_lo := word.mul m (word.of_Z modulus)).
+    do 2 (unfold nlet at 1).
+    assert (word.unsigned m * modulus = r * (word.unsigned t_hi) + (word.unsigned t_lo)) as ->.
+    { unfold t_hi, t_lo. rewrite word.unsigned_mulhuu_nowrap, word.unsigned_mul.
+      rewrite word.unsigned_of_Z_nowrap by Lia.lia.
+      apply Z_div_mod_eq_full. }
+    assert (Hcond_spec: forall (a b: word), word.ltu (word.add a b) b = true <-> (word.unsigned a + word.unsigned b) >= r).
+    { intros. rewrite word.unsigned_ltu, word.unsigned_add. unfold word.wrap, r.
+      generalize (word.unsigned_range a); intros Ha.
+      generalize (word.unsigned_range b); intros Hb.
+      split; intros X.
+      - apply Z.ltb_lt in X.
+        destruct (Z_lt_dec (word.unsigned a + word.unsigned b) (2 ^ width)); [|Lia.lia].
+        rewrite Z.mod_small in X by Lia.lia. Lia.lia.
+      - apply Z.ltb_lt.
+        generalize (Z_mod_lt (word.unsigned a + word.unsigned b) (2 ^ width) ltac:(Lia.lia)).
+        rewrite Modulo.Z.mod_small_0_if; [|apply Z.pow_nonzero; destruct BW; Lia.lia|Lia.lia].
+        generalize (Zle_cases (2 ^ width) (word.unsigned a + word.unsigned b)); destruct (_ <=? _); Lia.lia. }
+    set (carry := word.ltu (word.add (word.of_Z x) t_lo) t_lo).
+    set (t := word.add t_hi (word.b2w carry)).
+    do 2 (unfold nlet at 1).
+    fold t. assert ((x + (r * word.unsigned t_hi + word.unsigned t_lo)) / r = word.unsigned t) as ->.
+    { assert (x + (r * word.unsigned t_hi + word.unsigned t_lo) = (x + word.unsigned t_lo) + (word.unsigned t_hi) * r) as -> by Lia.lia.
+      rewrite Z_div_plus by (unfold r; Lia.lia).
+      unfold t, carry. rewrite word.unsigned_add_nowrap.
+      2:{ generalize (word.unsigned_range t_hi).
+          destruct (word.ltu _); unfold word.b2w; cbn; rewrite word.unsigned_of_Z_nowrap by Lia.lia; [|Lia.lia].
+          intros _. unfold t_hi. rewrite word.unsigned_mulhuu_nowrap.
+          pose proof (word.unsigned_range m) as Hm.
+          rewrite word.unsigned_of_Z_nowrap by Lia.lia.
+          apply (Z.le_lt_trans _ modulus); [|Lia.lia].
+          apply Z.lt_pred_le.
+          assert (Z.pred _ = (word.unsigned m * modulus) / 2 ^ width) as -> by Lia.lia.
+          apply (Zdiv_lt_upper_bound ((word.unsigned m) * modulus) (2 ^ width) modulus ZZ).
+          rewrite (Z.mul_comm modulus).
+          apply Zmult_lt_compat_r; Lia.lia. }
+      rewrite (Z.add_comm (word.unsigned t_hi)). f_equal.
+      pose proof (word.unsigned_range t_lo) as Hlo.
+      destruct (Z_lt_dec (x + word.unsigned t_lo) r) as [Hlt|Hnlt].
+      - rewrite <- (Z.mod_small (x + word.unsigned t_lo) r) by Lia.lia.
+        rewrite Zmod_div. pose proof (Hcond_spec (word.of_Z x) t_lo) as W.
+        destruct (word.ltu _ _); unfold word.b2w; cbn; rewrite word.unsigned_of_Z_nowrap by Lia.lia; [|reflexivity].
+        specialize ((proj1 W) eq_refl). rewrite word.unsigned_of_Z_nowrap by Lia.lia. Lia.lia.
+      - rewrite (proj2 (Hcond_spec (word.of_Z x) t_lo) ltac:(rewrite word.unsigned_of_Z_nowrap; Lia.lia)).
+        unfold word.b2w; cbn; rewrite word.unsigned_of_Z_nowrap by Lia.lia.
+        pose proof (Zdiv_le_lower_bound (x + word.unsigned t_lo) r 1 ZZ ltac:(Lia.lia)) as Hlow.
+        pose proof (Zdiv_lt_upper_bound (x + word.unsigned t_lo) r 2 ZZ ltac:(unfold r; Lia.lia)).
+        Lia.lia. }
+    assert (modulus <=? word.unsigned t = word.ltu (word.of_Z (Z.pred modulus)) t) as ->.
+    { rewrite word.unsigned_ltu, word.unsigned_of_Z_nowrap by Lia.lia.
+      pose proof (Zle_cases modulus (word.unsigned t)) as Hcond.
+      destruct (_ <=? _); [apply Z.lt_pred_le in Hcond; rewrite (proj2 (Z.ltb_lt _ _)); auto|].
+      pose proof (Zlt_cases (Z.pred modulus) (word.unsigned t)); destruct (_ <? _); Lia.lia. }
+    pose proof (word.ltu_spec (word.of_Z (Z.pred modulus)) t) as E.
+    destruct (word.ltu (word.of_Z (Z.pred modulus)) t); unfold word.b2w, nlet; cbn.
+    - rewrite word.mul_1_l. inversion E.
+      rewrite word.unsigned_sub_nowrap, word.unsigned_of_Z_nowrap; try Lia.lia.
+      rewrite word.unsigned_of_Z_nowrap in H by Lia.lia.
+      rewrite word.unsigned_of_Z_nowrap; Lia.lia.
+    - rewrite word.mul_0_l, word.sub_0_r. reflexivity.
+  Qed.
+
+  Lemma montgomery_reduce_correct2 x (Hx: 0 <= x <= r * modulus) (modulus_smaller: 2 * modulus < 2 ^ width):
+    word.unsigned (montgomery_reduce2 (word.of_Z (x / r)) (word.of_Z x)) = reduce_spec x.
+  Proof.
+    pose proof (Z.pow_pos_nonneg 2 width ltac:(Lia.lia) ltac:(destruct BW; Lia.lia)) as ZZ.
+    unfold reduce_spec, prereduce, montgomery_reduce2.
+    rewrite <- word.ring_morph_mul. set (m := word.of_Z (x * modulus')).
+    unfold nlet at 1. repeat rewrite <- word.ring_morph_mul.
+    assert ((x mod r * modulus') mod r = word.unsigned (@word.of_Z _ word (x * modulus'))) as ->.
+    { rewrite word.unsigned_of_Z.
+      rewrite <- PullPush.Z.mul_mod_l. reflexivity. }
+    fold m. set (t_hi := word.mulhuu m (word.of_Z modulus)).
+    set (t_lo := word.mul m (word.of_Z modulus)).
+    do 2 (unfold nlet at 1).
+    assert (word.unsigned m * modulus = r * (word.unsigned t_hi) + (word.unsigned t_lo)) as ->.
+    { unfold t_hi, t_lo. rewrite word.unsigned_mulhuu_nowrap, word.unsigned_mul.
+      rewrite word.unsigned_of_Z_nowrap by Lia.lia.
+      apply Z_div_mod_eq_full. }
+    assert (Hcond_spec: forall (a b: word), word.ltu (word.add a b) b = true <-> (word.unsigned a + word.unsigned b) >= r).
+    { intros. rewrite word.unsigned_ltu, word.unsigned_add. unfold word.wrap, r.
+      generalize (word.unsigned_range a); intros Ha.
+      generalize (word.unsigned_range b); intros Hb.
+      split; intros X.
+      - apply Z.ltb_lt in X.
+        destruct (Z_lt_dec (word.unsigned a + word.unsigned b) (2 ^ width)); [|Lia.lia].
+        rewrite Z.mod_small in X by Lia.lia. Lia.lia.
+      - apply Z.ltb_lt.
+        generalize (Z_mod_lt (word.unsigned a + word.unsigned b) (2 ^ width) ltac:(Lia.lia)).
+        rewrite Modulo.Z.mod_small_0_if; [|apply Z.pow_nonzero; destruct BW; Lia.lia|Lia.lia].
+        generalize (Zle_cases (2 ^ width) (word.unsigned a + word.unsigned b)); destruct (_ <=? _); Lia.lia. }
+    set (carry := word.ltu (word.add (word.of_Z x) t_lo) t_lo).
+    set (t_hi' := word.add t_hi (word.b2w carry)).
+    set (t := word.add t_hi' (word.of_Z (x / r))).
+    do 3 (unfold nlet at 1).
+    fold t_hi' t. assert ((x + (r * word.unsigned t_hi + word.unsigned t_lo)) / r = word.unsigned t) as ->.
+    { rewrite (Z_div_mod_eq_full x r).
+      assert (r * (x / r) + x mod r + (r * word.unsigned t_hi + word.unsigned t_lo) = (x mod r + word.unsigned t_lo) + (word.unsigned t_hi + (x / r)) * r) as -> by Lia.lia.
+      rewrite Z_div_plus by (unfold r; Lia.lia).
+      unfold t, t_hi', carry.
+      assert (CC: 0 <= x / r <= modulus).
+      { generalize (Zdiv_le_upper_bound x r modulus ZZ ltac:(Lia.lia)); intros.
+        split; [apply Z.div_pos|]; Lia.lia. }
+      assert (SS: word.unsigned t_hi + word.unsigned (@word.b2w _ word (word.ltu (word.add (@word.of_Z _ word x) t_lo) t_lo)) <= modulus).
+      { transitivity (word.unsigned t_hi + 1); [destruct (word.ltu _); unfold word.b2w; cbn; rewrite word.unsigned_of_Z_nowrap by Lia.lia; Lia.lia|].
+        unfold t_hi. rewrite word.unsigned_mulhuu_nowrap.
+        pose proof (word.unsigned_range m) as Hm.
+        rewrite word.unsigned_of_Z_nowrap by Lia.lia.
+        apply Z.lt_pred_le.
+        assert (Z.pred _ = (word.unsigned m * modulus) / 2 ^ width) as -> by Lia.lia.
+        apply (Zdiv_lt_upper_bound ((word.unsigned m) * modulus) (2 ^ width) modulus ZZ).
+        rewrite (Z.mul_comm modulus).
+        apply Zmult_lt_compat_r; Lia.lia. }
+      repeat rewrite word.unsigned_add_nowrap; try Lia.lia.
+      2:{ apply (Z.le_lt_trans _ (2 * modulus)); [|assumption].
+          assert (word.unsigned (@word.of_Z _ word (x / r)) <= modulus); [|Lia.lia].
+          rewrite word.unsigned_of_Z_nowrap; Lia.lia. }
+      rewrite (word.unsigned_of_Z_nowrap (x/r)) by Lia.lia.
+      assert ((x mod r + word.unsigned t_lo) / r = word.unsigned (word.b2w (word.ltu (word.add (word.of_Z x) t_lo) t_lo))) as <-; [|Lia.lia].
+      pose proof (word.unsigned_range t_lo) as Hlo.
+      pose proof (Z.mod_pos_bound x r ZZ) as [Hxlo].
+      destruct (Z_lt_dec (x mod r + word.unsigned t_lo) r) as [Hlt|Hnlt].
+      - rewrite <- (Z.mod_small ((x mod r) + word.unsigned t_lo) r) by Lia.lia.
+        rewrite Zmod_div. pose proof (Hcond_spec (word.of_Z x) t_lo) as W.
+        destruct (word.ltu _ _); unfold word.b2w; cbn; rewrite word.unsigned_of_Z_nowrap by Lia.lia; [|reflexivity].
+        specialize ((proj1 W) eq_refl). rewrite word.unsigned_of_Z. unfold word.wrap.
+        unfold r in *. Lia.lia.
+      - rewrite (proj2 (Hcond_spec (word.of_Z x) t_lo)).
+        2: rewrite word.unsigned_of_Z; unfold word.wrap, r in *; Lia.lia.
+        unfold word.b2w; cbn; rewrite word.unsigned_of_Z_nowrap by Lia.lia.
+        pose proof (Zdiv_le_lower_bound (x mod r + word.unsigned t_lo) r 1 ZZ ltac:(Lia.lia)) as Hlow.
+        pose proof (Zdiv_lt_upper_bound (x mod r + word.unsigned t_lo) r 2 ZZ ltac:(unfold r; Lia.lia)).
+        Lia.lia. }
+    assert (modulus <=? word.unsigned t = word.ltu (word.of_Z (Z.pred modulus)) t) as ->.
+    { rewrite word.unsigned_ltu, word.unsigned_of_Z_nowrap by Lia.lia.
+      pose proof (Zle_cases modulus (word.unsigned t)) as Hcond.
+      destruct (_ <=? _); [apply Z.lt_pred_le in Hcond; rewrite (proj2 (Z.ltb_lt _ _)); auto|].
+      pose proof (Zlt_cases (Z.pred modulus) (word.unsigned t)); destruct (_ <? _); Lia.lia. }
+    pose proof (word.ltu_spec (word.of_Z (Z.pred modulus)) t) as E.
+    destruct (word.ltu (word.of_Z (Z.pred modulus)) t); unfold word.b2w, nlet; cbn.
+    - rewrite word.mul_1_l. inversion E.
+      rewrite word.unsigned_sub_nowrap, word.unsigned_of_Z_nowrap; try Lia.lia.
+      rewrite word.unsigned_of_Z_nowrap in H by Lia.lia.
+      rewrite word.unsigned_of_Z_nowrap; Lia.lia.
+    - rewrite word.mul_0_l, word.sub_0_r. reflexivity.
+  Qed.
+
+  Lemma to_montgomery_word_correct1 x (Hx: 0 <= x < modulus) (modulus_very_small: modulus * modulus < 2 ^ width):
+    word.unsigned (to_montgomery_word1 (word.of_Z x)) = to_montgomery_spec x.
+  Proof.
+    unfold to_montgomery_word1, to_montgomery_spec.
+    unfold nlet. rewrite <- word.ring_morph_mul.
+    rewrite montgomery_reduce_correct1; [reflexivity|].
+    unfold r2. pose proof (Z.mod_pos_bound (r * r) modulus ltac:(Lia.lia)) as XX.
+    split; [Lia.lia|]. transitivity (modulus * modulus); [|Lia.lia].
+    apply Zmult_lt_compat; Lia.lia.
+  Qed.
+
+  Lemma to_montgomery_word_correct2 x (Hx: 0 <= x < 2 ^ width) (modulus_smaller: 2 * modulus < 2 ^ width):
+    word.unsigned (to_montgomery_word2 (word.of_Z x)) = to_montgomery_spec x.
+  Proof.
+    unfold to_montgomery_word2, to_montgomery_spec.
+    unfold nlet. rewrite <- word.ring_morph_mul.
+    pose proof (Z.mod_pos_bound (r * r) modulus ltac:(Lia.lia)) as XX.
+    assert (SS: 0 <= x * ((r * r) mod modulus) <= r * modulus).
+    { split; [Lia.lia|]. apply Z.lt_le_incl.
+      apply Zmult_lt_compat; unfold r; Lia.lia. }
+    rewrite <- montgomery_reduce_correct2; auto.
+    assert (word.mulhuu _ _ = (word.of_Z (x * ((r * r) mod modulus) / r))) as ->; [|reflexivity].
+    apply word.unsigned_inj.
+    rewrite word.unsigned_mulhuu_nowrap.
+    repeat rewrite word.unsigned_of_Z_nowrap; try Lia.lia.
+    - reflexivity.
+    - split; [apply Z.div_pos; unfold r; Lia.lia|].
+      apply (Z.le_lt_trans _ modulus); [|Lia.lia].
+      apply Z.div_le_upper_bound; [unfold r|]; Lia.lia.
+    - unfold r2; Lia.lia.
+  Qed.
+
+  Lemma from_montgomery_word_correct x (Hx: 0 <= x < 2 ^ width):
+    word.unsigned (from_montgomery_word (word.of_Z x)) = from_montgomery_spec x.
+  Proof.
+    unfold from_montgomery_word, from_montgomery_spec, nlet.
+    apply montgomery_reduce_correct1; auto.
+  Qed.
+
+  Lemma montgomery_mul_correct1 (modulus_very_small: modulus * modulus < 2 ^ width) x y a b:
+    feval x = Some a ->
+    feval y = Some b ->
+    feval (montgomery_mul1 x y) = Some (a * b)%F.
+  Proof.
+    intros Ha Hb.
+    pose proof (feval_is_Some_implies _ _ Ha) as [Hx Heqa].
+    pose proof (feval_is_Some_implies _ _ Hb) as [Hy Heqb].
+    assert ((word.unsigned (montgomery_mul1 x y)) < modulus) as Hbound.
+    { unfold montgomery_mul1, nlet.
+      rewrite <- (word.of_Z_unsigned x), <- (word.of_Z_unsigned y).
+      rewrite <- word.ring_morph_mul.
+      rewrite montgomery_reduce_correct1.
+      - apply reduce_in_range.
+        + apply modulus_nonzero.
+        + apply modulus_range'.
+        + split; [Lia.lia|]. unfold r; apply Zmult_le_compat; Lia.lia.
+      - split; [Lia.lia|]. transitivity (modulus * modulus); [|Lia.lia].
+        apply Zmult_lt_compat; Lia.lia. }
+    assert (exists ab, feval (montgomery_mul1 x y) = Some ab) as [ab Hab].
+    { unfold feval. destruct (Z_lt_dec _ _) as [_|?]; [|Lia.lia].
+      eexists; reflexivity. }
+    pose proof (feval_is_Some_implies _ _ Hab) as [Hxy Heqab].
+    rewrite Hab. f_equal.
+    apply ModularArithmeticTheorems.F.eq_to_Z_iff.
+    rewrite Heqab. unfold montgomery_mul1, nlet.
+    rewrite <- (word.of_Z_unsigned x), <- (word.of_Z_unsigned y).
+    rewrite <- word.ring_morph_mul.
+    rewrite montgomery_reduce_correct1 by (split; [Lia.lia|]; transitivity (modulus * modulus); [|Lia.lia]; apply Zmult_lt_compat; Lia.lia).
+    cbn. rewrite Heqa, Heqb.
+    assert (reduce_spec _ = mul_spec (word.unsigned x) (word.unsigned y)) as -> by reflexivity.
+    rewrite <- Z.mod_mod at 1 by Lia.lia.
+    assert (mul_spec _ _ * _ mod _ = from_montgomery_spec (mul_spec (word.unsigned x) (word.unsigned y))) as ->.
+    { unfold from_montgomery_spec.
+      rewrite <- (Z.mod_small (reduce_spec _) modulus).
+      - rewrite reduce_spec_correct. reflexivity.
+      - apply (reduce_in_range _ modulus_nonzero _ _ modulus_range').
+        assert (0 <= mul_spec (word.unsigned x) (word.unsigned y) < modulus); [|split; [Lia.lia|]].
+        + apply (reduce_in_range _ modulus_nonzero _ _ modulus_range').
+          split; [Lia.lia|]. apply Zmult_le_compat; unfold r; Lia.lia.
+        + transitivity modulus; [Lia.lia|]. unfold r.
+          rewrite <- Z.mul_1_l at 1. apply Zmult_le_compat; Lia.lia. }
+    rewrite mul_spec_correct.
+    rewrite <- Z.mul_mod_idemp_l, <- Z.mul_mod_idemp_r at 1 by Lia.lia.
+    f_equal. f_equal; unfold from_montgomery_spec; apply reduce_spec_correct.
+  Qed.
+
+  Lemma montgomery_mul_correct2 (modulus_smaller: 2 * modulus < 2 ^ width) x y a b:
+    feval x = Some a ->
+    feval y = Some b ->
+    feval (montgomery_mul2 x y) = Some (a * b)%F.
+  Proof.
+    intros Ha Hb.
+    pose proof (feval_is_Some_implies _ _ Ha) as [Hx Heqa].
+    pose proof (feval_is_Some_implies _ _ Hb) as [Hy Heqb].
+    assert ((word.unsigned (montgomery_mul2 x y)) = reduce_spec (word.unsigned x * word.unsigned y)) as XX.
+    { unfold montgomery_mul2, nlet.
+      rewrite <- (word.of_Z_unsigned x), <- (word.of_Z_unsigned y).
+      rewrite <- word.ring_morph_mul.
+      assert (word.mulhuu _ _ = (word.of_Z ((word.unsigned x * word.unsigned y) / r))) as ->.
+      { apply word.unsigned_inj.
+        rewrite word.unsigned_mulhuu_nowrap.
+        do 2 rewrite word.of_Z_unsigned.
+        symmetry; apply word.unsigned_of_Z_nowrap.
+        split; [apply Z.div_le_lower_bound; Lia.lia|].
+        apply Z.div_lt_upper_bound; [Lia.lia|].
+        apply Zmult_lt_compat; Lia.lia. }
+      repeat rewrite word.of_Z_unsigned.
+      rewrite montgomery_reduce_correct2; auto.
+      split; [Lia.lia|]. transitivity (modulus * modulus); [|unfold r; apply Zmult_le_compat; Lia.lia].
+      apply Z.lt_le_incl. apply Zmult_lt_compat; Lia.lia. }
+    assert ((word.unsigned (montgomery_mul2 x y)) < modulus) as Hbound.
+    { rewrite XX.
+      apply reduce_in_range.
+      - apply modulus_nonzero.
+      - apply modulus_range'.
+      - split; [Lia.lia|]. unfold r; apply Zmult_le_compat; Lia.lia. }
+    assert (exists ab, feval (montgomery_mul2 x y) = Some ab) as [ab Hab].
+    { unfold feval. destruct (Z_lt_dec _ _) as [_|?]; [|Lia.lia].
+      eexists; reflexivity. }
+    pose proof (feval_is_Some_implies _ _ Hab) as [Hxy Heqab].
+    rewrite Hab. f_equal.
+    apply ModularArithmeticTheorems.F.eq_to_Z_iff.
+    rewrite Heqab. rewrite XX. cbn. rewrite Heqa, Heqb.
+    assert (reduce_spec _ = mul_spec (word.unsigned x) (word.unsigned y)) as -> by reflexivity.
+    rewrite <- Z.mod_mod at 1 by Lia.lia.
+    assert (mul_spec _ _ * _ mod _ = from_montgomery_spec (mul_spec (word.unsigned x) (word.unsigned y))) as ->.
+    { unfold from_montgomery_spec.
+      rewrite <- (Z.mod_small (reduce_spec _) modulus).
+      - rewrite reduce_spec_correct. reflexivity.
+      - apply (reduce_in_range _ modulus_nonzero _ _ modulus_range').
+        assert (0 <= mul_spec (word.unsigned x) (word.unsigned y) < modulus); [|split; [Lia.lia|]].
+        + apply (reduce_in_range _ modulus_nonzero _ _ modulus_range').
+          split; [Lia.lia|]. apply Zmult_le_compat; unfold r; Lia.lia.
+        + transitivity modulus; [Lia.lia|]. unfold r.
+          rewrite <- Z.mul_1_l at 1. apply Zmult_le_compat; Lia.lia. }
+    rewrite mul_spec_correct.
+    rewrite <- Z.mul_mod_idemp_l, <- Z.mul_mod_idemp_r at 1 by Lia.lia.
+    f_equal. f_equal; unfold from_montgomery_spec; apply reduce_spec_correct.
+  Qed.
+
+  Instance spec_of_to_montgomery1 : spec_of to_montgomery_name :=
+    fnspec! to_montgomery_name (X: word) ~> res,
+    { requires tr mem :=
+        True;
+      ensures tr' mem' :=
+        tr' = tr /\
+        mem' = mem /\
+        res = to_montgomery_word1 X }.
+
+  Derive to_montgomery_br2fn1 SuchThat
+    (defn! to_montgomery_name("x") ~> "res"
+       { to_montgomery_br2fn1 },
+      implements to_montgomery_word1)
+    As to_montgomery_br2fn_ok1.
+  Proof.
+    compile_setup.
+    unfold montgomery_reduce1.
+    repeat repeat compile_step.
+  Qed.
+
+  Instance spec_of_to_montgomery2 : spec_of to_montgomery_name :=
+    fnspec! to_montgomery_name (X: word) ~> res,
+    { requires tr mem :=
+        True;
+      ensures tr' mem' :=
+        tr' = tr /\
+        mem' = mem /\
+        res = to_montgomery_word2 X }.
+
+  Derive to_montgomery_br2fn2 SuchThat
+    (defn! to_montgomery_name("x") ~> "res"
+       { to_montgomery_br2fn2 },
+      implements to_montgomery_word2)
+    As to_montgomery_br2fn_ok2.
+  Proof.
+    compile_setup.
+    unfold montgomery_reduce2.
+    repeat repeat compile_step.
+    - unfold v0. apply expr_compile_word_mul.
+      + eapply expr_compile_var. instantiate (1 := "x").
+        cbn. repeat rewrite map.get_put_diff by congruence.
+        apply map.get_put_same.
+      + apply expr_compile_Z_literal.
+    - apply expr_compile_word_mulhuu.
+      + eapply expr_compile_var. instantiate (1 := "x").
+        cbn. repeat rewrite map.get_put_diff by congruence.
+        apply map.get_put_same.
+      + apply expr_compile_Z_literal.
+  Qed.
+
+  Instance spec_of_from_montgomery : spec_of from_montgomery_name :=
+    fnspec! from_montgomery_name (X: word) ~> res,
+    { requires tr mem :=
+        True;
+      ensures tr' mem' :=
+        tr' = tr /\
+        mem' = mem /\
+        res = from_montgomery_word X }.
+
+  Derive from_montgomery_br2fn SuchThat
+    (defn! from_montgomery_name("x") ~> "res"
+       { from_montgomery_br2fn },
+      implements from_montgomery_word)
+    As from_montgomery_br2fn_ok.
+  Proof.
+    compile_setup.
+    unfold montgomery_reduce1.
+    repeat repeat compile_step.
+  Qed.
+
+  Instance spec_of_mul_dummy1 : spec_of mul_name :=
+    fnspec! mul_name (X Y: word) ~> res,
+    { requires tr mem :=
+        True;
+      ensures tr' mem' :=
+        tr' = tr /\
+        mem' = mem /\
+        res = montgomery_mul1 X Y }.
+
+  Derive mul_br2fn1 SuchThat
+    (defn! mul_name("x", "y") ~> "res"
+       { mul_br2fn1 },
+      implements montgomery_mul1)
+    As dummy_mul_br2fn_ok1.
+  Proof.
+    compile_setup.
+    unfold montgomery_reduce1.
+    repeat repeat compile_step.
+  Qed.
+
+  Lemma mul_br2fn_ok1 (modulus_very_small: modulus * modulus < 2 ^ width):
+    program_logic_goal_for mul_br2fn1
+      (forall functions : map.rep,
+          map.get functions mul_name = Some mul_br2fn1 ->
+          spec_of_mul functions).
+  Proof.
+    red. intros. red. red. red. intros. destruct H0.
+    generalize (dummy_mul_br2fn_ok1 I _ H).
+    intros. eapply Proper_call; [|apply dummy_mul_br2fn_ok1; auto; exact I].
+    intros ? ? ? ?. destruct H3 as (? & -> & -> & -> & ->).
+    eexists; repeat split; try reflexivity.
+    apply montgomery_mul_correct1; auto.
+  Qed.
+
+  Instance spec_of_mul_dummy2 : spec_of mul_name :=
+    fnspec! mul_name (X Y: word) ~> res,
+    { requires tr mem :=
+        True;
+      ensures tr' mem' :=
+        tr' = tr /\
+        mem' = mem /\
+        res = montgomery_mul2 X Y }.
+
+  Derive mul_br2fn2 SuchThat
+    (defn! mul_name("x", "y") ~> "res"
+       { mul_br2fn2 },
+      implements montgomery_mul2)
+    As dummy_mul_br2fn_ok2.
+  Proof.
+    compile_setup.
+    unfold montgomery_reduce2.
+    repeat repeat compile_step.
+    - unfold v0. apply expr_compile_word_mul.
+      + eapply expr_compile_var. instantiate (1 := "x").
+        cbn. repeat rewrite map.get_put_diff by congruence.
+        apply map.get_put_same.
+      + eapply expr_compile_var. instantiate (1 := "y").
+        cbn. repeat rewrite map.get_put_diff by congruence.
+        apply map.get_put_same.
+    - apply expr_compile_word_mulhuu.
+      + eapply expr_compile_var. instantiate (1 := "x").
+        cbn. repeat rewrite map.get_put_diff by congruence.
+        apply map.get_put_same.
+      + eapply expr_compile_var. instantiate (1 := "y").
+        cbn. repeat rewrite map.get_put_diff by congruence.
+        apply map.get_put_same.
+  Qed.
+
+  Lemma mul_br2fn_ok2 (modulus_smaller: 2 * modulus < 2 ^ width):
+    program_logic_goal_for mul_br2fn2
+      (forall functions : map.rep,
+          map.get functions mul_name = Some mul_br2fn2 ->
+          spec_of_mul functions).
+  Proof.
+    red. intros. red. red. red. intros. destruct H0.
+    generalize (dummy_mul_br2fn_ok2 I _ H).
+    intros. eapply Proper_call; [|apply dummy_mul_br2fn_ok2; auto; exact I].
+    intros ? ? ? ?. destruct H3 as (? & -> & -> & -> & ->).
+    eexists; repeat split; try reflexivity.
+    apply montgomery_mul_correct2; auto.
+  Qed.
+
+End __.
+
+(* Require Import bedrock2.BasicC64Semantics. *)
+
+(* Eval compute in ToCString.c_func ("to_montgomery", (@to_montgomery_br2fn1 64 (Naive.word _) 8380417)). *)
+
+(* Eval compute in ToCString.c_func ("from_montgomery", (@from_montgomery_br2fn 64 (Naive.word _) 8380417)). *)

--- a/src/NTT/RupicolaNTT.v
+++ b/src/NTT/RupicolaNTT.v
@@ -1,0 +1,670 @@
+Require Import Spec.ModularArithmetic.
+Require Import Rupicola.Lib.Api.
+Require Import Rupicola.Lib.Arrays.
+Require Import Rupicola.Lib.Loops.
+Require Import Rupicola.Lib.InlineTables.
+Require Import Rupicola.Lib.Alloc.
+Require Import Rupicola.Lib.SepLocals.
+Require Import Crypto.Bedrock.Specs.Field.
+Require Import Crypto.NTT.Polynomial.
+Require Import Crypto.NTT.CyclotomicDecomposition.
+Require Import Crypto.Util.ListUtil.
+
+Section Utils.
+  (* To be moved somewhere ? *)
+  Lemma nat_rect_to_nat_iter (A: Type) (a: A) (f: nat -> A -> A) (i: nat):
+    nat_rect (fun _ => A) a f i = P2.cdr (Nat.iter i (fun a => \<S (P2.car a), f (P2.car a) (P2.cdr a)\>) \<0%nat, a\>).
+  Proof.
+    assert (Nat.iter i _ \<0%nat, a\> = \<i, nat_rect (fun _ : nat => A) a f i\>) as ->.
+    { induction i; [reflexivity|].
+      simpl in *. rewrite IHi. reflexivity. }
+    reflexivity.
+  Qed.
+
+  Lemma nat_iter_mul:
+    forall (p q : nat) (A : Type) (f : A -> A) (x : A),
+      Nat.iter (p * q)%nat f x = Nat.iter p (Nat.iter q f) x.
+  Proof.
+    induction p; intros; [reflexivity|].
+    simpl. rewrite Nat.iter_add, IHp. reflexivity.
+  Qed.
+
+  Lemma z_range'_seq:
+    forall len from,
+      (0 <= from)%Z ->
+      z_range' from len = List.map Z.of_nat (seq (Z.to_nat from) len).
+  Proof.
+    induction len; intros from Hfrom; [reflexivity|].
+    simpl. rewrite IHlen by Lia.lia.
+    rewrite Z2Nat.id by Lia.lia.
+    rewrite <- Z2Nat.inj_succ by Lia.lia.
+    rewrite Z.add_1_r. reflexivity.
+  Qed.
+
+  Lemma seq_add:
+    forall a b len,
+      seq (a + b)%nat len = List.map (fun x => x + b)%nat (seq a len).
+  Proof.
+    induction len; [reflexivity|].
+    rewrite seq_S, seq_S, map_app, IHlen; simpl.
+    f_equal. f_equal. Lia.lia.
+  Qed.
+
+  Lemma put_eq_set_nth {K: Type} {Conv: Convertible K nat}
+    {V: Type} {HD: HasDefault V}:
+    forall a k (v: V),
+      ListArray.put a k v = set_nth (cast k) v a.
+  Proof.
+    unfold ListArray.put. intros.
+    assert (forall l i (x: V), replace_nth i l x = set_nth i x l) as IH.
+    { induction l; intros; [rewrite set_nth_nil; reflexivity|].
+      simpl. destruct i.
+      - rewrite set_nth_cons. reflexivity.
+      - rewrite IHl. rewrite <- cons_set_nth.
+        reflexivity. }
+    apply IH.
+  Qed.
+
+  Lemma get_eq_nth_default {K: Type} {Conv: Convertible K nat}
+    {V: Type} {HD: HasDefault V}:
+    forall (a: list V) k,
+      ListArray.get a k = nth_default default a (cast k).
+  Proof. unfold ListArray.get; intros; rewrite nth_default_eq; reflexivity. Qed.
+
+  Lemma set_nth_app {T: Type} (i: nat) (v: T) (l1 l2: list T):
+    set_nth i v (l1 ++ l2) = if lt_dec i (length l1) then (set_nth i v l1) ++ l2 else l1 ++ (set_nth (i - length l1) v l2).
+  Proof.
+    apply nth_error_ext.
+    intros j. rewrite nth_set_nth.
+    destruct (Nat.eq_dec j i); [subst j|].
+    - destruct (lt_dec i (length (l1 ++ l2))) as [Hlt|Hnlt].
+      + destruct (lt_dec i (length l1)).
+        * rewrite nth_error_app1 by (rewrite length_set_nth; Lia.lia).
+          rewrite nth_set_nth, NatUtil.eq_nat_dec_refl.
+          destruct (lt_dec _ _); [reflexivity|Lia.lia].
+        * rewrite nth_error_app2 by Lia.lia.
+          rewrite nth_set_nth, NatUtil.eq_nat_dec_refl.
+          rewrite app_length in Hlt.
+          destruct (lt_dec _ _); [|Lia.lia]. reflexivity.
+      + rewrite app_length in Hnlt. destruct (lt_dec _ _) as [|_]; [Lia.lia|].
+        rewrite nth_error_app2 by Lia.lia.
+        rewrite nth_set_nth, NatUtil.eq_nat_dec_refl.
+        destruct (lt_dec _ _); [Lia.lia|reflexivity].
+    - destruct (lt_dec j (length l1)) as [Hlt|Hnlt].
+      + rewrite nth_error_app1 by Lia.lia.
+        destruct (lt_dec i (length l1)) as [Hll|Hll].
+        * rewrite nth_error_app1 by (rewrite length_set_nth; Lia.lia).
+          rewrite nth_set_nth. destruct (Nat.eq_dec j i) as [|_]; [congruence|].
+          reflexivity.
+        * rewrite nth_error_app1 by Lia.lia. reflexivity.
+      + rewrite nth_error_app2 by Lia.lia.
+        destruct (lt_dec i (length l1)) as [Hll|Hll].
+        * rewrite nth_error_app2 by (rewrite length_set_nth; Lia.lia).
+          rewrite length_set_nth; reflexivity.
+        * rewrite nth_error_app2 by Lia.lia.
+          rewrite nth_set_nth. destruct (Nat.eq_dec _ _) as [|_]; [Lia.lia|].
+          reflexivity.
+  Qed.
+
+End Utils.
+
+Section NTT.
+  Context {q: positive}.
+  Local Notation F := (F q).
+  Context {n: nat} {km1: nat}.
+  Local Open Scope F_scope.
+
+  Variable (zetas: list F).
+
+  Local Instance HasDefault_F: HasDefault F := 0%F.
+
+  Definition polynomial_decompose_loop (i start len: Z) (z: F) (p: ListArray.t F) :=
+    nd_ranged_for_all start (start + i)
+      (fun p j =>
+         let/n x := ListArray.get p (j + len)%Z in
+         let/n tmp := z * x in
+         let/n y := ListArray.get p j in
+         let/n p := ListArray.put p (j + len)%Z (y - tmp) in
+         let/n p := ListArray.put p j (y + tmp) in
+         p
+      )
+      p.
+
+  Definition polynomial_list_loop (k old_len len: Z) (state: \<< Z, Z, ListArray.t F \>>) :=
+    nd_ranged_for_all 0%Z k
+      (fun state _ =>
+         let '\< m, start, p \> := state in
+         let/n m := (m + 1)%Z in
+         let/n z := InlineTable.get zetas m in
+         let/n p := polynomial_decompose_loop len start len z p in
+         let/n start := (start + old_len)%Z in
+         \< m, start, p \>
+      )
+      state.
+
+  Definition layer_decomposition_loop (n: nat) (state: \<< Z, Z, ListArray.t F \>>) :=
+      nd_ranged_for_all 0%Z (Z.of_nat n)
+        (fun state i =>
+           let '\< m, len, p \> := state in
+           let/n old_len := len in
+           let/n len := Z.shiftr len 1 in
+           let/n start := 0%Z in
+           let/n (m, start, p) := polynomial_list_loop (Z.pow 2 i) old_len len \< m, start, p\> in
+           \< m, len, p \>
+        )
+        state.
+
+  Definition NTT_gallina (p: ListArray.t F): ListArray.t F :=
+    let/n m := 0%Z in
+    let/n len := (Z.pow 2 (Z.of_nat n)) in
+    let/n (m, len, p) :=
+      layer_decomposition_loop km1 (\< m, len, p \>) in p.
+
+  Section Correctness.
+    Context {field: @Hierarchy.field F eq F.zero F.one F.opp F.add F.sub F.mul F.inv F.div}
+      {char_ge_3: @Ring.char_ge F eq F.zero F.one F.opp F.add F.sub F.mul (BinNat.N.succ_pos (BinNat.N.two))}.
+
+    Context {zeta: F}.
+
+    Local Notation NTT_spec := (@NTT_phi_list q zeta (N.of_nat km1) n km1).
+    Local Notation NTT_layer_spec := (@NTT_phi_layer_list q zeta (N.of_nat km1) n).
+    Local Notation enumerate := Datatypes.List.enumerate.
+
+    Hypothesis n_ge_km1: (km1 <= n)%nat.
+    Hypothesis zetas_eq: zetas = List.map (fun k => F.pow zeta k) (@zeta_powers (N.of_nat km1) km1).
+
+    Lemma NTT_gallina_correct (p: list F) (Hp: length p = Nat.pow 2 n):
+      NTT_gallina p = NTT_spec p.
+    Proof.
+      unfold NTT_gallina, layer_decomposition_loop, polynomial_list_loop, polynomial_decompose_loop, NTT_spec. unfold nlet.
+      replace (Z.of_nat km1) with (0 + Z.of_nat km1)%Z by Lia.lia.
+      rewrite <- fold_left_as_nd_ranged_for_all.
+      unfold z_range. rewrite Z.add_simpl_l.
+      rewrite Nat2Z.id. rewrite z_range'_seq by Lia.lia.
+      assert (Z.to_nat 0 = 0)%nat as -> by Lia.lia.
+      rewrite ListUtil.fold_left_map.
+      match goal with | |- context [fold_left ?ff _ _] => set (f:=ff) end.
+      assert (forall k, (k <= km1)%nat -> fold_left f (seq 0 k) \< 0%Z, (2 ^ Z.of_nat n)%Z, p \> = \< ((2 ^ Z.of_nat k) - 1)%Z,  (2 ^ (Z.of_nat (n - k)%nat))%Z, nat_rect _ p NTT_layer_spec k \>) as IH.
+      { induction k; intros Hk.
+        - simpl. rewrite PeanoNat.Nat.sub_0_r. reflexivity.
+        - rewrite seq_S, PeanoNat.Nat.add_0_l.
+          rewrite fold_left_app. cbn [fold_left]; rewrite IHk by Lia.lia.
+          cbn [nat_rect].
+          set (l := (nat_rect _ p NTT_layer_spec k)).
+          unfold f. assert (2 ^ Z.of_nat k = 0 + Z.of_nat (Nat.pow 2 k))%Z as ->.
+          { rewrite Z2Nat.Z.pow_Zpow. Lia.lia. }
+          rewrite <- Nat_iter_as_nd_ranged_for_all.
+          rewrite Z.add_0_l, Z2Nat.Z.pow_Zpow.
+          assert (Z.of_nat 2%nat = 2%Z) as -> by Lia.lia.
+          assert (Z.shiftr _ 1 = 2 ^ Z.of_nat (n - S k))%Z as ->.
+          { rewrite Z.shiftr_div_pow2, <- ZLib.Z.pow2_div2 by Lia.lia.
+            f_equal. Lia.lia. }
+          clear IHk. clear f. set (f := Nat.iter _ _ _).
+          assert (f = \< (2 ^ Z.of_nat (S k) - 1)%Z, (2 ^ Z.of_nat n)%Z, NTT_layer_spec k l \>) as ->; [|reflexivity].
+          unfold f. clear f. unfold NTT_layer_spec.
+          unfold fold_left_chunked.
+          assert (Hl: length l = length p).
+          { unfold l. induction k; [reflexivity|].
+            simpl. erewrite NTT_phi_layer_list_length.
+            rewrite IHk by Lia.lia. reflexivity.
+            Unshelve. rewrite Nnat.Nat2N.id. Lia.lia. }
+          assert (Hlen: length (enumerate 0%nat (chunk (Nat.pow 2 (n - k)) l)) = Nat .pow 2 k).
+          { unfold enumerate. rewrite combine_length, seq_length, PeanoNat.Nat.min_id, length_chunk.
+            2: generalize (NatUtil.pow_nonzero 2 (n - k) ltac:(Lia.lia)); Lia.lia.
+            rewrite Hl, Hp. replace n with (k + (n - k))%nat at 1 by Lia.lia.
+            rewrite PeanoNat.Nat.pow_add_r.
+            rewrite Nat.div_up_exact; [reflexivity|].
+            apply NatUtil.pow_nonzero. Lia.lia. }
+          match goal with
+          | |- Nat.iter ?m ?f (\< ?x, ?y, ?z \>) = \< _, _, fold_left ?g ?a _ \> =>
+              assert (forall j, (j <= m)%nat -> Nat.iter j f \<x, y, z\> = \< (x + Z.of_nat j)%Z, (y + Z.of_nat j * 2 ^ Z.of_nat (n - k))%Z, (fold_left g (List.firstn j a) nil) ++ (concat (List.map snd (List.skipn j a))) \>) as IH
+          end.
+          { induction j; intros Hj.
+            - simpl. rewrite Nat2Z.inj_0, Z.add_0_r. f_equal.
+              f_equal. unfold enumerate. rewrite ListUtil.map_snd_combine.
+              rewrite seq_length. rewrite List.firstn_all.
+              rewrite concat_chunk; reflexivity.
+            - rewrite Nat.iter_succ, IHj by Lia.lia.
+              f_equal; [Lia.lia|].
+              f_equal; [Lia.lia|].
+              rewrite <- (firstn_nth _ j (enumerate 0 (chunk (2 ^ (n - k)) l)) (0%nat, nil)) by (rewrite Hlen; Lia.lia).
+              rewrite (ListUtil.skipn_nth_default j _ (0%nat, nil)) by (rewrite Hlen; Lia.lia).
+              rewrite fold_left_app. cbn [fold_left].
+              unfold enumerate. rewrite combine_nth by (rewrite seq_length; reflexivity).
+              set (acc := fold_left _ _ _).
+              rewrite map_cons, concat_cons, nth_default_eq.
+              rewrite combine_nth by (rewrite seq_length; reflexivity).
+              cbn [snd]. unfold Pmod_cyclotomic_list.
+              rewrite <- fold_left_as_nd_ranged_for_all.
+              unfold z_range. rewrite Z.add_simpl_l, Z.add_0_l.
+              rewrite Z2Nat.inj_pow by Lia.lia.
+              rewrite Nat2Z.id. assert (Z.to_nat 2 = 2)%nat as -> by Lia.lia.
+              rewrite z_range'_seq by Lia.lia.
+              rewrite Z2Nat.inj_mul, Z2Nat.inj_pow, Nat2Z.id, Nat2Z.id by Lia.lia.
+              assert (Z.to_nat 2 = 2)%nat as -> by Lia.lia.
+              rewrite ListUtil.fold_left_map.
+              rewrite <- (PeanoNat.Nat.add_0_l (j * _)).
+              rewrite (seq_add 0%nat).
+              rewrite ListUtil.fold_left_map.
+              clear IHj. rewrite <- List.app_assoc.
+              assert (Hlen2: (length acc = j * Nat.pow 2 (n - k))%nat).
+              { unfold acc. clear acc.
+                erewrite ListUtil.fold_left_ext; [rewrite <- ListUtil.eq_flat_map_fold_left|].
+                2: instantiate (1:=(fun y => Pmod_cyclotomic_list (snd y) (2 ^ (n - S k)) (nth_default 0 (List.map (fun x0 : N => zeta ^ x0) (cyclotomic_decompose (S k)))  (2 * (fst y))))); intros x y; destruct y; reflexivity.
+                rewrite (flat_map_constant_length (c:=Nat.pow 2 (n - k))).
+                - unfold enumerate in Hlen.
+                  rewrite firstn_length, Hlen.
+                  assert (Init.Nat.min j _ = j) as -> by Lia.lia.
+                  Lia.lia.
+                - intros x Hx. rewrite Pmod_cyclotomic_list_length.
+                  destruct x as [? x].
+                  apply ListUtil.In_firstn in Hx.
+                  apply in_combine_r in Hx. simpl.
+                  eapply (Forall_In (P:=fun x => length x = _)); [|apply Hx].
+                  apply (Forall_chunk_length_eq _ (Nat.pow 2 k)). rewrite Hl, Hp.
+                  rewrite <- PeanoNat.Nat.pow_add_r. f_equal. Lia.lia. }
+              match goal with
+              | |- fold_left ?f _ ?l = acc ++ fold_left ?g _ ?l2 ++ ?l3 =>
+                  assert (forall m, (m <= Nat.pow 2 (n - S k))%nat -> fold_left f (seq 0%nat m) l = acc ++ fold_left g (seq 0%nat m) l2 ++ l3) as IH
+              end.
+              { induction m; intros Hm; [reflexivity|].
+                rewrite seq_S, fold_left_app, fold_left_app, PeanoNat.Nat.add_0_l.
+                rewrite IHm by Lia.lia. cbn [fold_left].
+                set (middle:=fold_left _ _ _).
+                repeat rewrite put_eq_set_nth.
+                repeat rewrite get_eq_nth_default.
+                unfold InlineTable.get. repeat rewrite <- nth_default_eq.
+                cbv [cast Convertible_Z_nat].
+                repeat rewrite Nat2Z.id.
+                assert (Z.to_nat (2 ^ Z.of_nat k - 1 + Z.of_nat j + 1) = (Nat.pow 2 k) + j)%nat as ->.
+                { repeat rewrite Z2Nat.inj_add by Lia.lia.
+                  rewrite Z2Nat.inj_sub by Lia.lia.
+                  rewrite Z2Nat.inj_pow by Lia.lia.
+                  repeat rewrite Nat2Z.id.
+                  assert (Z.to_nat 1 = 1)%nat as -> by Lia.lia.
+                  assert (Z.to_nat 2 = 2)%nat as -> by Lia.lia. Lia.lia. }
+                assert (Z.to_nat (Z.of_nat (m + j * 2 ^ (n - k)) + 2 ^ Z.of_nat (n - S k)) = m + j * Nat.pow 2 (n - k) + Nat.pow 2 (n - S k))%nat as ->.
+                { repeat rewrite Z2Nat.inj_add by Lia.lia.
+                  rewrite Z2Nat.inj_pow by Lia.lia.
+                  repeat rewrite Nat2Z.id.
+                  reflexivity. }
+                rewrite <- Hlen2.
+                rewrite ListUtil.nth_default_app.
+                destruct (lt_dec (m + _) _) as [|_]; [Lia.lia|].
+                repeat match goal with | |- context [(?a + ?b - ?b)%nat] => assert (a + b - b = a)%nat as -> by Lia.lia end.
+                assert (Hmiddle: (length middle = 2 * Nat.pow 2 (n - S k))%nat).
+                { unfold middle. rewrite <- PeanoNat.Nat.pow_succ_r'.
+                  assert (S (n - S k) = n - k)%nat as -> by Lia.lia.
+                  match goal with | |- context [fold_left ?f _ _] => assert (forall l x, length (fold_left f l x) = length x) as -> end.
+                  { induction l0; intros; [reflexivity|].
+                    simpl. rewrite IHl0. do 2 rewrite length_set_nth. reflexivity. }
+                  eapply (Forall_In (P:=fun x => length x = _)); [apply (Forall_chunk_length_eq _ (Nat.pow 2 k)); rewrite Hl, Hp, <- PeanoNat.Nat.pow_add_r; f_equal; Lia.lia|].
+                  apply nth_In.
+                  unfold enumerate in Hlen. rewrite combine_length, seq_length, Nat.min_id in Hlen.
+                  rewrite Hlen. Lia.lia. }
+                rewrite ListUtil.nth_default_app, Hmiddle.
+                destruct (lt_dec m _) as [_|]; [|Lia.lia].
+                rewrite ListUtil.nth_default_app.
+                destruct (lt_dec _ _) as [|_]; [Lia.lia|].
+                rewrite set_nth_app.
+                destruct (lt_dec _ _) as [|_]; [Lia.lia|].
+                assert (m + length acc + Nat.pow 2 (n - S k) - length acc = m + Nat.pow 2 (n - S k))%nat as -> by Lia.lia.
+                rewrite ListUtil.nth_default_app.
+                destruct (lt_dec _ _) as [_|Hnlt]; [|rewrite Hmiddle in Hnlt; Lia.lia].
+                rewrite set_nth_app.
+                destruct (lt_dec _ _) as [|_]; [Lia.lia|].
+                assert (m + length acc - length acc = m)%nat as -> by Lia.lia.
+                f_equal.
+                rewrite set_nth_app.
+                destruct (lt_dec _ _) as [_|Hnlt]; [|rewrite Hmiddle in Hnlt; Lia.lia].
+                rewrite set_nth_app.
+                rewrite length_set_nth.
+                destruct (lt_dec _ _) as [_|Hnlt]; [|rewrite Hmiddle in Hnlt; Lia.lia].
+                rewrite nth_default_seq_inbounds.
+                2:{ unfold enumerate in Hlen.
+                    rewrite combine_length, seq_length, Nat.min_id in Hlen.
+                    rewrite Hlen. Lia.lia. }
+                rewrite PeanoNat.Nat.add_0_l.
+                f_equal. cbv [default HasDefault_F].
+                assert (nth_default 0 zetas (2 ^ k + j) = nth_default 0 (List.map (fun x : N => zeta ^ x) (cyclotomic_decompose (S k))) (2 * j)) as <-.
+                { rewrite zetas_eq.
+                  erewrite map_nth_default.
+                  2:{ rewrite zeta_powers_length.
+                      generalize (Nat.pow_le_mono_r 2%nat _ _ ltac:(Lia.lia) Hk).
+                      rewrite PeanoNat.Nat.pow_succ_r'. Lia.lia. }
+                  destruct (@cyclotomic_decompose_zeta_powers_nth (N.of_nat km1) n ltac:(rewrite Nnat.Nat2N.id; Lia.lia) k km1 j Hk ltac:(Lia.lia)) as [v [Hv1 Hv2]].
+                  instantiate (1 := N0).
+                  rewrite (ListUtil.nth_error_value_eq_nth_default _ _ _ Hv1).
+                  erewrite map_nth_default.
+                  2:{ rewrite cyclotomic_decompose_length, PeanoNat.Nat.pow_succ_r'; Lia.lia. }
+                  instantiate (1 := N0).
+                  rewrite (ListUtil.nth_error_value_eq_nth_default _ _ _ Hv2).
+                  reflexivity. }
+                f_equal. }
+              apply IH. Lia.lia. }
+          rewrite IH by Lia.lia. cbn. rewrite Z2Nat.Z.pow_Zpow.
+          assert (Z.of_nat 2 = 2)%Z as -> by Lia.lia.
+          rewrite <- Z.pow_add_r by Lia.lia.
+          f_equal; [rewrite Nat2Z.inj_succ, Z.pow_succ_r by Lia.lia; Lia.lia|].
+          f_equal; [f_equal; Lia.lia|].
+          rewrite <- Hlen, firstn_all, skipn_all by Lia.lia.
+          rewrite ListUtil.List.map_nil, concat_nil, app_nil_r. reflexivity. }
+      rewrite IH by Lia.lia. simpl. reflexivity.
+    Qed.
+  End Correctness.
+End NTT.
+
+Section NTT_INVERSE.
+  Context {q: positive}.
+  Local Notation F := (F q).
+  Context {n: nat} {km1: nat}.
+  Local Open Scope F_scope.
+
+  Variables (zetas: list F) (c: F).
+
+  Local Existing Instance HasDefault_F.
+
+  Definition div_loop (i:Z) (p: ListArray.t F): ListArray.t F :=
+    nd_ranged_for_all 0%Z i
+      (fun p j =>
+         let/n x := ListArray.get p j in
+         let/n p := ListArray.put p j (c * x) in
+         p)
+      p.
+
+  Definition inverse_polynomial_decompose_loop (i start old_len: Z) (z: F) (p: ListArray.t F) :=
+    nd_ranged_for_all start (start + i)
+      (fun p j =>
+         let/n tmp := ListArray.get p j in
+         let/n x := ListArray.get p (j + old_len)%Z in
+         let/n p := ListArray.put p j (tmp + x) in
+         let/n x := (x - tmp) in
+         let/n p := ListArray.put p (j + old_len)%Z (z * x) in
+         p
+      )
+      p.
+
+  Definition inverse_polynomial_list_loop (k old_len len: Z) (state: \<< Z, Z, ListArray.t F \>>) :=
+    nd_ranged_for_all 0%Z k
+      (fun state _ =>
+         let '\< m, start, p \> := state in
+         let/n m := (m - 1)%Z in
+         let/n z := InlineTable.get zetas m in
+         let/n p :=
+           inverse_polynomial_decompose_loop old_len start old_len z p in
+         let/n start := (start + len)%Z in
+         \< m, start, p \>
+      )
+      state.
+
+  Definition inverse_layer_decomposition_loop (n: nat) (state: \<< Z, Z, ListArray.t F \>>) :=
+      nd_ranged_for_all 0%Z (Z.of_nat n)
+        (fun state i =>
+           let '\< m, len, p \> := state in
+           let/n start := 0%Z in
+           let/n old_len := len in
+           let/n len := Z.shiftl len 1 in
+           let/n (m, start, p) :=
+             inverse_polynomial_list_loop (Z.pow 2 (Z.of_nat km1 - (i + 1))) old_len len \< m, start, p\> in
+           \< m, len, p \>
+        )
+        state.
+
+  Definition NTT_inverse_gallina (p: ListArray.t F): ListArray.t F :=
+    let/n m := (Z.pow 2 (Z.of_nat km1)) in
+    let/n len := (Z.pow 2 (Z.of_nat (n - km1))) in
+    let/n (m, len, p) :=
+      inverse_layer_decomposition_loop km1 \< m, len, p \> in
+    let/n p := div_loop (Z.pow 2 (Z.of_nat n)) p
+    in p.
+
+  Section Correctness.
+    Context {field: @Hierarchy.field F eq F.zero F.one F.opp F.add F.sub F.mul F.inv F.div}
+      {char_ge_3: @Ring.char_ge F eq F.zero F.one F.opp F.add F.sub F.mul (BinNat.N.succ_pos (BinNat.N.two))}.
+
+    Context {zeta: F}.
+
+    Local Notation NTT_inverse_nodiv_spec := (@NTT_psi_list_no_div q zeta (N.of_nat km1) n).
+    Local Notation NTT_inverse_spec := (@NTT_psi_list q zeta (N.of_nat km1) n km1).
+    Local Notation NTT_inverse_layer_spec := (@NTT_psi_layer_list q zeta (N.of_nat km1) n).
+    Local Notation enumerate := Datatypes.List.enumerate.
+
+    Hypothesis n_ge_km1: (km1 <= n)%nat.
+    Hypothesis zetas_eq: zetas = List.map (fun k => F.pow zeta k) (@zeta_powers (N.of_nat km1) km1).
+    Hypothesis Hkm1: zeta ^ (N.pow 2 (N.of_nat km1)) = F.opp 1.
+    Hypothesis c_eq: c = F.inv (F.of_Z _ (Zpower.two_power_nat km1)).
+
+    Lemma NTT_inverse_nodiv_spec_as_fold_right:
+      forall k p,
+        NTT_inverse_nodiv_spec k p = fold_right NTT_inverse_layer_spec p (seq 0 k).
+    Proof.
+      induction k; intros; [reflexivity|].
+      rewrite seq_S, fold_right_app, PeanoNat.Nat.add_0_l; simpl.
+      apply IHk.
+    Qed.
+
+    Lemma NTT_inverse_gallina_correct (p: list F) (Hp: length p = Nat.pow 2 n):
+      NTT_inverse_gallina p = NTT_inverse_spec p.
+    Proof.
+      unfold NTT_inverse_gallina, div_loop, inverse_layer_decomposition_loop, inverse_polynomial_list_loop, inverse_polynomial_decompose_loop.
+      unfold nlet.
+      match goal with
+      | |- context [nd_ranged_for_all 0%Z (Z.of_nat km1) ?f ?x] =>
+          assert (nd_ranged_for_all 0%Z (Z.of_nat km1) f x = \< 1%Z, Z.pow 2 (Z.of_nat n), NTT_inverse_nodiv_spec km1 p \>) as ->
+      end.
+      { rewrite <- (Z.add_0_l (Z.of_nat km1)), <- fold_left_as_nd_ranged_for_all, Z.add_0_l.
+        unfold z_range; rewrite z_range'_seq by reflexivity.
+        rewrite Z.sub_0_r, Nat2Z.id. rewrite fold_left_map.
+        match goal with
+        | |- fold_left ?f (seq _ ?up) \< ?m, ?len, ?p \> = _ =>
+            assert (forall i, (i <= up)%nat -> fold_left f (seq (Z.to_nat 0) i) \< m, len, p \> = \< (Z.pow 2 (Z.of_nat (km1 - i)%nat))%Z, (Z.pow 2 (Z.of_nat (n - km1 + i)%nat)%Z), fold_right NTT_inverse_layer_spec p (seq (up - i) i) \>) as ->; try Lia.lia
+        end.
+        { induction i; intros Hi. unfold NTT_inverse_nodiv_spec.
+          - simpl. rewrite PeanoNat.Nat.sub_0_r, PeanoNat.Nat.add_0_r.
+            reflexivity.
+          - rewrite seq_S, fold_left_app, Nat.add_0_l, IHi by Lia.lia.
+            cbn [fold_left]. cbn [P2.car P2.cdr]. clear IHi.
+            rewrite Z.shiftl_mul_pow2 by Lia.lia.
+            rewrite <- Z.pow_add_r by Lia.lia.
+            assert (Z.of_nat km1 - (Z.of_nat i + 1) = Z.of_nat (km1 - S i))%Z as -> by Lia.lia.
+            assert (Z.of_nat (n - km1 + i) + 1 = Z.of_nat (n - km1 + S i))%Z as -> by Lia.lia.
+            match goal with
+            | |- context [nd_ranged_for_all ?a ?b ?f ?x] =>
+                assert (nd_ranged_for_all a b f x = nd_ranged_for_all a (0 + Z.of_nat (Nat.pow 2 (km1 - S i))) f x) as ->
+            end.
+            { f_equal. rewrite <- (Z.add_0_l (Z.pow 2 _)). f_equal.
+              rewrite Nat2Z.inj_pow. reflexivity. }
+            rewrite <- Nat_iter_as_nd_ranged_for_all.
+            cbn [seq fold_right]. assert (S (km1 - S i) = km1 - i)%nat as -> by Lia.lia.
+            set (l := fold_right _ _ _).
+            unfold NTT_inverse_layer_spec, fold_left_chunked.
+            assert (Hl: length l = length p).
+            { unfold l. apply ListUtil.fold_right_invariant; [reflexivity|].
+              intros. rewrite (@NTT_psi_layer_list_length q zeta (N.of_nat km1) n ltac:(rewrite Nnat.Nat2N.id; Lia.lia)). auto. }
+            rewrite Hp in Hl.
+            assert (length (chunk (2 ^ (n - (km1 - S i))) l) = Nat.pow 2 (km1 - S i))%nat as Hlen.
+            { rewrite length_chunk by (generalize (NatUtil.pow_nonzero 2 (n - (km1 - S i)) ltac:(Lia.lia)); Lia.lia).
+              rewrite Hl.
+              replace n with ((km1- S i) + (n - (km1 - S i)))%nat at 1 by Lia.lia.
+              rewrite PeanoNat.Nat.pow_add_r.
+              apply Nat.div_up_exact.
+              generalize (NatUtil.pow_nonzero 2 (n - (km1 - S i))%nat ltac:(Lia.lia)); Lia.lia. }
+            assert (length (enumerate 0 (chunk (2 ^ (n - (km1 - S i))) l)) = Nat.pow 2 (km1 - S i))%nat as Hlen2.
+            { unfold enumerate. rewrite combine_length, seq_length, PeanoNat.Nat.min_id, Hlen; reflexivity. }
+            assert (HF: Forall (fun x => length x = (2 ^ (n - (km1 - S i)))%nat) (chunk (2 ^ (n - (km1 - S i))) l)).
+            { eapply Forall_chunk_length_eq. rewrite Hl.
+              replace n with ((n - (km1 - S i)) + (km1 - S i))%nat at 1 by Lia.lia.
+              rewrite PeanoNat.Nat.pow_add_r. reflexivity. }
+            match goal with
+            | |- context [Nat.iter ?up ?f \< ?m, ?start, ?p \>] =>
+                match goal with
+                | |- context [fold_left ?g ?a nil] =>
+                assert (forall k, (k <= up)%nat -> Nat.iter k f \< m, start, p \> = \< (m - Z.of_nat k)%Z, (start + Z.of_nat k * 2 ^ Z.of_nat (n - km1 + S i))%Z, (fold_left g (List.firstn k a) nil) ++ (concat (List.map snd (List.skipn k a))) \>) as ->; try Lia.lia
+                end
+            end.
+            { induction k; intro Hk.
+              - simpl. rewrite Z.sub_0_r.
+                unfold enumerate. rewrite map_combine_snd by (rewrite seq_length; reflexivity).
+                rewrite concat_chunk. reflexivity.
+              - rewrite Nat.iter_succ, IHk by Lia.lia.
+                f_equal; [Lia.lia|]. f_equal; [Lia.lia|].
+                clear IHk. rewrite Z.add_0_l.
+                rewrite <- fold_left_as_nd_ranged_for_all.
+                rewrite <- (firstn_nth _ _ _ (0%nat, nil)) by (rewrite Hlen2; Lia.lia).
+                rewrite (ListUtil.skipn_nth_default k _ (0%nat, nil)) by (rewrite Hlen2; Lia.lia).
+                unfold z_range. rewrite Z.add_simpl_l.
+                rewrite Z2Nat.inj_pow by Lia.lia.
+                rewrite Nat2Z.id. assert (Z.to_nat 2 = 2)%nat as -> by Lia.lia.
+                rewrite z_range'_seq by Lia.lia.
+                rewrite Z2Nat.inj_mul, Z2Nat.inj_pow, Nat2Z.id, Nat2Z.id by Lia.lia.
+                assert (Z.to_nat 2 = 2)%nat as -> by Lia.lia.
+                rewrite fold_left_app. cbn [fold_left].
+                set (hd := fold_left _ (List.firstn _ _) nil).
+                rewrite nth_default_eq.
+                unfold enumerate. rewrite combine_nth by (rewrite seq_length; Lia.lia).
+                rewrite seq_nth by (rewrite Hlen; Lia.lia).
+                cbn [List.map snd concat].
+                set (middle := nth k _ nil).
+                set (tl := concat _).
+                rewrite PeanoNat.Nat.add_0_l.
+                unfold NTT_base_psi_unpacked_list.
+                assert (length hd = k * (Nat.pow 2 (n - (km1 - S i))))%nat as Hlen_hd.
+                { unfold hd. erewrite fold_left_ext; [rewrite <- ListUtil.eq_flat_map_fold_left|].
+                  2: instantiate (1:=(fun y => NTT_base_psi_unpacked_list (snd y) (2 ^ (n - S (km1 - S i))) (F.inv (zeta ^ nth_default 0%N (cyclotomic_decompose (S (km1 - S i))) (2 * (fst y))%nat)))).
+                  2: intros a b; destruct b; reflexivity.
+                  erewrite flat_map_constant_length.
+                  2:{ intros x Hx. rewrite NTT_base_psi_unpacked_list_length.
+                      apply ListUtil.In_firstn in Hx.
+                      unfold enumerate in Hx.
+                      destruct x. apply in_combine_r in Hx.
+                      eapply (Forall_In HF). auto. }
+                  rewrite firstn_length. unfold enumerate.
+                  rewrite combine_length, seq_length, Hlen, PeanoNat.Nat.min_id.
+                  rewrite Nat.min_l by Lia.lia. reflexivity. }
+                assert (length middle = (2 ^ (n - (km1 - S i))))%nat as Hlen_mid.
+                { eapply (Forall_In HF). unfold middle.
+                  apply nth_In. rewrite Hlen. Lia.lia. }
+                rewrite <- (PeanoNat.Nat.add_0_l (k * _)).
+                rewrite seq_add, List.map_map, fold_left_map.
+                assert (n - S (km1 - S i) = n - km1 + i)%nat as <- by Lia.lia.
+                rewrite <- List.app_assoc.
+                match goal with
+                | |- fold_left ?f _ ?l = hd ++ (fold_left ?g _ ?l2) ++ tl =>
+                    assert (forall m, (m <= Nat.pow 2 (n - S (km1 - S i)))%nat -> fold_left f (seq 0%nat m) l = hd ++ fold_left g (seq 0%nat m) l2 ++ tl) as ->; try Lia.lia
+                end.
+                { induction m; intros Hm; [reflexivity|].
+                  rewrite seq_S, fold_left_app, fold_left_app, IHm by Lia.lia.
+                  set (acc := fold_left _ _ middle).
+                  clear IHm. rewrite PeanoNat.Nat.add_0_l.
+                  cbn [fold_left].
+                  unfold InlineTable.get. rewrite <- nth_default_eq.
+                  repeat rewrite put_eq_set_nth.
+                  repeat rewrite get_eq_nth_default.
+                  cbv [cast Convertible_Z_nat].
+                  rewrite Nat2Z.inj_add.
+                  repeat rewrite Z2Nat.inj_add by Lia.lia.
+                  repeat rewrite Z2Nat.inj_sub by Lia.lia.
+                  repeat rewrite Z2Nat.inj_pow by Lia.lia.
+                  repeat rewrite Nat2Z.id.
+                  assert (Z.to_nat 2 = 2)%nat as -> by reflexivity.
+                  assert (n - km1 + S i = n - (km1 - S i))%nat as -> by Lia.lia.
+                  assert (length acc = length middle) as Hlen_acc.
+                  { unfold acc. apply fold_left_invariant; [reflexivity|].
+                    intros. repeat rewrite length_set_nth; auto. }
+                  rewrite ListUtil.nth_default_app.
+                  rewrite Hlen_hd. destruct (lt_dec _ _) as [|_]; [Lia.lia|].
+                  rewrite ListUtil.nth_default_app.
+                  rewrite Hlen_acc, Hlen_mid.
+                  assert (2 ^ (n - S (km1 - S i)) < 2 ^ (n - (km1 - S i)))%nat as Hmono.
+                  { apply Nat.pow_lt_mono_r; Lia.lia. }
+                  assert (m + k * 2 ^ (n - (km1 - S i)) + 2 ^ (n - S (km1 - S i)) - k * 2 ^ (n - (km1 - S i)) = m + 2 ^ (n - S (km1 - S i)))%nat as -> by Lia.lia.
+                  assert (2 ^ (n - (km1 - S i)) = 2 * (2 ^ (n - S (km1 - S i))))%nat as Heq.
+                  { rewrite <- PeanoNat.Nat.pow_succ_r'.
+                    f_equal. Lia.lia. }
+                  destruct (lt_dec _ _) as [_|]; [|Lia.lia].
+                  rewrite ListUtil.nth_default_app, Hlen_hd.
+                  destruct (lt_dec _ _) as [|_]; [Lia.lia|].
+                  rewrite ListUtil.nth_default_app, Hlen_acc, Hlen_mid.
+                  destruct (lt_dec _ _); [|Lia.lia].
+                  rewrite set_nth_app, Hlen_hd.
+                  destruct (lt_dec _ _) as [|_]; [Lia.lia|].
+                  rewrite set_nth_app, Hlen_hd.
+                  destruct (lt_dec _ _) as [|_]; [Lia.lia|].
+                  rewrite set_nth_app, Hlen_acc, Hlen_mid.
+                  destruct (lt_dec _ _) as [_|]; [|Lia.lia].
+                  rewrite set_nth_app, length_set_nth, Hlen_acc, Hlen_mid.
+                  destruct (lt_dec _ _) as [_|]; [|Lia.lia].
+                  assert (m + k * 2 ^ (n - (km1 - S i)) - k * 2 ^ (n - (km1 - S i)) = m)%nat as -> by Lia.lia.
+                  assert (m + k * 2 ^ (n - (km1 - S i)) + 2 ^ (n - S (km1 - S i)) - k * 2 ^ (n - (km1 - S i)) = m + 2 ^ (n - S (km1 - S i)))%nat as -> by Lia.lia.
+                  f_equal. f_equal.
+                  apply nth_error_ext.
+                  intros o. repeat rewrite nth_set_nth.
+                  repeat rewrite length_set_nth.
+                  rewrite Hlen_acc, Hlen_mid.
+                  cbv [default HasDefault_F].
+                  destruct (Nat.eq_dec o (m + _)) as [->|].
+                  - destruct (lt_dec _ _) as [_|]; [|Lia.lia].
+                    rewrite set_nth_nth_default, NatUtil.eq_nat_dec_refl by (rewrite length_set_nth, Hlen_acc, Hlen_mid; Lia.lia).
+                    f_equal.
+                    transitivity ((F.opp (nth_default 0 zetas (2 ^ (km1 - i) - k - Z.to_nat 1))) * (nth_default 0 acc m - nth_default 0 acc (m + 2 ^ (n - S (km1 - S i))))).
+                    { set (x := nth_default 0 zetas (2 ^ (km1 - i) - k - Z.to_nat 1)).
+                      set (y := nth_default 0 acc (m + 2 ^ (n - S (km1 - S i)))).
+                      set (z := nth_default 0 acc m).
+                      (* Now goal is x * (y - z) = F.opp x * (z - y) *)
+                      rewrite Ring.mul_opp_l, <- Ring.mul_opp_r.
+                      do 2 rewrite Hierarchy.ring_sub_definition.
+                      rewrite Group.inv_op, Group.inv_inv. reflexivity. }
+                    f_equal.
+                    rewrite zetas_eq.
+                    erewrite map_nth_default.
+                    2:{ rewrite zeta_powers_length.
+                        generalize (NatUtil.pow_nonzero 2%nat (km1 - i)%nat ltac:(Lia.lia)).
+                        generalize (Nat.pow_le_mono_r 2%nat (km1 - i)%nat km1 ltac:(Lia.lia) ltac:(Lia.lia)).
+                        Lia.lia. }
+                    rewrite (@neg_zeta_power_eq _ _ (N.of_nat km1) Hkm1).
+                    destruct (@cyclotomic_decompose_zeta_powers_nth (N.of_nat km1) n ltac:(rewrite Nnat.Nat2N.id; Lia.lia) (km1 - S i) km1 k ltac:(Lia.lia) ltac:(Lia.lia)) as [v [Hv1 Hv2]].
+                    assert (km1 - i = S (km1 - S i))%nat as -> by Lia.lia.
+                    rewrite PeanoNat.Nat.pow_succ_r'.
+                    assert (2 * 2 ^ (km1 - S i) - k - Z.to_nat 1 = 2 ^ (km1 - S i) + (2 ^ (km1 - S i) - k - 1))%nat as -> by Lia.lia.
+                    destruct (@cyclotomic_decompose_zeta_powers_nth (N.of_nat km1) n ltac:(rewrite Nnat.Nat2N.id; Lia.lia) (km1 - S i) km1 (2 ^ (km1 - S i) - k - 1) ltac:(Lia.lia) ltac:(Lia.lia)) as [v' [Hv1' Hv2']].
+                    instantiate (1 := N0).
+                    rewrite (ListUtil.nth_error_value_eq_nth_default _ _ _ Hv1'), (ListUtil.nth_error_value_eq_nth_default _ _ _ Hv2).
+                    assert (nth_error (@cyclotomic_decompose (N.of_nat km1) (S (km1 - S i))) (2 ^ S (km1 - S i) - 1 - 2 * k) = Some (2 ^ N.of_nat km1 + v')%N) as Hvv.
+                    { rewrite PeanoNat.Nat.pow_succ_r'.
+                      assert (2 * 2 ^ (km1 - S i) - 1 - 2 * k = 2 * (2 ^ (km1 - S i) - k - 1) + 1)%nat as -> by Lia.lia.
+                      destruct (nth_error_length_exists_value (2 ^ (km1 - S i) - k - 1) (@cyclotomic_decompose (N.of_nat km1) (km1 - S i)) ltac:(rewrite cyclotomic_decompose_length; Lia.lia)) as [vx Hvx].
+                      destruct (@cyclotomic_decompose_S_nth_error (N.of_nat km1) n ltac:(rewrite Nnat.Nat2N.id; Lia.lia) (km1 - S i) ltac:(Lia.lia) (2 ^ (km1 - S i) - k - 1) vx Hvx) as [X1 [X2 _]].
+                      rewrite X2. rewrite X1 in Hv2'. congruence. }
+                    destruct (@cyclotomic_decompose_inv q zeta (N.of_nat km1) Hkm1 n ltac:(rewrite Nnat.Nat2N.id; Lia.lia) (S (km1 - S i)) ltac:(Lia.lia) (2 * k) ltac:(rewrite PeanoNat.Nat.pow_succ_r'; Lia.lia) v (2 ^ N.of_nat km1 + v') Hv2 Hvv) as [XA XB].
+                    apply Field.right_inv_unique. auto.
+                  - destruct (Nat.eq_dec o m) as [->|].
+                    + destruct (lt_dec _ _); reflexivity.
+                    + reflexivity. }
+                reflexivity. }
+            f_equal.
+            + rewrite Nat2Z.inj_pow. assert (km1 - i = S (km1 - S i))%nat as -> by Lia.lia.
+              rewrite Nat2Z.inj_succ, Z.pow_succ_r by Lia.lia.
+              Lia.lia.
+            + f_equal. f_equal.
+              rewrite firstn_all, skipn_all by Lia.lia.
+              cbn [List.map concat]. rewrite List.app_nil_r. reflexivity. }
+        rewrite PeanoNat.Nat.sub_diag, Nat2Z.inj_0, Z.pow_0_r.
+        assert (n - km1 + km1 = n)%nat as -> by Lia.lia.
+        rewrite NTT_inverse_nodiv_spec_as_fold_right.
+        f_equal. }
+      unfold NTT_inverse_spec.
+      assert (Z.pow 2 _ = Z.of_nat (length (NTT_inverse_nodiv_spec km1 p))) as ->.
+      { rewrite (@NTT_psi_list_no_div_length q zeta (N.of_nat km1) n ltac:(rewrite Nnat.Nat2N.id; Lia.lia)), Hp, Nat2Z.inj_pow. reflexivity. }
+      symmetry; eapply map_as_nd_ranged_for_all.
+      unfold acts_as_replace_nth. intros.
+      rewrite put_eq_set_nth, get_eq_nth_default.
+      cbv [cast Convertible_Z_nat]. rewrite Nat2Z.id.
+      rewrite nth_default_app, set_nth_app.
+      destruct (lt_dec _ _) as [|_]; [Lia.lia|].
+      rewrite PeanoNat.Nat.sub_diag.
+      rewrite nth_default_cons, set_nth_cons, c_eq.
+      f_equal. rewrite Hierarchy.field_div_definition.
+      rewrite Hierarchy.commutative. f_equal.
+    Qed.
+  End Correctness.
+End NTT_INVERSE.

--- a/src/NTT/RupicolaUtils.v
+++ b/src/NTT/RupicolaUtils.v
@@ -1,0 +1,337 @@
+From Coq Require List.
+Require Import Rupicola.Lib.Core Rupicola.Lib.Notations.
+Require Import Rupicola.Lib.InlineTables.
+Require Import Rupicola.Lib.Arrays.
+Require Import bedrock2.Memory.
+
+Section __.
+  (* TODO: upstream to Rupicola *)
+  Context {width: Z} {BW: Bitwidth width} {word: word.word width} {mem: map.map word Byte.byte}.
+  Context {locals: map.map String.string word}.
+  Context {ext_spec: bedrock2.Semantics.ExtSpec}.
+  Context {word_ok : word.ok word} {mem_ok : map.ok mem}.
+  Context {locals_ok : map.ok locals}.
+  Context {ext_spec_ok : Semantics.ext_spec.ok ext_spec}.
+
+  Context {K: Type}.
+  Context {Conv: Convertible K nat}.
+
+  Context {HD_word: HasDefault word}.
+
+  Section Utils.
+    Lemma truncate_word_nop_word (value: word):
+      truncate_word access_size.word value = value.
+    Proof.
+      cbv [truncate_word truncate_Z].
+      rewrite bytes_per_width_bytes_per_word.
+      unfold bytes_per_word. assert ((width + 7) / 8 * 8 = width) as ->.
+      { destruct BW.(width_cases) as [-> | ->]; reflexivity. }
+      rewrite word.of_Z_land_ones. apply word.of_Z_unsigned.
+    Qed.
+  End Utils.
+
+  Section InlineTableAnyWord.
+    Context {V: Type}.
+    Context {HD: HasDefault V}.
+    Context (ConvV: Convertible V word).
+    Context (ConvW: Convertible word V).
+
+    Lemma compile_inlinetable_get_any_as_word : forall {tr mem locals functions},
+      forall (idx: K) (t: InlineTable.t V),
+        let v := InlineTable.get t idx in
+        forall P (pred: P v -> predicate) (k: nlet_eq_k P v) k_impl
+          var idx_expr,
+
+      let n := cast idx in
+      (n < List.length t)%nat ->
+      (Z.of_nat (List.length (to_byte_table (List.map cast t))) <= 2 ^ width) ->
+
+      WeakestPrecondition.dexpr mem locals idx_expr (word.of_Z (Z.of_nat n)) ->
+
+      (let v := v in
+         <{ Trace := tr;
+            Memory := mem;
+            Locals := map.put locals var (cast v);
+            Functions := functions }>
+         k_impl
+         <{ pred (k v eq_refl) }>) ->
+
+      <{ Trace := tr;
+         Memory := mem;
+         Locals := locals;
+         Functions := functions }>
+      (cmd.seq (cmd.set
+                  var
+                  (expr.inlinetable access_size.word (to_byte_table (List.map cast t))
+                                    (expr.op bopname.mul (expr.literal (width / 8))
+                                             idx_expr)))
+               k_impl)
+      <{ pred (nlet_eq [var] v k) }>.
+    Proof.
+      intros; repeat straightline.
+      exists (cast v); split; repeat straightline; eauto.
+      eapply WeakestPrecondition_dexpr_expr; eauto.
+      eexists; split; eauto.
+      unfold v0; rewrite <- word.ring_morph_mul.
+      erewrite load_from_word_table; auto.
+      - rewrite map_nth. reflexivity.
+      - rewrite map_length. auto.
+    Qed.
+
+    Lemma compile_inlinetable_get_any_as_word' : forall {tr mem locals functions},
+      forall (idx: K) (t: InlineTable.t V) (t': InlineTable.t word),
+        let v := InlineTable.get t idx in
+        let v' := InlineTable.get t' idx in
+        forall P (pred: P v -> predicate) (k: nlet_eq_k P v) k_impl
+          var idx_expr,
+
+      let n := cast idx in
+      (n < List.length t)%nat ->
+      (Z.of_nat (List.length (to_byte_table t')) <= 2 ^ width) ->
+      (t = List.map cast t') ->
+
+      WeakestPrecondition.dexpr mem locals idx_expr (word.of_Z (Z.of_nat n)) ->
+
+      (let v := v in
+         <{ Trace := tr;
+            Memory := mem;
+            Locals := map.put locals var v';
+            Functions := functions }>
+         k_impl
+         <{ pred (k v eq_refl) }>) ->
+
+      <{ Trace := tr;
+         Memory := mem;
+         Locals := locals;
+         Functions := functions }>
+      (cmd.seq (cmd.set
+                  var
+                  (expr.inlinetable access_size.word (to_byte_table t')
+                                    (expr.op bopname.mul (expr.literal (width / 8))
+                                             idx_expr)))
+               k_impl)
+      <{ pred (nlet_eq [var] v k) }>.
+    Proof.
+      intros; repeat straightline.
+      exists v'; split; repeat straightline; eauto.
+      eapply WeakestPrecondition_dexpr_expr; eauto.
+      eexists; split; eauto.
+      unfold v0; rewrite <- word.ring_morph_mul.
+      erewrite load_from_word_table; auto.
+      - reflexivity.
+      - unfold t in H. rewrite map_length in H. assumption.
+    Qed.
+  End InlineTableAnyWord.
+  Section ArrayAnyWord.
+    Context {V: Type}.
+    Context {HD: HasDefault V}.
+    Context (ConvV: Convertible V word).
+    Context (ConvW: Convertible word V).
+
+    Lemma compile_sizedlistarray_get_any_as_word : forall {len} {tr mem locals functions}
+          (a: ListArray.t V) (idx: K),
+      let v := ListArray.get a idx in
+      forall P (pred: P v -> predicate) (k: nlet_eq_k P v) k_impl
+        R (a_ptr: word) a_expr idx_expr var,
+
+        sep (sizedlistarray_value access_size.word len a_ptr (List.map cast a)) R mem ->
+        WeakestPrecondition.dexpr mem locals a_expr a_ptr ->
+        WeakestPrecondition.dexpr mem locals idx_expr (word.of_Z (Z.of_nat (cast idx))) ->
+
+        Z.of_nat (cast idx) < Z.of_nat len ->
+
+        (let v := v in
+         <{ Trace := tr;
+            Memory := mem;
+            Locals := map.put locals var (cast v);
+            Functions := functions }>
+         k_impl
+         <{ pred (k v eq_refl) }>) ->
+        <{ Trace := tr;
+           Memory := mem;
+           Locals := locals;
+           Functions := functions }>
+        cmd.seq
+          (cmd.set
+             var
+             (expr.load
+                access_size.word
+                (offset a_expr idx_expr (expr.literal (Z.of_nat (@Memory.bytes_per width access_size.word))))))
+          k_impl
+        <{ pred (nlet_eq [var] v k) }>.
+    Proof.
+      intros. repeat straightline.
+      assert (Hlen: Datatypes.length (List.map cast a) = len).
+      { erewrite <- SizedListArray_length by eassumption. reflexivity. }
+      exists (cast (ListArray.get a idx)); split; repeat straightline; eauto.
+      eapply WeakestPrecondition_dexpr_expr; eauto.
+      eapply WeakestPrecondition_dexpr_expr; eauto.
+      - eexists; split; eauto.
+        seprewrite_in (SizedListArray_Hrw (sz:=access_size.word)) H.
+        + assumption.
+        + cbv [array_repr Arrays._access_info] in H. simpl in H.
+          erewrite array_load_of_sep; try eassumption.
+          2: reflexivity.
+          2: rewrite Hlen; instantiate (1 := cast idx); Lia.lia.
+          rewrite truncate_word_nop_word.
+          unfold ListArray.get.
+          erewrite nth_indep by (rewrite Hlen; Lia.lia).
+          rewrite map_nth. reflexivity.
+      - repeat straightline.
+        eapply WeakestPrecondition_dexpr_expr; eauto.
+        unfold v0; rewrite word.ring_morph_mul.
+        cbv [bytes_per].
+        rewrite Z2Nat.id by (destruct BW.(width_cases) as [-> | ->]; cbv; congruence).
+        rewrite word.unsigned_of_Z. f_equal.
+        rewrite <- word.of_Z_wrap. reflexivity.
+    Qed.
+
+    Lemma compile_sizedlistarray_get_any_as_word' : forall {len} {tr mem locals functions}
+          (a: ListArray.t V) (a': ListArray.t word) (idx: K),
+      let v := ListArray.get a idx in
+      let v' := ListArray.get a' idx in
+      forall P (pred: P v -> predicate) (k: nlet_eq_k P v) k_impl
+        R (a_ptr: word) a_expr idx_expr var,
+
+        a = List.map cast a' ->
+        sep (sizedlistarray_value access_size.word len a_ptr a') R mem ->
+        WeakestPrecondition.dexpr mem locals a_expr a_ptr ->
+        WeakestPrecondition.dexpr mem locals idx_expr (word.of_Z (Z.of_nat (cast idx))) ->
+
+        Z.of_nat (cast idx) < Z.of_nat len ->
+
+        (let v := v in
+         <{ Trace := tr;
+            Memory := mem;
+            Locals := map.put locals var v';
+            Functions := functions }>
+         k_impl
+         <{ pred (k v eq_refl) }>) ->
+        <{ Trace := tr;
+           Memory := mem;
+           Locals := locals;
+           Functions := functions }>
+        cmd.seq
+          (cmd.set
+             var
+             (expr.load
+                access_size.word
+                (offset a_expr idx_expr (expr.literal (Z.of_nat (@Memory.bytes_per width access_size.word))))))
+          k_impl
+        <{ pred (nlet_eq [var] v k) }>.
+    Proof.
+      intros. repeat straightline.
+      assert (Hlen: Datatypes.length a' = len).
+      { erewrite <- SizedListArray_length by eassumption. reflexivity. }
+      exists v'; split; repeat straightline; eauto.
+      eapply WeakestPrecondition_dexpr_expr; eauto.
+      eapply WeakestPrecondition_dexpr_expr; eauto.
+      - eexists; split; eauto.
+        seprewrite_in (SizedListArray_Hrw (sz:=access_size.word)) H0.
+        + assumption.
+        + cbv [array_repr Arrays._access_info] in H0. simpl in H0.
+          erewrite array_load_of_sep; try eassumption.
+          2: reflexivity.
+          2: rewrite Hlen; instantiate (1 := cast idx); Lia.lia.
+          rewrite truncate_word_nop_word.
+          unfold v', ListArray.get.
+          erewrite nth_indep by (rewrite Hlen; Lia.lia). reflexivity.
+      - repeat straightline.
+        eapply WeakestPrecondition_dexpr_expr; eauto.
+        unfold v0; rewrite word.ring_morph_mul.
+        cbv [bytes_per].
+        rewrite Z2Nat.id by (destruct BW.(width_cases) as [-> | ->]; cbv; congruence).
+        rewrite word.unsigned_of_Z. f_equal.
+        rewrite <- word.of_Z_wrap. reflexivity.
+    Qed.
+
+    Lemma compile_sizedlistarray_put_any_as_word : forall {len} {tr mem locals functions}
+          (a: ListArray.t V) (idx: K) val,
+      let v := ListArray.put a idx val in
+      forall P (pred: P v -> predicate) (k: nlet_eq_k P v) k_impl
+        R (a_ptr: word) a_expr idx_expr val_expr var,
+
+        sep (sizedlistarray_value access_size.word len a_ptr (List.map cast a)) R mem ->
+        WeakestPrecondition.dexpr mem locals a_expr a_ptr ->
+        WeakestPrecondition.dexpr mem locals idx_expr (word.of_Z (Z.of_nat (cast idx))) ->
+        WeakestPrecondition.dexpr mem locals val_expr (cast val) ->
+
+        Z.of_nat (cast idx) < Z.of_nat len ->
+
+        (let v := v in
+         forall mem',
+           sep (sizedlistarray_value access_size.word len a_ptr (List.map cast v)) R mem' ->
+           <{ Trace := tr;
+              Memory := mem';
+              Locals := locals;
+              Functions := functions }>
+           k_impl
+           <{ pred (k v eq_refl) }>) ->
+        <{ Trace := tr;
+           Memory := mem;
+           Locals := locals;
+           Functions := functions }>
+        cmd.seq
+          (cmd.store
+             access_size.word
+             (offset a_expr idx_expr (expr.literal (Z.of_nat (@Memory.bytes_per width access_size.word))))
+             val_expr)
+          k_impl
+        <{ pred (nlet_eq [var] v k) }>.
+    Proof.
+      intros. repeat straightline.
+      assert (Hlen: Datatypes.length (List.map cast a) = len).
+      { erewrite <- SizedListArray_length by eassumption. reflexivity. }
+      eexists; split; repeat straightline; eauto.
+      - repeat (eapply WeakestPrecondition_dexpr_expr; eauto).
+        repeat straightline.
+        eapply WeakestPrecondition_dexpr_expr; eauto.
+      - eexists; split; eauto.
+        seprewrite_in (SizedListArray_Hrw (sz:=access_size.word)) H; auto.
+        cbv [array_repr Arrays._access_info] in H. simpl in H.
+        seprewrite_in (array_index_nat_inbounds (T:=word)) H.
+        + rewrite Hlen; instantiate (1 := cast idx); Lia.lia.
+        + rewrite word.ring_morph_mul in H.
+          rewrite word.of_Z_unsigned in H.
+          eapply store_word_of_sep; [unfold bytes_per; ecancel_assumption|].
+          intros m Hm. apply H4.
+          assert (Hlen': Datatypes.length (List.map cast v) = len).
+          { unfold v. rewrite <- Hlen. unfold ListArray.put.
+            rewrite map_length, map_length, replace_nth_length. reflexivity. }
+          seprewrite (SizedListArray_Hrw (sz:=access_size.word)); auto.
+          cbv [array_repr Arrays._access_info]; simpl.
+          seprewrite (array_index_nat_inbounds (T:=word)).
+          { rewrite Hlen'. instantiate (1 := cast idx); Lia.lia. }
+          assert (List.firstn (cast idx) (List.map cast v) = List.firstn (cast idx) (List.map cast a)) as ->.
+          { unfold v, ListArray.put.
+            rewrite replace_nth_eqn, firstn_map, firstn_map.
+            2: rewrite map_length in Hlen; Lia.lia.
+            rewrite firstn_app_l; [reflexivity|].
+            rewrite firstn_length. rewrite map_length in Hlen. Lia.lia. }
+          assert (List.skipn (S (cast idx)) (List.map cast v) = List.skipn (S (cast idx)) (List.map cast a)) as ->.
+          { unfold v, ListArray.put.
+            rewrite replace_nth_eqn, skipn_map, skipn_map.
+            2: rewrite map_length in Hlen; Lia.lia.
+            rewrite assoc_app_cons, skipn_app_r; [reflexivity|].
+            rewrite app_length, firstn_length. rewrite map_length in Hlen.
+            simpl. Lia.lia. }
+          rewrite word.ring_morph_mul, word.of_Z_unsigned.
+          instantiate (1:=default).
+          assert (List.hd _ (List.skipn (cast idx) (List.map cast v)) = cast val) as ->.
+          { unfold v, ListArray.put.
+            rewrite replace_nth_eqn, skipn_map.
+            2: rewrite map_length in Hlen; Lia.lia.
+            rewrite skipn_app_r; [reflexivity|].
+            rewrite firstn_length. rewrite map_length in Hlen. Lia.lia. }
+          ecancel_assumption_impl Hm.
+          Unshelve. exact default.
+    Qed.
+  End ArrayAnyWord.
+End __.
+
+#[export] Hint Extern 1 (WP_nlet_eq (ListArray.get _ _)) =>
+  simple eapply (@compile_sizedlistarray_get_any_as_word); shelve : compiler.
+#[export] Hint Extern 1 (WP_nlet_eq (ListArray.put _ _ _)) =>
+  simple eapply (@compile_sizedlistarray_put_any_as_word); shelve : compiler.
+#[export] Hint Extern 5 (WP_nlet_eq (InlineTable.get _ _)) =>
+  simple eapply @compile_inlinetable_get_any_as_word; shelve : compiler.


### PR DESCRIPTION
The PR is still in a bit of a rough state, but I'm opening it to see if there is interest in adding it.

The Number-Theoretic Transform is a technique to accelerate polynomial multiplications used in recent lattice-based cryptography for PQC.

This PR defines:
- a theory of polynomials and its Chinese Remainder Theorem in `Polynomial.v`
- definition of the NTT in `CyclotomicDecomposition.v` which defines an homomorphism from a type `Pquotl (cyclotomic_decomposition n 0)` to `Pquotl (cyclotomic_decomposition n k)` where `Pquotl ql` is defined as `Pquotl (ql: list P): Type := { pl: list P | List.Forall2 (fun p q => Peq p (Pmod p q)) pl ql }`, and `cyclotomic_decomposition n i` is the i-th layer decomposition of `X^n + 1`. It also defines various optimizations for the NTT.
- lower-level Gallina code of the NTT in `RupicolaNTT.v`
- verified Bedrock2 code in `BedrockNTT.v`, I initially tried to automatically synthesize the code using Rupicola, but ended up doing the proof manually
- Bedrock2 code for Barrett and Montgomery Reduction when the field element fits in one word in `RupicolaBarrettReduction.v` and `RupicolaMontgomeryArithmetic.v`
- examples using all the above to synthesize C code of the (inverse) NTT for MLKEM and MLDSA in `MLKEM.v` and `MLDSA.v`.

I believe the C code should look like what someone would write after reading the NIST standards with no other reference. In terms of performance, this is slower than the handwritten C reference implementations for Kyber/Dilithium which use a so-called centered signed representation for field elements, and delay reduction of the coefficients to the end of the NTT instead of systematically doing it at each step like the synthesised code.