### PR TITLE
CI: stop checking proofs on the x86_64 macOS leg

### DIFF
--- a/.github/workflows/coq-macos.yml
+++ b/.github/workflows/coq-macos.yml
@@ -21,8 +21,10 @@ jobs:
         include:
         - os: { name: 'macOS 15', arch: 'x86_64', runs-on: 'macos-15-intel' }
           ocaml-compiler: '4.13.0'
+          proofs: 'skip'
         - os: { name: 'macOS 14', arch: 'arm64' , runs-on: 'macos-14' }
           ocaml-compiler: '4.14.2'
+          proofs: 'full'
 
     runs-on: ${{ matrix.os.runs-on }}
 
@@ -64,21 +66,42 @@ jobs:
       run: etc/ci/describe-system-config-macos.sh
     - name: deps
       run: opam exec -- etc/ci/github-actions-make.sh -j2 deps
-    # The x86_64 macOS runners are roughly 3x slower than the arm64 ones and
+    # The x86_64 macOS runners are roughly 2-3x slower than the arm64 ones and
     # were hitting the 6h job limit on the full `all` target.  Mirror the
     # Windows workflow and build the leaner set of targets instead: produce the
     # standalone binary first, then check the proofs, and use
     # `c-files lite-generated-files` rather than the full `generated-files`
     # (which regenerates and diff-checks every curve in every backend language
     # and is architecture-independent work already covered by the Linux CI).
+    #
+    # That was still not enough: the x86_64 leg kept hitting the 6h limit
+    # inside the `coq` step alone.  On the last timed-out run, setup + `deps` +
+    # `standalone-ocaml` consumed 2h04 before `coq` even started, and `coq` was
+    # still running when the job was killed 3h56 later, so every step after it
+    # was skipped and the leg produced nothing at all.
+    #
+    # So on x86_64 we now skip proof checking entirely (`proofs: 'skip'`).
+    # Proof checking is architecture-independent and is already covered by the
+    # Linux CI and by the arm64 macOS leg; what this leg uniquely provides is
+    # the x86_64 macOS binary that `combine-standalone` lipo's into the
+    # universal binary, plus native x86_64 execution of the generated amd64
+    # assembly tests.  Those are exactly the steps that are kept.
+    #
+    # Note that trimming has to skip whole steps rather than swap `coq` for a
+    # lighter target: `all-except-compiled` and `install` both list `coq` as a
+    # prerequisite (Makefile), so building e.g. `lite` in the `coq` step and
+    # leaving those steps in place would rebuild every skipped file anyway and
+    # save nothing.
     - name: standalone-ocaml
       run: opam exec -- etc/ci/github-actions-make.sh -j2 standalone-ocaml
     - name: install-standalone-unified-ocaml
       run: opam exec -- etc/ci/github-actions-make.sh install-standalone-unified-ocaml BINDIR=dist
     - name: coq
       run: opam exec -- etc/ci/github-actions-make.sh -j2 coq
+      if: matrix.proofs == 'full'
     - name: all-except-generated-and-js-of-ocaml
       run: opam exec -- etc/ci/github-actions-make.sh -j2 all-except-generated-and-js-of-ocaml
+      if: matrix.proofs == 'full'
     - name: standalone-js-of-ocaml
       run: opam exec -- etc/ci/github-actions-make.sh -j2 standalone-js-of-ocaml
     - name: install-standalone-js-of-ocaml
@@ -116,12 +139,18 @@ jobs:
       with:
         name: standalone-html-macos-${{ matrix.os.arch }}
         path: fiat-html
+    # `install` depends on the `coq` target, so these are skipped wherever
+    # proof checking is skipped; otherwise they would rebuild the whole
+    # development that the `coq` step above deliberately did not build.
     - name: install
       run: opam exec -- etc/ci/github-actions-make.sh EXTERNAL_DEPENDENCIES=1 SKIP_COQSCRIPTS_INCLUDE=1 install install-standalone-ocaml
+      if: matrix.proofs == 'full'
     - name: install-without-bedrock2
       run: opam exec -- etc/ci/github-actions-make.sh EXTERNAL_DEPENDENCIES=1 SKIP_BEDROCK2=1 install-without-bedrock2 install-standalone-ocaml
+      if: matrix.proofs == 'full'
     - name: install-dev
       run: opam exec -- etc/ci/github-actions-make.sh EXTERNAL_REWRITER=1 EXTERNAL_COQPRIME=1 install install-standalone-ocaml
+      if: matrix.proofs == 'full'
     - name: display timing info
       run: cat time-of-build-pretty.log
     - name: display per-line timing info


### PR DESCRIPTION
The x86_64 macOS leg keeps hitting the 6h job limit inside the `coq` step, so it produces no artifacts at all. It has been timing out on unrelated PRs, e.g. #2395.

Step timings from that run:

| step | x86_64 | arm64 |
| --- | --- | --- |
| setup + `opam pin add coq` + js_of_ocaml | 23m | 8m |
| `deps` | 41m | 21m |
| `standalone-ocaml` | 60m | 30m |
| `coq` | **killed at 3h56, unfinished** | 97m |
| everything after | skipped | ~18m |

2h04 is gone before `coq` starts, and `coq` alone does not fit in the remaining 3h56. The tail of the job never runs, so the previous round of trimming (which shortened steps *after* `coq`) could not have helped.

The runners are 4-core i7-8700B (x86_64) vs 3-core M1 (arm64), both at `-j2`, with x86_64 measuring ~2x slower per step.

## What this does

Skip proof checking on x86_64 only, via a `proofs:` matrix key. Dropped there: `coq`, `all-except-generated-and-js-of-ocaml`, and the three `install` steps. arm64 is unchanged.

Proof checking is architecture-independent and already covered by the Linux CI and the arm64 leg. What the x86_64 leg uniquely provides is the x86_64 binary that `combine-standalone` lipo's into the universal binary, plus native x86_64 execution of the generated amd64 assembly tests. Both are kept, along with `standalone-ocaml`, `standalone-js-of-ocaml`, `c-files lite-generated-files` and `only-test-amd64-files-lite`. Note `standalone-ocaml` still builds the `.vo` files the extraction depends on, so the leg keeps real compile coverage.

## Why whole steps rather than a lighter target

Swapping `coq` for `lite` would save nothing: `all-except-compiled: coq pre-standalone-extracted check-output` and `install: coq $(filter %.vo,$(FILESTOINSTALL))` both list `coq` as a prerequisite, so the following steps would rebuild every file `lite` skipped.

For reference, `lite` does target the right files — from the arm64 `coq` timing dump (242m cumulative), `Bedrock/Secp256k1/JoyeLadder.vo` alone is 43m, and it plus `JacobianCoZ`, `Addchain` and the Weierstrass files in `LITE_UNMADE_VOFILES` are ~68m. But that is only ~28%, which would have left the job at roughly 340m against the 360m limit even if the prerequisite problem did not exist. Estimated new x86_64 wall time is ~2h40.

## What is lost

On x86_64 only: `coq`, `perf-standalone`, `check-output`, and the `install` / `install-without-bedrock2` / `install-dev` packaging checks. All still run on arm64 macOS and on Linux.

Raising `NJOBS` on x86_64 is a possible follow-up — the 4-core runner is under-subscribed at `-j2` — but `JoyeLadder` peaks at 3.9GB and these runners have 14GB, so it is not obviously free, and it is not needed once the proof steps are gone.

CI on this PR is the only way to confirm the new runtime.
