### PR TITLE
Verify beeu normalize

### DIFF
--- a/src/Bedrock/P256/modinv/beeu_normalize.v
+++ b/src/Bedrock/P256/modinv/beeu_normalize.v
@@ -7,7 +7,6 @@ Require Import Util.ZRange.
 Require Import P256.modinv.u320_sub.
 From Coq Require Import Zmod ZArith.
 Local Open Scope string_scope. Local Open Scope Z_scope.
-Require Import Setoid.
 
 Local Notation eval := (fold_right (fun (a : word) (s : Z) => a + 2^64*s) 0).
 Local Notation array := (array scalar (word.of_Z 8)).
@@ -24,10 +23,9 @@ From Coq Require Import ZArith Lia.
             M =* array p_y r ⋆ array p_m MOD ⋆ R /\ length r = 5%nat /\ 
                 Zmod.of_Z (eval MOD) (eval y) = Zmod.of_Z (eval MOD) (eval r) 
                 /\ 0%nat <= (eval r) < (eval MOD)
-    }
-.
+    }.
 
-#[export] Instance spec_of_u320_set : spec_of "u320_set" := fnspec! "u320_set" (p_x p_y : word) / (x y : list word) R, 
+#[local] Instance spec_of_u320_set : spec_of "u320_set" := fnspec! "u320_set" (p_x p_y : word) / (x y : list word) R, 
     {
         requires t m := 
             m =* array p_x x ⋆ array p_y y ⋆ R /\ 

--- a/src/Bedrock/P256/modinv/beeu_normalize.v
+++ b/src/Bedrock/P256/modinv/beeu_normalize.v
@@ -1,0 +1,196 @@
+From Coq Require Import BinInt String List InitialRing.
+From bedrock2 Require Import BasicC64Semantics WeakestPrecondition ProgramLogic NotationsCustomEntry ZnWords ArrayCasts.
+Import ListNotations ProgramLogic.Coercions SeparationLogic Array Scalars.
+From coqutil Require Import Tactics.Tactics WithBaseName Map.SeparationLogic.
+Require Import Util.ZRange.
+Require Import P256.modinv.u320_sub.
+From Coq Require Import Zmod ZArith.
+Local Open Scope string_scope. Local Open Scope Z_scope.
+Require Import Setoid.
+
+Local Notation eval := (fold_right (fun (a : word) (s : Z) => a + 2^64*s) 0).
+Local Notation array := (array scalar (word.of_Z 8)).
+
+From Coq Require Import ZArith Lia.
+
+#[export] Instance spec_of_beeu_normalize : spec_of "beeu_normalize" :=
+    fnspec! "beeu_normalize" (p_y p_m : word) / (y MOD : list word) R, 
+    {
+        requires t m := 
+            m =* array p_y y ⋆ array p_m MOD ⋆ R /\ 
+            length y = 5%nat /\ length MOD = 5%nat /\ eval MOD > 0;
+        ensures T M := exists (r : list word), 
+            M =* array p_y r ⋆ array p_m MOD ⋆ R /\ length r = 5%nat /\ 
+                Zmod.of_Z (eval MOD) (eval y) = Zmod.of_Z (eval MOD) (eval r) 
+                /\ 0%nat <= (eval r) < (eval MOD)
+    }
+.
+
+#[export] Instance spec_of_u320_set : spec_of "u320_set" := fnspec! "u320_set" (p_x p_y : word) / (x y : list word) R, 
+    {
+        requires t m := 
+            m =* array p_x x ⋆ array p_y y ⋆ R /\ 
+            length x = 5%nat /\ length y = 5%nat;
+        ensures T M := T = t /\
+            M =* array p_x y ⋆ array p_y y ⋆ R 
+    }.
+
+Local Ltac lists_into_elements := repeat match goal with
+  | H : length ?l = ?n |- _ =>  constr_eq true ltac:(isnatcst n);
+  let x := fresh l "0" in destruct l as [|x l]; inversion H; clear H end.
+
+Definition u320_set := func! (p_x, p_y) {
+    store(p_x, load(p_y));
+    store(p_x + $8, load(p_y + $8));
+    store(p_x + $8 + $8, load(p_y + $8 + $8));
+    store(p_x + $8 + $8 + $8, load(p_y + $8 + $8 + $8));
+    store(p_x + $8 + $8 + $8 + $8, load(p_y + $8 + $8 + $8 + $8))
+}.
+
+Lemma u320_set_ok : program_logic_goal_for_function! u320_set.
+Proof.
+    repeat straightline. lists_into_elements; cbn [array] in *; repeat straightline. ecancel_assumption.
+Qed. 
+
+Definition beeu_normalize := func! (p_y, p_m) {
+    borrow = $0;
+    stackalloc 40 as p_prev;
+
+    u320_set(p_prev, p_y);
+    unpack! borrow = u320_sub(p_y, p_m);
+
+    while borrow == $0 {
+        u320_set(p_prev, p_y);
+
+        unpack! borrow = u320_sub(p_y, p_m)
+    };
+
+    u320_set(p_y, p_prev)
+}.
+
+Lemma Zmod_diff {m n : Z} : ((n - m) mod m) = n mod m.
+Proof.
+    rewrite Zminus_mod, Z_mod_same_full, Z.sub_0_r, Zmod_mod. eauto.
+Qed.
+
+Lemma array_to_bytes ptr ws :
+    Lift1Prop.iff1 (array ptr ws) (@Array.array _ word _ mem _ ptsto (word.of_Z 1) ptr (ws2bs 8 ws)).
+Proof.
+    eapply (@bytes_of_words 64 _ word mem _ _).
+Qed.
+
+Lemma bytes_to_array ptr bs : 
+    (length bs mod 8)%nat = 0%nat ->
+    Lift1Prop.iff1 (@Array.array _ word _ mem _ ptsto (word.of_Z 1) ptr bs) (array ptr (bs2ws 8 bs)).
+Proof. intros H. eapply (@words_of_bytes 64 _ word mem _ _).
+    cbn. replace (PosDef.Pos.to_nat 8) with 8%nat by lia.
+    lia.
+Qed.
+
+#[local] Ltac ensure_map m := lazymatch type of m with | @Interface.map.rep _ _ _ => true | _ => false end.
+#[local] Ltac newest_memory_hyp := match goal with | H: ?G ?m |- _ =>
+    match (ensure_map m) with true => H | false => fail end end.
+
+#[local] Ltac alloc_array ptr st := 
+    match goal with 
+    | [H : Datatypes.length st = ?n |- _] => 
+        let Hmem := newest_memory_hyp in 
+        seprewrite_in_by (bytes_to_array ptr st) Hmem ltac:(rewrite H; eauto);
+        let prev := fresh "prev" in
+        let Heqprev := fresh "Heqprev" in
+        remember (bs2ws 8 st) as prev eqn:Heqprev; 
+        let m := eval cbv in (Z.to_nat (n / 8)) in
+        assert (length prev = m) by (rewrite Heqprev, bs2ws_length; try rewrite !H; eauto);
+        clear dependent st
+    end.
+
+#[local] Ltac dealloc_array ptr arr := 
+    match goal with 
+    | [H : Datatypes.length arr = ?n |- _] => 
+        let Hmem := newest_memory_hyp in
+        seprewrite_in (array_to_bytes ptr arr) Hmem;
+        let m := eval cbv in (Z.to_nat (8 * n)) in 
+            assert (length (ws2bs 8 arr) = m) by (lists_into_elements; eauto)
+    end.
+
+#[local] Ltac destruct_cond := match goal with 
+        | [H : ?T |- _] => 
+            match T with 
+            | ?A -> False =>
+                match A with 
+                | context m [if (word.eqb ?x ?y) then _ else _] => 
+                    let Heq := fresh "Heq" in
+                    destruct (word.eqb x y) eqn:Heq; [| contradiction]; 
+                    eapply Properties.word.eqb_true in Heq
+                end
+            | ?A => 
+                match A with 
+                | context m [if (word.eqb ?x ?y) then _ else _] => 
+                    let Heq := fresh "Heq" in
+                    destruct (word.eqb x y) eqn:Heq; [discriminate |];
+                    eapply Properties.word.eqb_false in Heq
+                end
+            end
+        end.
+
+
+Lemma beeu_normalize_ok : program_logic_goal_for_function! beeu_normalize.
+Proof.
+    repeat straightline.
+
+    alloc_array a stack.
+
+    repeat (straightline_call; ssplit; try ecancel_assumption; eauto; repeat straightline).
+    rename a into p_prev; rename y into prv; rename x0 into y.
+
+    refine ((Loops.tailrec
+        (* types of ghost variables*) (HList.polymorphic_list.cons _
+                                    (HList.polymorphic_list.cons _
+                                    (HList.polymorphic_list.cons _
+                                    HList.polymorphic_list.nil)))
+        (* program variables *) (["borrow"; "p_prev"; "p_y"; "p_m"] : list String.string))
+        (fun v y_ prev_ R t m borrow p_prev p_y p_m => PrimitivePair.pair.mk (* precondition *)
+        ( v = eval prev_  /\ m=* array p_y y_ ⋆ array p_m MOD ⋆ array p_prev prev_ ⋆ R 
+      /\ length y_ = 5%nat /\ length MOD = 5%nat /\ length prev_ = 5%nat /\
+      eval y_ -2^320*borrow = (eval prev_) - (eval MOD) /\ 
+      Zmod.of_Z (eval MOD) (eval prev_) = Zmod.of_Z (eval MOD) (eval prv) /\
+      0 <= (eval prev_))
+        (fun            T M BORROW P_PREV P_Y P_M => (* postcondition *)
+        T = t /\ P_PREV = p_prev /\ P_Y = p_y /\ P_M = p_m /\ exists Y PREV, 
+        M =* array p_y Y ⋆ array p_prev PREV ⋆ array p_m MOD ⋆ R
+        /\ length Y = 5%nat /\ length PREV = 5%nat /\  
+        Zmod.of_Z (eval MOD) (eval PREV) = Zmod.of_Z (eval MOD) (eval prv) /\ 
+        0 <= (eval PREV) < (eval MOD)))
+        (fun n m => 0 <= n < m) (* well_founded relation *)
+        _ _ _ _ _ _ _ _);
+    Loops.loop_simpl.
+    { repeat straightline. }
+    { eapply Z.lt_wf. }
+    { repeat straightline; ssplit; try ecancel_assumption; eauto; lists_into_elements; cbv [fold_right] in *. ZnWords. }
+    { intros. repeat straightline; subst br. 
+        { 
+            repeat (straightline_call; intuition try ecancel_assumption; repeat straightline). 
+            eexists _,_,_,_. repeat straightline; intuition try ecancel_assumption. 
+            {
+                
+                destruct_cond.
+                rewrite <-H24, <-!Zmod.unsigned_inj_iff, !Zmod.unsigned_of_Z. symmetry. 
+                rewrite <-Zmod_diff. f_equal. ZnWords.
+            }
+            { lists_into_elements. cbv [fold_right] in *. ZnWords. } 
+            { 
+                split; repeat straightline; intuition try ecancel_assumption.
+                1,2: lists_into_elements; cbv [fold_right] in *; destruct_cond; ZnWords. 
+                eexists _, _. intuition try ecancel_assumption. 
+            }
+        }
+        { eexists _, _. intuition try ecancel_assumption. lists_into_elements; cbv [fold_right length] in *.
+        destruct_cond; ZnWords.  }
+    }
+    { 
+        repeat straightline. straightline_call; intuition try ecancel_assumption. repeat straightline.
+        dealloc_array p_prev x5.
+        repeat straightline. eexists; intuition try ecancel_assumption; lists_into_elements; 
+        cbv [fold_right length] in *; eauto; ZnWords.
+    }
+Qed.

--- a/src/Bedrock/P256/modinv/beeu_normalize.v
+++ b/src/Bedrock/P256/modinv/beeu_normalize.v
@@ -2,6 +2,7 @@ From Coq Require Import BinInt String List InitialRing.
 From bedrock2 Require Import BasicC64Semantics WeakestPrecondition ProgramLogic NotationsCustomEntry ZnWords ArrayCasts.
 Import ListNotations ProgramLogic.Coercions SeparationLogic Array Scalars.
 From coqutil Require Import Tactics.Tactics WithBaseName Map.SeparationLogic.
+Require Import bedrock2Examples.full_sub.
 Require Import Util.ZRange.
 Require Import P256.modinv.u320_sub.
 From Coq Require Import Zmod ZArith.
@@ -194,3 +195,11 @@ Proof.
         cbv [fold_right length] in *; eauto; ZnWords.
     }
 Qed.
