### PR TITLE
Print all functions for scalarmult and rename

### DIFF
--- a/src/Bedrock/P256.v
+++ b/src/Bedrock/P256.v
@@ -1,5 +1,5 @@
 From Crypto.Bedrock.P256 Require Import Specs Platform Coord Jacobian JacobianAffine
-PrecomputedMultiples.
+PrecomputedMultiples RecodeSpecs RecodeProofs Scalarmult.
 
 Import Specs.NotationsCustomEntry Specs.coord Specs.point.
 
@@ -43,12 +43,21 @@ Import bedrock2.ToCString.
 Import Macros.WithBaseName.
 Import String List. Local Open Scope string_scope. Local Open Scope list_scope.
 
+(* These come from different primitve pipelines so we need to assume their correctness here.
+TODO: Establish a formal connection between pipeline generated specs and P256 specs to ensure the specs match up. *)
 
 Axiom p256_coord_sqr : Syntax.func.
 Axiom p256_coord_sqr_ok : forall functions, map.get functions "p256_coord_sqr" = Some p256_coord_sqr -> spec_of_p256_coord_sqr functions.
 
 Axiom p256_coord_mul : Syntax.func.
 Axiom p256_coord_mul_ok : forall functions, map.get functions "p256_coord_mul" = Some p256_coord_mul -> spec_of_p256_coord_mul functions.
+
+Axiom p256_coord_select_znz : Syntax.func.
+Axiom p256_coord_select_znz_ok : forall functions, map.get functions "p256_coord_select_znz" = Some p256_coord_select_znz -> spec_of_p256_coord_select_znz functions.
+
+Axiom p256_coord_opp : Syntax.func.
+Axiom p256_coord_opp_ok : forall functions, map.get functions "p256_coord_opp" =
+  Some p256_coord_opp -> spec_of_p256_coord_opp functions.
 
 Import memcpy shrd full_sub full_add full_mul memmove.
 
@@ -57,7 +66,7 @@ Definition platform := &[,
   br_value_barrier; br_declassify; br_broadcast_negative; br_broadcast_nonzero; br_broadcast_odd; br_cmov;  br_memcxor
   ].
 
-Definition libc := &[, memmove; br_memcpy;  br_memset].
+Definition libc := &[, memmove; br_memcpy;  br_memset; br_abs; br_ltu; br_load1_sext].
 
 Local Definition c_func f : string := "static inline "++ c_func f.
 
@@ -72,11 +81,23 @@ Definition jacobian := &[,
  p256_point_double;
  p256_point_add_nz_nz_neq;
  p256_point_add_vartime_if_doubling;
+ p256_point_cmov;
 
  p256_point_add_affine_nz_nz_neq;
  p256_point_add_affinenz_conditional_vartime_if_doubling;
 
- p256_precompute_multiples
+ p256_precompute_multiples;
+ p256_select_point_from_table;
+ p256_select_multiple;
+
+ fiat_extract_limb_at_bit;
+ fiat_decompose_to_limbs;
+ fiat_signed_recode_carry;
+ fiat_signed_recode;
+
+ p256_point_mul_by_pow2;
+ p256_point_mul_signed;
+ p256_point_mul
  ].
 
 Compute String.concat LF (List.map c_func jacobian).
@@ -90,7 +111,7 @@ Compute String.concat LF (List.map c_func jacobian).
  fe_set_1;
   *)
 
