### PR TITLE
Reject data-emitting directives in assembly equivalence checks

### DIFF
--- a/src/Assembly/Equivalence.v
+++ b/src/Assembly/Equivalence.v
@@ -1438,7 +1438,12 @@ Section check_equivalence.
             (out_bounds : ZRange.type.base.option.interp (type.final_codomain t)).
 
     Definition strip_ret (asm : Lines) :=
-      let isinstr := fun l => match l.(rawline) with INSTR _ => true | _ => false end in
+      let iscode := fun l => match l.(rawline) with
+                            | INSTR _
+                            | ALIGN _
+                            | ASCII_ _ _ => true
+                            | _ => false
+                            end in
       let notret := fun l => match l.(rawline) with
                              | INSTR {| Syntax.op := Syntax.ret ; Syntax.args := nil |} => false
                              | _ => true
@@ -1446,7 +1451,7 @@ Section check_equivalence.
       match dropWhile notret asm with
       | nil => Error Missing_ret
       | cons _r trailer =>
-          if List.existsb isinstr trailer then Error (Code_after_ret (List.filter isinstr trailer) trailer)
+          if List.existsb iscode trailer then Error (Code_after_ret (List.filter iscode trailer) trailer)
           else Success (takeWhile notret asm)
       end.
 

--- a/src/Assembly/EquivalenceTests.v
+++ b/src/Assembly/EquivalenceTests.v
@@ -1,0 +1,34 @@
+From Coq Require Import String List NArith.
+Require Import Crypto.Util.ErrorT.
+Require Import Crypto.Assembly.Syntax.
+Require Import Crypto.Assembly.Equivalence.
+
+Import ListNotations.
+Local Open Scope string_scope.
+Local Open Scope N_scope.
+
+Definition test_line (l : RawLine) : Line :=
+  {| indent := ""
+   ; rawline := l
+   ; pre_comment_whitespace := ""
+   ; comment := None
+   ; line_number := 1 |}.
+
+Definition test_ret : Line :=
+  test_line (INSTR {| prefix := None; op := ret; args := [] |}).
+
+Example strip_ret_rejects_ascii_after_ret s :
+  strip_ret [test_ret; test_line (ASCII s)]
+  = Error (Code_after_ret [test_line (ASCII s)] [test_line (ASCII s)]).
+Proof. reflexivity. Qed.
+
+Example strip_ret_rejects_asciz_after_ret s :
+  strip_ret [test_ret; test_line (ASCIZ s)]
+  = Error (Code_after_ret [test_line (ASCIZ s)] [test_line (ASCIZ s)]).
+Proof. reflexivity. Qed.
+
+Example strip_ret_rejects_p2align_after_ret :
+  strip_ret [test_ret; test_line (ALIGN "4, 0xc3")]
+  = Error (Code_after_ret [test_line (ALIGN "4, 0xc3")]
+                          [test_line (ALIGN "4, 0xc3")]).
+Proof. reflexivity. Qed.

--- a/src/Assembly/Parse.v
+++ b/src/Assembly/Parse.v
@@ -235,7 +235,11 @@ Definition parse_RawLine {opts : assembly_program_options} : ParserAction RawLin
         then [(SECTION args, "")]
         else if (String.to_upper mnemonic =? "GLOBAL") || (String.to_upper mnemonic =? ".GLOBAL") || (String.to_upper mnemonic =? ".GLOBL")
         then [(GLOBAL args, "")]
-        else if (String.to_upper mnemonic =? "ALIGN") || (String.to_upper mnemonic =? ".ALIGN")
+        (* Alignment directives can emit padding bytes, so keep them out of the
+           metadata-only DIRECTIVE case below. *)
+        else if (String.to_upper mnemonic =? "ALIGN")
+                || (String.to_upper mnemonic =? ".ALIGN")
+                || (String.to_upper mnemonic =? ".P2ALIGN")
         then [(ALIGN args, "")]
         else if (String.to_upper mnemonic =? "DEFAULT") && (String.to_upper args =? "REL")
         then [(DEFAULT_REL, "")]
@@ -260,7 +264,6 @@ Definition parse_RawLine {opts : assembly_program_options} : ParserAction RawLin
            ; ".ident"
            ; ".intel_syntax"
            ; ".loc"
-           ; ".p2align"
            ; ".size"
            ; ".text"
            ; ".type"

