### PR TITLE
CI (docker): derive required binaryen version from wasm_of_ocaml sources

### DIFF
--- a/.github/workflows/coq-docker.yml
+++ b/.github/workflows/coq-docker.yml
@@ -325,11 +325,11 @@ jobs:
     - name: echo build params
       run: etc/ci/describe-system-config.sh
     - run: opam update -y
-    - name: Set up binaryen >= 118
+    - name: Set up binaryen >= 119
       uses: acifani/setup-tinygo@v3
       with:
         tinygo-version: '0.30.0'
-        binaryen-version: '118'
+        binaryen-version: '119'
     - name: install wasm_of_ocaml
       run: opam install -y wasm_of_ocaml-compiler ocamlfind
     - name: echo build params

--- a/.github/workflows/coq-docker.yml
+++ b/.github/workflows/coq-docker.yml
@@ -325,11 +325,28 @@ jobs:
     - name: echo build params
       run: etc/ci/describe-system-config.sh
     - run: opam update -y
-    - name: Set up binaryen >= 119
+    - name: Determine binaryen version required by wasm_of_ocaml-compiler
+      id: binaryen
+      run: |
+        version=""
+        src="$(mktemp -d)/src"
+        # wasm_of_ocaml checks the binaryen version at build time via
+        # `let min_version = NNN` in runtime/wasm/check_binaryen.ml, so
+        # extract the requirement from the sources before installing.
+        if opam source wasm_of_ocaml-compiler --dir="$src"; then
+          version="$(find "$src" -name check_binaryen.ml -exec grep -hoE 'min_version *= *[0-9]+' {} + | grep -oE '[0-9]+' | head -1)"
+        fi
+        if [ -z "$version" ]; then
+          version=119
+          echo "::warning::Could not determine required binaryen version from wasm_of_ocaml-compiler sources; falling back to ${version} (if this is too old, the install step below will say so)"
+        fi
+        echo "wasm_of_ocaml-compiler requires binaryen >= ${version}"
+        echo "version=${version}" | tee -a "$GITHUB_OUTPUT"
+    - name: Set up binaryen ${{ steps.binaryen.outputs.version }}
       uses: acifani/setup-tinygo@v3
       with:
         tinygo-version: '0.30.0'
-        binaryen-version: '119'
+        binaryen-version: ${{ steps.binaryen.outputs.version }}
     - name: install wasm_of_ocaml
       run: opam install -y wasm_of_ocaml-compiler ocamlfind
     - name: echo build params


### PR DESCRIPTION
The `build-wasm-of-ocaml` job pinned `binaryen-version: '118'`, but wasm_of_ocaml-compiler 6.4.1 checks the binaryen version at build time and now requires ≥ 119:

```
# (cd _build/default/runtime/wasm && .../_opam/bin/ocaml ./check_binaryen.ml)
# Error: wasm-merge version 118 is too old. Binaryen >= 119 is required.
```

Rather than bumping to a new hard pin that will go stale again, derive the requirement from the package itself before installing: `opam source wasm_of_ocaml-compiler` fetches the exact sources opam would build, and the requirement lives there as `let min_version = NNN` in `runtime/wasm/check_binaryen.ml` — the same constant the package's build-time check enforces. The extracted value is printed in the log, exposed as a step output, and fed to `setup-tinygo`'s `binaryen-version`, so the job always installs exactly the binaryen version the package demands.

If extraction ever fails (e.g. upstream restructures the check), the step falls back to 119 with a workflow warning; a too-old fallback is still reported clearly by the existing build-time check during `opam install`, so nothing is masked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9QkShrWJDYSi6Z7Q38ZgF