### PR TITLE
fix: ulimit typo

### DIFF
--- a/etc/ensure_stack_limit.sh
+++ b/etc/ensure_stack_limit.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-recstacksize=66520
+recstacksize=65520
 if command -v ulimit >/dev/null 2>/dev/null; then
     hardstacksize="$(ulimit -H -s || true)"
     (


### PR DESCRIPTION
mac os has a hard limit of `65520` not `66520`
<img width="682" alt="Screenshot 2025-04-24 at 11 56 57 AM" src="https://github.com/user-attachments/assets/7628c6da-9d57-4789-9039-83a795ef62a1" />
