### PR TITLE
Make AMD64 field operations safe for in-place use

### DIFF
--- a/fiat-amd64/Readme.md
+++ b/fiat-amd64/Readme.md
@@ -23,3 +23,8 @@ Every `asm` file contains a footer comment with some metadata on which CPU it wa
 
 All assembly files use the *Linux System-V ABI* and require the CPU flags `-adx` and `-bmi2` (Supported at least from Intel Cores since the 6th generation (Skylake), released in 2016).
 The files are written using Intel assembly syntax.
+
+As with the corresponding generated C functions, the output array may be the
+same array as either input.  On an x86-64 host with ADX and BMI2,
+`./fiat-amd64/test_aliasing.py` assembles every implementation and checks both
+supported in-place calling patterns.

--- a/fiat-amd64/fiat_curve25519_carry_mul/seed0000000482209796_ratio12672.asm
+++ b/fiat-amd64/fiat_curve25519_carry_mul/seed0000000482209796_ratio12672.asm
@@ -1,6 +1,18 @@
 SECTION .text
 	GLOBAL fiat_curve25519_carry_mul
 fiat_curve25519_carry_mul:
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 mov rax, [ rdx + 0x20 ]
 lea r10, [rax + 8 * rax]
 lea r11, [rax + 2 * r10]
@@ -161,6 +173,7 @@ mov r12, [ rsp - 0x70 ]
 mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
+add rsp, 80
 ret
 ; cpu 13th Gen Intel(R) Core(TM) i9-13900KF
 ; ratio 1.2672

--- a/fiat-amd64/fiat_p448_solinas_carry_mul/seed0000000550927794_ratio10833.asm
+++ b/fiat-amd64/fiat_p448_solinas_carry_mul/seed0000000550927794_ratio10833.asm
@@ -1,6 +1,24 @@
 SECTION .text
 	GLOBAL fiat_p448_solinas_carry_mul
 fiat_p448_solinas_carry_mul:
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 552
 mov rax, rdx
 mov rdx, [ rdx + 0x38 ]
@@ -542,6 +560,8 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 552
+add rsp, 64
+add rsp, 64
 ret
 ; cpu AMD Ryzen 9 5950X 16-Core Processor
 ; ratio 1.0833

--- a/fiat-amd64/fiat_p448_solinas_carry_mul/seed0000000655786545_ratio10191.asm
+++ b/fiat-amd64/fiat_p448_solinas_carry_mul/seed0000000655786545_ratio10191.asm
@@ -1,6 +1,24 @@
 SECTION .text
 	GLOBAL fiat_p448_solinas_carry_mul
 fiat_p448_solinas_carry_mul:
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 656
 mov rax, rdx
 mov rdx, [ rsi + 0x38 ]
@@ -552,6 +570,8 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 656
+add rsp, 64
+add rsp, 64
 ret
 ; cpu AMD Ryzen 7 5800X 8-Core Processor
 ; ratio 1.0191

--- a/fiat-amd64/fiat_p448_solinas_carry_mul/seed0000000837011030_ratio11590.asm
+++ b/fiat-amd64/fiat_p448_solinas_carry_mul/seed0000000837011030_ratio11590.asm
@@ -1,6 +1,24 @@
 SECTION .text
 	GLOBAL fiat_p448_solinas_carry_mul
 fiat_p448_solinas_carry_mul:
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 824
 mov rax, rdx
 mov rdx, [ rdx + 0x0 ]
@@ -578,6 +596,8 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 824
+add rsp, 64
+add rsp, 64
 ret
 ; cpu 12th Gen Intel(R) Core(TM) i9-12900KF
 ; ratio 1.1590

--- a/fiat-amd64/fiat_p448_solinas_carry_mul/seed0000000881706917_ratio10757.asm
+++ b/fiat-amd64/fiat_p448_solinas_carry_mul/seed0000000881706917_ratio10757.asm
@@ -1,6 +1,24 @@
 SECTION .text
 	GLOBAL fiat_p448_solinas_carry_mul
 fiat_p448_solinas_carry_mul:
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 744
 mov rax, rdx
 mov rdx, [ rdx + 0x18 ]
