### PR TITLE
Register field_parameters before the MontgomeryLadder derives (fix build on Rocq dev)

### DIFF
--- a/src/Bedrock/End2End/X25519/MontgomeryLadder.v
+++ b/src/Bedrock/End2End/X25519/MontgomeryLadder.v
@@ -28,6 +28,7 @@ Require Import Crypto.Bedrock.End2End.X25519.clamp.
 Local Open Scope string_scope.
 Import ListNotations.
 
+Local Existing Instance field_parameters.
 Local Existing Instance frep25519.
 Local Existing Instance frep25519_ok.
 Derive ladderstep SuchThat (ladderstep = ladderstep_body) As ladderstep_defn.


### PR DESCRIPTION
*[Written by Claude (Fable 5) via Claude Code, on behalf of @JasonGross.]*

Fixes #2356 (fiat-crypto side; the upstream discussion continues in rocq-prover/rocq#22227 / rocq-prover/rocq#22228).

`docker-master` fails since the `rocq/rocq-prover:dev` image picked up rocq-prover/rocq#22037 ("Fix goal-tactic association in typeclass search"):

```
File "./src/Bedrock/End2End/X25519/MontgomeryLadder.v", line 34, characters 26-39:
Error: ... Unable to unify "?ladderstep" with ... match ?field_representaton with ...
```

The `Derive ladderstep`/`Derive montladder` statements resolve the typeclass arguments of `ladderstep_body`/`montladder_body`, among which `?field_parameters : FieldParameters`. `Field25519.field_parameters` is declared inside a section and its discharged instance hint is not usable at query time (`Set Typeclasses Debug` shows `no match for FieldParameters, 0 possibilities` — on all Rocq versions), so this resolution only ever succeeded indirectly: solving the *later* goal `?field_representaton : FieldRepresentation` with `frep25519` instantiates `?field_parameters` by unification. Rocq's fixed goal-tactic association makes the `FieldParameters` goal fail hard before the `FieldRepresentation` goal is attempted, so the whole resolution now fails (analysis in mit-plv/fiat-crypto#2356 and rocq-prover/rocq#22227).

The fix mirrors what this very file already does later (line ~73, before the `x25519` lemmas) and what `EdwardsXYZT.v` does before *its* derives: re-register `field_parameters` locally before the `Derive`s, making the instance directly resolvable.

Verified against a locally built Rocq at master `2274c5dc56` (the commit in the failing `dev` images, with the full coqutil/bedrock2/rewriter dependency stack): `MontgomeryLadder.vo` fails before this change with the CI error and compiles after it. Also verified on Rocq `c87d4f7338` (the last passing dev image) during the investigation, where the indirect path still works — the line is a no-op there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ttctspSoVoquHLQtbPVZw
