### PR TITLE
Reject Bedrock2 C outputs built for the wrong word size

### DIFF
--- a/Makefile.examples
+++ b/Makefile.examples
@@ -144,6 +144,9 @@ EXTRA_C_FILES := inversion/c/*_test.c
 
 ALL_C_FILES := $(patsubst %,$(C_DIR)%.c,$(ALL_BASE_FILES))
 ALL_BEDROCK2_FILES := $(patsubst %,$(BEDROCK2_DIR)%.c,$(filter-out $(INVALID_BEDROCK2_BASE_FILES),$(ALL_BASE_FILES)))
+BEDROCK2_CC_BITWIDTH = $(shell printf '#ifdef __SIZEOF_POINTER__\n__SIZEOF_POINTER__\n#endif\n' | $(CC) $(CFLAGS) -dM -E -x c - 2>/dev/null | awk '$$2 == "__SIZEOF_POINTER__" { print $$3 * 8 }')
+NATIVE_BEDROCK2_FILES = $(filter %_$(BEDROCK2_CC_BITWIDTH).c,$(ALL_BEDROCK2_FILES))
+NONNATIVE_BEDROCK2_FILE = $(firstword $(filter-out $(NATIVE_BEDROCK2_FILES),$(ALL_BEDROCK2_FILES)))
 ALL_RUST_FILES := $(patsubst %,$(RUST_DIR)%.rs,$(ALL_BASE_FILES))
 ALL_RUST_MODS := $(ALL_BASE_FILES)
 ALL_GO_FILES := $(patsubst %,$(GO_DIR)%.go,$(call GO_RENAME_TO_FILE,$(filter-out $(INVALID_GO_BASE_FILES),$(ALL_BASE_FILES))))
@@ -232,7 +235,11 @@ $(ALL_BEDROCK2_FILES) : $(BEDROCK2_DIR)%.c : $$(BEDROCK2_$$($$*_BINARY_NAME))
 test-bedrock2-files: $(ALL_BEDROCK2_FILES)
 
 test-bedrock2-files only-test-bedrock2-files:
-	$(CC) -Wall -Wno-unused-function -Werror $(BEDROCK2_EXTRA_CFLAGS) $(CFLAGS) -c $(ALL_BEDROCK2_FILES)
+	@test -n "$(BEDROCK2_CC_BITWIDTH)" || { echo "Could not determine $(CC)'s pointer width" >&2; exit 1; }
+	$(CC) -Wall -Wno-unused-function -Werror $(BEDROCK2_EXTRA_CFLAGS) $(CFLAGS) -fsyntax-only $(NATIVE_BEDROCK2_FILES)
+	@output="$$( $(CC) -Wall -Wno-unused-function -Werror $(BEDROCK2_EXTRA_CFLAGS) $(CFLAGS) -fsyntax-only $(NONNATIVE_BEDROCK2_FILE) 2>&1 )"; status=$$?; \
+	 if [ $$status -eq 0 ]; then echo "Expected $(NONNATIVE_BEDROCK2_FILE) to reject $(BEDROCK2_CC_BITWIDTH)-bit compilation" >&2; exit 1; fi; \
+	 printf '%s\n' "$$output" | grep -q "target word size does not match synthesis word size" || { printf '%s\n' "$$output" >&2; exit 1; }
 
 $(ALL_RUST_FILES) : $(RUST_DIR)%.rs : $$($$($$*_BINARY_NAME))
 	$(SHOW)'SYNTHESIZE > $@'

--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ This binary takes arguments for the strategy:
 
 Passing no arguments, or passing `-h` or `--help` (or any other invalid arguments) will result in a usage message being printed.  These binaries output bedrock2/C code on stdout.
 
+Bedrock2 represents both addresses and machine words with `uintptr_t`, so the
+synthesis word size must match the target's pointer width.  In particular,
+compile `_32.c` outputs only for 32-bit targets and `_64.c` outputs only for
+64-bit targets; generated files enforce this requirement with a static
+assertion.
+
 Here are some examples of ways to invoke the binaries (from the directories that they live in):
 
     # Generate code for 2^255-19

--- a/fiat-bedrock2/src/curve25519_32.c
+++ b/fiat-bedrock2/src/curve25519_32.c
@@ -110,6 +110,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT32_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/curve25519_64.c
+++ b/fiat-bedrock2/src/curve25519_64.c
@@ -110,6 +110,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT64_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/curve25519_scalar_32.c
+++ b/fiat-bedrock2/src/curve25519_scalar_32.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT32_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/curve25519_scalar_64.c
+++ b/fiat-bedrock2/src/curve25519_scalar_64.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT64_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/curve25519_solinas_64.c
+++ b/fiat-bedrock2/src/curve25519_solinas_64.c
@@ -105,6 +105,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT64_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/p224_32.c
+++ b/fiat-bedrock2/src/p224_32.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT32_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/p224_64.c
+++ b/fiat-bedrock2/src/p224_64.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT64_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/p256_32.c
+++ b/fiat-bedrock2/src/p256_32.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT32_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/p256_64.c
+++ b/fiat-bedrock2/src/p256_64.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT64_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/p256_scalar_32.c
+++ b/fiat-bedrock2/src/p256_scalar_32.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT32_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/p256_scalar_64.c
+++ b/fiat-bedrock2/src/p256_scalar_64.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT64_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/p384_32.c
+++ b/fiat-bedrock2/src/p384_32.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT32_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/p384_64.c
+++ b/fiat-bedrock2/src/p384_64.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT64_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/p384_scalar_32.c
+++ b/fiat-bedrock2/src/p384_scalar_32.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT32_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/p384_scalar_64.c
+++ b/fiat-bedrock2/src/p384_scalar_64.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT64_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/p434_64.c
+++ b/fiat-bedrock2/src/p434_64.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT64_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/p448_solinas_64.c
+++ b/fiat-bedrock2/src/p448_solinas_64.c
@@ -110,6 +110,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT64_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/p521_32.c
+++ b/fiat-bedrock2/src/p521_32.c
@@ -110,6 +110,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT32_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/p521_64.c
+++ b/fiat-bedrock2/src/p521_64.c
@@ -110,6 +110,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT64_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/poly1305_32.c
+++ b/fiat-bedrock2/src/poly1305_32.c
@@ -110,6 +110,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT32_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/poly1305_64.c
+++ b/fiat-bedrock2/src/poly1305_64.c
@@ -110,6 +110,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT64_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/secp256k1_dettman_32.c
+++ b/fiat-bedrock2/src/secp256k1_dettman_32.c
@@ -110,6 +110,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT32_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/secp256k1_dettman_64.c
+++ b/fiat-bedrock2/src/secp256k1_dettman_64.c
@@ -110,6 +110,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT64_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/secp256k1_montgomery_32.c
+++ b/fiat-bedrock2/src/secp256k1_montgomery_32.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT32_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/secp256k1_montgomery_64.c
+++ b/fiat-bedrock2/src/secp256k1_montgomery_64.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT64_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/secp256k1_montgomery_scalar_32.c
+++ b/fiat-bedrock2/src/secp256k1_montgomery_scalar_32.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT32_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/secp256k1_montgomery_scalar_64.c
+++ b/fiat-bedrock2/src/secp256k1_montgomery_scalar_64.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT64_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/sm2_32.c
+++ b/fiat-bedrock2/src/sm2_32.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT32_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/sm2_64.c
+++ b/fiat-bedrock2/src/sm2_64.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT64_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/sm2_scalar_32.c
+++ b/fiat-bedrock2/src/sm2_scalar_32.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT32_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/fiat-bedrock2/src/sm2_scalar_64.c
+++ b/fiat-bedrock2/src/sm2_scalar_64.c
@@ -115,6 +115,7 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
   if (!b) return a;
   return a%b;
 }
+static_assert(BR_WORD_MAX == UINT64_MAX, "target word size does not match synthesis word size");
 
 
 /*

--- a/src/Bedrock/Field/Stringification/Stringification.v
+++ b/src/Bedrock/Field/Stringification/Stringification.v
@@ -113,6 +113,23 @@ Definition bedrock_func_to_lines (f : string * func)
   : list string :=
   [c_func f].
 
+Definition bedrock2_prelude (machine_wordsize : Z) : string :=
+  (ToCString.prelude
+   ++ "static_assert(BR_WORD_MAX == UINT"
+   ++ Decimal.Z.to_string machine_wordsize
+   ++ "_MAX, ""target word size does not match synthesis word size"");"
+   ++ String.NewLine)%string.
+
+Definition bedrock2_header
+           {language_naming_conventions : language_naming_conventions_opt}
+           {documentation_options : documentation_options_opt}
+           {package_name : package_name_opt}
+           {class_name : class_name_opt}
+           {output_options : output_options_opt}
+           (machine_wordsize : Z) (_ _ : bool) (_ : string)
+           (_ : ToString.ident_infos) (_ : list ToString.typedef_info) : list string :=
+  [""; bedrock2_prelude machine_wordsize].
+
 Definition wrap_call
   {width BW word mem locals ext_spec varname_gen error}
   `{parameters_sentinel : @parameters width BW word mem locals ext_spec varname_gen error}
@@ -259,7 +276,7 @@ Definition OutputBedrock2API : ToString.OutputLanguageAPI :=
 
     ToString.ToFunctionLines := @Bedrock2_ToFunctionLines;
 
-    ToString.header := fun _ _ _ _ _ _ _ _ _ _ _ => [""; ToCString.prelude];
+    ToString.header := @bedrock2_header;
 
     ToString.footer := fun _ _ _ _ _ _ _ _ _ => [];
 


### PR DESCRIPTION
## Summary

- emit an exact target-word-width assertion in the Bedrock2 C prelude
- regenerate all checked-in Bedrock2 C outputs with the assertion
- compile only native-width outputs in the generated-C test and verify that a mismatched output is rejected
- document the Bedrock2 target-width requirement

## Rationale

Bedrock2 uses `uintptr_t` for both addresses and arithmetic words. Previously, compiling a `_32.c` output for a 64-bit target made `_br_load` and `_br_store` access eight bytes while generated limb offsets advanced by four bytes. That caused overlapping limb accesses, a four-byte overrun at the end of caller buffers, and incorrect field arithmetic.

The generator already receives the synthesis word size. This change preserves Bedrock2’s pointer-sized word model and turns any mismatch into a compile-time error before the affected code can run. The checked-in generated artifacts now reject both 32-on-64 and 64-on-32 mismatches. This addresses Scrutineer finding #2509.

## Testing

- `opam exec -- make src/Bedrock/Field/Stringification/Stringification.vo EXTERNAL_DEPENDENCIES=1 -j2`
- `make -f Makefile.examples only-test-bedrock2-files CC=cc`
- `make -f Makefile.examples only-test-bedrock2-files CC=clang`
- `git diff --check`

A genuine 32-bit compiler/sysroot was not available locally, so successful `_32.c` compilation on a 32-bit host was not executed. The generated assertion is symmetric, and its rejection path is covered on this 64-bit host.

> *Authorship note: this was researched and written by an AI coding agent
> (OpenAI Codex), working on Jason Gross's behalf; Jason reviews what is
> posted from this account.*