@@ -575,6 +593,8 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 744
+add rsp, 64
+add rsp, 64
 ret
 ; cpu AMD Ryzen Threadripper 1900X 8-Core Processor
 ; ratio 1.0757

--- a/fiat-amd64/fiat_p448_solinas_carry_square/seed0000000631030080_ratio10692.asm
+++ b/fiat-amd64/fiat_p448_solinas_carry_square/seed0000000631030080_ratio10692.asm
@@ -1,6 +1,15 @@
 SECTION .text
 	GLOBAL fiat_p448_solinas_carry_square
 fiat_p448_solinas_carry_square:
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 448
 mov rax, [ rsi + 0x30 ]
 lea r10, [rax + rax]
@@ -369,6 +378,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 448
+add rsp, 64
 ret
 ; cpu 12th Gen Intel(R) Core(TM) i9-12900KF
 ; ratio 1.0692

--- a/fiat-amd64/fiat_p448_solinas_carry_square/seed0000000774378589_ratio10909.asm
+++ b/fiat-amd64/fiat_p448_solinas_carry_square/seed0000000774378589_ratio10909.asm
@@ -1,6 +1,15 @@
 SECTION .text
 	GLOBAL fiat_p448_solinas_carry_square
 fiat_p448_solinas_carry_square:
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 432
 mov rax, [ rsi + 0x20 ]
 mov r10, rax
@@ -357,6 +366,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 432
+add rsp, 64
 ret
 ; cpu 11th Gen Intel(R) Core(TM) i7-11700KF @ 3.60GHz
 ; ratio 1.0909

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000047835794_ratio11868.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000047835794_ratio11868.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 824
 mov rax, rdx
 mov rdx, [ rdx + 0x20 ]
@@ -587,6 +607,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 824
+add rsp, 144
 ret
 ; cpu AMD Ryzen 9 5950X 16-Core Processor
 ; ratio 1.1868

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000052696454_ratio11943.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000052696454_ratio11943.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 688
 mov rax, [ rdx + 0x20 ]
 lea r10, [rax + rax]
@@ -567,6 +587,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 688
+add rsp, 144
 ret
 ; cpu AMD Ryzen 9 5950X 16-Core Processor
 ; ratio 1.1943

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000158362706_ratio13832.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000158362706_ratio13832.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 456
 mov rax, [ rdx + 0x18 ]
 lea r10, [rax + rax]
@@ -509,6 +529,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 456
+add rsp, 144
 ret
 ; cpu Intel(R) Core(TM) i7-6770HQ CPU @ 2.60GHz
 ; ratio 1.3832

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000189072207_ratio13305.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000189072207_ratio13305.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 544
 mov rax, rdx
 mov rdx, [ rdx + 0x8 ]
@@ -523,6 +543,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 544
+add rsp, 144
 ret
 ; cpu Intel(R) Core(TM) i7-6770HQ CPU @ 2.60GHz
 ; ratio 1.3305

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000395771804_ratio12002.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000395771804_ratio12002.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 1088
 mov rax, rdx
 mov rdx, [ rdx + 0x18 ]
@@ -619,6 +639,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 1088
+add rsp, 144
 ret
 ; cpu 13th Gen Intel(R) Core(TM) i9-13900KF
 ; ratio 1.2002

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000493556566_ratio13800.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000493556566_ratio13800.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 952
 mov rax, rdx
 mov rdx, [ rdx + 0x28 ]
@@ -595,6 +615,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 952
+add rsp, 144
 ret
 ; cpu 12th Gen Intel(R) Core(TM) i9-12900KF
 ; ratio 1.3800

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000514257310_ratio12929.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000514257310_ratio12929.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 664
 mov rax, 0x1 
 shlx r10, [ rdx + 0x30 ], rax
@@ -549,6 +569,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 664
+add rsp, 144
 ret
 ; cpu Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz
 ; ratio 1.2929

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000536672946_ratio11327.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000536672946_ratio11327.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 872
 mov rax, [ rdx + 0x28 ]
 mov r10, rax
@@ -594,6 +614,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 872
+add rsp, 144
 ret
 ; cpu AMD Ryzen 9 7950X 16-Core Processor
 ; ratio 1.1327

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000542486320_ratio10714.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000542486320_ratio10714.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 944
 mov rax, [ rdx + 0x18 ]
 lea r10, [rax + rax]
