### PR TITLE
Field ops with map.of_list_word_at precondition

### DIFF
--- a/src/Bedrock/End2End/Poly1305/Field1305.v
+++ b/src/Bedrock/End2End/Poly1305/Field1305.v
@@ -1,6 +1,7 @@
 From Coq Require Import String.
 From Coq Require Import List.
 From Coq Require Import ZArith.
+Require Import Lia.
 Require Import Crypto.Arithmetic.PrimeFieldTheorems.
 Require Import Crypto.Bedrock.Field.Interface.Representation.
 Require Import Crypto.Bedrock.Field.Synthesis.New.ComputedOp.
@@ -31,6 +32,16 @@ Section Field.
          M ((a - F.of_Z _ 2) / F.of_Z _ 4)%F prefix).
   Defined.
 
+  #[export] Instance frep1305 : FieldRepresentation := field_representation n s c.
+
+  #[export] Instance frep1305_ok : FieldRepresentation_ok(field_representation:=frep1305).
+  Proof.
+    apply Crypto.Bedrock.Field.Synthesis.New.Signature.field_representation_ok.
+    apply UnsaturatedSolinas.relax_valid.
+    change felem_size_in_bytes with 20%Z.
+    lia.
+  Qed.
+
   (* Call fiat-crypto pipeline on all field operations *)
   Instance fe1305_ops : unsaturated_solinas_ops n s c.
   Proof using Type. Time constructor; make_computed_op. Defined.
@@ -45,7 +56,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions fe1305_from_bytes ->
                       spec_of_from_bytes
-                        (field_representation:=field_representation n s c)
+                        (field_representation:=frep1305)
                         functions)
          As fe1305_from_bytes_correct.
   Proof. Time derive_bedrock2_func from_bytes_op. Qed.
@@ -54,7 +65,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions fe1305_to_bytes ->
                       spec_of_to_bytes
-                        (field_representation:=field_representation n s c)
+                        (field_representation:=frep1305)
                         functions)
          As fe1305_to_bytes_correct.
   Proof. Time derive_bedrock2_func to_bytes_op. Qed.
@@ -63,7 +74,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions fe1305_mul ->
                       spec_of_BinOp bin_mul
-                        (field_representation:=field_representation n s c)
+                        (field_representation:=frep1305)
                         functions)
          As fe1305_mul_correct.
   Proof. Time derive_bedrock2_func mul_op. Qed.
@@ -72,7 +83,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions fe1305_square ->
                       spec_of_UnOp un_square
-                        (field_representation:=field_representation n s c)
+                        (field_representation:=frep1305)
                         functions)
          As fe1305_square_correct.
   Proof. Time derive_bedrock2_func square_op. Qed.
@@ -81,7 +92,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions fe1305_add ->
                       spec_of_BinOp bin_add
-                        (field_representation:=field_representation n s c)
+                        (field_representation:=frep1305)
                         functions)
          As fe1305_add_correct.
   Proof. Time derive_bedrock2_func add_op. Qed.
@@ -90,7 +101,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions fe1305_carry_add ->
                       spec_of_BinOp bin_carry_add
-                        (field_representation:=field_representation n s c)
+                        (field_representation:=frep1305)
                         (functions))
          As fe1305_carry_add_correct.
   Proof. Time derive_bedrock2_func carry_add_op. Qed.
@@ -99,7 +110,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions fe1305_sub ->
                       spec_of_BinOp bin_sub
-                        (field_representation:=field_representation n s c)
+                        (field_representation:=frep1305)
                         functions)
          As fe1305_sub_correct.
   Proof. Time derive_bedrock2_func sub_op. Qed.
@@ -108,7 +119,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions fe1305_carry_sub ->
                       spec_of_BinOp bin_carry_sub
-                        (field_representation:=field_representation n s c)
+                        (field_representation:=frep1305)
                         (functions))
          As fe1305_carry_sub_correct.
   Proof. Time derive_bedrock2_func carry_sub_op. Qed.

--- a/src/Bedrock/End2End/X25519/Field25519.v
+++ b/src/Bedrock/End2End/X25519/Field25519.v
@@ -42,9 +42,18 @@ Section Field.
   Instance field_parameters : FieldParameters :=
     field_parameters_prefixed Curve25519.p Curve25519.M.a24 "fe25519_"%string.
 
+  #[export] Instance frep25519 : FieldRepresentation := field_representation n s c.
+
   (* Call fiat-crypto pipeline on all field operations *)
   Instance fe25519_ops : unsaturated_solinas_ops (ext_spec:=ext_spec) n s c.
   Proof using Type. Time constructor; make_computed_op. Defined.
+
+  #[export] Instance frep25519_ok : FieldRepresentation_ok(field_representation:=frep25519).
+  Proof.
+    apply Crypto.Bedrock.Field.Synthesis.New.Signature.field_representation_ok.
+    apply UnsaturatedSolinas.relax_valid.
+    change felem_size_in_bytes with 40%Z. Lia.lia.
+  Qed.
 
   (**** Translate each field operation into bedrock2 and apply bedrock2 backend
         field pipeline proofs to prove the bedrock2 functions are correct. ****)
@@ -54,7 +63,7 @@ Section Field.
       Interface.map.get functions "fe25519_from_bytes" = Some fe25519_from_bytes ->
       spec_of_from_bytes
         (ext_spec:=ext_spec)
-        (field_representation:=field_representation n s c)
+        (field_representation:=frep25519)
         functions)
     As fe25519_from_bytes_correct.
   Proof. Time derive_bedrock2_func from_bytes_op. Qed.
@@ -63,7 +72,7 @@ Section Field.
     SuchThat (forall functions,
       Interface.map.get functions "fe25519_to_bytes" = Some fe25519_to_bytes ->
       spec_of_to_bytes
-        (field_representation:=field_representation n s c)
+        (field_representation:=frep25519)
         functions)
     As fe25519_to_bytes_correct.
   Proof. Time derive_bedrock2_func to_bytes_op. Qed.
@@ -72,7 +81,7 @@ Section Field.
     SuchThat (forall functions,
       Interface.map.get functions "fe25519_copy" = Some fe25519_copy ->
       spec_of_felem_copy
-        (field_representation:=field_representation n s c)
+        (field_representation:=frep25519)
         functions)
     As fe25519_copy_correct.
   Proof. Time derive_bedrock2_func felem_copy_op. Qed.
@@ -81,7 +90,7 @@ Section Field.
     SuchThat (forall functions,
       Interface.map.get functions "fe25519_from_word" = Some fe25519_from_word ->
       spec_of_from_word
-        (field_representation:=field_representation n s c)
+        (field_representation:=frep25519)
         functions)
     As fe25519_from_word_correct.
   Proof. Time derive_bedrock2_func from_word_op. Qed.
@@ -90,7 +99,7 @@ Section Field.
     SuchThat (forall functions,
       Interface.map.get functions "fe25519_mul" = Some fe25519_mul ->
       spec_of_BinOp bin_mul
-        (field_representation:=field_representation n s c)
+        (field_representation:=frep25519)
         functions)
     As fe25519_mul_correct.
   Proof. Time derive_bedrock2_func mul_op. Qed.
@@ -99,7 +108,7 @@ Section Field.
     SuchThat (forall functions,
       Interface.map.get functions "fe25519_square" = Some fe25519_square ->
       spec_of_UnOp un_square
-        (field_representation:=field_representation n s c)
+        (field_representation:=frep25519)
         functions)
     As fe25519_square_correct.
   Proof. Time derive_bedrock2_func square_op. Qed.
@@ -108,7 +117,7 @@ Section Field.
     SuchThat (forall functions,
       Interface.map.get functions "fe25519_add" = Some fe25519_add ->
       spec_of_BinOp bin_add
-        (field_representation:=field_representation n s c)
+        (field_representation:=frep25519)
         functions)
     As fe25519_add_correct.
   Proof. Time derive_bedrock2_func add_op. Qed.
@@ -117,7 +126,7 @@ Section Field.
     SuchThat (forall functions,
       Interface.map.get functions "fe25519_carry_add" = Some fe25519_carry_add ->
       spec_of_BinOp bin_carry_add
-        (field_representation:=field_representation n s c)
+        (field_representation:=frep25519)
         functions)
     As fe25519_carry_add_correct.
   Proof. Time derive_bedrock2_func carry_add_op. Qed.
@@ -126,7 +135,7 @@ Section Field.
     SuchThat (forall functions,
       Interface.map.get functions "fe25519_sub" = Some fe25519_sub ->
       spec_of_BinOp bin_sub
-        (field_representation:=field_representation n s c)
+        (field_representation:=frep25519)
         functions)
     As fe25519_sub_correct.
   Proof. Time derive_bedrock2_func sub_op. Qed.
@@ -135,7 +144,7 @@ Section Field.
     SuchThat (forall functions,
       Interface.map.get functions "fe25519_carry_sub" = Some fe25519_carry_sub ->
       spec_of_BinOp bin_carry_sub
-        (field_representation:=field_representation n s c)
+        (field_representation:=frep25519)
         functions)
     As fe25519_carry_sub_correct.
   Proof. Time derive_bedrock2_func carry_sub_op. Qed.
@@ -144,14 +153,8 @@ Section Field.
     SuchThat (forall functions,
       Interface.map.get functions "fe25519_scmula24" = Some fe25519_scmula24 ->
       spec_of_UnOp un_scmula24
-        (field_representation:=field_representation n s c)
+        (field_representation:=frep25519)
         functions)
     As fe25519_scmula24_correct.
   Proof. Time derive_bedrock2_func scmula24_op. Qed.
