### PR TITLE
CI (macOS): drop redundant `opam update` that trips opam 2.5.1 patch bug

### DIFF
--- a/.github/workflows/coq-macos.yml
+++ b/.github/workflows/coq-macos.yml
@@ -58,7 +58,6 @@ jobs:
         brew link pkg-config
     - name: Install system dependencies
       run: brew install gnu-time gnu-sed coreutils grep
-    - run: opam update
     - run: opam pin add coq ${COQ_VERSION}
     - run: opam install js_of_ocaml
     - name: echo build params


### PR DESCRIPTION
ocaml/setup-ocaml@v3 already runs `opam update` after restoring its cache, so the explicit `- run: opam update` step in the macOS workflow re-updates an already-up-to-date opam repository. With opam 2.5.1 this second update can fail with:

```
[ERROR] Could not update repository "default": OpamSystem.Internal_patch_error("Patch "in directory /Users/runner/.opam/repo/default" does not apply cleanly.")
```

(e.g. both macOS jobs in [this run](https://github.com/mit-plv/fiat-crypto/actions/runs/28913346684/job/85775113022)).

This is opam's internal patch implementation failing on rename/copy-related git diff output (ocaml/opam#6937; fixes pending in ocaml/opam#6992 and hannesm/patch#44, not in opam 2.5.2). Per the analysis in https://github.com/ocaml/setup-ocaml/issues/1108#issuecomment-4959199626, the immediate workaround is to drop the redundant `opam update`, which sidesteps the bug entirely — there is no window for the local repo snapshot to drift from the fetched ref between setup-ocaml's update and the package installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9QkShrWJDYSi6Z7Q38ZgF

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9QkShrWJDYSi6Z7Q38ZgF)_