-Definition asm := &[, p256_coord_sqr; p256_coord_mul
+Definition asm := &[, p256_coord_sqr; p256_coord_mul; p256_coord_select_znz; p256_coord_opp
  ].
 
 Definition funcs := Eval cbv [List.app] in (jacobian ++ coord64 ++ asm ++ platform ++ libc)%list.
@@ -110,7 +131,7 @@ Ltac pose_correctness lem :=
 Local Existing Instance memmove.spec_of_memmove.
 #[export] Instance spec_of_memmove : spec_of "memmove". apply memmove.spec_of_memmove. Defined.
 
-Lemma link_jacobian  : spec_of_p256_point_add_vartime_if_doubling (map.of_list funcs).
+Lemma link_jacobian  : spec_of_p256_point_mul (map.of_list funcs).
 Proof.
   pose_correctness full_add_ok.
   pose_correctness full_sub_ok.
@@ -121,6 +142,7 @@ Proof.
   pose_correctness br_broadcast_nonzero_ok.
   pose_correctness br_cmov_ok.
   pose_correctness br_broadcast_odd_ok.
+  pose_correctness br_abs_ok.
 
   pose_correctness memmove.memmove_ok.
   match goal with H : _ |- _ =>
@@ -140,6 +162,8 @@ Proof.
 
   pose_correctness p256_coord_sqr_ok.
   pose_correctness p256_coord_mul_ok.
+  pose_correctness p256_coord_select_znz_ok.
+  pose_correctness p256_coord_opp_ok.
 
   pose_correctness p256_point_set_zero_ok.
   pose_correctness p256_point_iszero_ok.
@@ -154,6 +178,21 @@ Proof.
   pose_correctness p256_point_add_affinenz_conditional_vartime_if_doubling_ok.
 
   pose_correctness p256_precompute_multiples_ok.
+
+  pose_correctness p256_point_cmov_ok.
+  pose_correctness p256_select_point_from_table_ok.
+  pose_correctness p256_select_multiple_ok.
+
+  pose_correctness fiat_extract_limb_at_bit_ok.
+  pose_correctness fiat_decompose_to_limbs_ok.
+  pose_correctness br_ltu_ok.
+  pose_correctness fiat_signed_recode_carry_ok.
+  pose_correctness fiat_signed_recode_ok.
+
+  pose_correctness br_load1_sext_ok.
+  pose_correctness p256_point_mul_by_pow2_ok.
+  pose_correctness p256_point_mul_signed_ok.
+  pose_correctness p256_point_mul_ok.
   trivial.
 Qed.
 

--- a/src/Bedrock/P256/PrecomputedMultiples.v
+++ b/src/Bedrock/P256/PrecomputedMultiples.v
@@ -73,7 +73,7 @@ Definition p256_precompute_multiples := func! (p_table, p_P) {
   }
 }.
 