+
+(* Linking Proof *)
+(** * Linking Proof *)
+Definition beeu_normalize_funcs := &[, beeu_normalize; u320_set; u320_sub; br_full_sub].
+
+Lemma link_beeu_normalize : spec_of_beeu_normalize (Interface.map.of_list beeu_normalize_funcs).
+Proof. apply beeu_normalize_ok; try apply u320_set_ok; try apply u320_sub_correct; try apply full_sub_ok; trivial. Qed.
+

--- a/src/Bedrock/P256/modinv/beeu_normalize.v
+++ b/src/Bedrock/P256/modinv/beeu_normalize.v
@@ -1,4 +1,4 @@
-From Coq Require Import BinInt String List InitialRing.
+From Coq Require Import BinInt String List InitialRing ZArith Lia.
 From bedrock2 Require Import BasicC64Semantics WeakestPrecondition ProgramLogic NotationsCustomEntry ZnWords ArrayCasts.
 Import ListNotations ProgramLogic.Coercions SeparationLogic Array Scalars.
 From coqutil Require Import Tactics.Tactics WithBaseName Map.SeparationLogic.
@@ -6,13 +6,10 @@ Require Import bedrock2Examples.full_sub.
 Require Import Util.ZRange.
 Require Import P256.modinv.u320_sub.
 Require Import coqutil.Z.PushPullMod.
