### PR TITLE
Handle rip-relative addressing

### DIFF
--- a/src/Assembly/Equality.v
+++ b/src/Assembly/Equality.v
@@ -102,6 +102,20 @@ Proof. rewrite <- AccessSize_beq_eq; destruct (x =? y)%AccessSize; intuition con
 Global Instance AccessSize_beq_compat : Proper (eq ==> eq ==> eq) AccessSize_beq | 10.
 Proof. repeat intro; subst; reflexivity. Qed.
 
+Declare Scope rip_relative_kind_scope.
+Delimit Scope rip_relative_kind_scope with rip_relative_kind.
+Bind Scope rip_relative_kind_scope with rip_relative_kind.
+
+Infix "=?" := rip_relative_kind_beq : rip_relative_kind_scope.
+
+Global Instance rip_relative_kind_beq_spec : reflect_rel (@eq rip_relative_kind) rip_relative_kind_beq | 10
+  := reflect_of_beq internal_rip_relative_kind_dec_bl internal_rip_relative_kind_dec_lb.
+Definition rip_relative_kind_beq_eq x y : (x =? y)%rip_relative_kind = true <-> x = y := conj (@internal_rip_relative_kind_dec_bl _ _) (@internal_rip_relative_kind_dec_lb _ _).
+Lemma rip_relative_kind_beq_neq x y : (x =? y)%rip_relative_kind = false <-> x <> y.
+Proof. rewrite <- rip_relative_kind_beq_eq; destruct (x =? y)%rip_relative_kind; intuition congruence. Qed.
+Global Instance rip_relative_kind_beq_compat : Proper (eq ==> eq ==> eq) rip_relative_kind_beq | 10.
+Proof. repeat intro; subst; reflexivity. Qed.
+
 Declare Scope MEM_scope.
 Delimit Scope MEM_scope with MEM.
 Bind Scope MEM_scope with MEM.
@@ -111,7 +125,8 @@ Definition MEM_beq (x y : MEM) : bool
       && option_beq String.eqb x.(mem_base_label) y.(mem_base_label)
       && (option_beq REG_beq x.(mem_base_reg) y.(mem_base_reg))
       && (option_beq (prod_beq _ _ Z.eqb REG_beq) x.(mem_scale_reg) y.(mem_scale_reg))
-      && (option_beq Z.eqb x.(mem_offset) y.(mem_offset)))%bool.
+      && (option_beq Z.eqb x.(mem_offset) y.(mem_offset))
+      && (rip_relative_kind_beq x.(rip_relative) y.(rip_relative)))%bool.
 Global Arguments MEM_beq !_ !_ / .
 
 Infix "=?" := MEM_beq : MEM_scope.

--- a/src/Assembly/Syntax.v
+++ b/src/Assembly/Syntax.v
@@ -53,10 +53,21 @@ Coercion bits_of_AccessSize (x : AccessSize) : N
      | qword => 64
      end.
 
-Record MEM := { mem_bits_access_size : option AccessSize ; mem_base_reg : option REG ; mem_scale_reg : option (Z * REG) ; mem_base_label : option string ; mem_offset : option Z }.
+Local Set Boolean Equality Schemes.
+Local Set Decidable Equality Schemes.
+Variant rip_relative_kind := explicitly_rip_relative | implicitly_rip_relative | not_rip_relative.
+Local Unset Boolean Equality Schemes.
+Local Unset Decidable Equality Schemes.
+Global Coercion bool_of_rip_relative_kind (x : rip_relative_kind) : bool :=
+  match x with
+  | explicitly_rip_relative => true
+  | implicitly_rip_relative => true
+  | not_rip_relative => false
+  end.
+Record MEM := { mem_bits_access_size : option AccessSize ; mem_base_reg : option REG ; mem_scale_reg : option (Z * REG) ; mem_base_label : option string ; mem_offset : option Z ; rip_relative : rip_relative_kind }.
 
 Definition mem_of_reg (r : REG) : MEM :=
-  {| mem_base_reg := Some r ; mem_offset := None ; mem_scale_reg := None ; mem_bits_access_size := None ; mem_base_label := None |}.
+  {| mem_base_reg := Some r ; mem_offset := None ; mem_scale_reg := None ; mem_bits_access_size := None ; mem_base_label := None ; rip_relative := not_rip_relative |}.
 
 Inductive FLAG := CF | PF | AF | ZF | SF | OF.
 


### PR DESCRIPTION
The idea to parse `rip` specially rather than as a register is due to @andres-erbsen 

Supersedes #2023
Closes #2023