-
-  #[export] Instance frep25519_ok : FieldRepresentation_ok(field_representation:=field_representation n s c).
-  Proof.
-    apply Crypto.Bedrock.Field.Synthesis.New.Signature.field_representation_ok.
-    apply UnsaturatedSolinas.relax_valid.
-  Qed.
 End Field.

--- a/src/Bedrock/End2End/X25519/GarageDoor.v
+++ b/src/Bedrock/End2End/X25519/GarageDoor.v
@@ -9,7 +9,8 @@ Require Import compiler.Symbols.
 Require Import compiler.MMIO.
 Require Import coqutil.Word.Bitwidth32.
 Require Import Crypto.Arithmetic.PrimeFieldTheorems.
-Require Import Crypto.Bedrock.Field.Interface.Compilation2.
+Require Crypto.Bedrock.End2End.RupicolaCrypto.ChaCha20.
+Require Crypto.Bedrock.End2End.RupicolaCrypto.Spec.
 Require Import Crypto.Bedrock.Field.Synthesis.New.UnsaturatedSolinas.
 Require Import Crypto.Bedrock.Group.AdditionChains.
 Require Import Crypto.Bedrock.Group.ScalarMult.LadderStep.
@@ -23,7 +24,6 @@ Require Import bedrock2Examples.memequal.
 Require Import bedrock2Examples.memswap.
 Require Import bedrock2Examples.memconst.
 Require Import Rupicola.Examples.Net.IPChecksum.IPChecksum.
-Require Crypto.Bedrock.End2End.RupicolaCrypto.ChaCha20.
 
 Local Open Scope string_scope.
 Import Syntax Syntax.Coercions NotationsCustomEntry.
@@ -171,7 +171,6 @@ Proof.
 Qed.
 
 Local Open Scope list_scope.
-Require Crypto.Bedrock.End2End.RupicolaCrypto.Spec.
 Local Definition be2 z := rev (le_split 2 z).
 Local Coercion to_list : tuple >-> list.
 Local Coercion Z.b2z : bool >-> Z.

--- a/src/Bedrock/End2End/X25519/GarageDoorTop.v
+++ b/src/Bedrock/End2End/X25519/GarageDoorTop.v
@@ -9,7 +9,6 @@ Require Import compiler.Symbols.
 Require Import compiler.MMIO.
 Require Import coqutil.Word.Bitwidth32.
 Require Import Crypto.Arithmetic.PrimeFieldTheorems.
-Require Import Crypto.Bedrock.Field.Interface.Compilation2.
 Require Import Crypto.Bedrock.Field.Synthesis.New.UnsaturatedSolinas.
 Require Import Crypto.Bedrock.Group.AdditionChains.
 Require Import Crypto.Bedrock.Group.ScalarMult.LadderStep.

--- a/src/Bedrock/End2End/X25519/MontgomeryLadder.v
+++ b/src/Bedrock/End2End/X25519/MontgomeryLadder.v
@@ -4,6 +4,7 @@ From Coq Require Import ZArith.
 Require Import Crypto.Util.Decidable.
 Require Import Crypto.Spec.MontgomeryCurve.
 Require Import Crypto.Spec.Curve25519.
+Require Import Crypto.Bedrock.Specs.Field.
 Require Import bedrock2.Map.Separation.
 Require Import bedrock2.Syntax.
 Require Import bedrock2Examples.memmove.
@@ -24,7 +25,8 @@ Require Import Crypto.Bedrock.End2End.X25519.clamp.
 Local Open Scope string_scope.
 Import ListNotations.
 
-Local Instance frep25519 : Field.FieldRepresentation(field_parameters:=field_parameters) := field_representation n Field25519.s c.
+Local Existing Instance frep25519.
+Local Existing Instance frep25519_ok.
 Derive ladderstep SuchThat (ladderstep = ladderstep_body) As ladderstep_defn.
 Proof. vm_compute. subst; exact eq_refl. Qed.
 
@@ -100,12 +102,11 @@ Proof.
   straightline_call; ssplit; try ecancel_assumption; repeat straightline; try listZnWords; [].
   straightline_call; ssplit; try ecancel_assumption; repeat straightline; try listZnWords; [].
 
-  seprewrite_in (@Bignum.Bignum_of_bytes _ _ _ _ _ _ 10 a0) H17. { transitivity 40%nat; trivial. }
 
   straightline_call; ssplit.
   { eexists. ecancel_assumption. }
-  { cbv [Field.FElem].
-    use_sep_assumption. cancel. cancel_seps_at_indices 0%nat 0%nat; cbn [seps]; eapply RelationClasses.reflexivity. }
+  { ecancel_assumption_impl. }
+
   { unfold Field.bytes_in_bounds, frep25519, field_representation, Signature.field_representation, Representation.frep.
     match goal with |- ?P ?x ?z => let y := eval cbv in x in change (P y z) end; cbn.
     repeat (destruct p as [|? p]; try (cbn [length] in *;discriminate); []).
@@ -122,11 +123,9 @@ Proof.
   seprewrite_in (@Bignum.Bignum_of_bytes _ _ _ _ _ _ 10 a2) H24. { transitivity 40%nat; trivial. }
 
   straightline_call; ssplit.
-  { unfold FElem, Field.FElem in *; extract_ex1_and_emp_in_goal; ssplit.
-       { use_sep_assumption. cancel; repeat ecancel_step.
-       cancel_seps_at_indices 0%nat 0%nat; trivial. cbn; reflexivity. }
-    all : eauto.
-    { instantiate (1:=None). exact I. } }
+  { unfold FElem in *; extract_ex1_and_emp_in_goal; ssplit; try ecancel_assumption_impl.
+    all: eauto.
+    instantiate (1:=None). exact I. }
   { reflexivity. }
   { rewrite ?length_le_split. vm_compute. inversion 1. }
   repeat straightline.
@@ -151,15 +150,12 @@ Proof.
   repeat straightline.
 
   cbv [Field.FElem] in *.
-  seprewrite_in @Bignum.Bignum_to_bytes H34.
-  seprewrite_in @Bignum.Bignum_to_bytes H34.
-  extract_ex1_and_emp_in H34.
+  repeat seprewrite_in @Bignum.Bignum_to_bytes H32; extract_ex1_and_emp_in H32.
   pose proof length_le_split 32 (Curve25519.clamp (le_combine s)).
-
-  repeat straightline; intuition eauto.
+  repeat straightline.
   cbv [x25519_spec].
   use_sep_assumption; cancel.
-  rewrite H38, le_combine_split.
+  rewrite H36, le_combine_split.
   do 7 Morphisms.f_equiv.
   pose proof clamp_range (le_combine s).
   change (Z.of_nat (Z.to_nat (Z.log2 (Z.pos order)))) with 255.
@@ -173,9 +169,8 @@ Proof.
   straightline_call; ssplit; try ecancel_assumption; repeat straightline; try listZnWords; [].
   straightline_call; ssplit; try ecancel_assumption; repeat straightline; try listZnWords; [].
 
-  seprewrite_in (@Bignum.Bignum_of_bytes _ _ _ _ _ _ 10 a0) H14. { transitivity 40%nat; trivial. }
   straightline_call; ssplit.
-  { cbv [Field.FElem]. cbn. cbv [n]. ecancel_assumption. }
+  { cbv [Field.FElem]. cbn. cbv [n]. ecancel_assumption_impl. }
   repeat straightline.
 
   seprewrite_in (@Bignum.Bignum_of_bytes _ _ _ _ _ _ 10 a2) H21. { transitivity 40%nat; trivial. }
@@ -189,7 +184,7 @@ Proof.
   { reflexivity. }
   { rewrite length_le_split. vm_compute. inversion 1. }
   repeat straightline.
-  unfold FElem in H28. extract_ex1_and_emp_in H28.
+  unfold FElem in H26. extract_ex1_and_emp_in H26.
   straightline_call; ssplit.
   { ecancel_assumption. }
   { transitivity 32%nat; auto. }
@@ -199,15 +194,15 @@ Proof.
   repeat straightline.
 
   cbv [Field.FElem] in *.
-  seprewrite_in @Bignum.Bignum_to_bytes H31.
-  seprewrite_in @Bignum.Bignum_to_bytes H31.
-  extract_ex1_and_emp_in H31.
+  seprewrite_in @Bignum.Bignum_to_bytes H29.
+  seprewrite_in @Bignum.Bignum_to_bytes H29.
+  extract_ex1_and_emp_in H29.
   pose proof length_le_split 32 (Curve25519.clamp (le_combine s)).
 
   repeat straightline; intuition eauto.
   cbv [x25519_spec].
   use_sep_assumption; cancel.
-  rewrite H35, le_combine_split.
+  rewrite H33, le_combine_split.
   do 7 Morphisms.f_equiv.
   pose proof clamp_range (le_combine s).
   change (Z.of_nat (Z.to_nat (Z.log2 (Z.pos order)))) with 255.

--- a/src/Bedrock/End2End/X25519/MontgomeryLadderRISCV.v
+++ b/src/Bedrock/End2End/X25519/MontgomeryLadderRISCV.v
@@ -12,7 +12,6 @@ Require Import Crypto.Arithmetic.PrimeFieldTheorems.
 Require Import Crypto.Bedrock.End2End.X25519.Field25519.
 Require Import Crypto.Bedrock.Field.Synthesis.New.UnsaturatedSolinas.
 Require Import Crypto.Bedrock.Specs.Field.
-Require Import Crypto.Bedrock.Field.Interface.Compilation2.
 Require Import Crypto.Bedrock.Group.ScalarMult.MontgomeryLadder.
 Require Import Crypto.Bedrock.End2End.X25519.MontgomeryLadder.
 

--- a/src/Bedrock/Field/Interface/Representation.v
+++ b/src/Bedrock/Field/Interface/Representation.v
@@ -34,7 +34,6 @@ Section Representation.
             and for word-by-word Montgomery, the argument must be pulled out of the Montgomery domain*)
           (eval_transformation : list Z -> list Z).
 