@@ -601,6 +621,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 944
+add rsp, 144
 ret
 ; cpu AMD Ryzen 9 7950X 16-Core Processor
 ; ratio 1.0714

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000551110011_ratio13870.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000551110011_ratio13870.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 568
 mov rax, [ rdx + 0x40 ]
 mov r10, rax
@@ -531,6 +551,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 568
+add rsp, 144
 ret
 ; cpu Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz
 ; ratio 1.3870

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000575796058_ratio13139.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000575796058_ratio13139.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 688
 mov rax, rdx
 mov rdx, [ rsi + 0x18 ]
@@ -548,6 +568,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 688
+add rsp, 144
 ret
 ; cpu Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz
 ; ratio 1.3139

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000607492436_ratio11667.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000607492436_ratio11667.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 736
 mov rax, rdx
 mov rdx, [ rsi + 0x8 ]
@@ -566,6 +586,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 736
+add rsp, 144
 ret
 ; cpu AMD Ryzen 7 5800X 8-Core Processor
 ; ratio 1.1667

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000611646699_ratio11498.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000611646699_ratio11498.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 864
 mov rax, rdx
 mov rdx, [ rdx + 0x8 ]
@@ -598,6 +618,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 864
+add rsp, 144
 ret
 ; cpu AMD Ryzen 7 5800X 8-Core Processor
 ; ratio 1.1498

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000616296185_ratio11314.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000616296185_ratio11314.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 848
 mov rax, rdx
 mov rdx, [ rdx + 0x10 ]
@@ -597,6 +617,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 848
+add rsp, 144
 ret
 ; cpu AMD Ryzen 7 5800X 8-Core Processor
 ; ratio 1.1314

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000689435637_ratio13006.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000689435637_ratio13006.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 560
 mov rax, [ rdx + 0x10 ]
 mov r10, rax
@@ -528,6 +548,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 560
+add rsp, 144
 ret
 ; cpu Intel(R) Core(TM) i9-10900K CPU @ 3.70GHz
 ; ratio 1.3006

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000693719722_ratio13596.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000693719722_ratio13596.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 496
 mov rax, rdx
 mov rdx, [ rdx + 0x10 ]
@@ -520,6 +540,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 496
+add rsp, 144
 ret
 ; cpu Intel(R) Core(TM) i9-10900K CPU @ 3.70GHz
 ; ratio 1.3596

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000698136414_ratio13478.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000698136414_ratio13478.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 504
 mov rax, [ rdx + 0x40 ]
 mov r10, rax
@@ -522,6 +542,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 504
+add rsp, 144
 ret
 ; cpu Intel(R) Core(TM) i9-10900K CPU @ 3.70GHz
 ; ratio 1.3478

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000702866409_ratio11667.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000702866409_ratio11667.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 784
 mov rax, rdx
 mov rdx, [ rdx + 0x18 ]
@@ -574,6 +594,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 784
+add rsp, 144
 ret
 ; cpu 11th Gen Intel(R) Core(TM) i7-11700KF @ 3.60GHz
 ; ratio 1.1667

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000711337808_ratio12394.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000711337808_ratio12394.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 696
 mov rax, [ rdx + 0x18 ]
 mov r10, rax
@@ -557,6 +577,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 696
+add rsp, 144
 ret
 ; cpu 11th Gen Intel(R) Core(TM) i7-11700KF @ 3.60GHz
 ; ratio 1.2394

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000889476832_ratio11162.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000889476832_ratio11162.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 888
 mov rax, rdx
 mov rdx, [ rsi + 0x0 ]
@@ -596,6 +616,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 888
+add rsp, 144
 ret
 ; cpu AMD Ryzen Threadripper 1900X 8-Core Processor
 ; ratio 1.1162

--- a/fiat-amd64/fiat_p521_carry_mul/seed0000000909478978_ratio10887.asm
+++ b/fiat-amd64/fiat_p521_carry_mul/seed0000000909478978_ratio10887.asm
@@ -1,6 +1,26 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_mul
 fiat_p521_carry_mul:
