### PR TITLE
EdwardsXYZT.v: drop 4 vestigial imports

### DIFF
--- a/src/Bedrock/End2End/X25519/EdwardsXYZT.v
+++ b/src/Bedrock/End2End/X25519/EdwardsXYZT.v
@@ -1,6 +1,5 @@
 Require Import bedrock2.Array.
 Require Import bedrock2.bottom_up_simpl.
-Require Import bedrock2.FE310CSemantics.
 Require Import bedrock2.Loops.
 Require Import bedrock2.Map.Separation.
 Require Import bedrock2.Map.SeparationLogic.
@@ -13,9 +12,6 @@ Require Import bedrock2.Syntax.
 Require Import bedrock2.WeakestPrecondition.
 Require Import bedrock2.WeakestPreconditionProperties.
 Require Import bedrock2.ZnWords.
-Require Import compiler.MMIO.
-Require Import compiler.Pipeline.
-Require Import compiler.Symbols.
 Require Import coqutil.Byte.
 Require Import coqutil.Map.Interface.
 Require Import coqutil.Map.OfListWord.


### PR DESCRIPTION
## Summary

Drops 4 unused imports from `src/Bedrock/End2End/X25519/EdwardsXYZT.v`:

- `bedrock2.FE310CSemantics`
- `compiler.MMIO`
- `compiler.Pipeline`
- `compiler.Symbols`

None of these are referenced in the file. They appear to have been copy-pasted from an upstream LAN9250-style example. Removing them allows the file to be built in environments where the `compiler` package isn't available (e.g., downstream consumers running on a bedrock2-only setup).

## Test plan

- [x] Verified clean build with both old and new imports — same `.vo` size, same proof terms.