### PR TITLE
[CI] [MacOS] Enable JSOO again

### DIFF
--- a/.github/workflows/coq-macos.yml
+++ b/.github/workflows/coq-macos.yml
@@ -20,7 +20,7 @@ jobs:
         # macOS 12, 13 are x86_64; macOS 14 is arm64
         include:
         - os: { name: 'macOS 13', arch: 'x86_64', runs-on: 'macos-13' }
-          ocaml-compiler: '4.11.1'
+          ocaml-compiler: '4.13.0'
         - os: { name: 'macOS 14', arch: 'arm64' , runs-on: 'macos-14' }
           ocaml-compiler: '4.14.2'
 

--- a/.github/workflows/coq-macos.yml
+++ b/.github/workflows/coq-macos.yml
@@ -71,8 +71,6 @@ jobs:
       run: opam exec -- etc/ci/github-actions-make.sh -j2 pre-standalone-extracted
     - name: all
       run: opam exec -- etc/ci/github-actions-make.sh -j2 all
-      if: ${{ matrix.os.arch != 'arm64' }}
-      # js_of_ocaml is too heavy for M1 GH Action runners which have only 7GB RAM, cf https://github.com/ocsigen/js_of_ocaml/issues/1612, https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
     - run: find . -name "*.timing" | xargs tar -czvf timing-files.tgz
       if: failure()
     - name: upload generated timing files
@@ -85,7 +83,6 @@ jobs:
       run: opam exec -- etc/ci/github-actions-make.sh install-standalone-unified-ocaml BINDIR=dist
     - name: install-standalone-js-of-ocaml
       run: opam exec -- etc/ci/github-actions-make.sh install-standalone-js-of-ocaml
-      if: ${{ matrix.os.arch != 'arm64' }}
     - name: only-test-amd64-files-lite
       run: opam exec -- etc/ci/github-actions-make.sh -j2 only-test-amd64-files-lite SLOWEST_FIRST=1
 

--- a/Makefile.standalone
+++ b/Makefile.standalone
@@ -24,14 +24,27 @@ CAMLOPT_PERF ?= $(OCAMLOPTP)
 CAMLOPT_PERF_SHOW:=OCAMLOPTP
 endif
 CAMLEXTRAFLAGS ?=
+
+JSOO_NO_INLINE?=1
+ifneq ($(JSOO_NO_INLINE),)
+JSOO_NO_INLINE_FLAG ?= --no-inline
+else
+JSOO_NO_INLINE_FLAG ?=
+endif
+EMIT_WAT?=1
+ifneq ($(EMIT_WAT),)
+EMIT_WAT_FLAG ?= --debug wat
+else
+EMIT_WAT_FLAG ?=
+endif
 JS_OF_OCAML ?= js_of_ocaml
 WASM_OF_OCAML ?= wasm_of_ocaml
 STANDALONE_CAMLFLAGS ?= -package unix -w -20 -g $(CAMLEXTRAFLAGS)
 STANDALONE_JS_CAMLFLAGS ?= -package js_of_ocaml $(STANDALONE_CAMLFLAGS)
 JS_OF_OCAML_EXTRAFLAGS ?=
-JS_OF_OCAML_FLAGS ?= --source-map --no-inline --enable=effects $(JS_OF_OCAML_EXTRAFLAGS)
+JS_OF_OCAML_FLAGS ?= --source-map $(JSOO_NO_INLINE_FLAG) --enable=effects $(JS_OF_OCAML_EXTRAFLAGS)
 WASM_OF_OCAML_EXTRAFLAGS ?=
-WASM_OF_OCAML_FLAGS ?= --source-map --no-inline $(WASM_OF_OCAML_EXTRAFLAGS)
+WASM_OF_OCAML_FLAGS ?= --source-map $(JSOO_NO_INLINE_FLAG) $(EMIT_WAT_FLAG) $(WASM_OF_OCAML_EXTRAFLAGS)
 
 PACKAGE ?= standalone.tar.gz
 PACKAGE_CMD ?= tar -czvf
@@ -112,7 +125,10 @@ standalone-haskell: standalone-unified-haskell standalone-separate-haskell
 standalone-unified-haskell: $(UNIFIED_STANDALONE_HASKELL:%=src/ExtractionHaskell/%)
 standalone-separate-haskell: $(SEPARATE_STANDALONE_HASKELL:%=src/ExtractionHaskell/%)
 standalone-js-of-ocaml: $(STANDALONE_JS_OF_OCAML:%=src/ExtractionJsOfOCaml/%.js)
-standalone-wasm-of-ocaml: $(STANDALONE_WASM_OF_OCAML:%=src/ExtractionJsOfOCaml/%.wasm) $(STANDALONE_WASM_OF_OCAML:%=src/ExtractionJsOfOCaml/%.wat.gz)
+standalone-wasm-of-ocaml: $(STANDALONE_WASM_OF_OCAML:%=src/ExtractionJsOfOCaml/%.wasm)
+ifneq ($(EMIT_WAT),)
+standalone-wasm-of-ocaml: $(STANDALONE_WASM_OF_OCAML:%=src/ExtractionJsOfOCaml/%.wat.gz)
+endif
 
 uninstall-standalone-ocaml:: FILESTOINSTALL=$(OCAML_BINARIES)
 uninstall-standalone-unified-ocaml:: FILESTOINSTALL=$(UNIFIED_OCAML_BINARIES)


### PR DESCRIPTION
As per https://github.com/mit-plv/fiat-crypto/commit/4986ba94a6edc20fb09f82d9a1144c922ebd5fa5#r161506462, jsoo.6.1.0 includes significant memory usage improvements, and will hopefully work even work even with M1 GH Action runners which have only 7GB RAM.

cc @hhugo