+push qword [ rdx + 0x40 ]
+push qword [ rdx + 0x38 ]
+push qword [ rdx + 0x30 ]
+push qword [ rdx + 0x28 ]
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 960
 mov rax, [ rdx + 0x38 ]
 lea r10, [rax + rax]
@@ -606,6 +626,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 960
+add rsp, 144
 ret
 ; cpu AMD Ryzen Threadripper 1900X 8-Core Processor
 ; ratio 1.0887

--- a/fiat-amd64/fiat_p521_carry_square/seed0000000143339698_ratio14734.asm
+++ b/fiat-amd64/fiat_p521_carry_square/seed0000000143339698_ratio14734.asm
@@ -1,6 +1,16 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_square
 fiat_p521_carry_square:
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 280
 imul rax, [ rsi + 0x38 ], 0x2
 mov r10, [ rsi + 0x38 ]
@@ -326,6 +336,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 280
+add rsp, 72
 ret
 ; cpu Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz
 ; ratio 1.4734

--- a/fiat-amd64/fiat_p521_carry_square/seed0000000179780534_ratio15196.asm
+++ b/fiat-amd64/fiat_p521_carry_square/seed0000000179780534_ratio15196.asm
@@ -1,6 +1,16 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_square
 fiat_p521_carry_square:
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 272
 mov rax, [ rsi + 0x10 ]
 lea r10, [rax + rax]
@@ -327,6 +337,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 272
+add rsp, 72
 ret
 ; cpu Intel(R) Core(TM) i7-10710U CPU @ 1.10GHz
 ; ratio 1.5196

--- a/fiat-amd64/fiat_p521_carry_square/seed0000000283327682_ratio13642.asm
+++ b/fiat-amd64/fiat_p521_carry_square/seed0000000283327682_ratio13642.asm
@@ -1,6 +1,16 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_square
 fiat_p521_carry_square:
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 408
 mov rax, [ rsi + 0x38 ]
 mov r10, rax
@@ -356,6 +366,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 408
+add rsp, 72
 ret
 ; cpu 12th Gen Intel(R) Core(TM) i9-12900KF
 ; ratio 1.3642

--- a/fiat-amd64/fiat_p521_carry_square/seed0000000287256225_ratio14276.asm
+++ b/fiat-amd64/fiat_p521_carry_square/seed0000000287256225_ratio14276.asm
@@ -1,6 +1,16 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_square
 fiat_p521_carry_square:
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 344
 mov rax, [ rsi + 0x10 ]
 mov r10, rax
@@ -338,6 +348,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 344
+add rsp, 72
 ret
 ; cpu 12th Gen Intel(R) Core(TM) i9-12900KF
 ; ratio 1.4276

--- a/fiat-amd64/fiat_p521_carry_square/seed0000000405805584_ratio14749.asm
+++ b/fiat-amd64/fiat_p521_carry_square/seed0000000405805584_ratio14749.asm
@@ -1,6 +1,16 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_square
 fiat_p521_carry_square:
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 256
 mov rax, 0x2 
 shlx r10, [ rsi + 0x40 ], rax
@@ -328,6 +338,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 256
+add rsp, 72
 ret
 ; cpu Intel(R) Core(TM) i9-10900K CPU @ 3.70GHz
 ; ratio 1.4749

--- a/fiat-amd64/fiat_p521_carry_square/seed0000000410723976_ratio14599.asm
+++ b/fiat-amd64/fiat_p521_carry_square/seed0000000410723976_ratio14599.asm
@@ -1,6 +1,16 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_square
 fiat_p521_carry_square:
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 280
 imul rax, [ rsi + 0x28 ], 0x2
 mov r10, [ rsi + 0x38 ]
@@ -332,6 +342,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 280
+add rsp, 72
 ret
 ; cpu Intel(R) Core(TM) i9-10900K CPU @ 3.70GHz
 ; ratio 1.4599

--- a/fiat-amd64/fiat_p521_carry_square/seed0000000469077339_ratio15442.asm
+++ b/fiat-amd64/fiat_p521_carry_square/seed0000000469077339_ratio15442.asm
@@ -1,6 +1,16 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_square
 fiat_p521_carry_square:
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 488
 mov rax, [ rsi + 0x38 ]
 mov r10, rax
