### PR TITLE
Escape output filenames in HTML attributes

### DIFF
--- a/fiat-html/main.js
+++ b/fiat-html/main.js
@@ -149,7 +149,7 @@ document.addEventListener('DOMContentLoaded', function () {
         var text = document.createTextNode(html);
         var p = document.createElement('p');
         p.appendChild(text);
-        return p.innerHTML;
+        return p.innerHTML.replace(/"/g, '&quot;');
     }
 
 


### PR DESCRIPTION
## Summary

Escape double quotes in `escapeHtml()` so attacker-controlled output filenames cannot break out of the double-quoted `id` and `data-target` attributes in the existing output template.

This is a one-line fix for Scrutineer finding #2518.

## Testing

- `node --check fiat-html/main.js`
- parsed the reported quote-breaking filename with jsdom and verified it remains one `id`/`data-target` value without injected event-handler attributes
- `git diff --check`

> *Authorship note: this was researched and written by an AI coding agent
> (OpenAI Codex), working on Jason Gross's behalf; Jason reviews what is
> posted from this account.*