-
   Definition eval_words : list word -> F M_pos :=
     fun ws =>
       F.of_Z _ (Positional.eval weight n (eval_transformation (map word.unsigned ws))).
@@ -58,6 +57,11 @@ Section Representation.
       tight_bounds := tight_bounds;
     }.
 
+  Context (felem_size_ok : felem_size_in_bytes <= 2 ^ width).
+
   Local Instance frep_ok : FieldRepresentation_ok.
-  Proof. split. cbn [bounded_by frep]; intros. apply relax_bounds; auto. Qed.
+  Proof.
+    split. cbn [bounded_by frep]; intros. apply relax_bounds; auto.
+    apply felem_size_ok.
+  Qed.
 End Representation.

--- a/src/Bedrock/Field/Synthesis/Examples/p224_64_new.v
+++ b/src/Bedrock/Field/Synthesis/Examples/p224_64_new.v
@@ -49,6 +49,23 @@ Section Field.
   Instance p224_ops : @word_by_word_Montgomery_ops from_mont_string to_mont_string _ _ _ _ _ _ _ _ _ _ (WordByWordMontgomery.n m machine_wordsize) m.
   Proof using Type. Time constructor; make_computed_op. Defined.
 
+  Instance frep224 : FieldRepresentation := field_representation m.
+  Instance frep224_raw : FieldRepresentation := field_representation_raw m.
+  Instance frep224_ok : FieldRepresentation_ok (field_representation:=frep224).
+  Proof.
+    apply Crypto.Bedrock.Field.Synthesis.New.Signature.field_representation_ok.
+    intros. assumption.
+    let c := eval lazy in felem_size_in_bytes in change felem_size_in_bytes with c.
+    Lia.lia.
+  Defined.
+  Instance frep224_raw_ok : FieldRepresentation_ok (field_representation:=frep224_raw).
+  Proof.
+    apply Crypto.Bedrock.Field.Synthesis.New.Signature.field_representation_ok.
+    intros. assumption.
+    let c := eval lazy in felem_size_in_bytes in change felem_size_in_bytes with c.
+    Lia.lia.
+  Defined.
+
 
   (**** Translate each field operation into bedrock2 and apply bedrock2 backend
         field pipeline proofs to prove the bedrock2 functions are correct. ****)
@@ -88,6 +105,7 @@ Section Field.
           eapply Func.valid_func_bool_iff;
           abstract vm_cast_no_check (eq_refl true)
         | |- (_ = _)%Z => vm_compute; reflexivity
+        | |- (felem_size_in_bytes <= 2 ^ _)%Z => apply felem_size_ok
         end.
 
   Local Notation functions_contain functions f :=
@@ -97,7 +115,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions p224_from_bytes ->
                       spec_of_from_bytes
-                        (field_representation:=field_representation_raw m)
+                        (field_representation:=frep224_raw)
                         functions)
          As p224_from_bytes_correct.
   Proof. Time derive_bedrock2_func from_bytes_op. Qed.
@@ -106,7 +124,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions p224_to_bytes ->
                       spec_of_to_bytes
-                        (field_representation:=field_representation_raw m)
+                        (field_representation:=frep224_raw)
                         functions)
          As p224_to_bytes_correct.
   Proof. Time derive_bedrock2_func to_bytes_op. Qed.
@@ -115,7 +133,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions p224_mul ->
                       spec_of_BinOp bin_mul
-                        (field_representation:=field_representation m)
+                        (field_representation:=frep224)
                         functions)
          As p224_mul_correct.
   Proof. Time derive_bedrock2_func mul_op. Qed.
@@ -124,7 +142,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions p224_square ->
                       spec_of_UnOp un_square
-                        (field_representation:=field_representation m)
+                        (field_representation:=frep224)
                         functions)
          As p224_square_correct.
   Proof. Time derive_bedrock2_func square_op. Qed.
@@ -133,7 +151,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions p224_add ->
                       spec_of_BinOp bin_add
-                        (field_representation:=field_representation m)
+                        (field_representation:=frep224)
                         functions)
          As p224_add_correct.
   Proof. Time derive_bedrock2_func add_op. Qed.
@@ -142,7 +160,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions p224_sub ->
                       spec_of_BinOp bin_sub
-                        (field_representation:=field_representation m)
+                        (field_representation:=frep224)
                         functions)
          As p224_sub_correct.
   Proof. Time derive_bedrock2_func sub_op. Qed.
@@ -152,13 +170,14 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions p224_from_mont ->
                       spec_of_UnOp un_from_mont
-                        (field_representation:=field_representation m)
+                        (field_representation:=frep224)
                         functions)
          As p224_from_mont_correct.
   Proof.
     epair.
     eapply (from_mont_func_correct _ _ _ from_mont_string to_mont_string).
         - vm_compute; reflexivity.
+        - apply felem_size_ok.
         - eapply Func.valid_func_bool_iff. abstract vm_cast_no_check (eq_refl true).
           Unshelve.
             + auto.
@@ -169,13 +188,14 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions p224_to_mont ->
                       spec_of_UnOp un_to_mont
-                        (field_representation:=field_representation m)
+                        (field_representation:=frep224)
                         functions)
          As to_from_mont_correct.
   Proof.
     epair.
     eapply (to_mont_func_correct _ _ _ from_mont_string to_mont_string).
         - vm_compute; reflexivity.
+        - apply felem_size_ok.
         - eapply Func.valid_func_bool_iff. abstract vm_cast_no_check (eq_refl true).
           Unshelve. all: auto.
      Qed.
@@ -184,13 +204,14 @@ Section Field.
            SuchThat (forall functions,
                       functions_contain functions p224_select_znz ->
                       spec_of_selectznz
-                        (field_representation:=field_representation m)
+                        (field_representation:=frep224)
                         functions)
          As select_znz_correct.
   Proof.
     epair.
     eapply select_znz_func_correct. 1,2:auto.
         - vm_compute; reflexivity.
+        - apply felem_size_ok.
         - eapply Func.valid_func_bool_iff. abstract vm_cast_no_check (eq_refl true).
      Qed.
 End Field.

--- a/src/Bedrock/Field/Synthesis/New/UnsaturatedSolinas.v
+++ b/src/Bedrock/Field/Synthesis/New/UnsaturatedSolinas.v
@@ -2,6 +2,7 @@ From Coq Require Import String.
 From Coq Require Import List.
 From Coq Require Import ZArith.
 Require Import bedrock2.Syntax.
+Require Import coqutil.Map.Interface.
 Require Import Crypto.Arithmetic.Core.
 Require Import Crypto.Spec.ModularArithmetic.
 Require Import Crypto.Arithmetic.ModularArithmeticTheorems.
@@ -111,6 +112,7 @@ Section UnsaturatedSolinas.
           (loose_bounds_tighter_than:
              list_Z_tighter_than (loose_bounds n s c)
                                  (@MaxBounds.max_bounds width n)).
+  Local Open Scope Z_scope.
 
   Context (ops : unsaturated_solinas_ops n s c)
           mul_func add_func carry_add_func sub_func carry_sub_func opp_func square_func
@@ -143,6 +145,7 @@ Section UnsaturatedSolinas.
          (UnsaturatedSolinasHeuristics.tight_bounds n s c)
          (prime_bytes_bounds_value)
          list_Z_bounded_by (fun x => x).