@@ -370,6 +380,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 488
+add rsp, 72
 ret
 ; cpu 11th Gen Intel(R) Core(TM) i7-11700KF @ 3.60GHz
 ; ratio 1.5442

--- a/fiat-amd64/fiat_p521_carry_square/seed0000000710270997_ratio14259.asm
+++ b/fiat-amd64/fiat_p521_carry_square/seed0000000710270997_ratio14259.asm
@@ -1,6 +1,16 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_square
 fiat_p521_carry_square:
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 336
 mov rax, [ rsi + 0x38 ]
 lea r10, [ 4 * rax]
@@ -333,6 +343,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 336
+add rsp, 72
 ret
 ; cpu Intel(R) Core(TM) i7-6770HQ CPU @ 2.60GHz
 ; ratio 1.4259

--- a/fiat-amd64/fiat_p521_carry_square/seed0000000730891366_ratio14312.asm
+++ b/fiat-amd64/fiat_p521_carry_square/seed0000000730891366_ratio14312.asm
@@ -1,6 +1,16 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_square
 fiat_p521_carry_square:
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 360
 mov rax, [ rsi + 0x28 ]
 lea r10, [rax + rax]
@@ -332,6 +342,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 360
+add rsp, 72
 ret
 ; cpu Intel(R) Core(TM) i7-6770HQ CPU @ 2.60GHz
 ; ratio 1.4312

--- a/fiat-amd64/fiat_p521_carry_square/seed0000000749000018_ratio16680.asm
+++ b/fiat-amd64/fiat_p521_carry_square/seed0000000749000018_ratio16680.asm
@@ -1,6 +1,16 @@
 SECTION .text
 	GLOBAL fiat_p521_carry_square
 fiat_p521_carry_square:
+push qword [ rsi + 0x40 ]
+push qword [ rsi + 0x38 ]
+push qword [ rsi + 0x30 ]
+push qword [ rsi + 0x28 ]
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 sub rsp, 240
 mov rax, 0x2 
 shlx r10, [ rsi + 0x40 ], rax
@@ -317,6 +327,7 @@ mov r13, [ rsp - 0x68 ]
 mov r14, [ rsp - 0x60 ]
 mov r15, [ rsp - 0x58 ]
 add rsp, 240
+add rsp, 72
 ret
 ; cpu Intel(R) Core(TM) i7-6770HQ CPU @ 2.60GHz
 ; ratio 1.6680

--- a/fiat-amd64/fiat_secp256k1_dettman_mul/seed0000000085598755_ratio14415.asm
+++ b/fiat-amd64/fiat_secp256k1_dettman_mul/seed0000000085598755_ratio14415.asm
@@ -1,6 +1,18 @@
 SECTION .text
 	GLOBAL fiat_secp256k1_dettman_mul
 fiat_secp256k1_dettman_mul:
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 mov rax, rdx; preserving value of arg2 into a new reg
 mov rdx, [ rdx + 0x0 ]; saving arg2[0] in rdx.
 mulx r11, r10, [ rsi + 0x20 ]; x10012_1, x10012_0<- arg1[4] * arg2[0] (_0*_0)
@@ -192,6 +204,7 @@ mov r12, [ rsp - 0x70 ]; pop
 mov r13, [ rsp - 0x68 ]; pop
 mov r14, [ rsp - 0x60 ]; pop
 mov r15, [ rsp - 0x58 ]; pop
+add rsp, 80
 ret
 ; cpu 13th Gen Intel(R) Core(TM) i9-13900KF
 ; ratio 1.4415

--- a/fiat-amd64/fiat_secp256k1_dettman_mul/seed0000000089299041_ratio11830.asm
+++ b/fiat-amd64/fiat_secp256k1_dettman_mul/seed0000000089299041_ratio11830.asm
@@ -1,6 +1,18 @@
 SECTION .text
 	GLOBAL fiat_secp256k1_dettman_mul
 fiat_secp256k1_dettman_mul:
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 mov rax, rdx; preserving value of arg2 into a new reg
 mov rdx, [ rdx + 0x0 ]; saving arg2[0] in rdx.
 mulx r11, r10, [ rsi + 0x18 ]; x10003_1, x10003_0<- arg1[3] * arg2[0] (_0*_0)
