### PR TITLE
Fix signed semantics for one-operand IMUL

### DIFF
--- a/src/Assembly/Symbolic.v
+++ b/src/Assembly/Symbolic.v
@@ -4298,10 +4298,28 @@ Definition SymexNormalInstruction {opts : symbolic_options_computed_opt} {descr:
     vh <- Symeval (shrZ@(v,PreARG (Z.of_N s)));
     _ <- SetOperand lo v;
          SetOperand hi vh
-  | (Syntax.mul | imul), [src2] =>
+  | Syntax.mul, [src2] =>
     let src1 : ARG := rax in
     v  <- Symeval (mulZ@(src1,src2));
     vh <- Symeval (shrZ@(v,PreARG (Z.of_N s)));
+    lo <- resize_reg rax;
+    hi <- (if (s =? 8)%N
+           then ret ah
+           else resize_reg rdx);
+    _ <- SetOperand (lo:ARG) v;
+    _ <- SetOperand (hi:ARG) vh;
+    HavocFlags (* This is conservative and can be made more precise *)
+  | imul, [src2] =>
+    let src1 : ARG := rax in
+    (* The one-operand form of IMUL sign-extends both operands before
+       producing its double-width result.  Express [Z.signed] using the
+       existing unbounded integer operations so that the signed high word
+       remains visible in the symbolic DAG. *)
+    let sign_bit := Z.shiftl 1 (Z.of_N s - 1) in
+    let zconst z := PreApp (const z) nil in
+    let signed x := addZ@(andZ@(addZ@(zconst sign_bit,x),zconst (Z.ones (Z.of_N s))),zconst (-sign_bit)) in
+    v  <- Symeval (mulZ@(signed src1,signed src2));
+    vh <- Symeval (shrZ@(v,zconst (Z.of_N s)));
     lo <- resize_reg rax;
     hi <- (if (s =? 8)%N
            then ret ah

--- a/src/Assembly/WithBedrock/Semantics.v
+++ b/src/Assembly/WithBedrock/Semantics.v
@@ -245,11 +245,23 @@ Definition DenoteNormalInstruction (st : machine_state) (instr : NormalInstructi
     let v := v1 * v2 in
     st <- SetOperand sa s st lo v;
     SetOperand sa s st hi (Z.shiftr v (Z.of_N s))
-  | (Syntax.mul | imul), [src2] =>
+  | Syntax.mul, [src2] =>
     let src1 : ARG := rax in
     v1 <- DenoteOperand sa s st src1;
     v2 <- DenoteOperand sa s st src2;
     let v := v1 * v2 in
+    lo <- resize_reg rax;
+    hi <- (if (s =? 8)%N
+           then Some ah
+           else resize_reg rdx);
+    st <- SetOperand sa s st lo v;
+    st <- SetOperand sa s st hi (Z.shiftr v (Z.of_N s));
+    Some (HavocFlags st) (* conservative *)
+  | imul, [src2] =>
+    let src1 : ARG := rax in
+    v1 <- DenoteOperand sa s st src1;
+    v2 <- DenoteOperand sa s st src2;
+    let v := Z.signed s v1 * Z.signed s v2 in
     lo <- resize_reg rax;
     hi <- (if (s =? 8)%N
            then Some ah

--- a/src/Assembly/WithBedrock/SemanticsTests.v
+++ b/src/Assembly/WithBedrock/SemanticsTests.v
@@ -1,0 +1,78 @@
+From Coq Require Import List ZArith.
+Require Import Crypto.Util.ErrorT.
+Require Import Crypto.Assembly.Syntax.
+Require Import Crypto.Assembly.Symbolic.
+Require Import Crypto.Assembly.WithBedrock.Semantics.
+Require coqutil.Map.Interface.
+Import ListNotations.
+
+Local Open Scope list_scope.
+Local Open Scope x86symex_scope.
+
+Definition imul_test_lhs : Z := 0xffffffff00000001.
+Definition imul_test_rhs : Z := 3.
+
+Definition imul_test_instruction (opc : OpCode) : NormalInstruction :=
+  {| prefix := None; Syntax.op := opc; args := [reg rcx] |}.
+
+Definition imul_test_machine_state : machine_state :=
+  {| machine_reg_state :=
+       set_reg (set_reg (Crypto.Util.Tuple.repeat 0%Z _) rax imul_test_lhs)
+               rcx imul_test_rhs;
+     machine_flag_state := havoc_flags;
+     machine_mem_state := coqutil.Map.Interface.map.empty |}.
+
+Definition concrete_mul_result (opc : OpCode) : option (Z * Z) :=
+  match DenoteNormalInstruction imul_test_machine_state
+          (imul_test_instruction opc) with
+  | Some st => Some (get_reg st rax, get_reg st rdx)
+  | None => None
+  end.
+
+Example one_operand_imul_is_signed_concrete :
+  concrete_mul_result imul =
+    Some (0xfffffffd00000003%Z, 0xffffffffffffffff%Z).
+Proof. vm_compute. reflexivity. Qed.
+
+Example one_operand_mul_remains_unsigned_concrete :
+  concrete_mul_result Syntax.mul = Some (0xfffffffd00000003%Z, 2%Z).
+Proof. vm_compute. reflexivity. Qed.
+
+Local Instance imul_test_options : symbolic_options_computed_opt :=
+  {| asm_rewriting_passes := RewritePass.default_rewrite_pass_order;
+     asm_debug_symex_asm_first_computed := false;
+     asm_node_reveal_depth_computed := default_node_reveal_depth |}.
+Local Instance imul_test_description : description := no_description.
+
+Definition imul_test_symbolic_state : symbolic_state :=
+  {| dag_state := dag.empty;
+     symbolic_reg_state := Crypto.Util.Tuple.repeat None _;
+     symbolic_flag_state := Crypto.Util.Tuple.repeat None _;
+     symbolic_mem_state := [] |}.
+
+Definition symbolic_mul (opc : OpCode) : M (Z * Z) :=
+  lhs <- App (const imul_test_lhs, []);
+  rhs <- App (const imul_test_rhs, []);
+  _ <- SetReg64 (reg_index rax) lhs;
+  _ <- SetReg64 (reg_index rcx) rhs;
+  _ <- SymexNormalInstruction (imul_test_instruction opc);
+  lo <- GetReg rax;
+  hi <- GetReg rdx;
+  lo <- RevealConst lo;
+  hi <- RevealConst hi;
+  ret (lo, hi).
+
+Definition symbolic_mul_result (opc : OpCode) : option (Z * Z) :=
+  match symbolic_mul opc imul_test_symbolic_state with
+  | Success (result, _) => Some result
+  | Error _ => None
+  end.
+
+Example one_operand_imul_is_signed_symbolic :
+  symbolic_mul_result imul =
+    Some (0xfffffffd00000003%Z, 0xffffffffffffffff%Z).
+Proof. vm_compute. reflexivity. Qed.
+
+Example one_operand_mul_remains_unsigned_symbolic :
+  symbolic_mul_result Syntax.mul = Some (0xfffffffd00000003%Z, 2%Z).
+Proof. vm_compute. reflexivity. Qed.


### PR DESCRIPTION
## Summary

- model one-operand `imul` as a signed double-width product in both the symbolic and concrete x86 semantics
- preserve the existing unsigned semantics of one-operand `mul` and the low-word behavior of the other `imul` forms
- add focused regressions using a top-bit-set operand, checking both semantic models and the distinct unsigned `mul` high word

## Testing

- `opam exec -- make -f Makefile.coq src/Assembly/WithBedrock/SemanticsTests.vo -j2`
- `opam exec -- make -f Makefile.coq src/Assembly/WithBedrock/SymbolicProofs.vo -j2`
- `git diff --check`

Addresses Scrutineer finding #2514.

> *Authorship note: this was researched and written by an AI coding agent
> (OpenAI Codex), working on Jason Gross's behalf; Jason reviews what is
> posted from this account.*