-From Coq Require Import Zmod ZArith.
 Local Open Scope string_scope. Local Open Scope Z_scope.
 
 Local Notation eval := (fold_right (fun (a : word) (s : Z) => a + 2^64*s) 0).
 Local Notation array := (array scalar (word.of_Z 8)).
-
-From Coq Require Import ZArith Lia.
 
 #[export] Instance spec_of_beeu_normalize : spec_of "beeu_normalize" :=
     fnspec! "beeu_normalize" (p_y p_m : word) / (y MOD : list word) R,

--- a/src/Bedrock/P256/modinv/beeu_normalize.v
+++ b/src/Bedrock/P256/modinv/beeu_normalize.v
@@ -5,6 +5,7 @@ From coqutil Require Import Tactics.Tactics WithBaseName Map.SeparationLogic.
 Require Import bedrock2Examples.full_sub.
 Require Import Util.ZRange.
 Require Import P256.modinv.u320_sub.
+Require Import coqutil.Z.PushPullMod.
 From Coq Require Import Zmod ZArith.
 Local Open Scope string_scope. Local Open Scope Z_scope.
 
@@ -14,24 +15,23 @@ Local Notation array := (array scalar (word.of_Z 8)).
 From Coq Require Import ZArith Lia.
 
 #[export] Instance spec_of_beeu_normalize : spec_of "beeu_normalize" :=
