### PR TITLE
CI (macOS): skip generated-files and amd64-asm tests on x86_64 to fit the 6h limit

### DIFF
--- a/.github/workflows/coq-macos.yml
+++ b/.github/workflows/coq-macos.yml
@@ -83,10 +83,16 @@ jobs:
       run: opam exec -- etc/ci/github-actions-make.sh -j2 standalone-js-of-ocaml
     - name: install-standalone-js-of-ocaml
       run: opam exec -- etc/ci/github-actions-make.sh install-standalone-js-of-ocaml
+    # The x86_64 runners are back over the 6h job limit (~5h56m used before
+    # these steps even start), so skip the file-generation and amd64-asm test
+    # steps there; they are architecture-independent and still covered by the
+    # arm64 macOS job as well as the Linux and Windows CI.
     - name: c-files lite-generated-files
       run: opam exec -- etc/ci/github-actions-make.sh -j2 c-files lite-generated-files
+      if: matrix.os.arch != 'x86_64'
     - name: only-test-amd64-files-lite
       run: opam exec -- etc/ci/github-actions-make.sh -j2 only-test-amd64-files-lite SLOWEST_FIRST=1
+      if: matrix.os.arch != 'x86_64'
     - run: find . -name "*.timing" | xargs tar -czvf timing-files.tgz
       if: failure()
     - name: upload generated timing files


### PR DESCRIPTION
The macOS x86_64 job is over the 6h GitHub Actions job limit again. On #2366 it was cancelled at exactly 6h00m: 52m `deps` + 1h13m `standalone-ocaml` + **3h10m `coq`** + setup/misc left it at 5h56m before `c-files lite-generated-files` even started (the cancellation landed 4 minutes into that step). The arm64 job finished the same work in 2h23m.

Per the plan from #2343's follow-up discussion: gate `c-files lite-generated-files` and `only-test-amd64-files-lite` off on the x86_64 runner (`if: matrix.os.arch != 'x86_64'`). Both are architecture-independent checks that remain covered by the arm64 macOS job as well as the Linux and Windows CI. The x86_64 job still builds the full proofs and the standalone/js binaries it uploads, so release artifacts (including the lipo universal binary) are unchanged.

This buys back roughly the 1h+ those steps would take at x86_64 speeds, putting the job at ~5h50m — still not a huge margin. If it creeps over again, the remaining levers are `SKIP_BEDROCK2=1` on x86_64 (changes the published x86_64/universal binary) or splitting the proof build across two jobs, both bigger hammers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9QkShrWJDYSi6Z7Q38ZgF

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9QkShrWJDYSi6Z7Q38ZgF)_