+  Context (felem_size_ok : felem_size_in_bytes <= 2 ^ width).
 
   Local Ltac specialize_correctness_hyp Hcorrect :=
     cbv [feval feval_bytes bounded_by bytes_in_bounds Field.loose_bounds
@@ -321,7 +324,7 @@ Section UnsaturatedSolinas.
     forall functions, Interface.map.get functions mul = Some mul_func ->
                       spec_of_BinOp bin_mul functions.
   Proof using M_eq check_args_ok mul_func_eq ok
-        tight_bounds_tighter_than.
+        tight_bounds_tighter_than felem_size_ok.
     cbv [spec_of_BinOp bin_mul]. rewrite mul_func_eq. intros.
     pose proof carry_mul_correct
          _ _ _ _ _ ltac:(eassumption) _ (res_eq mul_op)
@@ -342,7 +345,7 @@ Section UnsaturatedSolinas.
     forall functions, Interface.map.get functions square = Some square_func ->
                       spec_of_UnOp un_square functions.
   Proof using M_eq check_args_ok ok square_func_eq
-        tight_bounds_tighter_than.
+        tight_bounds_tighter_than felem_size_ok.
     cbv [spec_of_UnOp un_square]. rewrite square_func_eq. intros.
     pose proof carry_square_correct
          _ _ _ _ _ ltac:(eassumption) _ (res_eq square_op)
@@ -362,7 +365,7 @@ Section UnsaturatedSolinas.
     forall functions, Interface.map.get functions Field.add = Some add_func ->
                       spec_of_BinOp bin_add functions.
   Proof using M_eq check_args_ok add_func_eq ok
-        tight_bounds_tighter_than loose_bounds_tighter_than.
+        tight_bounds_tighter_than loose_bounds_tighter_than felem_size_ok.
     cbv [spec_of_BinOp bin_add]. rewrite add_func_eq. intros.
     pose proof add_correct
          _ _ _ _ _ ltac:(eassumption) _ (res_eq add_op)
@@ -383,7 +386,7 @@ Section UnsaturatedSolinas.
     forall functions, Interface.map.get functions Field.carry_add = Some carry_add_func ->
                       spec_of_BinOp bin_carry_add functions.
   Proof using M_eq check_args_ok carry_add_func_eq ok
-        tight_bounds_tighter_than.
+        tight_bounds_tighter_than felem_size_ok.
     cbv [spec_of_BinOp bin_carry_add]. rewrite carry_add_func_eq. intros.
     pose proof carry_add_correct
          _ _ _ _ _ ltac:(eassumption) _ (res_eq carry_add_op)
@@ -404,7 +407,7 @@ Section UnsaturatedSolinas.
     forall functions, Interface.map.get functions Field.sub = Some sub_func ->
                       spec_of_BinOp bin_sub functions.
   Proof using M_eq check_args_ok sub_func_eq ok
-        tight_bounds_tighter_than loose_bounds_tighter_than.
+        tight_bounds_tighter_than loose_bounds_tighter_than felem_size_ok.
     cbv [spec_of_BinOp bin_sub]. rewrite sub_func_eq. intros.
     pose proof sub_correct
          _ _ _ _ _ ltac:(eassumption) _ (res_eq sub_op)
@@ -425,7 +428,7 @@ Section UnsaturatedSolinas.
     forall functions, Interface.map.get functions Field.carry_sub = Some carry_sub_func ->
                       spec_of_BinOp bin_carry_sub functions.
   Proof using M_eq check_args_ok carry_sub_func_eq ok
-        tight_bounds_tighter_than.
+        tight_bounds_tighter_than felem_size_ok.
     cbv [spec_of_BinOp bin_carry_sub]. rewrite carry_sub_func_eq. intros.
     pose proof carry_sub_correct
          _ _ _ _ _ ltac:(eassumption) _ (res_eq carry_sub_op)
@@ -445,7 +448,7 @@ Section UnsaturatedSolinas.
     valid_func (res opp_op _) ->
     forall functions, Interface.map.get functions Field.opp = Some opp_func ->
                       spec_of_UnOp un_opp functions.
-  Proof using M_eq check_args_ok loose_bounds_tighter_than opp_func_eq ok.
+  Proof using M_eq check_args_ok loose_bounds_tighter_than opp_func_eq ok felem_size_ok.
     cbv [spec_of_UnOp un_opp]. rewrite opp_func_eq. intros.
     pose proof opp_correct
          _ _ _ _ _ ltac:(eassumption) _ (res_eq opp_op)
@@ -466,7 +469,7 @@ Section UnsaturatedSolinas.
     forall functions, Interface.map.get functions scmula24 = Some scmula24_func ->
                       spec_of_UnOp un_scmula24 functions.
   Proof using M_eq check_args_ok ok scmula24_func_eq
-        tight_bounds_tighter_than.
+        tight_bounds_tighter_than felem_size_ok.
     cbv [spec_of_UnOp un_scmula24]. rewrite scmula24_func_eq. intros.
     pose proof carry_scmul_const_correct
          _ _ _ _ _ (ltac:(eassumption)) (F.to_Z a24) _
@@ -501,11 +504,8 @@ Section UnsaturatedSolinas.
     forall functions, Interface.map.get functions felem_copy = Some felem_copy_func ->
                       spec_of_felem_copy functions.
   Proof using M_eq check_args_ok ok felem_copy_func_eq
-        tight_bounds_tighter_than parameters_sentinel ok
-to_bytes_func_eq to_bytes_func sub_func_eq sub_func square_func_eq
-square_func scmula24_func_eq scmula24_func opp_func_eq opp_func mul_func_eq
-mul_func loose_bounds_tighter_than from_word_func_eq from_word_func
-from_bytes_func_eq from_bytes_func add_func_eq.
+        tight_bounds_tighter_than loose_bounds_tighter_than
+        parameters_sentinel felem_size_ok.
     cbv [spec_of_felem_copy]. rewrite felem_copy_func_eq. intros.
     pose proof copy_correct _ _ _ _ _ ltac:(eassumption) _ (res_eq felem_copy_op)
       as Hcorrect.
@@ -526,7 +526,7 @@ from_bytes_func_eq from_bytes_func add_func_eq.
     forall functions, Interface.map.get functions from_word = Some from_word_func ->
                       spec_of_from_word functions.
   Proof using M_eq check_args_ok from_word_func_eq ok
-        tight_bounds_tighter_than.
+        tight_bounds_tighter_than felem_size_ok.
     cbv [spec_of_from_word]. rewrite from_word_func_eq. intros.
     epose proof encode_word_correct _ _ _ _ _ ltac:(eassumption) _ (res_eq from_word_op)
       as Hcorrect.
@@ -568,7 +568,7 @@ from_bytes_func_eq from_bytes_func add_func_eq.
       Interface.map.get functions Field.from_bytes = Some from_bytes_func ->
       spec_of_from_bytes functions.
   Proof using M_eq check_args_ok from_bytes_func_eq ok
-        tight_bounds_tighter_than.
+        tight_bounds_tighter_than felem_size_ok.
     cbv [spec_of_from_bytes]. rewrite from_bytes_func_eq. intros.
     pose proof UnsaturatedSolinas.from_bytes_correct
          _ _ _ _ _ ltac:(eassumption) _ (res_eq from_bytes_op) (eq_refl true)
@@ -694,6 +694,7 @@ Ltac derive_bedrock2_func op :=
     abstract vm_cast_no_check (eq_refl true)
   | |- _ = m _ _ => vm_compute; reflexivity
   | |- _ = default_varname_gen => vm_compute; reflexivity
+  | |- (felem_size_in_bytes <= 2 ^ _)%Z => apply felem_size_ok
   end.
 
 (*

--- a/src/Bedrock/Field/Synthesis/New/WordByWordMontgomery.v
+++ b/src/Bedrock/Field/Synthesis/New/WordByWordMontgomery.v
@@ -214,6 +214,8 @@ Section WordByWordMontgomery.
          bytelist
          list_in_bounds eval_trans.
 
+  Context (felem_size_ok : (felem_size_in_bytes <= 2 ^ width)%Z).
+
   Local Ltac specialize_correctness_hyp Hcorrect :=
     cbv [feval feval_bytes bounded_by bytes_in_bounds Field.loose_bounds
                field_representation Signature.field_representation
@@ -339,8 +341,7 @@ Qed.
     valid_func (res mul_op _) ->
     forall functions, Interface.map.get functions Field.mul = Some mul_func ->
                       spec_of_BinOp bin_mul functions.
-  Proof using M_eq check_args_ok mul_func_eq ok.
-        (* tight_bounds_tighter_than. *)
+  Proof using M_eq check_args_ok mul_func_eq ok felem_size_ok.
     cbv [spec_of_BinOp bin_mul]. rewrite mul_func_eq. intros.
     pose proof mul_correct
          m width _ ltac:(eassumption) _ (res_eq mul_op)
@@ -372,7 +373,7 @@ Qed.
     valid_func (res square_op _) ->
     forall functions, Interface.map.get functions Field.square = Some square_func ->
                       spec_of_UnOp un_square functions.
-  Proof using M_eq check_args_ok ok square_func_eq.
+  Proof using M_eq check_args_ok ok square_func_eq felem_size_ok.
     cbv [spec_of_UnOp un_square]. rewrite square_func_eq. intros.
     pose proof square_correct
          _ _ _ ltac:(eassumption) _ (res_eq square_op)
@@ -405,7 +406,7 @@ Qed.
     valid_func (res add_op _) ->
     forall functions, Interface.map.get functions Field.add = Some add_func ->
                       spec_of_BinOp bin_add functions.
-  Proof using M_eq check_args_ok add_func_eq ok.
+  Proof using M_eq check_args_ok add_func_eq ok felem_size_ok.
     cbv [spec_of_BinOp bin_add]. rewrite add_func_eq. intros.
     pose proof add_correct
          _ _ _ ltac:(eassumption) _ (res_eq add_op)
@@ -437,7 +438,7 @@ Qed.
     valid_func (res sub_op _) ->
     forall functions, Interface.map.get functions Field.sub = Some sub_func ->
                       spec_of_BinOp bin_sub functions.
-  Proof using M_eq check_args_ok sub_func_eq ok.
+  Proof using M_eq check_args_ok sub_func_eq ok felem_size_ok.
     cbv [spec_of_BinOp bin_sub]. rewrite sub_func_eq. intros.
     pose proof sub_correct
          _ _ _ ltac:(eassumption) _ (res_eq sub_op)
@@ -468,7 +469,7 @@ Qed.
     valid_func (res opp_op _) ->
     forall functions, Interface.map.get functions Field.opp = Some opp_func ->
                       spec_of_UnOp un_opp functions.
-  Proof using M_eq check_args_ok opp_func_eq ok.
+  Proof using M_eq check_args_ok opp_func_eq ok felem_size_ok.
     cbv [spec_of_UnOp un_opp]. rewrite opp_func_eq. intros.
     pose proof opp_correct
          _ _ _ ltac:(eassumption) _ (res_eq opp_op)
@@ -515,7 +516,7 @@ Qed.
     forall functions,
       Interface.map.get functions Field.felem_copy = Some felem_copy_func ->
       (@spec_of_felem_copy _ _ _ _ _ _ _ field_representation_raw) functions.
-  Proof using M_eq check_args_ok felem_copy_func_eq ok.
+  Proof using M_eq check_args_ok felem_copy_func_eq ok felem_size_ok.
     cbv [spec_of_felem_copy]. rewrite felem_copy_func_eq. intros.
     pose proof copy_correct
          _ _ _ ltac:(eassumption) _ (res_eq felem_copy_op)
@@ -537,7 +538,7 @@ Qed.
     forall functions,
       Interface.map.get functions Field.from_bytes = Some from_bytes_func ->
       (@spec_of_from_bytes _ _ _ _ _ _ _ field_representation_raw) functions.
-  Proof using M_eq check_args_ok from_bytes_func_eq ok.
+  Proof using M_eq check_args_ok from_bytes_func_eq ok felem_size_ok.
     cbv [spec_of_from_bytes]. rewrite from_bytes_func_eq. intros.
     pose proof from_bytes_correct
          _ _ _ ltac:(eassumption) _ (res_eq from_bytes_op)
@@ -668,7 +669,7 @@ Qed.
   forall functions,
     Interface.map.get functions from_mont = Some from_mont_func ->
     (@spec_of_UnOp _ _ _ _ _ _ _ _ from_mont) un_from_mont functions.
-    Proof using M_eq check_args_ok ok from_mont_func_eq.
+    Proof using M_eq check_args_ok ok from_mont_func_eq felem_size_ok.
     clear field_parameters_ok.
     cbv [spec_of_UnOp un_from_mont]. rewrite from_mont_func_eq. intros.
     pose proof from_montgomery_correct
@@ -710,7 +711,7 @@ Qed.
   forall functions,
     Interface.map.get functions to_mont = Some to_mont_func ->
     (@spec_of_UnOp _ _ _ _ _ _ _ _ to_mont) un_to_mont functions.
-    Proof using M_eq check_args_ok ok to_mont_func_eq.
+    Proof using M_eq check_args_ok ok to_mont_func_eq felem_size_ok.
     cbv [spec_of_UnOp un_to_mont]. rewrite to_mont_func_eq. intros ? ? GetF.
     pose proof to_montgomery_correct
         _ _ _ ltac:(eassumption) _ (res_eq to_mont_op)
@@ -765,7 +766,7 @@ Qed.
   valid_func (res select_znz_op _) ->
   forall functions, Interface.map.get functions select_znz = Some select_znz_func ->
                     spec_of_selectznz functions.
-Proof using M_eq check_args_ok select_znz_func_eq ok.
+Proof using M_eq check_args_ok select_znz_func_eq ok felem_size_ok.
   cbv [spec_of_selectznz]. rewrite select_znz_func_eq. intros ? ? GetF * HH.
   rename x into x', y into y'.
   pose proof selectznz_correct
@@ -775,7 +776,7 @@ Proof using M_eq check_args_ok select_znz_func_eq ok.
     [ .. | eassumption | eassumption ];
     handle_side_conditions. intros x y c H0 H1 H2.
     unfold COperationSpecifications.WordByWordMontgomery.selectznz_correct in Hcorrect.
-    edestruct (bit_range_eq 1 (fun n => 1%Z) _ H2) as [Hbit | Hbit].
+    edestruct (@bit_range_eq 1 (Interface.word.unsigned c) H2) as [Hbit | Hbit].
     - specialize (Hcorrect (Interface.word.unsigned c) (map Interface.word.unsigned x) (map Interface.word.unsigned y) H2 ltac:(eauto) ltac:(eauto)).
       destruct Hcorrect as [H4 H5]. rewrite Hbit in H4. simpl in H4. rewrite Hbit. simpl. auto.
     - specialize (Hcorrect (Interface.word.unsigned c) (map Interface.word.unsigned x) (map Interface.word.unsigned y) H2 ltac:(eauto) ltac:(eauto)).

--- a/src/Bedrock/Secp256k1/Field256k1.v
+++ b/src/Bedrock/Secp256k1/Field256k1.v
@@ -30,6 +30,8 @@ Section Field.
          M ((a + F.of_Z _ 2) / F.of_Z _ 4)%F prefix).
   Defined.
 
+  #[export] Instance frep256k1 : Field.FieldRepresentation := field_representation m.
+
   Definition to_mont_string := (prefix ++ "to_mont")%string.
   Definition from_mont_string := (prefix ++ "from_mont")%string.
 
@@ -78,16 +80,34 @@ Section Field.
         eapply Func.valid_func_bool_iff;
         abstract vm_cast_no_check (eq_refl true)
     | |- (_ = _)%Z => vm_compute; reflexivity
+    | |- (felem_size_in_bytes <= 2 ^ _)%Z => apply felem_size_ok
     end.
 
   Local Notation functions_contain functions f :=
     (Interface.map.get functions (fst f) = Some (snd f)).
 
+  #[export] Instance frep256k1_raw : FieldRepresentation := field_representation_raw m.
+  #[export] Instance frep256k1_raw_ok : FieldRepresentation_ok (field_representation:=frep256k1_raw).
+  Proof.
+    apply Crypto.Bedrock.Field.Synthesis.New.Signature.field_representation_ok.
+    auto.
+    let sz := eval lazy in felem_size_in_bytes in change felem_size_in_bytes with sz.
+    Lia.lia.
+  Qed.
+
+  #[export] Instance frep256k1_ok : FieldRepresentation_ok(field_representation:=frep256k1).
+  Proof.
+    apply Crypto.Bedrock.Field.Synthesis.New.Signature.field_representation_ok.
+    auto.
+    let sz := eval lazy in felem_size_in_bytes in change felem_size_in_bytes with sz.
+    Lia.lia.
+  Qed.
+
   Derive secp256k1_felem_copy
          SuchThat (forall functions,
                       functions_contain functions secp256k1_felem_copy ->
                       spec_of_felem_copy
-                        (field_representation:=field_representation_raw m)
+                        (field_representation:=frep256k1_raw)
                         functions)
          As secp256k1_felem_copy_correct.
   Proof. Time derive_bedrock2_func felem_copy_op. Qed.
@@ -96,7 +116,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions secp256k1_from_bytes ->
                       spec_of_from_bytes
-                        (field_representation:=field_representation_raw m)
+                        (field_representation:=frep256k1_raw)
                         functions)
          As secp256k1_from_bytes_correct.
   Proof. Time derive_bedrock2_func from_bytes_op. Qed.
@@ -105,7 +125,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions secp256k1_to_bytes ->
                       spec_of_to_bytes
-                        (field_representation:=field_representation_raw m)
+                        (field_representation:=frep256k1_raw)
                         functions)
          As secp256k1_to_bytes_correct.
   Proof. Time derive_bedrock2_func to_bytes_op. Qed.