-    fnspec! "beeu_normalize" (p_y p_m : word) / (y MOD : list word) R, 
+    fnspec! "beeu_normalize" (p_y p_m : word) / (y MOD : list word) R,
     {
-        requires t m := 
-            m =* array p_y y ⋆ array p_m MOD ⋆ R /\ 
+        requires t m :=
+            m =* array p_y y ⋆ array p_m MOD ⋆ R /\
             length y = 5%nat /\ length MOD = 5%nat /\ eval MOD > 0;
-        ensures T M := exists (r : list word), 
-            M =* array p_y r ⋆ array p_m MOD ⋆ R /\ length r = 5%nat /\ 
-                Zmod.of_Z (eval MOD) (eval y) = Zmod.of_Z (eval MOD) (eval r) 
-                /\ 0%nat <= (eval r) < (eval MOD)
+        ensures T M := exists (r : list word),
+            M =* array p_y r ⋆ array p_m MOD ⋆ R /\ length r = 5%nat /\
+                (eval r) = (eval y) mod (eval MOD)
     }.
 
-#[local] Instance spec_of_u320_set : spec_of "u320_set" := fnspec! "u320_set" (p_x p_y : word) / (x y : list word) R, 
+#[local] Instance spec_of_u320_set : spec_of "u320_set" := fnspec! "u320_set" (p_x p_y : word) / (x y : list word) R,
     {
-        requires t m := 
-            m =* array p_x x ⋆ array p_y y ⋆ R /\ 
+        requires t m :=
+            m =* array p_x x ⋆ array p_y y ⋆ R /\
             length x = 5%nat /\ length y = 5%nat;
         ensures T M := T = t /\
-            M =* array p_x y ⋆ array p_y y ⋆ R 
+            M =* array p_x y ⋆ array p_y y ⋆ R
     }.
 
 Local Ltac lists_into_elements := repeat match goal with
