### PR TITLE
Add workflow and script to publish coq-fiat-crypto to opam archive on release

### DIFF
--- a/.github/workflows/publish-opam.yml
+++ b/.github/workflows/publish-opam.yml
@@ -1,0 +1,103 @@
+name: Publish to opam
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., v0.0.1)'
+        required: true
+
+permissions:
+  contents: read
+
+env:
+  PACKAGE_NAME: coq-fiat-crypto
+
+jobs:
+  publish-opam:
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.OPAM_VERSION_BUMPER_APP_ID }}
+          private-key: ${{ secrets.OPAM_VERSION_BUMPER_PRIVATE_KEY }}
+          owner: JasonGross
+          repositories: opam-coq-archive
+
+      - uses: actions/create-github-app-token@v3
+        id: app-token-upstream
+        with:
+          app-id: ${{ vars.OPAM_VERSION_BUMPER_APP_ID }}
+          private-key: ${{ secrets.OPAM_VERSION_BUMPER_PRIVATE_KEY }}
+          owner: rocq-prover
+          repositories: opam
+
+      - name: Checkout current repository
+        uses: actions/checkout@v6
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${{ github.event.release.tag_name }}"
+          fi
+          # Ensure version starts with 'v'
+          VERSION_TAG="v${VERSION#v}"
+          # Version without 'v' prefix
+          VERSION_NUM="${VERSION#v}"
+          echo "tag=${VERSION_TAG}" >> "$GITHUB_OUTPUT"
+          echo "num=${VERSION_NUM}" >> "$GITHUB_OUTPUT"
+          echo "Version tag: ${VERSION_TAG}, Version number: ${VERSION_NUM}"
+
+      - name: Prepare opam file
+        run: |
+          ./etc/prepare-opam-release.sh "${{ steps.version.outputs.tag }}"
+
+      - name: Clone opam repository
+        run: |
+          git clone https://github.com/rocq-prover/opam.git opam-repo
+
+      - name: Create package directory and copy opam file
+        run: |
+          PKG_DIR="opam-repo/released/packages/${{ env.PACKAGE_NAME }}/${{ env.PACKAGE_NAME }}.${{ steps.version.outputs.num }}"
+          mkdir -p "$PKG_DIR"
+          cp "${{ env.PACKAGE_NAME }}.opam" "$PKG_DIR/opam"
+          echo "Created $PKG_DIR/opam"
+          cat "$PKG_DIR/opam"
+
+      - name: Push branch and create PR
+        working-directory: opam-repo
+        run: |
+          BRANCH_NAME="${{ env.PACKAGE_NAME }}-${{ steps.version.outputs.num }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH_NAME"
+          git add .
+          git commit -m "Add ${{ env.PACKAGE_NAME }}.${{ steps.version.outputs.num }}"
+
+          git remote add fork https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/JasonGross/opam-coq-archive.git
+          git push -u fork "$BRANCH_NAME"
+
+          printf '%s\n\n%s\n\n%s\n' \
+            "Add ${{ env.PACKAGE_NAME }} version ${{ steps.version.outputs.num }}." \
+            "Released from: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ steps.version.outputs.tag }}" \
+            "Generated automatically by GitHub Actions" > /tmp/pr-body.md
+
+          gh pr create \
+            --repo rocq-prover/opam \
+            --base master \
+            --head "JasonGross:$BRANCH_NAME" \
+            --title "Add ${{ env.PACKAGE_NAME }}.${{ steps.version.outputs.num }}" \
+            --body-file /tmp/pr-body.md \
+            --no-maintainer-edit
+        env:
+          GH_TOKEN: ${{ steps.app-token-upstream.outputs.token }}

--- a/etc/prepare-opam-release.sh
+++ b/etc/prepare-opam-release.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# Prepares coq-fiat-crypto.opam for release by:
+# 1. Removing the version: line
+# 2. Replacing the git URL with a tarball URL and sha512 checksum
+
+set -e
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Get version from CLI or default to most recent tag
+version="${1:-$(git tag --sort=-v:refname | head -1)}"
+
+if [ -z "$version" ]; then
+    echo "Error: No version provided and no git tags found" >&2
+    exit 1
+fi
+
+# Strip leading 'v' if present for the version number
+version_num="${version#v}"
+# Ensure version starts with 'v' for the tag
+version_tag="v${version_num}"
+
+opam_file="coq-fiat-crypto.opam"
+
+if [ ! -f "$opam_file" ]; then
+    echo "Error: $opam_file not found" >&2
+    exit 1
+fi
+
+echo "Preparing $opam_file for release ${version_tag}..."
+
+# Download the tarball and compute sha512
+tarball_url="https://github.com/mit-plv/fiat-crypto/archive/refs/tags/${version_tag}.tar.gz"
+echo "Downloading ${tarball_url}..."
+
+tmpfile=$(mktemp)
+trap "rm -f '$tmpfile'" EXIT
+
+if ! wget -q "$tarball_url" -O "$tmpfile"; then
+    echo "Error: Failed to download tarball from $tarball_url" >&2
+    exit 1
+fi
+
+# Compute sha512 (works on both Linux and macOS)
+if command -v sha512sum >/dev/null 2>&1; then
+    sha512=$(sha512sum "$tmpfile" | cut -d' ' -f1)
+elif command -v shasum >/dev/null 2>&1; then
+    sha512=$(shasum -a 512 "$tmpfile" | cut -d' ' -f1)
+else
+    echo "Error: Neither sha512sum nor shasum found" >&2
+    exit 1
+fi
+
+echo "SHA512: $sha512"
+
+# Remove the version: line
+sed -i.bak '/^version:/d' "$opam_file"
+
+# Replace the url block
+# First, remove the existing url block (handles multiline)
+awk '
+/^url \{/ { in_url=1; next }
+in_url && /^\}/ { in_url=0; next }
+!in_url { print }
+' "$opam_file" > "${opam_file}.tmp"
+
+# Append the new url block
+cat >> "${opam_file}.tmp" << EOF
+url {
+  src: "${tarball_url}"
+  checksum: "sha512=${sha512}"
+}
+EOF
+
+mv "${opam_file}.tmp" "$opam_file"
+rm -f "${opam_file}.bak"
+
+echo "Done. Updated $opam_file:"
+echo "---"
+cat "$opam_file"


### PR DESCRIPTION
Adds etc/prepare-opam-release.sh to prepare the opam file for release (downloads tarball, computes sha512, replaces dev URL with release URL) and .github/workflows/publish-opam.yml to automatically create a PR to rocq-prover/opam when a GitHub release is published.