@@ -191,6 +203,7 @@ mov r12, [ rsp - 0x70 ]; pop
 mov r13, [ rsp - 0x68 ]; pop
 mov r14, [ rsp - 0x60 ]; pop
 mov r15, [ rsp - 0x58 ]; pop
+add rsp, 80
 ret
 ; cpu 13th Gen Intel(R) Core(TM) i9-13900KF
 ; ratio 1.1830

--- a/fiat-amd64/fiat_secp256k1_dettman_mul/seed0000000489048938_ratio10616.asm
+++ b/fiat-amd64/fiat_secp256k1_dettman_mul/seed0000000489048938_ratio10616.asm
@@ -1,6 +1,18 @@
 SECTION .text
 	GLOBAL fiat_secp256k1_dettman_mul
 fiat_secp256k1_dettman_mul:
+push qword [ rdx + 0x20 ]
+push qword [ rdx + 0x18 ]
+push qword [ rdx + 0x10 ]
+push qword [ rdx + 0x8 ]
+push qword [ rdx + 0x0 ]
+mov rdx, rsp
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 mov rax, rdx; preserving value of arg2 into a new reg
 mov rdx, [ rsi + 0x20 ]; saving arg1[4] in rdx.
 mulx r11, r10, [ rax + 0x20 ]; x1_1, x1_0<- arg1[4] * arg2[4] (_0*_0)
@@ -200,6 +212,7 @@ mov r12, [ rsp - 0x70 ]; pop
 mov r13, [ rsp - 0x68 ]; pop
 mov r14, [ rsp - 0x60 ]; pop
 mov r15, [ rsp - 0x58 ]; pop
+add rsp, 80
 ret
 ; cpu AMD Ryzen 9 7950X 16-Core Processor
 ; ratio 1.0616

--- a/fiat-amd64/fiat_secp256k1_dettman_square/seed0000000112902737_ratio11823.asm
+++ b/fiat-amd64/fiat_secp256k1_dettman_square/seed0000000112902737_ratio11823.asm
@@ -1,6 +1,12 @@
 SECTION .text
 	GLOBAL fiat_secp256k1_dettman_square
 fiat_secp256k1_dettman_square:
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 mov rax, [ rsi + 0x8 ]; load m64 arg1[1] to register64
 lea r10, [rax + rax]; x3 <- arg1[1] * 2 
 mov rax, 0x1 ; moving imm to reg
@@ -147,6 +153,7 @@ mov r12, [ rsp - 0x70 ]; pop
 mov r13, [ rsp - 0x68 ]; pop
 mov r14, [ rsp - 0x60 ]; pop
 mov r15, [ rsp - 0x58 ]; pop
+add rsp, 40
 ret
 ; cpu 12th Gen Intel(R) Core(TM) i9-12900KF
 ; ratio 1.1823

--- a/fiat-amd64/fiat_secp256k1_dettman_square/seed0000000965885279_ratio12004.asm
+++ b/fiat-amd64/fiat_secp256k1_dettman_square/seed0000000965885279_ratio12004.asm
@@ -1,6 +1,12 @@
 SECTION .text
 	GLOBAL fiat_secp256k1_dettman_square
 fiat_secp256k1_dettman_square:
+push qword [ rsi + 0x20 ]
+push qword [ rsi + 0x18 ]
+push qword [ rsi + 0x10 ]
+push qword [ rsi + 0x8 ]
+push qword [ rsi + 0x0 ]
+mov rsi, rsp
 mov rax, [ rsi + 0x8 ]; load m64 arg1[1] to register64
 lea r10, [rax + rax]; x3 <- arg1[1] * 2 
 mov rdx, [ rsi + 0x20 ]; arg1[4] to rdx
@@ -146,6 +152,7 @@ mov r12, [ rsp - 0x70 ]; pop
 mov r13, [ rsp - 0x68 ]; pop
 mov r14, [ rsp - 0x60 ]; pop
 mov r15, [ rsp - 0x58 ]; pop
+add rsp, 40
 ret
 ; cpu 13th Gen Intel(R) Core(TM) i9-13900KF
 ; ratio 1.2004