@@ -48,8 +48,9 @@ Definition u320_set := func! (p_x, p_y) {
 
 Lemma u320_set_ok : program_logic_goal_for_function! u320_set.
 Proof.
-    repeat straightline. lists_into_elements; cbn [array] in *; repeat straightline. ecancel_assumption.
-Qed. 
+    repeat (straightline || lists_into_elements; cbn [array] in *);
+    ecancel_assumption.
+Qed.
 
 Definition beeu_normalize := func! (p_y, p_m) {
     borrow = $0;
@@ -67,18 +68,13 @@ Definition beeu_normalize := func! (p_y, p_m) {
     u320_set(p_y, p_prev)
 }.
 
-Lemma Zmod_diff {m n : Z} : ((n - m) mod m) = n mod m.
-Proof.
-    rewrite Zminus_mod, Z_mod_same_full, Z.sub_0_r, Zmod_mod. eauto.
-Qed.
-
 Lemma array_to_bytes ptr ws :
     Lift1Prop.iff1 (array ptr ws) (@Array.array _ word _ mem _ ptsto (word.of_Z 1) ptr (ws2bs 8 ws)).
 Proof.
     eapply (@bytes_of_words 64 _ word mem _ _).
 Qed.
 
-Lemma bytes_to_array ptr bs : 
+Lemma bytes_to_array ptr bs :
     (length bs mod 8)%nat = 0%nat ->
     Lift1Prop.iff1 (@Array.array _ word _ mem _ ptsto (word.of_Z 1) ptr bs) (array ptr (bs2ws 8 bs)).
 Proof. intros H. eapply (@words_of_bytes 64 _ word mem _ _).
@@ -90,41 +86,41 @@ Qed.
 #[local] Ltac newest_memory_hyp := match goal with | H: ?G ?m |- _ =>
     match (ensure_map m) with true => H | false => fail end end.
 
-#[local] Ltac alloc_array ptr st := 
-    match goal with 
-    | [H : Datatypes.length st = ?n |- _] => 
-        let Hmem := newest_memory_hyp in 
+#[local] Ltac alloc_array ptr st :=
+    match goal with
+    | [H : Datatypes.length st = ?n |- _] =>
+        let Hmem := newest_memory_hyp in
         seprewrite_in_by (bytes_to_array ptr st) Hmem ltac:(rewrite H; eauto);
         let prev := fresh "prev" in
         let Heqprev := fresh "Heqprev" in
-        remember (bs2ws 8 st) as prev eqn:Heqprev; 
+        remember (bs2ws 8 st) as prev eqn:Heqprev;
         let m := eval cbv in (Z.to_nat (n / 8)) in
         assert (length prev = m) by (rewrite Heqprev, bs2ws_length; try rewrite !H; eauto);
         clear dependent st
     end.
 
-#[local] Ltac dealloc_array ptr arr := 
-    match goal with 
-    | [H : Datatypes.length arr = ?n |- _] => 
+#[local] Ltac dealloc_array ptr arr :=
+    match goal with
+    | [H : Datatypes.length arr = ?n |- _] =>
         let Hmem := newest_memory_hyp in
         seprewrite_in (array_to_bytes ptr arr) Hmem;
-        let m := eval cbv in (Z.to_nat (8 * n)) in 
+        let m := eval cbv in (Z.to_nat (8 * n)) in
             assert (length (ws2bs 8 arr) = m) by (lists_into_elements; eauto)
     end.
 
-#[local] Ltac destruct_cond := match goal with 
-        | [H : ?T |- _] => 
-            match T with 
+#[local] Ltac destruct_cond := match goal with
+        | [H : ?T |- _] =>
+            match T with
             | ?A -> False =>
-                match A with 
-                | context m [if (word.eqb ?x ?y) then _ else _] => 
+                match A with
+                | context m [if (word.eqb ?x ?y) then _ else _] =>
                     let Heq := fresh "Heq" in
-                    destruct (word.eqb x y) eqn:Heq; [| contradiction]; 
+                    destruct (word.eqb x y) eqn:Heq; [| contradiction];
                     eapply Properties.word.eqb_true in Heq
                 end
-            | ?A => 
-                match A with 
-                | context m [if (word.eqb ?x ?y) then _ else _] => 
+            | ?A =>
+                match A with
+                | context m [if (word.eqb ?x ?y) then _ else _] =>
                     let Heq := fresh "Heq" in
                     destruct (word.eqb x y) eqn:Heq; [discriminate |];
                     eapply Properties.word.eqb_false in Heq
@@ -132,14 +128,12 @@ Qed.
             end
         end.
 
-
 Lemma beeu_normalize_ok : program_logic_goal_for_function! beeu_normalize.
 Proof.
-    repeat straightline.
+    repeat straightline. alloc_array a stack.
 
-    alloc_array a stack.
+    repeat (straightline || straightline_call); intuition try ecancel_assumption.
 
-    repeat (straightline_call; ssplit; try ecancel_assumption; eauto; repeat straightline).
     rename a into p_prev; rename y into prv; rename x0 into y.
 
     refine ((Loops.tailrec
@@ -149,16 +143,16 @@ Proof.
                                     HList.polymorphic_list.nil)))
         (* program variables *) (["borrow"; "p_prev"; "p_y"; "p_m"] : list String.string))
         (fun v y_ prev_ R t m borrow p_prev p_y p_m => PrimitivePair.pair.mk (* precondition *)
-        ( v = eval prev_  /\ m=* array p_y y_ ⋆ array p_m MOD ⋆ array p_prev prev_ ⋆ R 
+        ( v = eval prev_  /\ m=* array p_y y_ ⋆ array p_m MOD ⋆ array p_prev prev_ ⋆ R
       /\ length y_ = 5%nat /\ length MOD = 5%nat /\ length prev_ = 5%nat /\
-      eval y_ -2^320*borrow = (eval prev_) - (eval MOD) /\ 
-      Zmod.of_Z (eval MOD) (eval prev_) = Zmod.of_Z (eval MOD) (eval prv) /\
+      eval y_ -2^320*borrow = (eval prev_) - (eval MOD) /\
+      (eval prev_) mod (eval MOD) = (eval prv) mod (eval MOD) /\
       0 <= (eval prev_))
         (fun            T M BORROW P_PREV P_Y P_M => (* postcondition *)
-        T = t /\ P_PREV = p_prev /\ P_Y = p_y /\ P_M = p_m /\ exists Y PREV, 
+        T = t /\ P_PREV = p_prev /\ P_Y = p_y /\ P_M = p_m /\ exists Y PREV,
         M =* array p_y Y ⋆ array p_prev PREV ⋆ array p_m MOD ⋆ R
-        /\ length Y = 5%nat /\ length PREV = 5%nat /\  
-        Zmod.of_Z (eval MOD) (eval PREV) = Zmod.of_Z (eval MOD) (eval prv) /\ 
+        /\ length Y = 5%nat /\ length PREV = 5%nat /\
+        (eval PREV) mod (eval MOD) = (eval prv) mod (eval MOD) /\
         0 <= (eval PREV) < (eval MOD)))
         (fun n m => 0 <= n < m) (* well_founded relation *)
         _ _ _ _ _ _ _ _);
