### PR TITLE
Pull field element length into felem

### DIFF
--- a/src/Bedrock/End2End/X25519/EdwardsXYZT.v
+++ b/src/Bedrock/End2End/X25519/EdwardsXYZT.v
@@ -123,7 +123,7 @@ Definition double := func! (p_out, p_a) {
   fe25519_mul(p_out.Z, cZ, cT)
 }.
 
-(* Converts a projective point p_a to a cached point p_out to prepare it for readdition. 
+(* Converts a projective point p_a to a cached point p_out to prepare it for readdition.
    Uses the field's parameter d, which is passed as p_d for now. *)
 Definition to_cached := func! (p_out, p_a, p_d) {
   fe25519_sub(p_out.half_YmX, p_a.Y, p_a.X);
@@ -135,7 +135,7 @@ Definition to_cached := func! (p_out, p_a, p_d) {
   fe25519_copy(p_out.Z, p_a.Z)
 }.
 
-(* Equivalent of m1_readd in src/Curves/Edwards/XYZT/Readdition.v 
+(* Equivalent of m1_readd in src/Curves/Edwards/XYZT/Readdition.v
    Adds a projective point p_a and cached point p_c and stores the result as projective point in p_out. *)
 Definition readd := func! (p_out, p_a, p_c) {
   stackalloc felem_size as A;
@@ -199,7 +199,7 @@ Local Notation m1_prep :=
                   (Fopp:=F.opp)(Fadd:=F.add)(Fsub:=F.sub)(Fmul:=F.mul)(Finv:=F.inv)(Fdiv:=F.div)
                   (field:=field)(char_ge_3:=char_ge_3)(Feq_dec:=F.eq_dec)
                   (a:=a)(d:=d)(nonzero_a:=nonzero_a)(a_eq_minus1:=a_eq_minus1)
-                  (twice_d:=twice_d)(k_eq_2d:=k_eq_2d)(nonzero_d:=nonzero_d)). 
+                  (twice_d:=twice_d)(k_eq_2d:=k_eq_2d)(nonzero_d:=nonzero_d)).
 Local Notation m1_readd :=
   (m1_readd(F:=F M_pos)(Feq:=Logic.eq)(Fzero:=F.zero)(Fone:=F.one)
            (Fopp:=F.opp)(Fadd:=F.add)(Fsub:=F.sub)(Fmul:=F.mul)(Finv:=F.inv)(Fdiv:=F.div)
@@ -219,7 +219,7 @@ Local Notation "a <> b" := (not (a = b)) : type_scope. Local Notation "0" := F.z
 Local Notation "1" := F.one. Local Infix "+" := F.add. Local Infix "*" := F.mul.
 Local Infix "-" := F.sub. Local Infix "/" := F.div. Local Notation "x ^ 2" := (x*x).
 
-Definition valid_projective_coords X Y Z Ta Tb :=
+Definition valid_projective_coords (X Y Z Ta Tb : felem):=
     ((a * (feval X)^2*(feval Z)^2 + (feval Y)^2*(feval Z)^2 = ((feval Z)^2)^2 + d * (feval X)^2 * (feval Y)^2)%F /\
     ((feval X) * (feval Y) = (feval Z) * (feval Ta) * (feval Tb))%F /\
     ((feval Z) <> 0)%F).
@@ -235,14 +235,14 @@ Definition coords_to_point (c : projective_coords) : point.
     cbv [proj1_sig feval_projective_coords valid_projective_coords] in *;
     destruct_head' prod; destruct_head' and; ssplit; assumption).
   Defined.
-Lemma point_implies_coords_valid (p : point) (X Y Z Ta Tb : felem): 
+Lemma point_implies_coords_valid (p : point) (X Y Z Ta Tb : felem):
   proj1_sig p = (feval X, feval Y, feval Z, feval Ta, feval Tb) -> valid_projective_coords X Y Z Ta Tb.
     intros.
     cbv[proj1_sig] in *. destruct_head' @Extended.point. destruct_head' prod. Prod.inversion_prod; subst.
-    assumption. 
+    assumption.
 Qed.
 
-Definition valid_precomputed_coords half_ypx half_ymx xyd :=
+Definition valid_precomputed_coords (half_ypx half_ymx xyd : felem) :=
     let x := (feval half_ypx) - (feval half_ymx) in
     let y := (feval half_ypx) + (feval half_ymx) in
     (a*x^2 + y^2 = 1 + d*x^2*y^2)
@@ -258,15 +258,15 @@ Definition precomputed_coords_to_precomputed (c : precomputed_coords) : precompu
   abstract (destruct_head' precomputed_coords; destruct_head' prod;
   destruct_head' and; cbv [feval_precomputed_coords valid_precomputed_coords proj1_sig] in *; assumption).
 Defined.
-Lemma precomputed_implies_coords_valid (p : precomputed_point) (half_ypx half_ymx xyd : felem): 
+Lemma precomputed_implies_coords_valid (p : precomputed_point) (half_ypx half_ymx xyd : felem):
   proj1_sig p = (feval half_ypx, feval half_ymx, feval xyd) -> valid_precomputed_coords half_ypx half_ymx xyd.
     intros.
     cbv[proj1_sig valid_precomputed_coords] in *. destruct_head' @Precomputed.precomputed_point.
     destruct_head' prod. Prod.inversion_prod; subst.
-    assumption. 
+    assumption.
 Qed.
 
-Definition valid_cached_coords half_YmX half_YpX Z Td :=
+Definition valid_cached_coords (half_YmX half_YpX Z Td : felem):=
   let X := (feval half_YpX) - (feval half_YmX) in
   let Y := (feval half_YpX) + (feval half_YmX) in
   let T := (feval Td) / d in
@@ -286,12 +286,12 @@ Definition cached_coords_to_cached (c : cached_coords) : cached.
   destruct_head' and;
     cbv [valid_cached_coords proj1_sig] in *; assumption).
 Defined.
-Lemma cached_implies_coords_valid (c : cached) (half_YmX half_YpX Z Td : felem): 
+Lemma cached_implies_coords_valid (c : cached) (half_YmX half_YpX Z Td : felem):
   proj1_sig c = (feval half_YmX, feval half_YpX, feval Z, feval Td) -> valid_cached_coords half_YmX half_YpX Z Td.
     intros.
     cbv[proj1_sig valid_cached_coords] in *. destruct_head' @Readdition.cached.
     destruct_head' prod. Prod.inversion_prod; subst.
-    assumption. 
+    assumption.
 Qed.
 
 (* Extended projective points. *)
@@ -310,7 +310,7 @@ Local Notation "c 'p4@' p" := (let '(half_ymx, half_ypx ,z,td) := proj1_sig c in
                               (FElem (p .+ (felem_size + felem_size + felem_size)) td))
                               (at level 10, format "c 'p4@' p").
 (* Precomputed points. *)
-Local Notation "c 'p3@' p" := (let '(half_ymx, half_ypx, xyd) := proj1_sig c in sep (sep 
+Local Notation "c 'p3@' p" := (let '(half_ymx, half_ypx, xyd) := proj1_sig c in sep (sep
                               (FElem (p) half_ymx)
                               (FElem (p .+ felem_size) half_ypx))
                               (FElem (p .+ (felem_size + felem_size)) xyd))
@@ -326,7 +326,7 @@ Instance spec_of_fe25519_half : spec_of "fe25519_half" :=
     m =* (FElem result_location old_result) * R;
     ensures t' m' :=
       t = t' /\
-      exists result,
+      exists result : felem,
         bounded_by tight_bounds result /\
         feval result = F.div (feval input) (F.add F.one F.one) /\
         m' =* (FElem result_location result)  * R}.
@@ -353,7 +353,7 @@ Global Instance spec_of_double : spec_of "double" :=
       requires t m :=
         m =* out $@ p_out * a p5@ p_a * R /\
         Datatypes.length out = Z.to_nat (5 * felem_size);
-      ensures t' m' := 
+      ensures t' m' :=
         t = t' /\
         exists a_double: projective_coords,
           m' =* a_double p5@ p_out * a p5@ p_a * R /\
@@ -436,40 +436,30 @@ Local Ltac solve_bounds :=
 
 Ltac split_stack_at_n_in stack p n H := rewrite <- (firstn_skipn n stack) in H;
   rewrite (map.of_list_word_at_app_n _ _ _ n) in H; try skipn_firstn_length;
-  let D := fresh in 
+  let D := fresh in
   unshelve(epose (sep_eq_putmany _ _ (map.adjacent_arrays_disjoint_n p (firstn n stack) (skipn n stack) n _ _)) as D);
   try skipn_firstn_length; seprewrite_in D H; rewrite ?skipn_skipn in H; bottom_up_simpl_in_hyp H; clear D.
 
-Local Ltac solve_mem :=
-  try match goal with  | |- exists _ : _ -> Prop, _%sep _ => eexists end;
-  match goal with  | H : _ %sep ?m |- _ %sep ?m => bottom_up_simpl_in_goal_nop_ok end;
+Local Ltac solve_length :=
+  try lia;
   match goal with
-  | |- _%sep _ => ecancel_assumption_impl
-  | H: ?P%sep ?m |- ?G%sep ?m =>  (* Solve Placeholder goals when a fixed size list is given *)
-    match P with context[map.of_list_word_at ?p ?stack] =>
-    match G with context[Placeholder ?p _] =>
-      solve [ cbv [Placeholder]; extract_ex1_and_emp_in_goal; bottom_up_simpl_in_goal_nop_ok;
-      split; [ecancel_assumption | skipn_firstn_length] ]
-    end end
+    | |- Datatypes.length _ = _ =>
+      solve [rewrite ?ws2bs_felem_length; try lia;
+          change felem_size_in_bytes with 40 in *; try listZnWords; lia]
+  end.
+
+Local Ltac solve_mem :=
+  repeat match goal with
+    | |- exists _ : _ -> Prop, _%sep _ => eexists
+    | H: ?P%sep ?m |- ?G%sep ?m => progress ecancel_assumption_preprocess_with solve_length
+    | H : _ %sep ?m |- _ %sep ?m => bottom_up_simpl_in_goal
+    | |- _%sep _ => ecancel_assumption
   end.
 
 Local Ltac single_step :=
-  repeat straightline; straightline_call; ssplit; try solve_mem; try solve_bounds.
+  repeat straightline; straightline_call; ssplit; try solve_mem; try solve_bounds; try solve_length.
 
-(* Attempts to find anybytes terms in the goal and rewrites the first corresponding stack hypothesis
-   to byte representation. straightline only supports deallocation for byte representation at the moment. *)
-Ltac solve_deallocation :=
-  lazy [FElem] in *;
-  match goal with
-    H: ?P%sep _ |- ?G =>
-      repeat match G with context[anybytes ?p _ _] =>
-        match P with context[Bignum.Bignum felem_size_in_words p ?v] =>
-          seprewrite_in (Bignum.Bignum_to_bytes felem_size_in_words p) H
-        end
-      end;
-      extract_ex1_and_emp_in H
-  end;
-  repeat straightline.
+Ltac solve_deallocation := dealloc_preprocess; repeat straightline.
 
 Ltac split_output_stack stack_var ptr_var num_points :=
   match goal with
@@ -518,7 +508,7 @@ Proof.
       un_outbounds bin_outbounds].
 
   do 4 straightline.
-  pose proof (point_implies_coords_valid (m1add_precomputed_coordinates (coords_to_point a0) 
+  pose proof (point_implies_coords_valid (m1add_precomputed_coordinates (coords_to_point a0)
     (precomputed_coords_to_precomputed b))) as HPost.
   destruct_points.
   split_output_stack out p_out 5.
@@ -556,8 +546,8 @@ Proof.
   (* Solve the postconditions *)
   repeat straightline.
   solve_deallocation.
-  cbv [coords_to_point feval_projective_coords projective_coords 
-    proj1_sig m1double bin_model bin_add bin_mul bin_sub bin_carry_add 
+  cbv [coords_to_point feval_projective_coords projective_coords
+    proj1_sig m1double bin_model bin_add bin_mul bin_sub bin_carry_add
     bin_sub bin_carry_sub un_model un_square] in *.
   unshelve eexists.
   eexists (_, _, _, _, _).

--- a/src/Bedrock/Field/Synthesis/New/WordByWordMontgomery.v
+++ b/src/Bedrock/Field/Synthesis/New/WordByWordMontgomery.v
@@ -549,7 +549,7 @@ Qed.
       handle_side_conditions; [ apply valid_max_bounds | apply valid_length | | | ].
     { (* output length *)
       cbv [list_in_bounds WordByWordMontgomery.valid WordByWordMontgomery.small ] in *.
-      intuition idtac. rewrite H5. rewrite Partition.length_partition; trivial. }
+      intuition idtac. rewrite H6. rewrite Partition.length_partition; trivial. }
 
     { (* output *value* is correct *)
     intros. cbv [feval]. simpl. cbv [Representation.eval_words]. simpl.

--- a/src/Bedrock/Specs/Field.v
+++ b/src/Bedrock/Specs/Field.v
@@ -1,11 +1,15 @@
+Require Import Bedrock.Field.Common.Types.
 Require Import coqutil.Byte coqutil.Word.LittleEndianList.
-Require Import Rupicola.Lib.Api.
+From coqutil.Macros Require Import symmetry.
 Require Import Crypto.Algebra.Hierarchy.
 Require Import Crypto.Arithmetic.PrimeFieldTheorems.
 Require Import Crypto.Bedrock.Field.Synthesis.Generic.Bignum.
 Require Import Crypto.Bedrock.Field.Common.Arrays.MaxBounds.
 Require Import Crypto.COperationSpecifications.
 Require Import Crypto.Util.ZUtil.ModInv.
+Require Import Rupicola.Lib.Api.
+Require Rupicola.Lib.Arrays.
+
 Local Open Scope Z_scope.
 Import bedrock2.Memory.
 
@@ -36,17 +40,18 @@ Class FieldRepresentation
       {field_parameters : FieldParameters}
       {width: Z} {BW: Bitwidth width} {word: word.word width} {mem: map.map word Byte.byte}
        :=
-  { felem := list word;
-    feval : felem -> F M_pos;
+  { felem_size_in_words : nat;
+    felem := {x : list word | length x = felem_size_in_words};
+    feval : list word -> F M_pos;
 
     feval_bytes : list byte -> F M_pos;
-    felem_size_in_words : nat;
-    felem_size_in_bytes : Z := Z.of_nat felem_size_in_words * bytes_per_word width; (* for stack allocation *)
+    felem_size_in_bytes : Z := (Z.of_nat felem_size_in_words) * bytes_per_word width; (* for stack allocation *)
     encoded_felem_size_in_bytes : nat; (* number of bytes when serialized *)
     bytes_in_bounds : list byte -> Prop;
 
     (* Memory layout *)
-    FElem : word -> list word -> mem -> Prop := Bignum felem_size_in_words;
+    FElem : word -> felem -> mem -> Prop := fun px x =>
+      (array scalar (word.of_Z (bytes_per_word width)) px (proj1_sig x));
     FElemBytes : word -> list byte -> mem -> Prop :=
       fun addr bs =>
         (emp (length bs = encoded_felem_size_in_bytes
@@ -54,28 +59,10 @@ Class FieldRepresentation
          * array ptsto (word.of_Z 1) addr bs)%sep;
 
     bounds : Type;
-    bounded_by : bounds -> felem -> Prop;
+    bounded_by : bounds -> list word -> Prop;
     (* for saturated implementations, loose/tight bounds are the same *)
     loose_bounds : bounds;
     tight_bounds : bounds;
-  }.
-
-Definition Placeholder
-        {field_parameters : FieldParameters}
-        {width: Z} {BW: Bitwidth width} {word: word.word width} {mem: map.map word Byte.byte}
-        {field_representation : FieldRepresentation(mem:=mem)}
-        (p : word) (bs : list byte): mem -> Prop :=
-(sep (map.of_list_word_at p bs)
-  (emp (Z.of_nat (length bs) = felem_size_in_bytes))).
-
-Class FieldRepresentation_ok
-      {field_parameters : FieldParameters}
-      {width: Z} {BW: Bitwidth width} {word: word.word width} {mem: map.map word Byte.byte}
-      {field_representation : FieldRepresentation} := {
-    relax_bounds :
-      forall X : felem, bounded_by tight_bounds X
-                        -> bounded_by loose_bounds X;
-    felem_size_ok : felem_size_in_bytes <= 2^width
   }.
 
 Section FunctionSpecs.
@@ -95,15 +82,21 @@ Section FunctionSpecs.
 
   Import WeakestPrecondition.
 
+  #[warnings="-uniform-inheritance", global]
+  Coercion felem_to_list (x : felem) : list word := proj1_sig x.
+
+  #[local] Coercion Z.to_nat : Z >-> nat.
+
   Definition unop_spec {name} (op: UnOp name) :=
     fnspec! name (pout px : word) / (x : felem) out Rr,
     { requires tr mem :=
         bounded_by un_xbounds x
+        /\ length out = felem_size_in_bytes
         /\ (exists Ra, (FElem px x * Ra)%sep mem)
-        /\ (Placeholder pout out * Rr)%sep mem;
+        /\ (out$@pout * Rr)%sep mem;
       ensures tr' mem' :=
         tr = tr' /\
-        exists out,
+        exists out : felem,
           feval out = un_model (feval x)
           /\ bounded_by un_outbounds out
           /\ (FElem pout out * Rr)%sep mem' }.
@@ -122,12 +115,13 @@ Section FunctionSpecs.
     { requires tr mem :=
         bounded_by bin_xbounds x
         /\ bounded_by bin_ybounds y
+        /\ length out = felem_size_in_bytes
         /\ (exists Rx, (FElem px x * Rx)%sep mem)
         /\ (exists Ry, (FElem py y * Ry)%sep mem)
-        /\ (Placeholder pout out * Rr)%sep mem;
+        /\ (out$@pout * Rr)%sep mem;
       ensures tr' mem' :=
         tr = tr' /\
-        exists out,
+        exists out : felem,
           feval out = bin_model (feval x) (feval y)
           /\ bounded_by bin_outbounds out
           /\ (FElem pout out * Rr)%sep mem' }.
@@ -158,11 +152,12 @@ Section FunctionSpecs.
     fnspec! from_bytes (pout px : word) / (out bs : list byte) Rr,
     { requires tr mem :=
         (exists Ra, (array ptsto (word.of_Z 1) px bs * Ra)%sep mem)
-        /\ (Placeholder pout out * Rr)%sep mem
+        /\ (out$@pout * Rr)%sep mem
+        /\ length out = felem_size_in_bytes
         /\ Field.bytes_in_bounds bs;
       ensures tr' mem' :=
         tr = tr' /\
-        exists X, feval X = feval_bytes bs
+        exists X : felem, feval X = feval_bytes bs
              /\ bounded_by tight_bounds X
              /\ (FElem pout X * Rr)%sep mem' }.
 
@@ -181,7 +176,8 @@ Section FunctionSpecs.
   Instance spec_of_felem_copy : spec_of felem_copy :=
     fnspec! felem_copy (pout px : word) / (x : felem) out R,
     { requires tr mem :=
-        (FElem px x * Placeholder pout out * R)%sep mem;
+        (FElem px x * out$@pout * R)%sep mem /\
+        length out = felem_size_in_bytes;
       ensures tr' mem' :=
         tr = tr' /\
         (FElem px x * FElem pout x * R)%sep mem' }.
@@ -189,10 +185,11 @@ Section FunctionSpecs.
   Instance spec_of_from_word : spec_of from_word :=
     fnspec! from_word (pout x : word) / out R,
     { requires tr mem :=
-        (Placeholder pout out * R)%sep mem;
+        (out$@pout * R)%sep mem /\
+        length out = felem_size_in_bytes;
       ensures tr' mem' :=
         tr = tr' /\
-        exists X, feval X = F.of_Z _ (word.unsigned x)
+        exists X : felem, feval X = F.of_Z _ (word.unsigned x)
              /\ bounded_by tight_bounds X
              /\ (FElem pout X * R)%sep mem' }.
 
@@ -202,9 +199,10 @@ Section FunctionSpecs.
     fnspec! select_znz (pout pc px py : word) / out Rout Rx Ry x y,
     {
         requires tr mem :=
-        (Placeholder pout out * Rout)%sep mem /\
+        (out$@pout * Rout)%sep mem /\
         (FElem px x * Rx)%sep mem /\
         (FElem py y * Ry)%sep mem /\
+        length out = felem_size_in_bytes /\
         ZRange.is_bounded_by_bool (word.unsigned pc) bit_range = true;
         ensures tr' mem' :=
         if ((word.unsigned pc) =? 1)
@@ -232,6 +230,16 @@ End FunctionSpecs.
 Existing Instances spec_of_UnOp spec_of_BinOp bin_mul un_square bin_add bin_sub
          un_scmula24 un_inv spec_of_felem_copy spec_of_from_word.
 
+Class FieldRepresentation_ok
+      {field_parameters : FieldParameters}
+      {width: Z} {BW: Bitwidth width} {word: word.word width} {mem: map.map word Byte.byte}
+      {field_representation : FieldRepresentation} := {
+    relax_bounds :
+      forall X : felem, bounded_by tight_bounds X
+                        -> bounded_by loose_bounds X;
+    felem_size_ok : felem_size_in_bytes <= 2^width
+  }.
+
 Section SpecProperties.
   Context {width: Z} {BW: Bitwidth width} {word: word.word width} {mem: map.map word Byte.byte}.
   Context {locals: map.map String.string word}.
@@ -241,102 +249,318 @@ Section SpecProperties.
   Context {ext_spec_ok : Semantics.ext_spec.ok ext_spec}.
   Context {field_parameters : FieldParameters}
           {field_representation : FieldRepresentation}
-          {field_representation_ok : FieldRepresentation_ok}.
+          {field_representation_ok : FieldRepresentation_ok}.    
 
-  Lemma felem_size_in_bytes_mod :
-         felem_size_in_bytes mod Memory.bytes_per_word width = 0.
-  Proof. apply Z_mod_mult. Qed.
+  #[local] Coercion Z.to_nat : Z >-> nat.
 
-  Local Coercion Z.to_nat : Z >-> nat.
-
-  Lemma Placeholder_impl_FElem_bytes p bs :
-    Lift1Prop.impl1 (Placeholder p bs) (FElem p (bs2ws (bytes_per_word width) bs)).
+  #[local] Notation ws2bs := (ws2bs (width:=width)).
+  #[local] Notation bs2ws := (bs2ws (width:=width)).
+  #[local] Notation bytes_per := (bytes_per (width:=width)).
+  
+  Lemma felem_length (x : felem) : length (felem_to_list x) = felem_size_in_words.
   Proof.
-    repeat intro.
-    pose (Bignum_of_bytes felem_size_in_words p bs) as HBignum.
-    epose (array1_iff_eq_of_list_word_at p bs) as HArray.
-    pose felem_size_ok.
-    cbv [FElem Placeholder felem_size_in_bytes] in *.
-    intros.
-    extract_ex1_and_emp_in_hyps. apply HBignum. lia.
-      apply HArray. lia. assumption.
+    cbv [felem_to_list]. destruct x. trivial.
   Qed.
 
-  Lemma FElem_impl_Placeholder p ws :
-    Lift1Prop.impl1 (FElem p ws) (Placeholder p (ws2bs (bytes_per_word width) ws)).
+  (* nat equality is decidable, which means that all length proofs are equal and field
+   elements are equal if their underlying lists are equal. *)
+  Lemma eq_felem {x y : felem} : proj1_sig x = proj1_sig y -> x = y.
   Proof.
-    repeat intro.
-    pose (Bignum_to_bytes felem_size_in_words p ws) as HBignum.
-    pose felem_size_ok.
-    cbv [FElem Placeholder felem_size_in_bytes] in *.
-    apply HBignum in H. extract_ex1_and_emp_in_hyps.
-    extract_ex1_and_emp_in_goal; split.
-    apply array1_iff_eq_of_list_word_at; try assumption.
-    lia.
-    pose Types.word_size_in_bytes_pos.
-    lia.
+    destruct x as [x px], y as [y py].
+    cbv [proj1_sig]. intro. subst.
+    apply f_equal,  Eqdep_dec.UIP_dec. eapply Nat.eq_dec.
   Qed.
 
-  Lemma Placeholder_iff_FElem_bytes p bs : 
-    Lift1Prop.iff1 (Placeholder p bs) (sep (FElem p ((bs2ws (bytes_per_word width) bs))) (emp (Datatypes.length bs = felem_size_in_bytes))).
+  Lemma bytes_per_as_Z : bytes_per access_size.word = bytes_per_word width.
   Proof.
-    repeat intro.
-    pose (Bignum_of_bytes felem_size_in_words p bs) as HBignum.
-    epose (array1_iff_eq_of_list_word_at p bs) as HArray.
-    pose felem_size_ok.
-    cbv [FElem Placeholder felem_size_in_bytes] in *.
-    split; intros.
-    - sepsimpl. apply HBignum. lia.
-      apply HArray. lia. assumption.
-      lia.
-    - sepsimpl. apply HArray; try lia. apply HBignum; try lia.
-      assumption. pose Types.word_size_in_bytes_pos. lia.
+    cbv [bytes_per_word bytes_per] in *; lia.
+  Qed.
+  Lemma bytes_per_of_nat_to_nat_id : Z.of_nat (bytes_per_word width) = bytes_per_word width.
+  Proof.
+    pose word_size_in_bytes_pos; lia.
+  Qed.
+  Lemma of_nat_bytes_per: (Z.of_nat (bytes_per access_size.word)) = bytes_per_word width.
+  Proof.
+    rewrite bytes_per_as_Z, bytes_per_of_nat_to_nat_id. exact eq_refl.
   Qed.
 
-  Lemma Placeholder_iff_FElem_words p ws :
-    Lift1Prop.iff1 (sep (Placeholder p (ws2bs (bytes_per_word width) ws)) (emp (Datatypes.length ws = felem_size_in_words))) (FElem p ws).
-  Proof.
-    repeat intro.
-    pose (Bignum_to_bytes felem_size_in_words p ws) as HBignum.
-    pose felem_size_ok.
-    cbv [FElem Placeholder felem_size_in_bytes] in *.
-    split; intros.
-    - sepsimpl. apply HBignum.
-      sepsimpl; try lia.
-      apply array1_iff_eq_of_list_word_at; try assumption; try lia.
-    - apply HBignum in H. sepsimpl.
-      apply array1_iff_eq_of_list_word_at; try assumption; lia.
-      rewrite H. pose Types.word_size_in_bytes_pos. lia.
-      pose Types.word_size_in_bytes_pos.
-      rewrite ws2bs_length in H. nia.
+  Lemma felem_size_in_bytes_mod : felem_size_in_bytes mod bytes_per_word width = 0.
+  Proof. 
+    apply Z_mod_mult.
   Qed.
 
-  (* this is almost bytearray_iff_bytes *)
-  Lemma Placeholder_iff_array1 p bs :
-    Datatypes.length bs = felem_size_in_bytes ->
-    Lift1Prop.iff1 (Placeholder p bs) (array ptsto (word.of_Z 1) p bs).
-  Proof.
-    repeat intro.
-    cbv [Placeholder].
-    pose felem_size_ok. apply iff1_sym.
-    rewrite array1_iff_eq_of_list_word_at; try assumption.
-    - split; intros; extract_ex1_and_emp_in_goal; extract_ex1_and_emp_in_hyps; try split; try assumption.
-      rewrite H. pose Types.word_size_in_bytes_pos. cbv [felem_size_in_bytes]. lia.
-    - lia.
+  Lemma felem_size_in_bytes_mod_nat :
+    (felem_size_in_bytes mod (bytes_per_word width) = 0)%nat.
+  Proof. 
+    pose proof word_size_in_bytes_pos.
+    cbv [bytes_per_word bytes_per felem_size_in_bytes] in *.
+    rewrite Modulo.Z.mod_to_nat; try lia.
+    rewrite Z_mod_mult. lia.
   Qed.
 
+  Lemma ws2bs_felem_length (x : felem):
+    length (ws2bs (bytes_per_word width) x) = felem_size_in_bytes.
+  Proof.
+    rewrite ws2bs_length, felem_length.
+    cbv [bytes_per_word felem_size_in_bytes] in *. lia.
+  Qed.
+
+  Lemma ws2bs_felem_width (x : felem):
+    Z.of_nat (length (ws2bs (bytes_per_word width) x)) <= 2 ^ width.
+  Proof.
+    destruct x. pose felem_size_ok.
+    cbv [felem_size_in_bytes bytes_per_word bytes_per felem_to_list proj1_sig] in *.
+    rewrite ws2bs_length. lia.
+  Qed.
+
+  Lemma bs2ws_felem_length bs : 
+    length bs = felem_size_in_bytes ->
+    length (bs2ws (bytes_per_word width) bs) = felem_size_in_words.
+  Proof.
+    intros H.
+    pose proof felem_size_ok.
+    pose proof word_size_in_bytes_pos.
+    pose proof felem_size_in_bytes_mod.
+    cbv [felem_size_in_bytes] in *. rewrite bs2ws_length; try ZnWords; try lia.
+    rewrite H, <- Z2Nat.inj_div; try lia.
+    rewrite Z_div_mult; try lia. (* TODO without div_mult neither lia nor ZnWords can solve this, expected? *)
+    rewrite H.
+    rewrite Modulo.Z.mod_to_nat; try lia. (* TODO without mod_to_nat neither lia nor ZnWords can solve this, expected?  *)
+  Qed.
+
+  Definition ws2felem (ws : list word) : felem.
+  Proof.
+    refine (exist _ (if (length ws =? felem_size_in_words)%nat then 
+      (ws) else 
+      (List.repeat (word.of_Z 0) felem_size_in_words)) _).
+    abstract (rewrite NatUtil.beq_nat_eq_nat_dec;
+    destruct (Nat.eq_dec (length ws) (felem_size_in_words));
+    [ assumption | apply repeat_length]).
+  Defined.
+
+  Lemma felem_to_list_ws2felem (ws : list word) :
+    length ws = felem_size_in_words ->
+    felem_to_list (ws2felem ws) = ws.
+  Proof.
+    intros H. cbv [ws2felem felem_to_list proj1_sig].
+    rewrite H.
+    rewrite Nat.eqb_refl.
+    exact eq_refl.
+  Qed.
+
+  Lemma ws2felem_felem_to_list (x : felem) :
+    ws2felem (felem_to_list x) = x.
+  Proof.
+    apply eq_felem.
+    pose proof felem_length as H.
+    cbv [ws2felem proj1_sig].
+    rewrite H.
+    rewrite Nat.eqb_refl.
+    exact eq_refl.
+  Qed.
+
+  Lemma felem_to_bytes p x :
+    Lift1Prop.iff1 (FElem p x) ((ws2bs (bytes_per_word width) x)$@p).
+  Proof.
+    cbv [FElem].
+    
+    epose proof ((bytes_of_words _ _)) as Hbytes_of_words.
+    cbn [id] in Hbytes_of_words.
+    rewrite of_nat_bytes_per in *.
+
+    etransitivity. exact Hbytes_of_words.
+    exact (array1_iff_eq_of_list_word_at _ _ (ws2bs_felem_width _)).
+  Qed.
+
+  Lemma felem_to_bytearray p x :
+    Lift1Prop.iff1 (FElem p x) (array ptsto (word.of_Z 1) p (ws2bs (bytes_per_word width) x)).
+  Proof.
+    etransitivity. exact (felem_to_bytes _ _).
+    exact (iff1_sym (array1_iff_eq_of_list_word_at _ _ (ws2bs_felem_width _))).
+  Qed.
+
+  Definition bs2felem (bs : list byte) : felem.
+  Proof.
+    refine (exist _ (if (length bs =? felem_size_in_bytes)%nat then 
+      ((bs2ws (bytes_per_word width) bs)) else 
+      (List.repeat (word.of_Z 0) felem_size_in_words)) _).
+    abstract (rewrite NatUtil.beq_nat_eq_nat_dec;
+    destruct (Nat.eq_dec (length bs) (felem_size_in_bytes));
+    [apply bs2ws_felem_length; assumption | apply repeat_length]).
+  Defined.
+
+  Lemma proj_bs2felem (bs : list byte) :
+    length bs = felem_size_in_bytes ->
+    proj1_sig (bs2felem bs) = (bs2ws (bytes_per_word width) bs).
+  Proof.
+    intros H.
+    cbv [bs2felem proj1_sig].
+    rewrite H.
+    rewrite Nat.eqb_refl.
+    exact eq_refl.
+  Qed.
+
+  Lemma felem_to_list_bs2felem (bs : list byte) :
+    length bs = felem_size_in_bytes ->
+    (felem_to_list (bs2felem bs)) = (bs2ws (bytes_per_word width) bs).
+  Proof.
+    intros H.
+    cbv [felem_to_list].
+    rapply proj_bs2felem.
+    assumption.
+  Qed.
+  
+  Lemma felem_from_bytes p bs :
+    length bs = felem_size_in_bytes ->
+    Lift1Prop.iff1 (bs$@p) (FElem p (bs2felem bs)).
+  Proof.
+    intros HL.
+    symmetry. etransitivity.
+    cbv [FElem]. 
+    rewrite proj_bs2felem; [|assumption].
+
+    epose proof ((words_of_bytes _ _)) as Hwords_of_bytes.
+    cbv [id] in Hwords_of_bytes.
+    rewrite of_nat_bytes_per in Hwords_of_bytes.
+    symmetry. rapply Hwords_of_bytes.
+    rewrite HL. rewrite bytes_per_as_Z. apply felem_size_in_bytes_mod_nat.
+
+    apply (array1_iff_eq_of_list_word_at _ _).
+    rewrite HL. pose proof felem_size_ok. lia.
+  Qed.
+
+  Lemma felem_from_bytearray p bs :
+    length bs = felem_size_in_bytes ->
+    Lift1Prop.iff1 (array ptsto (word.of_Z 1) p bs) (FElem p (bs2felem bs)).
+  Proof.
+    intros HL.
+
+    etransitivity.
+
+    apply array1_iff_eq_of_list_word_at.
+    assumption.
+    rewrite HL. pose proof felem_size_ok. lia.
+
+    apply felem_from_bytes.
+    assumption. 
+  Qed.
+
+  Lemma felem_to_Z_array p x :
+    Lift1Prop.iff1
+      (FElem p x)
+      (Array.array
+              (truncated_scalar access_size.word)
+              (word.of_Z (bytes_per_word width))
+              p (List.map word.unsigned x)).
+  Proof.
+    pose proof word_size_in_bytes_pos. 
+    cbv [FElem].
+    rewrite Util.array_truncated_scalar_scalar_iff1.
+    split; intros; sepsimpl; try assumption.
+  Qed.
+
+  Lemma FElemBytes_to_Z_array p bs :
+    Lift1Prop.iff1
+      (FElemBytes p bs)
+      (sep (map:=mem)
+           (emp (map:=mem)
+                (length bs = encoded_felem_size_in_bytes
+                 /\ bytes_in_bounds bs))
+           (Array.array
+              (Scalars.truncated_scalar access_size.one)
+              (word.of_Z 1) p (List.map byte.unsigned bs))).
+  Proof.
+    cbv [FElemBytes].
+    rewrite Util.array_truncated_scalar_ptsto_iff1.
+    rewrite ByteBounds.byte_map_of_Z_unsigned.
+    reflexivity.
+  Qed.
   Lemma M_nonzero : M <> 0.
   Proof. cbv [M]. congruence. Qed.
+
+  (* Rupicola Array helper lemmas.*)
+
+  Lemma FElem_as_array
+    : Field.FElem = Arrays.listarray_value access_size.word.
+  Proof.
+    unfold Field.FElem, Arrays.listarray_value.
+    simpl.
+    rewrite Z2Nat.id.
+    reflexivity.
+    pose word_size_in_bytes_pos.
+    lia.
+  Qed.
+    
+  Lemma felem_to_sizedlistarray p x :
+    Lift1Prop.iff1
+      (FElem p x)
+      (Arrays.sizedlistarray_value access_size.word felem_size_in_words p
+        (felem_to_list x)).
+  Proof.
+    rewrite FElem_as_array.
+    pose proof (felem_length x).
+    unfold Arrays.sizedlistarray_value.
+    split.
+    - intros. extract_ex1_and_emp_in_goal. split; assumption. 
+    - intros. extract_ex1_and_emp_in_hyps. assumption.
+  Qed. 
+
+  Lemma sizedlistarray_to_felem p x :
+    Datatypes.length x = felem_size_in_words ->
+    Lift1Prop.iff1 
+      (Arrays.sizedlistarray_value access_size.word felem_size_in_words p x)
+      (FElem p (ws2felem x)).
+  Proof.
+    split; intros.
+    SeparationLogic.seprewrite felem_to_sizedlistarray.
+    rewrite felem_to_list_ws2felem; [|assumption].
+    ecancel_assumption.
+    seprewrite_in felem_to_sizedlistarray H0.
+    rewrite felem_to_list_ws2felem in *; [|assumption].
+    ecancel_assumption.
+  Qed.
 End SpecProperties.
 
+(* FElem -> bytes for ecancel_assumption_impl. Prefer using the rewrite tactics below. *)
+#[export] Hint Extern 1 (Lift1Prop.impl1 (FElem ?px ?x) (sepclause_of_map (map.of_list_word_at ?px _))) => (rewrite felem_to_bytes; exact impl1_refl) : ecancel_impl.
 
-(* array1 -> Placeholder, only works if length sidecondition can be solved by ZnWords or lia. *)
-#[export] Hint Extern 1 (Lift1Prop.impl1 (array ptsto (word.of_Z 1) ?p ?stack) (Placeholder (field_representation:=?frep) ?p _)) => (
-    unshelve(erewrite <- (Placeholder_iff_array1 (field_representation:=frep) p _ _));
-      [ (let s := eval lazy in (felem_size_in_bytes (FieldRepresentation:=frep)) in
-          change (felem_size_in_bytes (FieldRepresentation:=frep)) with s in *; try lia; ZnWords) |
-        apply impl1_refl]) : ecancel_impl.
+(* Fail fast for non-separation logic goals. *)
+Ltac ensure_map m := lazymatch type of m with | @map.rep _ _ _ => idtac | _ => fail end.
 
-(* FElem -> Placeholder *)
-#[export] Hint Extern 1 (Lift1Prop.impl1 (FElem ?px ?x) (Placeholder ?px _)) => (apply FElem_impl_Placeholder) : ecancel_impl.
+(* Call before ecancel_assumption to recursively match and rewrite memory assumptions using the lemmas from this file.
+Applies length_tac to all side conditions.*)
+Ltac ecancel_assumption_preprocess_with length_tac :=
+  repeat match goal with
+    | |- ?G ?m => ensure_map m; match goal with H: ?P m |- _ => match P with 
+      | context[FElem ?p ?v] => match G with 
+        | context[Arrays.sizedlistarray_value _ _ p _] =>
+            seprewrite_in (felem_to_sizedlistarray p v) H
+        | context[sepclause_of_map (map.of_list_word_at p _)] =>
+            seprewrite_in (felem_to_bytes p v) H
+      end 
+      | context[Arrays.sizedlistarray_value _ _ ?p ?v] => match G with
+        | context[FElem p _] =>
+          seprewrite_in (sizedlistarray_to_felem p v) H; [length_tac |]
+      end 
+      | context[array ptsto (word.of_Z 1) ?p ?v] => match G with 
+        | context[sepclause_of_map (map.of_list_word_at p _)] =>
+            seprewrite_in (array1_iff_eq_of_list_word_at p v) H; [length_tac |]
+        | context[FElem p _] =>
+            seprewrite_in (felem_from_bytearray p v) H; [length_tac |]
+      end
+    end end
+  end.
+
+(* Rewrites FElem to bytearrays for deallocation. *)
+Ltac dealloc_preprocess :=
+    repeat match goal with
+    | |- context [anybytes ?p _ _] =>
+        match goal with
+        | H: ?P ?m |- context [map.split ?m _ _] =>
+          match P with context [FElem p ?v] =>
+            seprewrite_in (felem_to_bytearray p) H; pose proof (ws2bs_felem_length v)
+          end
+        end
+    end.
+
 


### PR DESCRIPTION
The main changes are in Field.v. Extract the length of the word list representing a field element in memory from the Bignum hidden inside FElem over to the felem type. That way, one does not need to fiddle with separation logic everytime the length of that list is needed.

There are a few helper lemmas for conversions between the different ways to represent field elements in memory in Field.v, and two new tactics to automatically rewrite between the types.

Use those new tactics throughout existing proofs, and get rid of some of the convolution the Bignum type was causing.