@@ -114,7 +134,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions secp256k1_opp ->
                       spec_of_UnOp un_opp
-                        (field_representation:=field_representation m)
+                        (field_representation:=frep256k1)
                         functions)
          As secp256k1_opp_correct.
   Proof. Time derive_bedrock2_func opp_op. Qed.
@@ -123,7 +143,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions secp256k1_mul ->
                       spec_of_BinOp bin_mul
-                        (field_representation:=field_representation m)
+                        (field_representation:=frep256k1)
                         functions)
          As secp256k1_mul_correct.
   Proof. Time derive_bedrock2_func mul_op. Qed.
@@ -132,7 +152,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions secp256k1_square ->
                       spec_of_UnOp un_square
-                        (field_representation:=field_representation m)
+                        (field_representation:=frep256k1)
                         functions)
          As secp256k1_square_correct.
   Proof. Time derive_bedrock2_func square_op. Qed.
@@ -141,7 +161,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions secp256k1_add ->
                       spec_of_BinOp bin_add
-                        (field_representation:=field_representation m)
+                        (field_representation:=frep256k1)
                         functions)
          As secp256k1_add_correct.
   Proof. Time derive_bedrock2_func add_op. Qed.
@@ -150,7 +170,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions secp256k1_sub ->
                       spec_of_BinOp bin_sub
-                        (field_representation:=field_representation m)
+                        (field_representation:=frep256k1)
                         functions)
          As secp256k1_sub_correct.
   Proof. Time derive_bedrock2_func sub_op. Qed.
@@ -159,7 +179,7 @@ Section Field.
            SuchThat (forall functions,
                       functions_contain functions secp256k1_select_znz ->
                       spec_of_selectznz
-                        (field_representation:=field_representation m)
+                        (field_representation:=frep256k1)
                         functions)
          As secp256k1_select_znz_correct.
   Proof. Time derive_bedrock2_func select_znz_op. Qed.
@@ -168,7 +188,7 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions secp256k1_from_mont ->
                       spec_of_UnOp un_from_mont
-                        (field_representation:=field_representation m)
+                        (field_representation:=frep256k1)
                         functions)
          As secp256k1_from_mont_correct.
   Proof. Time derive_bedrock2_func from_mont_op. Unshelve. 1,2: auto. Qed.
@@ -177,16 +197,10 @@ Section Field.
          SuchThat (forall functions,
                       functions_contain functions secp256k1_to_mont ->
                       spec_of_UnOp un_to_mont
-                        (field_representation:=field_representation m)
+                        (field_representation:=frep256k1)
                         functions)
          As secp256k1_to_mont_correct.
   Proof. Time derive_bedrock2_func to_mont_op. Unshelve. 1,2: auto. Qed.
-
-  #[export] Instance frep256k1_ok : FieldRepresentation_ok(field_representation:=field_representation m).
-  Proof.
-    apply Crypto.Bedrock.Field.Synthesis.New.Signature.field_representation_ok.
-    auto.
-  Qed.
 End Field.
 
 (* Require Import bedrock2.Syntax. *)

--- a/src/Bedrock/Secp256k1/JacobianCoZ.v
+++ b/src/Bedrock/Secp256k1/JacobianCoZ.v
@@ -25,7 +25,6 @@ Require Import Coq.Lists.List.
 Require Import Coq.Strings.String.
 Require Import Coq.ZArith.ZArith.
 Require Import Crypto.Arithmetic.PrimeFieldTheorems.
-Require Import Crypto.Bedrock.Field.Interface.Compilation2.
 Require Import Crypto.Bedrock.Field.Synthesis.New.WordByWordMontgomery.
 Require Import Crypto.Bedrock.Group.ScalarMult.CSwap.
 Require Import Crypto.Bedrock.Secp256k1.Field256k1.