--- a/fiat-amd64/test_aliasing.py
+++ b/fiat-amd64/test_aliasing.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Check that every shipped AMD64 implementation supports in-place use."""
+
+import concurrent.futures
+import os
+from pathlib import Path
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parent.parent
+ASM_ROOT = ROOT / "fiat-amd64"
+CC = os.environ.get("CC", "cc")
+
+
+def operation(path):
+    directory = path.parent.name
+    if directory.endswith("_square"):
+        return "square"
+    if directory.endswith("_mul"):
+        return "mul"
+    raise ValueError("unrecognized operation: %s" % directory)
+
+
+def limb_count(path):
+    directory = path.parent.name
+    counts = {
+        "curve25519_carry": 5,
+        "curve25519_solinas": 4,
+        "p224": 4,
+        "p256": 4,
+        "p384": 6,
+        "p434": 7,
+        "p448_solinas_carry": 8,
+        "p521_carry": 9,
+        "poly1305_carry": 3,
+        "secp256k1_dettman": 5,
+        "secp256k1_montgomery": 4,
+    }
+    family = re.sub(r"^fiat_|_(?:mul|square)$", "", directory)
+    return counts[family]
+
+
+def symbol(path):
+    for line in path.read_text().splitlines():
+        match = re.match(r"\s*GLOBAL\s+(\w+)", line)
+        if match:
+            return match.group(1)
+    raise ValueError("GLOBAL directive missing from %s" % path)
+
+
+def reference_path(path):
+    family = re.sub(r"^fiat_|_(?:mul|square)$", "", path.parent.name)
+    family = re.sub(r"_carry$", "", family)
+    return ROOT / "fiat-c" / "src" / (family + "_64.c")
+
+
+def reference_symbol(sym):
+    sym = sym.replace("fiat_curve25519_carry_", "fiat_25519_carry_")
+    return sym.replace("fiat_p448_solinas_carry_", "fiat_p448_carry_")
+
+
+def gas_source(path):
+    lines = [".intel_syntax noprefix"]
+    for line in path.read_text().splitlines():
+        line = re.sub(r";.*$", "", line)
+        if re.match(r"^\s*SECTION\s+\.text\s*$", line):
+            line = ".text"
+        line = re.sub(r"^\s*GLOBAL\s+(\w+)\s*$", r".globl \1", line)
+        line = re.sub(
+            r"\b(byte|qword|dword|word)\s+\[",
+            lambda match: match.group(1).upper() + " PTR [",
+            line,
+            flags=re.IGNORECASE,
+        )
+        lines.append(line)
+    lines.append('.section .note.GNU-stack,"",@progbits')
+    return "\n".join(lines) + "\n"
+
+
+def harness_source(sym, op, limbs, reference):
+    if op == "square":
+        declaration = "extern void %s(uint64_t *, const uint64_t *);" % sym
+        calls = """
+    %(sym)s(separate, a);
+    fiat_reference(reference, a);
+    if (memcmp(separate, reference, %(bytes)d) != 0) return 3;
+    memcpy(inplace1, a, sizeof(a));
+    %(sym)s(inplace1, inplace1);
+    if (memcmp(separate, inplace1, %(bytes)d) != 0) return 1;
+""" % {"sym": sym, "bytes": limbs * 8}
+    else:
+        declaration = (
+            "extern void %s(uint64_t *, const uint64_t *, const uint64_t *);" % sym
+        )
+        calls = """
+    %(sym)s(separate, a, b);
+    fiat_reference(reference, a, b);
+    if (memcmp(separate, reference, %(bytes)d) != 0) return 3;
+    memcpy(inplace1, a, sizeof(a));
+    %(sym)s(inplace1, inplace1, b);
+    if (memcmp(separate, inplace1, %(bytes)d) != 0) return 1;
+    memcpy(inplace2, b, sizeof(b));
+    %(sym)s(inplace2, a, inplace2);
+    if (memcmp(separate, inplace2, %(bytes)d) != 0) return 2;
+""" % {"sym": sym, "bytes": limbs * 8}
+    return """#include <stdint.h>
+#include <string.h>
+#define %(reference_symbol)s fiat_reference
+#include "%(reference)s"
+#undef %(reference_symbol)s
+%(declaration)s
+
+int main(void) {
+  uint64_t a[9], b[9], reference[9], separate[9], inplace1[9], inplace2[9];
+  for (uint64_t trial = 0; trial < 8; trial++) {
+    for (uint64_t i = 0; i < 9; i++) {
+      a[i] = 0x101 + 0x111 * i + 0x1001 * trial;
+      b[i] = 0x202 + 0x121 * i + 0x2003 * trial;
+    }
+%(calls)s
+  }
+  return 0;
+}
+""" % {
+        "sym": sym,
+        "reference_symbol": reference_symbol(sym),
+        "reference": reference,
+        "declaration": declaration,
+        "calls": calls,
+    }
+
+
+def check(path, temporary_root):
+    relative = path.relative_to(ROOT)
+    work = temporary_root / (path.parent.name + "-" + path.stem)
+    work.mkdir()
+    asm = work / "implementation.s"
+    harness = work / "harness.c"
+    obj = work / "implementation.o"
+    executable = work / "test"
+    sym = symbol(path)
+    op = operation(path)
+    asm.write_text(gas_source(path))
+    harness.write_text(
+        harness_source(sym, op, limb_count(path), reference_path(path).as_posix())
+    )
+    try:
+        subprocess.run(
+            [CC, "-c", str(asm), "-o", str(obj)],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        subprocess.run(
+            [CC, "-O2", str(harness), str(obj), "-o", str(executable)],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        result = subprocess.run(
+            [str(executable)], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.decode(errors="replace").strip()
+        return relative, "build failed: " + detail
+    if result.returncode == 0:
+        return relative, None
+    aliases = {
+        1: "out1 == arg1",
+        2: "out1 == arg2",
+        3: "non-aliased result differs from fiat-c",
+    }
+    detail = aliases.get(result.returncode, "signal/exit %d" % result.returncode)
+    return relative, "differs for " + detail
+
+
+def main():
+    if platform.machine().lower() not in ("x86_64", "amd64"):
+        print("error: the AMD64 aliasing test requires an x86-64 host", file=sys.stderr)
+        return 2
+    if shutil.which(CC) is None:
+        print("error: compiler not found: %s" % CC, file=sys.stderr)
+        return 2
+    paths = sorted(ASM_ROOT.glob("fiat_*/*.asm"))
+    with tempfile.TemporaryDirectory(prefix="fiat-amd64-aliasing-") as temporary:
+        temporary_root = Path(temporary)
+        workers = min(8, os.cpu_count() or 1)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+            results = list(
+                executor.map(lambda path: check(path, temporary_root), paths)
+            )
+    failures = [(path, detail) for path, detail in results if detail is not None]
+    for path, detail in failures:
+        print("FAIL: %s: %s" % (path, detail))
+    if failures:
+        print("%d of %d assembly files failed" % (len(failures), len(paths)))
+        return 1
+    print("All %d assembly files support output/input aliasing" % len(paths))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- snapshot input limbs before executing the optimized schedules in the 43 affected AMD64 implementations
- preserve support for both `out1 == arg1` and `out1 == arg2`
- document the in-place calling contract
- add an exhaustive regression test covering all 620 shipped assembly implementations

The regression assembles each implementation, compares its distinct-buffer result with the corresponding generated C function, and then verifies both supported output/input aliasing forms. This addresses Scrutineer finding #2521.

## Testing

- `fiat-amd64/test_aliasing.py`
- `CC=clang fiat-amd64/test_aliasing.py`
- `python3 -m py_compile fiat-amd64/test_aliasing.py`
- `git diff --check`

Both GCC and Clang runs report:

    All 620 assembly files support output/input aliasing

The extracted Coq checker was not available locally because the isolated worktree lacked `etc/coq-scripts/Makefile.vo_closure`; clean CI should formally revalidate the modified hints. Existing performance ratio/footer metadata also predates the snapshot prologues and should be rebenchmarked before marking this ready.

> *Authorship note: this was researched and written by an AI coding agent
> (OpenAI Codex), working on Jason Gross's behalf; Jason reviews what is
> posted from this account.*