--- a/src/Assembly/Symbolic.v
+++ b/src/Assembly/Symbolic.v
@@ -4398,7 +4398,6 @@ Definition SymexRawLine {opts : symbolic_options_computed_opt} {descr:descriptio
   | EMPTY
   | LABEL _
   | DIRECTIVE _
-  | ASCII_ _ _
     => ret tt
   | INSTR instr
     => SymexNormalInstruction instr
@@ -4406,6 +4405,8 @@ Definition SymexRawLine {opts : symbolic_options_computed_opt} {descr:descriptio
   | GLOBAL _
   | ALIGN _
   | DEFAULT_REL
+  (* ASCII directives emit their payload into the instruction stream. *)
+  | ASCII_ _ _
       => err (error.unsupported_line rawline)
   end.
 

--- a/src/Assembly/SymbolicTests.v
+++ b/src/Assembly/SymbolicTests.v
@@ -1,0 +1,30 @@
+From Coq Require Import String.
+Require Import Crypto.Util.ErrorT.
+Require Import Crypto.Util.Strings.Parse.Common.
+Require Import Crypto.Assembly.Syntax.
+Require Import Crypto.Assembly.Parse.
+Require Import Crypto.Assembly.Symbolic.
+
+Local Open Scope string_scope.
+
+Example parse_p2align_as_unsupported_alignment :
+  finalize parse_RawLine ".p2align 4, 0xc3" = Some (ALIGN "4, 0xc3").
+Proof. reflexivity. Qed.
+
+Lemma symex_alignment_is_unsupported
+      {opts : symbolic_options_computed_opt} {descr : description} amount st :
+  SymexRawLine (ALIGN amount) st
+  = Error (error.unsupported_line (ALIGN amount), st).
+Proof. reflexivity. Qed.
+
+Lemma symex_ascii_is_unsupported
+      {opts : symbolic_options_computed_opt} {descr : description} s st :
+  SymexRawLine (ASCII s) st
+  = Error (error.unsupported_line (ASCII s), st).
+Proof. reflexivity. Qed.
+
+Lemma symex_asciz_is_unsupported
+      {opts : symbolic_options_computed_opt} {descr : description} s st :
+  SymexRawLine (ASCIZ s) st
+  = Error (error.unsupported_line (ASCIZ s), st).
+Proof. reflexivity. Qed.

--- a/src/Assembly/WithBedrock/Semantics.v
+++ b/src/Assembly/WithBedrock/Semantics.v
@@ -474,7 +474,6 @@ Definition DenoteRawLine (st : machine_state) (rawline : RawLine) : option machi
   | EMPTY
   | LABEL _
   | DIRECTIVE _
-  | ASCII_ _ _
     => Some st
   | INSTR instr
     => DenoteNormalInstruction st instr
@@ -482,6 +481,8 @@ Definition DenoteRawLine (st : machine_state) (rawline : RawLine) : option machi
   | GLOBAL _
   | ALIGN _
   | DEFAULT_REL
+  (* ASCII directives emit their payload into the instruction stream. *)
+  | ASCII_ _ _
     => None
   end.
 

--- a/src/Assembly/WithBedrock/SemanticsTests.v
+++ b/src/Assembly/WithBedrock/SemanticsTests.v
@@ -1,0 +1,11 @@
+From Coq Require Import String.
+Require Import Crypto.Assembly.Syntax.
+Require Import Crypto.Assembly.WithBedrock.Semantics.
+
+Lemma denote_ascii_is_unsupported st s :
+  Semantics.DenoteRawLine st (ASCII s) = None.
+Proof. reflexivity. Qed.
+
+Lemma denote_asciz_is_unsupported st s :
+  Semantics.DenoteRawLine st (ASCIZ s) = None.
+Proof. reflexivity. Qed.


### PR DESCRIPTION
## Summary

- reject `.ascii` and `.asciz` during symbolic execution instead of silently treating emitted bytes as no-ops
- classify `.p2align` as an unsupported alignment directive rather than metadata
- reject ASCII and alignment payloads in the post-`ret` trailer before returning hinted assembly unchanged
- keep the Bedrock concrete semantics aligned with the symbolic fail-closed behavior
- add regression lemmas for parsing, symbolic rejection, trailer rejection, and concrete semantics

## Security impact

Previously, attacker-controlled byte payloads in a hints file could be omitted from the equivalence model while remaining in the assembly returned by the checker. This change makes every currently parsed code/data-emitting raw-line form fail closed, including payloads placed after `ret`. This fixes Scrutineer finding #2512.

## Testing

- compiled the modified parser and concrete semantics under Rocq 9.1
- compiled the new parser, trailer, and concrete-semantics regression lemmas
- checked the symbolic rejection match and regression lemma shapes independently
- confirmed the checked-in `fiat-amd64` corpus does not use any newly rejected directives

A full repository proof build was not available in the isolated audit worktree because its dependency submodules were initially pruned and the installed Crypto artifacts were built against a different rewriter revision. Clean CI is expected to provide the authoritative full build.

> *Authorship note: this was researched and written by an AI coding agent
> (OpenAI Codex), working on Jason Gross's behalf; Jason reviews what is
> posted from this account.*