### PR TITLE
Remove --output-sync from build log when make fails

### DIFF
--- a/etc/ci/github-actions-make.sh
+++ b/etc/ci/github-actions-make.sh
@@ -61,7 +61,7 @@ cat time-of-build-pretty.log
 if [ ! -f finished.ok ]; then
     # see https://stackoverflow.com/a/15394738/377022 for more alternatives
     if [[ ! " $* " =~ " validate " ]]; then
-        make "$@" ${OUTPUT_SYNC} TIMED=1 TIMING=1 VERBOSE=1 || exit $?
+        make "$@" TIMED=1 TIMING=1 VERBOSE=1 || exit $?
     else
         exit 1
     fi


### PR DESCRIPTION
This should make it a bit easier to debug cases like https://github.com/mit-plv/fiat-crypto/pull/2009#issuecomment-2627878238