### PR TITLE
Reduce function definitions before goal creation

### DIFF
--- a/src/Bedrock/Group/AdditionChains.v
+++ b/src/Bedrock/Group/AdditionChains.v
@@ -625,7 +625,10 @@ Section FElems.
     Require Import Crypto.Spec.Curve25519. *)
     Lemma fe_inv_correct :
       Z.pos M_pos = 2^255-19 ->
-      program_logic_goal_for_function! fe25519_inv.
+      (forall functions : map.rep,
+        map.get functions "fe25519_inv" = Some fe25519_inv ->
+        spec_of_UnOp un_square functions -> spec_of_BinOp bin_mul functions ->
+        spec_of_exp_large functions).
     Proof using ext_spec_ok field_representation_ok locals_ok mem_ok word_ok.
       intros Hm HmPrime ? ** ? **.
       eapply Proper_call; [|eapply fe25519_inv_correct_exp; eauto 1; exact I].

--- a/src/Bedrock/Secp256k1/Addchain.v
+++ b/src/Bedrock/Secp256k1/Addchain.v
@@ -110,7 +110,7 @@ Definition secp256k1_shift x y (n: nat) :=
                                   i = i + $1
                                 })).
 
-Definition secp256k1_inv :=
+Definition secp256k1_inv := Eval cbv in
   func! (z, x) {
     stackalloc 32 as t0;
     stackalloc 32 as t1;


### PR DESCRIPTION
I will change program_logic_goal_for to not reduce functions automatically. Prepare fiat-crypto by removing automatic goal creation or normalizing before calling the goal-creation tactic.

Not blindly calling cbv on function definitions will allow us to use parameterized functions without having to worry about unnecessary slow unfolding.