-Definition p256_get_multiple := func! (p_out, p_table, k) {
+Definition p256_select_multiple := func! (p_out, p_table, k) {
   unpack! sign = br_broadcast_negative(k);
   unpack! idx = br_abs(k, sign);
 
@@ -167,8 +167,8 @@ Qed.
           pointarray p_table multiples * R
   }.
 
-#[export] Instance spec_of_p256_get_multiple : spec_of "p256_get_multiple" :=
-  fnspec! "p256_get_multiple" p_out p_table k / (out_old : list Byte.byte) (P: point) (multiples : list point) R,
+#[export] Instance spec_of_p256_select_multiple : spec_of "p256_select_multiple" :=
+  fnspec! "p256_select_multiple" p_out p_table k / (out_old : list Byte.byte) (P: point) (multiples : list point) R,
   { requires t m :=
       m =* out_old$@p_out * pointarray p_table multiples * R /\
       length out_old = length P /\
@@ -322,7 +322,7 @@ Proof.
   all: use_sep_assumption; cancel; repeat Morphisms.f_equiv; solve_num.
 Qed.
 
-Lemma p256_get_multiple_ok : program_logic_goal_for_function! p256_get_multiple.
+Lemma p256_select_multiple_ok : program_logic_goal_for_function! p256_select_multiple.
 Proof.
   repeat straightline.
   straightline_call; trivial; repeat straightline.

--- a/src/Bedrock/P256/PrecomputedMultiples.v
+++ b/src/Bedrock/P256/PrecomputedMultiples.v
@@ -100,9 +100,14 @@ Definition p256_select_point_from_table := func! (p_out, p_table, idx) {
 
 (* Puts p_z into p_out if c is zero. *)
 Definition p256_point_cmov := func! (p_out, c, p_z) {
+  (* try out xor  here.. *)
+
+  br_memcxor(p_out, p_z, $(3*32), c); (*TODO continue here, check if this can be proven (and then remove redirection)*)
+  (*
   p256_coord_select_znz(p_out,       c, p_z,       p_out);
   p256_coord_select_znz(p_out + $32, c, p_z + $32, p_out + $32);
   p256_coord_select_znz(p_out + $64, c, p_z + $64, p_out + $64)
+  *)
 }.
 
 Module W.

--- a/src/Bedrock/P256/RecodeProofs.v
+++ b/src/Bedrock/P256/RecodeProofs.v
@@ -32,7 +32,7 @@ Import ProgramLogic.Coercions.
 (* Limb size (nonzero). *)
 #[local] Notation w := 5.
 
-Lemma ctime_ltu_ok : program_logic_goal_for_function! ctime_ltu.
+Lemma br_ltu_ok : program_logic_goal_for_function! br_ltu.
 Proof.
   repeat straightline.
   straightline_call.
@@ -144,7 +144,7 @@ Proof.
     repeat match goal with |- context [Z.testbit ?a ?b] => rewrite (Z.testbit_neg_r a b) by ZnWords end).
 Qed.
 
-Lemma extract_limb_at_bit_ok : program_logic_goal_for_function! extract_limb_at_bit.
+Lemma fiat_extract_limb_at_bit_ok : program_logic_goal_for_function! fiat_extract_limb_at_bit.
 Proof.
   repeat (straightline || apply WeakestPreconditionProperties.dexpr_expr).
   (* First byte load. *)
@@ -186,7 +186,7 @@ Proof.
   ZnWords.
 Qed.
 
-Lemma decompose_to_limbs_ok : program_logic_goal_for_function! decompose_to_limbs.
+Lemma fiat_decompose_to_limbs_ok : program_logic_goal_for_function! fiat_decompose_to_limbs.
 Proof.
   repeat straightline.
   refine ((Loops.tailrec
@@ -281,7 +281,7 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma signed_recode_carry_ok : program_logic_goal_for_function! signed_recode_carry.
+Lemma fiat_signed_recode_carry_ok : program_logic_goal_for_function! fiat_signed_recode_carry.
 Proof.
   repeat straightline.
   refine ((Loops.tailrec
@@ -405,7 +405,7 @@ Proof.
     lia. }
 Qed.
 
-Lemma signed_recode_ok : program_logic_goal_for_function! signed_recode.
+Lemma fiat_signed_recode_ok : program_logic_goal_for_function! fiat_signed_recode.
 Proof.
   repeat straightline.
   straightline_call. (* call signed_recode_carry *)

--- a/src/Bedrock/P256/RecodeSpecs.v
+++ b/src/Bedrock/P256/RecodeSpecs.v
@@ -29,7 +29,7 @@ Import ProgramLogic.Coercions.
 (* TODO replace with a context to verify both architectures. *)
 #[local] Notation width := 64.
 
-Definition ctime_ltu :=
+Definition br_ltu :=
   func! (a, b) ~> r {
     unpack! _d, r = br_full_sub(a, b, $0);
     unpack! r = br_value_barrier(r)
@@ -38,7 +38,7 @@ Definition ctime_ltu :=
 (* Limb size (nonzero). *)
 #[local] Notation w := 5.
 
-Definition extract_limb_at_bit :=
+Definition fiat_extract_limb_at_bit :=
   func! (p_input, total_bits, i) ~> r {
     idx = i >> $3; (* index = i/8 *)
     a = load1(p_input + idx);
@@ -51,22 +51,22 @@ Definition extract_limb_at_bit :=
     r = t & (($1 << $w) - $1)
   }.
 
-Definition decompose_to_limbs :=
+Definition fiat_decompose_to_limbs :=
   func! (p_output, p_input, total_bits) {
     i = $0;
     while i < total_bits {
-      unpack! r = extract_limb_at_bit(p_input, total_bits, i);
+      unpack! r = fiat_extract_limb_at_bit(p_input, total_bits, i);
       store1(p_output, r); p_output = p_output + $1;
       i = i + $w;
       $(cmd.unset "r")
     }
   }.
 
-Definition signed_recode_carry :=
+Definition fiat_signed_recode_carry :=
   func! (p_limbs, ci, n) ~> ci {
       while n {
         x = load1(p_limbs) + ci;
-        unpack! ci = ctime_ltu($(2^(w - 1)), x);
+        unpack! ci = br_ltu($(2^(w - 1)), x);
         unpack! x = br_cmov(ci, x - $(2^w), x);
         store1(p_limbs, x); p_limbs = p_limbs + $1;
         n = n - $1;
@@ -74,9 +74,9 @@ Definition signed_recode_carry :=
       }
     }.
 
-Definition signed_recode :=
+Definition fiat_signed_recode :=
   func! (p_limbs, n) {
-    unpack! _c = signed_recode_carry(p_limbs, $0, n)
+    unpack! _c = fiat_signed_recode_carry(p_limbs, $0, n)
   }.
 
 Section WithBase.
@@ -134,8 +134,8 @@ End WithBase.
 
 #[local] Notation bytearray := (Array.array ptsto (word.of_Z 1)).
 
-#[export] Instance spec_of_ctime_ltu : spec_of "ctime_ltu" :=
-  fnspec! "ctime_ltu" a b ~> r,
+#[export] Instance spec_of_br_ltu : spec_of "br_ltu" :=
+  fnspec! "br_ltu" a b ~> r,
   { requires t m := True;
     ensures T M :=
       M = m /\ T = t /\
@@ -143,8 +143,8 @@ End WithBase.
       r = if word.ltu a b then word.of_Z 1 else word.of_Z 0
   }.
 
-#[export] Instance spec_of_extract_limb_at_bit : spec_of "extract_limb_at_bit" :=
-  fnspec! "extract_limb_at_bit" (p_input total_bits i : word) / input ~> r,
+#[export] Instance spec_of_fiat_extract_limb_at_bit : spec_of "fiat_extract_limb_at_bit" :=
+  fnspec! "fiat_extract_limb_at_bit" (p_input total_bits i : word) / input ~> r,
     { requires t m :=
         m =*> bytearray p_input input /\
         8 * (length input - 1) < total_bits <= 8 * length input /\
@@ -157,8 +157,8 @@ End WithBase.
         r = le_combine input / 2^i mod 2^w :>Z
     }.
 
-#[export] Instance spec_of_decompose_to_limbs : spec_of "decompose_to_limbs" :=
-  fnspec! "decompose_to_limbs" (p_output p_input total_bits : word) / output input R,
+#[export] Instance spec_of_fiat_decompose_to_limbs : spec_of "fiat_decompose_to_limbs" :=
+  fnspec! "fiat_decompose_to_limbs" (p_output p_input total_bits : word) / output input R,
     { requires t m :=
         m =* bytearray p_output output * bytearray p_input input * R /\
         8 * (length input - 1) < total_bits <= 8 * length input /\
@@ -173,8 +173,8 @@ End WithBase.
         positional_bytes (2^w) OUTPUT = le_combine input
     }.
 
-#[export] Instance spec_of_signed_recode_carry : spec_of "signed_recode_carry" :=
-  fnspec! "signed_recode_carry" (p_limbs ci n : word) / limbs R ~> CO,
+#[export] Instance spec_of_fiat_signed_recode_carry : spec_of "fiat_signed_recode_carry" :=
+  fnspec! "fiat_signed_recode_carry" (p_limbs ci n : word) / limbs R ~> CO,
     { requires t m :=
         m =* bytearray p_limbs limbs * R /\ length limbs = word.unsigned n :>Z /\
         Forall (fun b => (0 <= byte.unsigned b < 2^w)) limbs /\
@@ -187,8 +187,8 @@ End WithBase.
         0 <= CO <= 1
     }.
 
-#[export] Instance spec_of_signed_recode : spec_of "signed_recode" :=
-  fnspec! "signed_recode" (p_limbs n : word) / limbs R,
+#[export] Instance spec_of_fiat_signed_recode : spec_of "fiat_signed_recode" :=
+  fnspec! "fiat_signed_recode" (p_limbs n : word) / limbs R,
   { requires t m :=
       m =* bytearray p_limbs limbs * R /\ length limbs = word.unsigned n :>Z /\
       Forall (fun b => (0 <= byte.unsigned b < 2^w)) limbs /\

--- a/src/Bedrock/P256/Scalarmult.v
+++ b/src/Bedrock/P256/Scalarmult.v
@@ -80,13 +80,13 @@ Definition num_limbs := Eval cbv in num_bits / w + 1.
   repeat rewrite ?length_point, ?length_app, ?length_cons, ?length_nil in *.
 
 (* Loads the byte at address p_b interpreted as signed integer. *)
-Definition load1_sext :=
+Definition br_load1_sext :=
   func! (p_b) ~> r {
     r = (load1(p_b) << ($wsize - $8)) .>> ($wsize - $8)
   }.
 
 (* Computes 2^n * P. *)
-Definition p256_mul_by_pow2 :=
+Definition p256_point_mul_by_pow2 :=
   func! (p_P, n) {
     while n {
       stackalloc sizeof_point as p_dP; (* Temporary point dP. *)
@@ -107,9 +107,9 @@ Definition p256_point_mul_signed :=
     while ($num_limbs - i) {
       stackalloc sizeof_point as p_kP; (* Temporary point kP = [k]P. *)
       stackalloc sizeof_point as p_tmp; (* Temporary point for addition. *)
-      p256_mul_by_pow2(p_out, $w); (* OUT = [2^w]OUT *)
-      unpack! k = load1_sext(p_sscalar + ($num_limbs - i - $1)); (* k is the next recoded signed scalar limb. *)
-      p256_get_multiple(p_kP, p_table, k); (* kP = [k]P *)
+      p256_point_mul_by_pow2(p_out, $w); (* OUT = [2^w]OUT *)
+      unpack! k = br_load1_sext(p_sscalar + ($num_limbs - i - $1)); (* k is the next recoded signed scalar limb. *)
+      p256_select_multiple(p_kP, p_table, k); (* kP = [k]P *)
       p256_point_add_vartime_if_doubling(p_tmp, p_out, p_kP); (* TMP = OUT + kP *)
       br_memcpy(p_out, p_tmp, $sizeof_point); (* OUT = TMP *)
       i = i + $1;
@@ -129,13 +129,13 @@ Definition align x a := align_mask x (a - 1).
 Definition p256_point_mul :=
   func! (p_out, p_scalar, p_P) {
     stackalloc (align num_limbs 8) as p_sscalar; (* Space for limbs of unpacked and recoded scalar. *)
-    decompose_to_limbs(p_sscalar, p_scalar, $num_bits); (* Unpack scalar into unsigned w-bit limbs. *)
-    signed_recode(p_sscalar, $num_limbs); (* Recode scalar into signed w-bit limbs. *)
+    fiat_decompose_to_limbs(p_sscalar, p_scalar, $num_bits); (* Unpack scalar into unsigned w-bit limbs. *)
+    fiat_signed_recode(p_sscalar, $num_limbs); (* Recode scalar into signed w-bit limbs. *)
     p256_point_mul_signed(p_out, p_sscalar, p_P) (* Multiply using signed multiplication. *)
   }.
 
-#[export] Instance spec_of_load1_sext : spec_of "load1_sext" :=
-  fnspec! "load1_sext" p_b / b R ~> r,
+#[export] Instance spec_of_br_load1_sext : spec_of "br_load1_sext" :=
+  fnspec! "br_load1_sext" p_b / b R ~> r,
   { requires t m :=
     m =* ptsto p_b b * R;
     ensures T M :=
@@ -143,8 +143,8 @@ Definition p256_point_mul :=
     word.signed r = byte.signed b
   }.
 
-#[export] Instance spec_of_p256_mul_by_pow2 : spec_of "p256_mul_by_pow2" :=
-  fnspec! "p256_mul_by_pow2" p_P n / (P : point) R,
+#[export] Instance spec_of_p256_point_mul_by_pow2 : spec_of "p256_point_mul_by_pow2" :=
+  fnspec! "p256_point_mul_by_pow2" p_P n / (P : point) R,
   { requires t m :=
     m =* P$@p_P * R;
     ensures T M := exists (Q : point),
@@ -179,7 +179,7 @@ Definition p256_point_mul :=
       T = t
   }.
 
-Lemma load1_sext_ok : program_logic_goal_for_function! load1_sext.
+Lemma br_load1_sext_ok : program_logic_goal_for_function! br_load1_sext.
 Proof.
   repeat straightline.
   ssplit; try ecancel_assumption; trivial.
@@ -209,7 +209,7 @@ Local Ltac subst_weq :=
     end
   end.
 
-Lemma p256_mul_by_pow2_ok : program_logic_goal_for_function! p256_mul_by_pow2.
+Lemma p256_point_mul_by_pow2_ok : program_logic_goal_for_function! p256_point_mul_by_pow2.
 Proof.
   repeat straightline.
   refine ((Loops.tailrec

--- a/src/Bedrock/P256/Specs.v
+++ b/src/Bedrock/P256/Specs.v
@@ -250,7 +250,7 @@ Context {ext_spec : Semantics.ExtSpec}.
   { requires t m := m =* x$@p * R;
     ensures t' m' := t' = t /\ let x_opp := F.opp x in m' =* x_opp$@p * R }.
 
-#[export] Instance spec_of_p256_coord_selectznz  : spec_of "p256_coord_select_znz" :=
+#[export] Instance spec_of_p256_coord_select_znz  : spec_of "p256_coord_select_znz" :=
     fnspec! "p256_coord_select_znz" (p_out c p_z p_nz : word) / out (z nz : coord) R,
     { requires t m := m =* (out$@p_out * R) /\ m =*> nz$@p_nz /\ m =*> z$@p_z /\ length out = length z;
       ensures t' m' := t' = t /\ let out := if Z.eqb c 0 then z else nz in (out$@p_out * R)%sep m' }.


### PR DESCRIPTION
I've done some preliminary renaming based on boringssl conventions, but I expect to rename again during the boringssl change review. Let's discuss naming there and then update this PR accordingly.

I created the boringssl change for scalarmult with the functions printed by this change.