### PR TITLE
Fix wasm worker: poll for synthesize and handle wasmoocaml events

### DIFF
--- a/fiat-html/wasm_fiat_crypto_worker.js
+++ b/fiat-html/wasm_fiat_crypto_worker.js
@@ -1,15 +1,61 @@
 self.importScripts("wasm/fiat_crypto.js");
+// The wasm_of_ocaml launcher fetches and instantiates the .wasm
+// asynchronously and only then runs the OCaml entry point that does
+// `Js.export "synthesize" ...`, so `self.synthesize` is not defined
+// when importScripts returns. Queue messages and poll until ready.
+// Newer wasm_of_ocaml (https://github.com/ocaml-wasm/wasm_of_ocaml/pull/143)
+// dispatches `wasmoocaml:loaded` / `wasmoocaml:error` on globalThis; we hook
+// those when available and keep the polling fallback for older releases.
 let pending = [];
+let ready = false;
 self.onmessage = function (e) { pending.push(e); };
-setTimeout(function () {
-    self.onmessage = function(e) {
+
+function installHandler() {
+    if (ready) return;
+    ready = true;
+    self.onmessage = function (e) {
         try {
-            const result = synthesize(e.data);
-            postMessage({result: result});
+            const result = self.synthesize(e.data);
+            postMessage({ result: result });
         } catch (err) {
-            postMessage({error: err});
+            postMessage({ error: err });
         }
     };
     pending.forEach(e => { self.onmessage(e); });
     pending = [];
-}, 1000);
+}
+
+function reportLoadError(err, src) {
+    if (ready) return;
+    ready = true;
+    const message = "wasm_fiat_crypto_worker: wasm load failed" + (src ? " (src=" + src + ")" : "");
+    console.error(message, err);
+    self.onmessage = function () {
+        postMessage({ error: { name: "WasmLoadError", message: message, cause: err } });
+    };
+    pending.forEach(e => { self.onmessage(e); });
+    pending = [];
+}
+
+self.addEventListener("wasmoocaml:loaded", function (e) {
+    console.log(
+        "wasm_fiat_crypto_worker: received wasmoocaml:loaded; the installed " +
+        "wasm_of_ocaml is new enough that the polling fallback in this file " +
+        "can be removed (see https://github.com/ocaml-wasm/wasm_of_ocaml/pull/143).",
+        e && e.detail
+    );
+    installHandler();
+});
+self.addEventListener("wasmoocaml:error", function (e) {
+    reportLoadError(e && e.detail && e.detail.error, e && e.detail && e.detail.src);
+});
+
+(function waitForReady() {
+    if (ready) return;
+    if (typeof self.synthesize === 'function') {
+        installHandler();
+    } else {
+        console.warn("wasm_fiat_crypto_worker: self.synthesize not yet defined, retrying in 50ms");
+        setTimeout(waitForReady, 50);
+    }
+})();


### PR DESCRIPTION
## Summary
- Replace the fixed 1s `setTimeout` in `fiat-html/wasm_fiat_crypto_worker.js` with a 50ms poll for `self.synthesize`. The current `wasm_of_ocaml` launcher loads/instantiates the (~13.8 MB) wasm asynchronously and only then runs the OCaml entry that does `Js.export "synthesize" ...`, so on the deployed site the timeout regularly elapsed before initialization finished, producing `ReferenceError: synthesize is not defined`.
- Subscribe to the `wasmoocaml:loaded` / `wasmoocaml:error` events introduced in https://github.com/ocaml-wasm/wasm_of_ocaml/pull/143: install the handler immediately on success, surface load failures back to the page (instead of polling forever), and log a note on the loaded path that the polling fallback can be removed once the deployed `wasm_of_ocaml` ships these events.

## Test plan
- [ ] Load https://mit-plv.github.io/fiat-crypto/ with the unsaturated-solinas/bedrock2 example query (the one in the bug report) and confirm WASM synthesis succeeds without the `ReferenceError`.
- [ ] Confirm the js_of_ocaml path is unaffected.
- [ ] Once deployed `wasm_of_ocaml` includes ocaml-wasm/wasm_of_ocaml#143, verify the `wasmoocaml:loaded` console message appears and remove the polling fallback.