### PR TITLE
Define Scalars, anybytes using $@ without tuples or ptsto_bytes

### DIFF
--- a/src/Assembly/WithBedrock/Semantics.v
+++ b/src/Assembly/WithBedrock/Semantics.v
@@ -85,7 +85,7 @@ End Byte.
 Require Import coqutil.Word.Interface.
 Require Import coqutil.Map.Interface. (* coercions *)
 Require Import coqutil.Word.LittleEndianList.
-Require Import bedrock2.Memory. Import WithoutTuples.
+Require Import bedrock2.Memory. Import coqutil.Map.Memory.
 Require coqutil.Word.Naive coqutil.Map.SortedListWord.
 Definition mem_state := (SortedListWord.map (Naive.word 64) Byte.byte).
 

--- a/src/Assembly/WithBedrock/SymbolicProofs.v
+++ b/src/Assembly/WithBedrock/SymbolicProofs.v
@@ -19,7 +19,7 @@ Import Sorting.Permutation.
 
 Require Import bedrock2.Map.Separation.
 Require Import bedrock2.Map.SeparationLogic.
-Require Import bedrock2.Memory. Import WithoutTuples.
+Require Import bedrock2.Memory. Import coqutil.Map.Memory.
 Require Import coqutil.Map.Interface. (* coercions *)
 Require Import coqutil.Word.Interface.
 Require Import coqutil.Word.LittleEndianList.

--- a/src/Bedrock/End2End/RupicolaCrypto/Broadcast.v
+++ b/src/Bedrock/End2End/RupicolaCrypto/Broadcast.v
@@ -639,7 +639,7 @@ Section with_parameters.
                                 (expr.op bopname.add a_var
                                                  (expr.op bopname.mul idx_var sz_word)))
                      scratch.
-  Proof using T_Fits_ok locals_ok mem_ok word_ok.
+  Proof using BW T_Fits_ok locals_ok mem_ok word_ok.
     unfold broadcast_expr; intuition idtac.
     repeat straightline.
     exists a_ptr; intuition idtac.
@@ -703,7 +703,7 @@ Section with_parameters.
            (expr.op bopname.add a_var
               (expr.op bopname.mul idx_var sz_word)))
         a_data.
-  Proof using T_Fits_ok locals_ok mem_ok word_ok.
+  Proof using T_Fits_ok locals_ok mem_ok word_ok BW.
     unfold broadcast_expr; intuition idtac.
     repeat straightline.
     exists a_ptr; intuition idtac.
@@ -799,25 +799,11 @@ Section with_parameters.
       reflexivity.
     }
     intros ptr t m.
-    split.
-    {
-      intro H.
-      unfold  truncated_word, truncated_scalar.
-      cbn.
-      rewrite word.unsigned_of_Z_nowrap.
-      rewrite word.byte_of_Z_unsigned.
-      ecancel_assumption.
-      apply byte_in_word_bounds.
-    }
-    {
-      intro H.
-      unfold truncated_word, truncated_scalar in H.
-      cbn in H.
-      rewrite word.unsigned_of_Z_nowrap in H.
-      rewrite word.byte_of_Z_unsigned in H.
-      ecancel_assumption.
-      apply byte_in_word_bounds.
-    }
+    cbv [truncated_word truncated_scalar].
+    simpl le_split.
+    rewrite word.unsigned_of_Z_nowrap, word.byte_of_Z_unsigned by apply byte_in_word_bounds.
+    rewrite OfListWord.map.of_list_word_singleton.
+    split; cbv [sepclause_of_map ptsto] in *; auto.
   Qed.
 
 

--- a/src/Bedrock/Field/Common/Util.v
+++ b/src/Bedrock/Field/Common/Util.v
@@ -675,8 +675,10 @@ Section Scalars.
              (LittleEndianList.le_split (Z.to_nat bytes_per_word)
              (word.unsigned x))).
   Proof.
-    unfold scalar, truncated_word, truncated_scalar, littleendian, ptsto_bytes.ptsto_bytes.
-    rewrite HList.tuple.to_list_of_list; reflexivity.
+    unfold scalar, truncated_word, truncated_scalar.
+    symmetry; eapply array1_iff_eq_of_list_word_at; trivial.
+    rewrite length_le_split.
+    case BW as [ [ -> | -> ] ]; cbv; discriminate.
   Qed.
 
   Lemma truncated_scalar_one_ptsto_iff1 :
@@ -685,8 +687,12 @@ Section Scalars.
         (truncated_scalar access_size.one addr x)
         (ptsto addr (Byte.byte.of_Z x)).
   Proof. intros.
