### PR TITLE
Disable BoringSSL-integration tests

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -37,7 +37,8 @@ jobs:
       run: make only-test-c-files CC=gcc EXTERNAL_DEPENDENCIES=1
     - name: make only-test-bedrock2-files CC=gcc
       run: make only-test-bedrock2-files CC=gcc EXTERNAL_DEPENDENCIES=1
-    - name: BoringSSL C test
-      run: EXTRA_CFLAGS="" etc/ci/test-fiat-c-boringssl.sh fiat-c/src
-    - name: BoringSSL bedrock2 test
-      run: EXTRA_CFLAGS="$(make bedrock2-extra-cflags SKIP_INCLUDE=1 2>/dev/null)" etc/ci/test-fiat-c-boringssl.sh fiat-bedrock2/src
+# These tests have not been updated to BoringSSL<->FiatCrypto interface changes related to BoringSSL using proven point arithmetic
+#    - name: BoringSSL C test
+#      run: EXTRA_CFLAGS="" etc/ci/test-fiat-c-boringssl.sh fiat-c/src
+#    - name: BoringSSL bedrock2 test
+#      run: EXTRA_CFLAGS="$(make bedrock2-extra-cflags SKIP_INCLUDE=1 2>/dev/null)" etc/ci/test-fiat-c-boringssl.sh fiat-bedrock2/src


### PR DESCRIPTION
We'd like to have them back, but right now they are just failing