### PR TITLE
Guard generated C against non-arithmetic signed right shift (scrutineer #2526)

### DIFF
--- a/fiat-c/src/curve25519_32.c
+++ b/fiat-c/src/curve25519_32.c
@@ -32,6 +32,9 @@ typedef uint32_t fiat_25519_tight_field_element[10];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_25519_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint32_t fiat_25519_value_barrier_u32(uint32_t a) {

--- a/fiat-c/src/curve25519_64.c
+++ b/fiat-c/src/curve25519_64.c
@@ -37,6 +37,9 @@ typedef uint64_t fiat_25519_tight_field_element[5];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_25519_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint64_t fiat_25519_value_barrier_u64(uint64_t a) {

--- a/fiat-c/src/curve25519_scalar_32.c
+++ b/fiat-c/src/curve25519_scalar_32.c
@@ -37,6 +37,9 @@ typedef uint32_t fiat_25519_scalar_non_montgomery_domain_field_element[8];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_25519_SCALAR_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint32_t fiat_25519_scalar_value_barrier_u32(uint32_t a) {

--- a/fiat-c/src/curve25519_scalar_64.c
+++ b/fiat-c/src/curve25519_scalar_64.c
@@ -42,6 +42,9 @@ typedef uint64_t fiat_25519_scalar_non_montgomery_domain_field_element[4];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_25519_SCALAR_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint64_t fiat_25519_scalar_value_barrier_u64(uint64_t a) {

--- a/fiat-c/src/curve25519_solinas_64.c
+++ b/fiat-c/src/curve25519_solinas_64.c
@@ -24,6 +24,9 @@ FIAT_CURVE25519_SOLINAS_FIAT_EXTENSION typedef unsigned __int128 fiat_curve25519
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_CURVE25519_SOLINAS_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint64_t fiat_curve25519_solinas_value_barrier_u64(uint64_t a) {

--- a/fiat-c/src/p224_32.c
+++ b/fiat-c/src/p224_32.c
@@ -37,6 +37,9 @@ typedef uint32_t fiat_p224_non_montgomery_domain_field_element[7];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_P224_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint32_t fiat_p224_value_barrier_u32(uint32_t a) {

--- a/fiat-c/src/p224_64.c
+++ b/fiat-c/src/p224_64.c
@@ -42,6 +42,9 @@ typedef uint64_t fiat_p224_non_montgomery_domain_field_element[4];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_P224_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint64_t fiat_p224_value_barrier_u64(uint64_t a) {

--- a/fiat-c/src/p256_32.c
+++ b/fiat-c/src/p256_32.c
@@ -37,6 +37,9 @@ typedef uint32_t fiat_p256_non_montgomery_domain_field_element[8];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_P256_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint32_t fiat_p256_value_barrier_u32(uint32_t a) {

--- a/fiat-c/src/p256_64.c
+++ b/fiat-c/src/p256_64.c
@@ -42,6 +42,9 @@ typedef uint64_t fiat_p256_non_montgomery_domain_field_element[4];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_P256_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint64_t fiat_p256_value_barrier_u64(uint64_t a) {

--- a/fiat-c/src/p256_scalar_32.c
+++ b/fiat-c/src/p256_scalar_32.c
@@ -37,6 +37,9 @@ typedef uint32_t fiat_p256_scalar_non_montgomery_domain_field_element[8];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_P256_SCALAR_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint32_t fiat_p256_scalar_value_barrier_u32(uint32_t a) {

--- a/fiat-c/src/p256_scalar_64.c
+++ b/fiat-c/src/p256_scalar_64.c
@@ -42,6 +42,9 @@ typedef uint64_t fiat_p256_scalar_non_montgomery_domain_field_element[4];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_P256_SCALAR_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint64_t fiat_p256_scalar_value_barrier_u64(uint64_t a) {

--- a/fiat-c/src/p384_32.c
+++ b/fiat-c/src/p384_32.c
@@ -37,6 +37,9 @@ typedef uint32_t fiat_p384_non_montgomery_domain_field_element[12];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_P384_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint32_t fiat_p384_value_barrier_u32(uint32_t a) {

--- a/fiat-c/src/p384_64.c
+++ b/fiat-c/src/p384_64.c
@@ -42,6 +42,9 @@ typedef uint64_t fiat_p384_non_montgomery_domain_field_element[6];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_P384_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint64_t fiat_p384_value_barrier_u64(uint64_t a) {

--- a/fiat-c/src/p384_scalar_32.c
+++ b/fiat-c/src/p384_scalar_32.c
@@ -37,6 +37,9 @@ typedef uint32_t fiat_p384_scalar_non_montgomery_domain_field_element[12];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_P384_SCALAR_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint32_t fiat_p384_scalar_value_barrier_u32(uint32_t a) {

--- a/fiat-c/src/p384_scalar_64.c
+++ b/fiat-c/src/p384_scalar_64.c
@@ -42,6 +42,9 @@ typedef uint64_t fiat_p384_scalar_non_montgomery_domain_field_element[6];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_P384_SCALAR_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint64_t fiat_p384_scalar_value_barrier_u64(uint64_t a) {

--- a/fiat-c/src/p434_64.c
+++ b/fiat-c/src/p434_64.c
@@ -42,6 +42,9 @@ typedef uint64_t fiat_p434_non_montgomery_domain_field_element[7];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_P434_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint64_t fiat_p434_value_barrier_u64(uint64_t a) {

--- a/fiat-c/src/p448_solinas_32.c
+++ b/fiat-c/src/p448_solinas_32.c
@@ -37,6 +37,9 @@ typedef uint32_t fiat_p448_tight_field_element[16];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_P448_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint32_t fiat_p448_value_barrier_u32(uint32_t a) {

--- a/fiat-c/src/p448_solinas_64.c
+++ b/fiat-c/src/p448_solinas_64.c
@@ -37,6 +37,9 @@ typedef uint64_t fiat_p448_tight_field_element[8];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_P448_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint64_t fiat_p448_value_barrier_u64(uint64_t a) {

--- a/fiat-c/src/p521_32.c
+++ b/fiat-c/src/p521_32.c
@@ -32,6 +32,9 @@ typedef uint32_t fiat_p521_tight_field_element[19];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_P521_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint32_t fiat_p521_value_barrier_u32(uint32_t a) {

--- a/fiat-c/src/p521_64.c
+++ b/fiat-c/src/p521_64.c
@@ -37,6 +37,9 @@ typedef uint64_t fiat_p521_tight_field_element[9];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_P521_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint64_t fiat_p521_value_barrier_u64(uint64_t a) {

--- a/fiat-c/src/poly1305_32.c
+++ b/fiat-c/src/poly1305_32.c
@@ -32,6 +32,9 @@ typedef uint32_t fiat_poly1305_tight_field_element[5];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_POLY1305_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint32_t fiat_poly1305_value_barrier_u32(uint32_t a) {

--- a/fiat-c/src/poly1305_64.c
+++ b/fiat-c/src/poly1305_64.c
@@ -37,6 +37,9 @@ typedef uint64_t fiat_poly1305_tight_field_element[3];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_POLY1305_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint64_t fiat_poly1305_value_barrier_u64(uint64_t a) {

--- a/fiat-c/src/secp256k1_dettman_32.c
+++ b/fiat-c/src/secp256k1_dettman_32.c
@@ -22,6 +22,9 @@
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 
 /*

--- a/fiat-c/src/secp256k1_dettman_64.c
+++ b/fiat-c/src/secp256k1_dettman_64.c
@@ -27,6 +27,9 @@ FIAT_SECP256K1_DETTMAN_FIAT_EXTENSION typedef unsigned __int128 fiat_secp256k1_d
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 
 /*

--- a/fiat-c/src/secp256k1_montgomery_32.c
+++ b/fiat-c/src/secp256k1_montgomery_32.c
@@ -37,6 +37,9 @@ typedef uint32_t fiat_secp256k1_montgomery_non_montgomery_domain_field_element[8
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_SECP256K1_MONTGOMERY_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint32_t fiat_secp256k1_montgomery_value_barrier_u32(uint32_t a) {

--- a/fiat-c/src/secp256k1_montgomery_64.c
+++ b/fiat-c/src/secp256k1_montgomery_64.c
@@ -42,6 +42,9 @@ typedef uint64_t fiat_secp256k1_montgomery_non_montgomery_domain_field_element[4
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_SECP256K1_MONTGOMERY_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint64_t fiat_secp256k1_montgomery_value_barrier_u64(uint64_t a) {

--- a/fiat-c/src/secp256k1_montgomery_scalar_32.c
+++ b/fiat-c/src/secp256k1_montgomery_scalar_32.c
@@ -37,6 +37,9 @@ typedef uint32_t fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_el
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_SECP256K1_MONTGOMERY_SCALAR_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint32_t fiat_secp256k1_montgomery_scalar_value_barrier_u32(uint32_t a) {

--- a/fiat-c/src/secp256k1_montgomery_scalar_64.c
+++ b/fiat-c/src/secp256k1_montgomery_scalar_64.c
@@ -42,6 +42,9 @@ typedef uint64_t fiat_secp256k1_montgomery_scalar_non_montgomery_domain_field_el
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_SECP256K1_MONTGOMERY_SCALAR_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint64_t fiat_secp256k1_montgomery_scalar_value_barrier_u64(uint64_t a) {

--- a/fiat-c/src/sm2_32.c
+++ b/fiat-c/src/sm2_32.c
@@ -37,6 +37,9 @@ typedef uint32_t fiat_sm2_non_montgomery_domain_field_element[8];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_SM2_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint32_t fiat_sm2_value_barrier_u32(uint32_t a) {

--- a/fiat-c/src/sm2_64.c
+++ b/fiat-c/src/sm2_64.c
@@ -42,6 +42,9 @@ typedef uint64_t fiat_sm2_non_montgomery_domain_field_element[4];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_SM2_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint64_t fiat_sm2_value_barrier_u64(uint64_t a) {

--- a/fiat-c/src/sm2_scalar_32.c
+++ b/fiat-c/src/sm2_scalar_32.c
@@ -37,6 +37,9 @@ typedef uint32_t fiat_sm2_scalar_non_montgomery_domain_field_element[8];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_SM2_SCALAR_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint32_t fiat_sm2_scalar_value_barrier_u32(uint32_t a) {

--- a/fiat-c/src/sm2_scalar_64.c
+++ b/fiat-c/src/sm2_scalar_64.c
@@ -42,6 +42,9 @@ typedef uint64_t fiat_sm2_scalar_non_montgomery_domain_field_element[4];
 #if (-1 & 3) != 3
 #error "This code only works on a two's complement system"
 #endif
+#if ((-1) >> 1) != -1
+#error "This code only works on a system with arithmetic right shift of negative signed values"
+#endif
 
 #if !defined(FIAT_SM2_SCALAR_NO_ASM) && (defined(__GNUC__) || defined(__clang__))
 static __inline__ uint64_t fiat_sm2_scalar_value_barrier_u64(uint64_t a) {

--- a/src/Stringification/C.v
+++ b/src/Stringification/C.v
@@ -159,6 +159,9 @@ Module Compilers.
                 ++ [""
                     ; "#if (-1 & 3) != 3"
                     ; "#error ""This code only works on a two's complement system"""
+                    ; "#endif"
+                    ; "#if ((-1) >> 1) != -1"
+                    ; "#error ""This code only works on a system with arithmetic right shift of negative signed values"""
                     ; "#endif"]
                 ++ (List.flat_map
                       (value_barrier_func internal_static prefix)


### PR DESCRIPTION
Fixes scrutineer finding #2526 (CWE-758, severity Low).

## Bug

The C emitter (`src/Stringification/C.v`) prepends one target guard to every generated file, `#if (-1 & 3) != 3` / `#error "This code only works on a two's complement system"`. That guard tests the *representation* of negative integers only. The generated `subborrowx_u<w>` functions for non-power-of-two limb widths (curve25519, p448_solinas, p521, poly1305) compute the borrow as `(int1)(x1 >> w)` on a negative `int<bits>_t`, which relies on `>>` being an *arithmetic* (sign-extending) shift. C99/C11/C17 6.5.7p5 leave that implementation-defined; only C23 mandates it. Under the other conforming choice (shifting in zeros), `fiat_25519_subborrowx_u26` returns `out2 = 193` for 5 of 6 in-bounds test inputs, outside its printed output bound `[0x0 ~> 0x1]` (reproduced locally with the finding's harness). No toolchain in current use does this, so this is a completeness gap in the compile-time refusal the project advertises, not a live bug.

## Fix

Emit a second guard immediately after the existing one:

```c
#if ((-1) >> 1) != -1
#error "This code only works on a system with arithmetic right shift of negative signed values"
#endif
```

`#if` arithmetic is done in `intmax_t`, so this tests exactly the property the generated code depends on, and a logical-shift implementation would refuse to compile the file instead of silently returning out-of-bound borrows.

Alternatives considered:
- Only documenting the assumption in the file-header NOTE. Weaker: a guard refuses to compile rather than relying on the integrator reading a comment, and matches the existing two's-complement treatment.
- Rewriting the emitted borrow computation to avoid signed shifts. Far more invasive (touches the pipeline and proofs) for a property every real compiler already provides.

Other backends need no change: Rust, Go, Java and Zig define `>>` on signed integers as arithmetic in their language specs; JSON carries no semantics; the bedrock2 C output contains no signed right shifts at all, and its prelude is produced by bedrock2's own `ToCString`, not this emitter.

## Generated files

All 32 `fiat-c/src/*.c` files were updated **by script** (the guard is fixed text inserted directly after the existing `#endif`), not by regenerating with a rebuilt binary. The regeneration check in CI must confirm they match the emitter. No other tracked file carries the two's-complement guard (`git grep` over the tree finds only `fiat-c/src/*.c` and `C.v`).

## Verification

- `coqc -q -R src Crypto ... src/Stringification/C.v` against the installed library: compiles (only the pre-existing `missing-proof-command` warning on line 398).
- The new guard expression, together with the old one, compiles with `-Wall -Wextra -Wpedantic -Werror` under gcc 12.2 and clang 14.0 for `-std=c99`, `c11`, `c17`, `c2x` (8/8 ok). A negated control (`#if ((-1) >> 1) != 0`) correctly triggers the `#error`, so the guard is live rather than vacuous.
- `make -f Makefile.examples only-test-c-files CC=gcc` and `CC=clang` (i.e. `-Wall -Wno-unused-function -Wpedantic -Werror -c` over all 32 `fiat-c/src/*.c` plus `inversion/c/*_test.c`): both exit 0, 36 object files each.
- Repro: the emitted `fiat_25519_subborrowx_u26` beside a copy with a logical shift gives `out2 = 193` for 5 of 6 in-bounds inputs, confirming the claim in the finding.

Not verified: no synthesis binary was rebuilt, so the regenerated-output equality relies on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Rbn2gww3MGhvrh52fNjpD