@@ -166,31 +160,30 @@ Proof.
     { repeat straightline. }
     { eapply Z.lt_wf. }
     { repeat straightline; ssplit; try ecancel_assumption; eauto; lists_into_elements; cbv [fold_right] in *. ZnWords. }
-    { intros. repeat straightline; subst br. 
-        { 
-            repeat (straightline_call; intuition try ecancel_assumption; repeat straightline). 
-            eexists _,_,_,_. repeat straightline; intuition try ecancel_assumption. 
+    { intros. repeat straightline; subst br.
+        {
+            repeat (straightline || (eexists _, _, _, _) || straightline_call);
+            progress (split; (repeat straightline));
+            intuition try ecancel_assumption;
+            destruct_cond;
+            try solve [lists_into_elements; cbv[eval] in *; ZnWords].
             {
-                
-                destruct_cond.
-                rewrite <-H24, <-!Zmod.unsigned_inj_iff, !Zmod.unsigned_of_Z. symmetry. 
-                rewrite <-Zmod_diff. f_equal. ZnWords.
+                rewrite <-H24. replace (eval x0) with (eval x1 - eval MOD) by ZnWords.
+                Z.push_mod. rewrite Z_mod_same by ZnWords. Z.mod_equality.
             }
-            { lists_into_elements. cbv [fold_right] in *. ZnWords. } 
-            { 
-                split; repeat straightline; intuition try ecancel_assumption.
-                1,2: lists_into_elements; cbv [fold_right] in *; destruct_cond; ZnWords. 
-                eexists _, _. intuition try ecancel_assumption. 
-            }
+            { eexists _, _; intuition try ecancel_assumption. }
         }
-        { eexists _, _. intuition try ecancel_assumption. lists_into_elements; cbv [fold_right length] in *.
-        destruct_cond; ZnWords.  }
+        {
+            eexists _, _. intuition try ecancel_assumption.
+            lists_into_elements; cbv [fold_right length] in *.
+            destruct_cond; ZnWords.
+        }
     }
-    { 
-        repeat straightline. straightline_call; intuition try ecancel_assumption. repeat straightline.
+    {
+        repeat (straightline || straightline_call); intuition try ecancel_assumption.
         dealloc_array p_prev x5.
-        repeat straightline. eexists; intuition try ecancel_assumption; lists_into_elements; 
-        cbv [fold_right length] in *; eauto; ZnWords.
+        repeat straightline. eexists; intuition try ecancel_assumption.
+        rewrite <- (Z.mod_small (eval x5) (eval MOD)); ZnWords.
     }
 Qed.
 
@@ -199,5 +192,9 @@ Qed.
 Definition beeu_normalize_funcs := &[, beeu_normalize; u320_set; u320_sub; br_full_sub].
 
 Lemma link_beeu_normalize : spec_of_beeu_normalize (Interface.map.of_list beeu_normalize_funcs).
-Proof. apply beeu_normalize_ok; try apply u320_set_ok; try apply u320_sub_correct; try apply full_sub_ok; trivial. Qed.
+Proof.
+    apply beeu_normalize_ok;
+    repeat (apply u320_set_ok || apply u320_sub_correct || apply full_sub_ok);
+    trivial.
+Qed.
 

--- a/src/Bedrock/P256/modinv/u320_sub.v
+++ b/src/Bedrock/P256/modinv/u320_sub.v
@@ -11,18 +11,18 @@ Local Notation array := (array scalar (word.of_Z 8)).
 (** * Specification *)
 
 #[export] Instance spec_of_u320_sub : spec_of "u320_sub" := 
-    fnspec! "u320_sub" (p_r p_x p_y : word) / (x y r : list word) R ~> b,
+    fnspec! "u320_sub" (p_x p_y : word) / (x y : list word) R ~> b,
     {
         requires t m := 
-            m =* array p_x x ⋆ array p_y y ⋆ array p_r r ⋆ R /\
-            length x = 5%nat /\ length y = 5%nat /\ length r = 5%nat;
+            m =* array p_x x ⋆ array p_y y ⋆ R /\
+            length x = 5%nat /\ length y = 5%nat;
         ensures T M := T = t /\ exists (r : list word), 
-            M =* array p_x x ⋆ array p_y y ⋆ array p_r r ⋆ R /\
+            M =* array p_x r ⋆ array p_y y ⋆ R /\
             length r = 5%nat /\ eval r - 2^320*b = eval x - eval y
     }.
 
 (** * Implementation *)
-Definition u320_sub := func! (p_r, p_x, p_y) ~> b {
+Definition u320_sub := func! (p_x, p_y) ~> b {
     b = $0;
     unpack! d0, b = br_full_sub(load(p_x) , load(p_y), b);
     unpack! d1, b = br_full_sub(load(p_x + $8), load(p_y + $8) , b);
@@ -30,11 +30,11 @@ Definition u320_sub := func! (p_r, p_x, p_y) ~> b {
     unpack! d3, b = br_full_sub(load(p_x + $8 + $8 + $8) , load(p_y + $8 + $8 + $8) , b);
     unpack! d4, b = br_full_sub(load(p_x + $8 + $8 + $8 + $8) , load(p_y + $8 + $8 + $8 + $8) , b);
 
-    store(p_r, d0);
-    store(p_r + $8, d1);
-    store(p_r + $8 + $8, d2);
-    store(p_r + $8 + $8 + $8, d3);
-    store(p_r + $8 + $8 + $8 + $8, d4)
+    store(p_x, d0);
+    store(p_x + $8, d1);
+    store(p_x + $8 + $8, d2);
+    store(p_x + $8 + $8 + $8, d3);
+    store(p_x + $8 + $8 + $8 + $8, d4)
 }.
 
 Local Ltac lists_into_elements := repeat match goal with


### PR DESCRIPTION
This PR proves the specification of the function `beeu_normalize`, with the following specifications: 

Precondition: two pointers `p_y` and `p_mod`, which point to 320-bit unsigned integers `y` and `MOD`, where `MOD > 0`. The two pointers do not alias. 

Postcondition: `p_y` will point to a 320-bit unsigned integer `y'`, s.t. `y' = y mod MOD`. 

Additionally, the PR modifies the signature and specification of `u320_sub` such that the result of the difference is stored in the input. The only usage of `u320_sub` occurs in this function, which does not need the more general version, where the difference is stored in an arbitrary pointer.  
  