-    unfold scalar, truncated_word, truncated_scalar, littleendian, ptsto_bytes.ptsto_bytes.
-    rewrite HList.tuple.to_list_of_list. unfold Memory.bytes_per, le_split, array.
+    unfold scalar, truncated_word, truncated_scalar.
+    etransitivity. {
+      symmetry; eapply array1_iff_eq_of_list_word_at; trivial.
+      rewrite length_le_split.
+      case BW as [ [ -> | -> ] ]; cbv; discriminate. }
+    unfold Memory.bytes_per, le_split, array.
     cancel.
   Qed.
 

--- a/src/Bedrock/Field/Common/Util.v
+++ b/src/Bedrock/Field/Common/Util.v
@@ -809,20 +809,10 @@ Section WeakestPrecondition.
       forall s (m:mem) a post,
         load s map.empty a post -> load s m a post.
     Proof.
-      intros *.
-      cbv [load Memory.load Memory.load_Z Memory.load_bytes].
-      rewrite getmany_of_tuple_empty; intros;
-        repeat match goal with
-               | H : exists _, _ |- _ => destruct H
-               | H : _ /\ _ |- _ => destruct H
-               | _ => congruence
-               end.
-      cbv [Memory.bytes_per]; break_match; try congruence.
-      change 0%nat with (Z.to_nat 0).
-      pose proof word.width_pos.
-      rewrite Z2Nat.inj_iff by (try apply Z.div_pos; lia).
-      rewrite Z.eq_sym_iff.
-      apply Z.lt_neq, Z.div_str_pos; lia.
+      cbv [load Memory.load Memory.load_Z Map.Memory.load_bytes]; intros *.
+      destruct option_all eqn:E; [exfalso|intros (?&?&?); discriminate].
+      destruct BW as [ [-> | ->] ], s in E;
+        simpl map in E; rewrite ?map.get_empty in E; discriminate.
     Qed.
   End Load.
 

--- a/src/Bedrock/Field/Synthesis/Generic/Bignum.v
+++ b/src/Bedrock/Field/Synthesis/Generic/Bignum.v
@@ -18,7 +18,7 @@ Require Import Crypto.Bedrock.Field.Common.Arrays.ByteBounds.
 Local Open Scope Z_scope.
 
 Section Bignum.
-  Import bedrock2.Memory bedrock2.ptsto_bytes.
+  Import bedrock2.Memory.
   Context  {width} {word : Interface.word width} {mem : map.map word Init.Byte.byte}.
 
   Local Notation k := (bytes_per_word width).

--- a/src/Bedrock/Group/AdditionChains.v
+++ b/src/Bedrock/Group/AdditionChains.v
@@ -585,11 +585,6 @@ Section FElems.
 
         instantiate (2 := pout). instantiate (1 := Rr).
 
-        About fe25519.
-        Print UnOp.
-        Print Build_UnOp.
-        Search UnOp.
-
         eapply H6.
         compile_step.
 


### PR DESCRIPTION
Cc @miriampolzer @lukaszobernig

This is the refactor I was talking about. It's not ready to land quite yet, but Fiat-crypto should build (but untested from clean build). You probably don't want to build on top of this branch, but perhaps it can be useful as a glimpse of things to come.

Key changes;
- [Scalars](https://github.com/mit-plv/bedrock2/compare/7a9231067c4bee29c2a6cd0b868281a28d669019...42910f02a8653edc2e12622079921968e157a7be#diff-ecabcc922edaeb5d11aca7cb817e8a72dc43591edfe439ddd7b0d16d90b568ffR22) are defined using `le_split`
- [Memory.v](https://github.com/mit-plv/bedrock2/compare/7a9231067c4bee29c2a6cd0b868281a28d669019...42910f02a8653edc2e12622079921968e157a7be#diff-11ec9d5dd13b52cadf5ab8a27aa5937c342dbc53d0ac0b8d0d5538de7b3cc7e8) rewritten, including definition of anybytes for stackalloc
- [Array.v](https://github.com/mit-plv/bedrock2/compare/7a9231067c4bee29c2a6cd0b868281a28d669019...42910f02a8653edc2e12622079921968e157a7be#diff-7941c73dfc2c8709ef7b1b31834b8e0543fb6000c5eb63890f9c6ce2ff1cea50) has stronger lemmas

Dependencies
- https://github.com/mit-plv/coqutil/pull/136
- https://github.com/mit-plv/riscv-coq/pull/42
- https://github.com/mit-plv/kami/pull/43
- https://github.com/mit-plv/bedrock2/pull/474
- https://github.com/mit-plv/rupicola/pull/162