@@ -44,7 +43,7 @@ Import WeakestPrecondition.
 Import BasicC64Semantics.
 
 Local Existing Instance field_parameters.
-Local Instance frep256k1 : Field.FieldRepresentation := field_representation Field256k1.m.
+Local Existing Instance frep256k1.
 Local Existing Instance frep256k1_ok.
 
 Definition secp256k1_jopp :=
@@ -493,7 +492,7 @@ Section WithParameters.
   Local Ltac solve_mem :=
     repeat match goal with
       | |- exists _ : _ -> Prop, _%sep _ => eexists
-      | |- _%sep _ => ecancel_assumption
+      | |- _%sep _ => ecancel_assumption_impl
       end.
 
   Local Ltac cbv_bounds H :=
@@ -634,22 +633,7 @@ Section WithParameters.
   Lemma secp256k1_dblu_ok: program_logic_goal_for_function! secp256k1_dblu.
   Proof.
     Strategy -1000 [un_xbounds bin_xbounds bin_ybounds un_square bin_mul bin_add bin_carry_add bin_sub un_outbounds bin_outbounds].
-
-    do 9 single_step.
-    single_step.
-    seprewrite_in (Bignum.Bignum_of_bytes 4 a4) H72; [ trivial |  ];
-    multimatch goal with
-    | |- _ ?m1 =>
-        multimatch goal with
-        | H:_ ?m2
-          |- _ =>
-            syntactic_unify._syntactic_unify_deltavar m1 m2;
-            refine (Lift1Prop.subrelation_iff1_impl1 _ _ _ _ _ H); clear H
-        end
-    end; cancel; repeat ecancel_step; cancel_seps_at_indices 0%nat 0%nat;
-    [ reflexivity |  ]; (solve [ ecancel ]).
-    do 11 single_step.
-    do 4 single_step.
+    repeat single_step.
 
     repeat straightline.
     cbv [FElem] in *.

--- a/src/Bedrock/Secp256k1/JoyeLadder.v
+++ b/src/Bedrock/Secp256k1/JoyeLadder.v
@@ -25,7 +25,6 @@ Require Import Coq.Lists.List.
 Require Import Coq.Strings.String.
 Require Import Coq.ZArith.ZArith.
 Require Import Crypto.Arithmetic.PrimeFieldTheorems.
-Require Import Crypto.Bedrock.Field.Interface.Compilation2.
 Require Import Crypto.Bedrock.Field.Synthesis.New.WordByWordMontgomery.
 Require Import Crypto.Bedrock.Group.ScalarMult.CSwap.
 Require Import Crypto.Bedrock.Secp256k1.Field256k1.
@@ -46,7 +45,7 @@ Import ProgramLogic.Coercions.
 Import WeakestPrecondition.
 
 Local Existing Instance field_parameters.
-Local Instance frep256k1 : Field.FieldRepresentation := field_representation Field256k1.m.
+Local Existing Instance frep256k1.
 Local Existing Instance frep256k1_ok.
 
 Section WithParameters.
@@ -137,7 +136,7 @@ Section WithParameters.
   Local Ltac solve_mem :=
     repeat match goal with
       | |- exists _ : _ -> Prop, _%sep _ => eexists
-      | |- _%sep _ => ecancel_assumption
+      | |- _%sep _ => ecancel_assumption_impl
       end.
 
   Local Ltac cbv_bounds H :=
@@ -463,7 +462,7 @@ Section WithParameters.
     straightline_call; ssplit.
     destruct (xorb _ _); simpl; auto.
     rewrite <- Bignum_as_array. unfold FElem in Hmem.
-    ecancel_assumption. repeat straightline.
+    ecancel_assumption_impl. repeat straightline.
     eexists. split. repeat straightline.
     eexists; split. apply map.get_put_same.
     repeat straightline. eexists; split.
@@ -476,7 +475,7 @@ Section WithParameters.
     cbv [dlet.dlet] in H26.
     straightline_call; ssplit.
     destruct (xorb _ _); auto.
-    rewrite <- Bignum_as_array. ecancel_assumption.
+    rewrite <- Bignum_as_array. ecancel_assumption_impl.
     repeat straightline.
     cbv [dlet.dlet] in H27.
     assert (Hlen: forall ptr v m R, (FElem ptr v * R)%sep m -> Datatypes.length v = felem_size_in_words).
@@ -497,7 +496,7 @@ Section WithParameters.
     eexists; split.
     repeat (repeat straightline; eexists; split; [unfold l; repeat rewrite map.get_put_diff by congruence; rewrite Hloc' by congruence; eassumption|]).
     repeat straightline. straightline_call; ssplit.
-    8: unfold Field.FElem; ecancel_assumption_impl.
+    8: unfold FElem; ecancel_assumption_impl.
     instantiate (1 := if xorb (snd (fst iter_res)) (Z.testbit k vi) then R0' else R1').
     destruct (xorb _ _); [exact Hproj0|exact Hproj1].
     instantiate (1 := if xorb (snd (fst iter_res)) (Z.testbit k vi) then R1' else R0').
@@ -535,7 +534,7 @@ Section WithParameters.
     1-5: solve_bounds.
     rewrite (surjective_pairing (proj1_sig _)).
     rewrite proj1_sig_zdau_co_z_points.
-    unfold JacobianCoZ.frep256k1 in H28, H29.
+    unfold frep256k1 in H28, H29.
     unfold frep256k1. rewrite <- H28, <- H29.
     rewrite <- (surjective_pairing (Jacobian.zdau _ _ _)).
     split; repeat f_equal; apply zdau_eq; rewrite proj1_sig_cswap_co_z_points; reflexivity.
@@ -574,7 +573,7 @@ Section WithParameters.
     cbn [proj1_sig]. rewrite H15. eexists. reflexivity.
     1-2: solve_bounds.
     repeat match goal with
-    | H: context [Array.array ptsto _ ?a _] |- context [Field.FElem ?a _] =>
+    | H: context [Array.array ptsto _ ?a _] |- context [FElem ?a _] =>
         seprewrite_in (@Bignum.Bignum_of_bytes _ _ _ _ _ _ 4 a) H; [trivial|]
     end.
     multimatch goal with
@@ -586,13 +585,12 @@ Section WithParameters.
             refine (Lift1Prop.subrelation_iff1_impl1 _ _ _ _ _ H); clear H
         end
     end.
+    cbv [FElem].
     cancel. cancel_seps_at_indices 0%nat 4%nat; [reflexivity|].
     cancel_seps_at_indices 0%nat 3%nat; [reflexivity|].
     cancel_seps_at_indices 0%nat 2%nat; [reflexivity|].
     cancel_seps_at_indices 0%nat 1%nat; [reflexivity|].
     cancel_seps_at_indices 0%nat 0%nat; [reflexivity|].
-    cancel_seps_at_indices 3%nat 0%nat; [reflexivity|].
-    cancel_seps_at_indices 3%nat 0%nat; [reflexivity|].
     ecancel.
 
     repeat straightline.
@@ -614,7 +612,7 @@ Section WithParameters.
     eexists; ssplit; [unfold loc'0; repeat rewrite map.get_put_diff by congruence; rewrite H46|]; repeat straightline. congruence.
 
     single_step. rewrite Core.word.b2w_if; destruct vswap; auto.
-    rewrite <- Bignum_as_array. unfold FElem in H56. ecancel_assumption.
+    rewrite <- Bignum_as_array. unfold FElem in H56. ecancel_assumption_impl.
     repeat straightline. red in H64.
     assert (Hlen: forall ptr v m R, (FElem ptr v * R)%sep m -> Datatypes.length v = felem_size_in_words).
     { unfold FElem. rewrite Bignum_as_array.
@@ -634,7 +632,7 @@ Section WithParameters.
     eexists; ssplit; [unfold loc'0; repeat rewrite map.get_put_diff by congruence; rewrite H46|]; repeat straightline. congruence.
 
     single_step. rewrite Core.word.b2w_if; destruct vswap; auto.
-    rewrite <- Bignum_as_array. ecancel_assumption.
+    rewrite <- Bignum_as_array. ecancel_assumption_impl.
     repeat straightline. red in H65.
     rewrite cswap_low_combine_eq in H65 by (repeat erewrite Hlen by ecancel_assumption; reflexivity).
     rewrite cswap_combine_eq in H65.
@@ -673,7 +671,7 @@ Section WithParameters.
     rewrite H15. reflexivity.
     1-3:solve_bounds.
     repeat match goal with
-    | H: context [Array.array ptsto _ ?a _] |- context [Field.FElem ?a _] =>
+    | H: context [Array.array ptsto _ ?a _] |- context [FElem ?a _] =>
         seprewrite_in (@Bignum.Bignum_of_bytes _ _ _ _ _ _ 4 a) H; [trivial|]
     end.
     multimatch goal with
@@ -698,8 +696,6 @@ Section WithParameters.
     eexists; ssplit. apply map.get_put_same. repeat straightline.
     eexists; ssplit; [apply map.get_put_same|]; repeat straightline.
     single_step.
-    2-3: ecancel_assumption_impl.
-    solve_bounds.
     repeat straightline.
     eexists; split. unfold l9, l8, loc'0.
     repeat (repeat straightline; eexists; ssplit; [repeat (rewrite map.get_put_diff by congruence); rewrite H46; repeat straightline; congruence|]).
@@ -726,12 +722,12 @@ Section WithParameters.
     instantiate (1:=Jacobian.opp (snd (Jacobian.make_co_z (if vswap then R1' else R0') (Jacobian.of_affine P) HPaff))).
     unfold Jacobian.opp.
     cbv [proj1_sig]. cbv [proj1_sig] in H75. rewrite H75.
-    unfold JacobianCoZ.frep256k1. unfold frep256k1 in H79.
+    unfold frep256k1. unfold frep256k1 in H79.
     rewrite H79. reflexivity.
     1-2: destruct vswap; solve_bounds.
     1-3: solve_bounds.
     repeat match goal with
-    | H: context [Array.array ptsto _ ?a _] |- context [Field.FElem ?a _] =>
+    | H: context [Array.array ptsto _ ?a _] |- context [FElem ?a _] =>
         seprewrite_in (@Bignum.Bignum_of_bytes _ _ _ _ _ _ 4 a) H; [trivial|]
     end.
     multimatch goal with
@@ -742,15 +738,14 @@ Section WithParameters.
             syntactic_unify._syntactic_unify_deltavar m1 m2;
             refine (Lift1Prop.subrelation_iff1_impl1 _ _ _ _ _ H); clear H
         end
-    end.
-    cancel. cancel_seps_at_indices 9%nat 0%nat; [reflexivity|].
-    cancel_seps_at_indices 9%nat 0%nat; [reflexivity|].
-    cancel_seps_at_indices 7%nat 0%nat; [reflexivity|].
-    cancel_seps_at_indices 5%nat 0%nat; [reflexivity|].
-    cancel_seps_at_indices 0%nat 0%nat; [reflexivity|].
+    end. fold FElem in *.
+    cancel. cancel_seps_at_indices 8%nat 0%nat; [reflexivity|].
+    cancel_seps_at_indices 8%nat 0%nat; [reflexivity|].
+    cancel_seps_at_indices 6%nat 0%nat; [reflexivity|].
     cancel_seps_at_indices 4%nat 0%nat; [reflexivity|].
-    cancel_seps_at_indices 3%nat 0%nat; [reflexivity|].
     cancel_seps_at_indices 0%nat 0%nat; [reflexivity|].
+    cancel_seps_at_indices 3%nat 0%nat; [reflexivity|].
+    cancel_seps_at_indices 2%nat 0%nat; [reflexivity|].
     ecancel.
     instantiate (1:=Hzaddu_ob) in H73.
     repeat first [match goal with | |- cmd _ bedrock_func_body:($_ = load1(coq:(expr.var "k") + coq:(expr.var "i") >> coq:(expr.literal 3)) >> (coq:(expr.var "i") & coq:(expr.literal 7)) & coq:(expr.literal 1)) _ _ _ _ => idtac end |straightline].
@@ -773,7 +768,7 @@ Section WithParameters.
     single_step.
     rewrite Core.word.b2w_if; destruct (Z.testbit k 0); auto.
     rewrite <- Bignum_as_array.
-    unfold Field.FElem in H89. ecancel_assumption_impl.
+    unfold FElem in H89. ecancel_assumption_impl.
     repeat straightline. red in H90.
     rewrite <- Bignum_as_array in H90.
     rewrite cswap_low_combine_eq in H90 by (repeat erewrite Hlen by ecancel_assumption_impl; reflexivity).
@@ -797,7 +792,7 @@ Section WithParameters.
     single_step.
     destruct (Z.testbit k 0); cbv; auto.
     rewrite <- Bignum_as_array.
-    unfold Field.FElem in H90. ecancel_assumption_impl.
+    unfold FElem in H90. ecancel_assumption_impl.
     repeat straightline. red in H91.
     rewrite <- Bignum_as_array in H91.
     rewrite cswap_low_combine_eq in H91 by (repeat erewrite Hlen by ecancel_assumption_impl; reflexivity).
@@ -817,7 +812,7 @@ Section WithParameters.
     rewrite H46 by congruence. reflexivity.
     repeat straightline.
     single_step.
-    3: unfold Field.FElem; ecancel_assumption_impl.
+    3: { fold FElem in H91. ecancel_assumption_impl. }
     reflexivity. solve_bounds.
     repeat straightline.
     eexists; ssplit. repeat straightline. eexists; ssplit.
@@ -831,24 +826,19 @@ Section WithParameters.
     rewrite H46 by congruence. reflexivity.
     repeat straightline.
     single_step.
-    3-5: unfold FElem; ecancel_assumption_impl.
     destruct (Z.testbit k 0); solve_bounds.
-    solve_bounds.
     repeat straightline.
     eexists; ssplit. repeat straightline.
     repeat (eexists; ssplit; [unfold loc'1, l10, l9, l8, loc'0; repeat (rewrite map.get_put_diff by congruence); rewrite H46 by congruence; reflexivity|]; repeat straightline).
     cbv [bin_model bin_mul] in H95.
 
     single_step.
-    3-5: unfold FElem in *; ecancel_assumption_impl.
-    1-2: solve_bounds.
     repeat straightline.
     eexists; ssplit. repeat straightline.
     repeat (eexists; ssplit; [unfold loc'1, l10, l9, l8, loc'0; repeat (rewrite map.get_put_diff by congruence); rewrite H46 by congruence; reflexivity|]; repeat straightline).
     cbv [bin_model bin_mul] in H98.
 
     single_step.
-    2-3: unfold FElem in *; ecancel_assumption_impl.
     destruct (Z.testbit k 0); solve_bounds.
     repeat straightline.
     eexists; ssplit. repeat straightline.
@@ -856,14 +846,10 @@ Section WithParameters.
     cbv [bin_model bin_mul] in H101.
 
     single_step.
-    3-5: unfold FElem in *; ecancel_assumption_impl.
-    1-2: solve_bounds.
     repeat straightline.
     cbv [bin_model bin_mul] in H104.
 
-    cbv [FElem] in *.
-    replace JacobianCoZ.frep256k1 with frep256k1 in * by reflexivity.
-    replace Addchain.frep256k1 with frep256k1 in * by reflexivity.
+    cbv [FElem Field.FElem] in *.
     repeat match goal with
     | |- context [anybytes ?a _ _] =>
         match goal with

--- a/src/Bedrock/Specs/Field.v
+++ b/src/Bedrock/Specs/Field.v
@@ -61,11 +61,12 @@ Class FieldRepresentation
   }.
 
 Definition Placeholder
-           {field_parameters : FieldParameters}
-           {width: Z} {BW: Bitwidth width} {word: word.word width} {mem: map.map word Byte.byte}
-           {field_representation : FieldRepresentation(mem:=mem)}
-           (p : word) : mem -> Prop :=
-  Memory.anybytes(mem:=mem) p felem_size_in_bytes.
+        {field_parameters : FieldParameters}
+        {width: Z} {BW: Bitwidth width} {word: word.word width} {mem: map.map word Byte.byte}
+        {field_representation : FieldRepresentation(mem:=mem)}
+        (p : word) (bs : list byte): mem -> Prop :=
+(sep (map.of_list_word_at p bs)
+  (emp (Z.of_nat (length bs) = felem_size_in_bytes))).
 
 Class FieldRepresentation_ok
       {field_parameters : FieldParameters}
@@ -74,44 +75,8 @@ Class FieldRepresentation_ok
     relax_bounds :
       forall X : felem, bounded_by tight_bounds X
                         -> bounded_by loose_bounds X;
+    felem_size_ok : felem_size_in_bytes <= 2^width
   }.
-
-Section BignumToFieldRepresentationAdapterLemmas.
-  Context
-  {field_parameters : FieldParameters}
-  {width: Z} {BW: Bitwidth width} {word: word.word width} {mem: map.map word Byte.byte}
-  {field_representation : FieldRepresentation}.
-  Context {word_ok : @word.ok width word} {map_ok : @map.ok word Init.Byte.byte mem}.
-
-  Lemma felem_size_in_bytes_mod :
-         felem_size_in_bytes mod Memory.bytes_per_word width = 0.
-  Proof. apply Z_mod_mult. Qed.
-  Lemma FElem_from_bytes p : Lift1Prop.iff1 (Placeholder p) (Lift1Prop.ex1 (FElem p)).
-  Proof.
-    cbv [Placeholder FElem felem_size_in_bytes].
-    repeat intro.
-    cbv [Lift1Prop.ex1]; split; intros;
-      repeat match goal with
-             | H : anybytes _ _ _ |- _ => eapply Array.anybytes_to_array_1 in H
-             | H : exists _, _ |- _ => destruct H
-             | H : _ /\ _ |- _ => destruct H
-             end.
-      all : repeat match goal with
-             | H : anybytes _ _ _ |- _ => eapply Array.anybytes_to_array_1 in H
-             | H : exists _, _ |- _ => destruct H
-             | H : _ /\ _ |- _ => destruct H
-             end.
-    { eexists; eapply Bignum_of_bytes; try eassumption.
-      destruct Bitwidth.width_cases; subst width; revert H0; cbn; lia. }
-    { eapply Bignum_to_bytes in H; sepsimpl.
-      let H := match goal with
-               | H : Array.array _ _ _ _ _ |- _ => H end in
-      eapply Array.array_1_to_anybytes in H.
-      unshelve (erewrite (_:_*_=_); eassumption).
-      rewrite H; destruct Bitwidth.width_cases as [W|W];
-        symmetry in W; destruct W; cbn; clear; lia. }
-  Qed.
-End BignumToFieldRepresentationAdapterLemmas.
 
 Section FunctionSpecs.
   Context {width: Z} {BW: Bitwidth width} {word: word.word width} {mem: map.map word Byte.byte}.
@@ -131,11 +96,11 @@ Section FunctionSpecs.
   Import WeakestPrecondition.
 
   Definition unop_spec {name} (op: UnOp name) :=
-    fnspec! name (pout px : word) / (out x : felem) Rr,
+    fnspec! name (pout px : word) / (x : felem) out Rr,
     { requires tr mem :=
         bounded_by un_xbounds x
         /\ (exists Ra, (FElem px x * Ra)%sep mem)
-        /\ (FElem pout out * Rr)%sep mem;
+        /\ (Placeholder pout out * Rr)%sep mem;
       ensures tr' mem' :=
         tr = tr' /\
         exists out,
@@ -153,13 +118,13 @@ Section FunctionSpecs.
       bin_outbounds: bounds }.
 
   Definition binop_spec  {name} (op: BinOp name) :=
-    fnspec! name (pout px py : word) / (out x y : felem) Rr,
+    fnspec! name (pout px py : word) / (x y : felem) out Rr,
     { requires tr mem :=
         bounded_by bin_xbounds x
         /\ bounded_by bin_ybounds y
         /\ (exists Rx, (FElem px x * Rx)%sep mem)
         /\ (exists Ry, (FElem py y * Ry)%sep mem)
-        /\ (FElem pout out * Rr)%sep mem;
+        /\ (Placeholder pout out * Rr)%sep mem;
       ensures tr' mem' :=
         tr = tr' /\
         exists out,
@@ -190,10 +155,10 @@ Section FunctionSpecs.
     {| un_model := F.opp; un_xbounds := tight_bounds; un_outbounds := loose_bounds |}.
 
   Instance spec_of_from_bytes : spec_of from_bytes :=
-    fnspec! from_bytes (pout px : word) / out (bs : list byte) Rr,
+    fnspec! from_bytes (pout px : word) / (out bs : list byte) Rr,
     { requires tr mem :=
         (exists Ra, (array ptsto (word.of_Z 1) px bs * Ra)%sep mem)
-        /\ (FElem pout out * Rr)%sep mem
+        /\ (Placeholder pout out * Rr)%sep mem
         /\ Field.bytes_in_bounds bs;
       ensures tr' mem' :=
         tr = tr' /\
@@ -214,9 +179,9 @@ Section FunctionSpecs.
         Field.bytes_in_bounds bs }.
 
   Instance spec_of_felem_copy : spec_of felem_copy :=
-    fnspec! felem_copy (pout px : word) / (out x : felem) R,
+    fnspec! felem_copy (pout px : word) / (x : felem) out R,
     { requires tr mem :=
-        (FElem px x * FElem pout out * R)%sep mem;
+        (FElem px x * Placeholder pout out * R)%sep mem;
       ensures tr' mem' :=
         tr = tr' /\
         (FElem px x * FElem pout x * R)%sep mem' }.
@@ -224,7 +189,7 @@ Section FunctionSpecs.
   Instance spec_of_from_word : spec_of from_word :=
     fnspec! from_word (pout x : word) / out R,
     { requires tr mem :=
-        (FElem pout out * R)%sep mem;
+        (Placeholder pout out * R)%sep mem;
       ensures tr' mem' :=
         tr = tr' /\
         exists X, feval X = F.of_Z _ (word.unsigned x)
@@ -237,7 +202,7 @@ Section FunctionSpecs.
     fnspec! select_znz (pout pc px py : word) / out Rout Rx Ry x y,
     {
         requires tr mem :=
-        (FElem pout out * Rout)%sep mem /\
+        (Placeholder pout out * Rout)%sep mem /\
         (FElem px x * Rx)%sep mem /\
         (FElem py y * Ry)%sep mem /\
         ZRange.is_bounded_by_bool (word.unsigned pc) bit_range = true;
@@ -278,13 +243,100 @@ Section SpecProperties.
           {field_representation : FieldRepresentation}
           {field_representation_ok : FieldRepresentation_ok}.
 
-  Lemma FElem_to_bytes px x :
-    Lift1Prop.impl1 (FElem px x) (Placeholder px).
+  Lemma felem_size_in_bytes_mod :
+         felem_size_in_bytes mod Memory.bytes_per_word width = 0.
+  Proof. apply Z_mod_mult. Qed.
+
+  Local Coercion Z.to_nat : Z >-> nat.
+
+  Lemma Placeholder_impl_FElem_bytes p bs :
+    Lift1Prop.impl1 (Placeholder p bs) (FElem p (bs2ws (bytes_per_word width) bs)).
   Proof.
-    rewrite FElem_from_bytes.
-    repeat intro; eexists; eauto.
+    repeat intro.
+    pose (Bignum_of_bytes felem_size_in_words p bs) as HBignum.
+    epose (array1_iff_eq_of_list_word_at p bs) as HArray.
+    pose felem_size_ok.
+    cbv [FElem Placeholder felem_size_in_bytes] in *.
+    intros.
+    extract_ex1_and_emp_in_hyps. apply HBignum. lia.
+      apply HArray. lia. assumption.
+  Qed.
+
+  Lemma FElem_impl_Placeholder p ws :
+    Lift1Prop.impl1 (FElem p ws) (Placeholder p (ws2bs (bytes_per_word width) ws)).
+  Proof.
+    repeat intro.
+    pose (Bignum_to_bytes felem_size_in_words p ws) as HBignum.
+    pose felem_size_ok.
+    cbv [FElem Placeholder felem_size_in_bytes] in *.
+    apply HBignum in H. extract_ex1_and_emp_in_hyps.
+    extract_ex1_and_emp_in_goal; split.
+    apply array1_iff_eq_of_list_word_at; try assumption.
+    lia.
+    pose Types.word_size_in_bytes_pos.
+    lia.
+  Qed.
+
+  Lemma Placeholder_iff_FElem_bytes p bs : 
+    Lift1Prop.iff1 (Placeholder p bs) (sep (FElem p ((bs2ws (bytes_per_word width) bs))) (emp (Datatypes.length bs = felem_size_in_bytes))).
+  Proof.
+    repeat intro.
+    pose (Bignum_of_bytes felem_size_in_words p bs) as HBignum.
+    epose (array1_iff_eq_of_list_word_at p bs) as HArray.
+    pose felem_size_ok.
+    cbv [FElem Placeholder felem_size_in_bytes] in *.
+    split; intros.
+    - sepsimpl. apply HBignum. lia.
+      apply HArray. lia. assumption.
+      lia.
+    - sepsimpl. apply HArray; try lia. apply HBignum; try lia.
+      assumption. pose Types.word_size_in_bytes_pos. lia.
+  Qed.
+
+  Lemma Placeholder_iff_FElem_words p ws :
+    Lift1Prop.iff1 (sep (Placeholder p (ws2bs (bytes_per_word width) ws)) (emp (Datatypes.length ws = felem_size_in_words))) (FElem p ws).
+  Proof.
+    repeat intro.
+    pose (Bignum_to_bytes felem_size_in_words p ws) as HBignum.
+    pose felem_size_ok.
+    cbv [FElem Placeholder felem_size_in_bytes] in *.
+    split; intros.
+    - sepsimpl. apply HBignum.
+      sepsimpl; try lia.
+      apply array1_iff_eq_of_list_word_at; try assumption; try lia.
+    - apply HBignum in H. sepsimpl.
+      apply array1_iff_eq_of_list_word_at; try assumption; lia.
+      rewrite H. pose Types.word_size_in_bytes_pos. lia.
+      pose Types.word_size_in_bytes_pos.
+      rewrite ws2bs_length in H. nia.
+  Qed.
+
+  (* this is almost bytearray_iff_bytes *)
+  Lemma Placeholder_iff_array1 p bs :
+    Datatypes.length bs = felem_size_in_bytes ->
+    Lift1Prop.iff1 (Placeholder p bs) (array ptsto (word.of_Z 1) p bs).
+  Proof.
+    repeat intro.
+    cbv [Placeholder].
+    pose felem_size_ok. apply iff1_sym.
+    rewrite array1_iff_eq_of_list_word_at; try assumption.
+    - split; intros; extract_ex1_and_emp_in_goal; extract_ex1_and_emp_in_hyps; try split; try assumption.
+      rewrite H. pose Types.word_size_in_bytes_pos. cbv [felem_size_in_bytes]. lia.
+    - lia.
   Qed.
 
   Lemma M_nonzero : M <> 0.
   Proof. cbv [M]. congruence. Qed.
 End SpecProperties.
+
+
+(* array1 -> Placeholder, only works if length sidecondition can be solved by ZnWords or lia. *)
+#[export] Hint Extern 1 (Lift1Prop.impl1 (array ptsto (word.of_Z 1) ?p ?stack) (Placeholder (field_representation:=?frep) ?p _)) => (
+    unshelve(erewrite <- (Placeholder_iff_array1 (field_representation:=frep) p _ _));
+      [ (let s := eval lazy in (felem_size_in_bytes (FieldRepresentation:=frep)) in
+          change (felem_size_in_bytes (FieldRepresentation:=frep)) with s in *; try lia; ZnWords) |
+        apply impl1_refl]) : ecancel_impl.
+
+(* FElem -> Placeholder *)
+#[export] Hint Extern 1 (Lift1Prop.impl1 (FElem ?px ?x) (Placeholder ?px _)) => (apply FElem_impl_Placeholder) : ecancel_impl.
+


### PR DESCRIPTION
Using map.of_list_word_at instead of FElem/Bignum/array will make it a bit easier to handle allocation of bigger chunks of memory that are then partially fed into field operations to fill them with values.

map.of_list_word_at requires a lenght assumption, which is wrapped into Placeholder.

The main difference between of_list_word_at and FElem is that one allows for equational reasoning (below Placeholder) while the other one does not need an explicit length assumption, as separation logic has it inherently.

As far as I understand it, both FElem and Placeholder have their advantages and disadvantages, this change hopefull allows to switch a bit more freely between them.

I've also removed some duplicated list byte <-> list word translations and removed unnecessary imports when I saw them. Furthermore, I tried to reduce the number of typeclass instances for fields and words, to avoid unintended
non-equality because of some instance parameter being different.