### PR TITLE
Guard bedrock2 C output against mismatched target word width

### DIFF
--- a/.github/workflows/c.yml
+++ b/.github/workflows/c.yml
@@ -25,7 +25,7 @@ jobs:
         sudo sed -i 's/azure\.//' /etc/apt/sources.list
         sudo apt-get -o Acquire::Retries=30 update -q
         sudo apt-get -o Acquire::Retries=30 install -y --allow-unauthenticated \
-             g++ libssl-dev \
+             g++ gcc-multilib libssl-dev \
              ninja-build libunwind-dev cmake
         #sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7
     - name: GCC Problem Matcher

--- a/Makefile.examples
+++ b/Makefile.examples
@@ -144,6 +144,11 @@ EXTRA_C_FILES := inversion/c/*_test.c
 
 ALL_C_FILES := $(patsubst %,$(C_DIR)%.c,$(ALL_BASE_FILES))
 ALL_BEDROCK2_FILES := $(patsubst %,$(BEDROCK2_DIR)%.c,$(filter-out $(INVALID_BEDROCK2_BASE_FILES),$(ALL_BASE_FILES)))
+ALL_BEDROCK2_FILES_32 := $(filter %_32.c,$(ALL_BEDROCK2_FILES))
+ALL_BEDROCK2_FILES_64 := $(filter %_64.c,$(ALL_BEDROCK2_FILES))
+ifneq ($(filter-out $(ALL_BEDROCK2_FILES_32) $(ALL_BEDROCK2_FILES_64),$(ALL_BEDROCK2_FILES)),)
+$(error Unknown word size for bedrock2 files: $(filter-out $(ALL_BEDROCK2_FILES_32) $(ALL_BEDROCK2_FILES_64),$(ALL_BEDROCK2_FILES)))
+endif
 ALL_RUST_FILES := $(patsubst %,$(RUST_DIR)%.rs,$(ALL_BASE_FILES))
 ALL_RUST_MODS := $(ALL_BASE_FILES)
 ALL_GO_FILES := $(patsubst %,$(GO_DIR)%.go,$(call GO_RENAME_TO_FILE,$(filter-out $(INVALID_GO_BASE_FILES),$(ALL_BASE_FILES))))
@@ -170,6 +175,16 @@ JSON_EXTRA_ARGS := --emit-all-casts
 
 BEDROCK2_ARGS := --no-wide-int --widen-carry --widen-bytes --split-multiret --no-select --no-field-element-typedefs
 BEDROCK2_EXTRA_CFLAGS := -Wno-error=unused-but-set-variable
+# The bedrock2 C backend represents every word as br_word_t, an alias
+# of uintptr_t, so a generated file only compiles (and only computes
+# correct results) on a target whose pointer width equals the word size
+# the file was synthesized for; each file carries a static_assert
+# enforcing this.  We therefore compile the *_32.c files as 32-bit code
+# and the *_64.c files as 64-bit code.  On x86-64 hosts, -m32 requires
+# multilib support (e.g. the gcc-multilib package on Debian/Ubuntu);
+# override these variables when using a cross compiler.
+BEDROCK2_CFLAGS_32 ?= -m32
+BEDROCK2_CFLAGS_64 ?=
 
 RUST_EXTRA_ARGS := --inline
 
@@ -232,7 +247,8 @@ $(ALL_BEDROCK2_FILES) : $(BEDROCK2_DIR)%.c : $$(BEDROCK2_$$($$*_BINARY_NAME))
 test-bedrock2-files: $(ALL_BEDROCK2_FILES)
 
 test-bedrock2-files only-test-bedrock2-files:
-	$(CC) -Wall -Wno-unused-function -Werror $(BEDROCK2_EXTRA_CFLAGS) $(CFLAGS) -c $(ALL_BEDROCK2_FILES)
+	$(CC) -Wall -Wno-unused-function -Werror $(BEDROCK2_EXTRA_CFLAGS) $(BEDROCK2_CFLAGS_64) $(CFLAGS) -c $(ALL_BEDROCK2_FILES_64)
+	$(CC) -Wall -Wno-unused-function -Werror $(BEDROCK2_EXTRA_CFLAGS) $(BEDROCK2_CFLAGS_32) $(CFLAGS) -c $(ALL_BEDROCK2_FILES_32)
 
 $(ALL_RUST_FILES) : $(RUST_DIR)%.rs : $$($$($$*_BINARY_NAME))
 	$(SHOW)'SYNTHESIZE > $@'

--- a/Makefile.examples
+++ b/Makefile.examples
@@ -249,6 +249,15 @@ test-bedrock2-files: $(ALL_BEDROCK2_FILES)
 test-bedrock2-files only-test-bedrock2-files:
 	$(CC) -Wall -Wno-unused-function -Werror $(BEDROCK2_EXTRA_CFLAGS) $(BEDROCK2_CFLAGS_64) $(CFLAGS) -c $(ALL_BEDROCK2_FILES_64)
 	$(CC) -Wall -Wno-unused-function -Werror $(BEDROCK2_EXTRA_CFLAGS) $(BEDROCK2_CFLAGS_32) $(CFLAGS) -c $(ALL_BEDROCK2_FILES_32)
+	$(SHOW)'CHECK word-size guard rejects mismatched targets'
+	$(HIDE)for spec in "$(firstword $(ALL_BEDROCK2_FILES_32)):32:$(BEDROCK2_CFLAGS_64)" "$(firstword $(ALL_BEDROCK2_FILES_64)):64:$(BEDROCK2_CFLAGS_32)"; do \
+	  f="$${spec%%:*}"; rest="$${spec#*:}"; bits="$${rest%%:*}"; flags="$${rest#*:}"; \
+	  if output="$$($(CC) $(BEDROCK2_EXTRA_CFLAGS) $$flags $(CFLAGS) -fsyntax-only "$$f" 2>&1)"; then \
+	    echo "ERROR: $$f compiled with '$$flags' but should have been rejected (it was synthesized for $$bits-bit words)" >&2; exit 1; \
+	  elif ! printf '%s\n' "$$output" | grep -q "synthesized for $$bits-bit words"; then \
+	    echo "ERROR: $$f was rejected with '$$flags' for the wrong reason:" >&2; printf '%s\n' "$$output" >&2; exit 1; \
+	  fi; \
+	done
 
 $(ALL_RUST_FILES) : $(RUST_DIR)%.rs : $$($$($$*_BINARY_NAME))
 	$(SHOW)'SYNTHESIZE > $@'

--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ A collection of bedrock2/C files for popular curves can be made with
 
 The bedrock2/C files will appear in [`fiat-bedrock2/src/`](./fiat-bedrock2/src/).
 
+**Note:** the bedrock2 C backend represents every machine word as `br_word_t`, an alias of `uintptr_t`, and the limb layout of the generated code is fixed by the word size it was synthesized for.
+Each generated file must therefore be compiled only for targets whose pointer width matches that word size: the `*_32.c` files are for 32-bit targets (e.g. `-m32` on x86, or a 32-bit cross compiler), and the `*_64.c` files are for 64-bit targets.
+Every file contains a `static_assert` that rejects a mismatched target at compile time, so a `*_32.c` file will not build on x86-64 without `-m32`.
+
 Just the compilers generating these bedrock2/C files can be made with
 
     make standalone-ocaml

--- a/fiat-bedrock2/src/curve25519_32.c
+++ b/fiat-bedrock2/src/curve25519_32.c
@@ -112,6 +112,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 32-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT32_MAX, "this file was synthesized for 32-bit words; compile it only for a target whose uintptr_t is 32 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xc000000], [0x0 ~> 0x6000000], [0x0 ~> 0xc000000], [0x0 ~> 0x6000000], [0x0 ~> 0xc000000], [0x0 ~> 0x6000000], [0x0 ~> 0xc000000], [0x0 ~> 0x6000000], [0x0 ~> 0xc000000], [0x0 ~> 0x6000000]]

--- a/fiat-bedrock2/src/curve25519_64.c
+++ b/fiat-bedrock2/src/curve25519_64.c
@@ -112,6 +112,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 64-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT64_MAX, "this file was synthesized for 64-bit words; compile it only for a target whose uintptr_t is 64 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0x18000000000000], [0x0 ~> 0x18000000000000], [0x0 ~> 0x18000000000000], [0x0 ~> 0x18000000000000], [0x0 ~> 0x18000000000000]]

--- a/fiat-bedrock2/src/curve25519_scalar_32.c
+++ b/fiat-bedrock2/src/curve25519_scalar_32.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 32-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT32_MAX, "this file was synthesized for 32-bit words; compile it only for a target whose uintptr_t is 32 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]

--- a/fiat-bedrock2/src/curve25519_scalar_64.c
+++ b/fiat-bedrock2/src/curve25519_scalar_64.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 64-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT64_MAX, "this file was synthesized for 64-bit words; compile it only for a target whose uintptr_t is 64 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]

--- a/fiat-bedrock2/src/curve25519_solinas_64.c
+++ b/fiat-bedrock2/src/curve25519_solinas_64.c
@@ -107,6 +107,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 64-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT64_MAX, "this file was synthesized for 64-bit words; compile it only for a target whose uintptr_t is 64 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]

--- a/fiat-bedrock2/src/p224_32.c
+++ b/fiat-bedrock2/src/p224_32.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 32-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT32_MAX, "this file was synthesized for 32-bit words; compile it only for a target whose uintptr_t is 32 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]

--- a/fiat-bedrock2/src/p224_64.c
+++ b/fiat-bedrock2/src/p224_64.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 64-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT64_MAX, "this file was synthesized for 64-bit words; compile it only for a target whose uintptr_t is 64 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]

--- a/fiat-bedrock2/src/p256_32.c
+++ b/fiat-bedrock2/src/p256_32.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 32-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT32_MAX, "this file was synthesized for 32-bit words; compile it only for a target whose uintptr_t is 32 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]

--- a/fiat-bedrock2/src/p256_64.c
+++ b/fiat-bedrock2/src/p256_64.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 64-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT64_MAX, "this file was synthesized for 64-bit words; compile it only for a target whose uintptr_t is 64 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]

--- a/fiat-bedrock2/src/p256_scalar_32.c
+++ b/fiat-bedrock2/src/p256_scalar_32.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 32-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT32_MAX, "this file was synthesized for 32-bit words; compile it only for a target whose uintptr_t is 32 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]

--- a/fiat-bedrock2/src/p256_scalar_64.c
+++ b/fiat-bedrock2/src/p256_scalar_64.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 64-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT64_MAX, "this file was synthesized for 64-bit words; compile it only for a target whose uintptr_t is 64 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]

--- a/fiat-bedrock2/src/p384_32.c
+++ b/fiat-bedrock2/src/p384_32.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 32-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT32_MAX, "this file was synthesized for 32-bit words; compile it only for a target whose uintptr_t is 32 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]

--- a/fiat-bedrock2/src/p384_64.c
+++ b/fiat-bedrock2/src/p384_64.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 64-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT64_MAX, "this file was synthesized for 64-bit words; compile it only for a target whose uintptr_t is 64 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]

--- a/fiat-bedrock2/src/p384_scalar_32.c
+++ b/fiat-bedrock2/src/p384_scalar_32.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 32-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT32_MAX, "this file was synthesized for 32-bit words; compile it only for a target whose uintptr_t is 32 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]

--- a/fiat-bedrock2/src/p384_scalar_64.c
+++ b/fiat-bedrock2/src/p384_scalar_64.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 64-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT64_MAX, "this file was synthesized for 64-bit words; compile it only for a target whose uintptr_t is 64 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]

--- a/fiat-bedrock2/src/p434_64.c
+++ b/fiat-bedrock2/src/p434_64.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 64-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT64_MAX, "this file was synthesized for 64-bit words; compile it only for a target whose uintptr_t is 64 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]

--- a/fiat-bedrock2/src/p448_solinas_64.c
+++ b/fiat-bedrock2/src/p448_solinas_64.c
@@ -112,6 +112,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 64-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT64_MAX, "this file was synthesized for 64-bit words; compile it only for a target whose uintptr_t is 64 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000], [0x0 ~> 0x300000000000000]]

--- a/fiat-bedrock2/src/p521_32.c
+++ b/fiat-bedrock2/src/p521_32.c
@@ -112,6 +112,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 32-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT32_MAX, "this file was synthesized for 32-bit words; compile it only for a target whose uintptr_t is 32 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0x30000000], [0x0 ~> 0x18000000], [0x0 ~> 0x30000000], [0x0 ~> 0x18000000], [0x0 ~> 0x30000000], [0x0 ~> 0x18000000], [0x0 ~> 0x18000000], [0x0 ~> 0x30000000], [0x0 ~> 0x18000000], [0x0 ~> 0x30000000], [0x0 ~> 0x18000000], [0x0 ~> 0x30000000], [0x0 ~> 0x18000000], [0x0 ~> 0x18000000], [0x0 ~> 0x30000000], [0x0 ~> 0x18000000], [0x0 ~> 0x30000000], [0x0 ~> 0x18000000], [0x0 ~> 0x18000000]]

--- a/fiat-bedrock2/src/p521_64.c
+++ b/fiat-bedrock2/src/p521_64.c
@@ -112,6 +112,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 64-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT64_MAX, "this file was synthesized for 64-bit words; compile it only for a target whose uintptr_t is 64 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0xc00000000000000], [0x0 ~> 0x600000000000000]]

--- a/fiat-bedrock2/src/poly1305_32.c
+++ b/fiat-bedrock2/src/poly1305_32.c
@@ -112,6 +112,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 32-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT32_MAX, "this file was synthesized for 32-bit words; compile it only for a target whose uintptr_t is 32 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xc000000], [0x0 ~> 0xc000000], [0x0 ~> 0xc000000], [0x0 ~> 0xc000000], [0x0 ~> 0xc000000]]

--- a/fiat-bedrock2/src/poly1305_64.c
+++ b/fiat-bedrock2/src/poly1305_64.c
@@ -112,6 +112,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 64-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT64_MAX, "this file was synthesized for 64-bit words; compile it only for a target whose uintptr_t is 64 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0x300000000000], [0x0 ~> 0x180000000000], [0x0 ~> 0x180000000000]]

--- a/fiat-bedrock2/src/secp256k1_dettman_32.c
+++ b/fiat-bedrock2/src/secp256k1_dettman_32.c
@@ -112,6 +112,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 32-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT32_MAX, "this file was synthesized for 32-bit words; compile it only for a target whose uintptr_t is 32 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7fffffe], [0x0 ~> 0x7ffffe]]

--- a/fiat-bedrock2/src/secp256k1_dettman_64.c
+++ b/fiat-bedrock2/src/secp256k1_dettman_64.c
@@ -112,6 +112,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 64-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT64_MAX, "this file was synthesized for 64-bit words; compile it only for a target whose uintptr_t is 64 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0x1ffffffffffffe], [0x0 ~> 0x1ffffffffffffe], [0x0 ~> 0x1ffffffffffffe], [0x0 ~> 0x1ffffffffffffe], [0x0 ~> 0x1fffffffffffe]]

--- a/fiat-bedrock2/src/secp256k1_montgomery_32.c
+++ b/fiat-bedrock2/src/secp256k1_montgomery_32.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 32-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT32_MAX, "this file was synthesized for 32-bit words; compile it only for a target whose uintptr_t is 32 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]

--- a/fiat-bedrock2/src/secp256k1_montgomery_64.c
+++ b/fiat-bedrock2/src/secp256k1_montgomery_64.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 64-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT64_MAX, "this file was synthesized for 64-bit words; compile it only for a target whose uintptr_t is 64 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]

--- a/fiat-bedrock2/src/secp256k1_montgomery_scalar_32.c
+++ b/fiat-bedrock2/src/secp256k1_montgomery_scalar_32.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 32-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT32_MAX, "this file was synthesized for 32-bit words; compile it only for a target whose uintptr_t is 32 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]

--- a/fiat-bedrock2/src/secp256k1_montgomery_scalar_64.c
+++ b/fiat-bedrock2/src/secp256k1_montgomery_scalar_64.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 64-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT64_MAX, "this file was synthesized for 64-bit words; compile it only for a target whose uintptr_t is 64 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]

--- a/fiat-bedrock2/src/sm2_32.c
+++ b/fiat-bedrock2/src/sm2_32.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 32-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT32_MAX, "this file was synthesized for 32-bit words; compile it only for a target whose uintptr_t is 32 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]

--- a/fiat-bedrock2/src/sm2_64.c
+++ b/fiat-bedrock2/src/sm2_64.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 64-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT64_MAX, "this file was synthesized for 64-bit words; compile it only for a target whose uintptr_t is 64 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]

--- a/fiat-bedrock2/src/sm2_scalar_32.c
+++ b/fiat-bedrock2/src/sm2_scalar_32.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 32-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT32_MAX, "this file was synthesized for 32-bit words; compile it only for a target whose uintptr_t is 32 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff], [0x0 ~> 0xffffffff]]

--- a/fiat-bedrock2/src/sm2_scalar_64.c
+++ b/fiat-bedrock2/src/sm2_scalar_64.c
@@ -117,6 +117,9 @@ static inline br_word_t _br_remu(br_word_t a, br_word_t b) {
 }
 
 
+// This file was synthesized for 64-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
+static_assert(BR_WORD_MAX == UINT64_MAX, "this file was synthesized for 64-bit words; compile it only for a target whose uintptr_t is 64 bits wide");
+
 /*
  * Input Bounds:
  *   in0: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]

--- a/src/Bedrock/Field/Stringification/Stringification.v
+++ b/src/Bedrock/Field/Stringification/Stringification.v
@@ -16,6 +16,7 @@ Require Import Crypto.Bedrock.Field.Translation.Func.
 Require Import Crypto.Bedrock.Field.Stringification.FlattenVarData.
 Require Import Crypto.Bedrock.Field.Stringification.LoadStoreListVarData.
 Require Import Crypto.Stringification.C.
+Require Import Crypto.Util.Strings.Decimal.
 Require Import Crypto.Language.API.
 Require Import Crypto.Util.Option.
 Import Stringification.Language.Compilers.
@@ -249,6 +250,27 @@ Definition Bedrock2_ToFunctionLines
     | _,_ => inr ("Only 32-bit and 64-bit targets are supported")
     end.
 
+(** The bedrock2 C prelude ([ToCString.prelude]) types every word as
+    [br_word_t], an alias of [uintptr_t], and [_br_load]/[_br_store]
+    access [sizeof(br_word_t)] bytes.  The limb stride and the buffer
+    sizes baked into the generated code, on the other hand, are fixed by
+    the [machine_wordsize] the code was synthesized for.  Compiling a
+    file synthesized for 32-bit words on a target whose [uintptr_t] is
+    64 bits wide would therefore read and write 4 bytes past the end of
+    every limb array and compute incorrect field arithmetic (and
+    vice-versa for 64-bit files on 32-bit targets).  The prelude's own
+    [static_assert(UINTPTR_MAX <= BR_WORD_MAX, ...)] cannot catch this,
+    since [BR_WORD_MAX] is defined as [UINTPTR_MAX].  We emit an
+    additional guard tying the target word width to the synthesis word
+    size, so that such a mismatch is a compile-time error rather than a
+    silent memory-safety and correctness bug. *)
+Definition bedrock2_machine_wordsize_guard (machine_wordsize : Z) : list string :=
+  let bits := Decimal.Z.to_string machine_wordsize in
+  [""
+   ; ("// This file was synthesized for " ++ bits ++ "-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.")%string
+   ; ("static_assert(BR_WORD_MAX == UINT" ++ bits ++ "_MAX, ""this file was synthesized for " ++ bits ++ "-bit words; compile it only for a target whose uintptr_t is " ++ bits ++ " bits wide"");")%string
+  ].
+
 Definition OutputBedrock2API : ToString.OutputLanguageAPI :=
   {|
     ToString.comment_block s
@@ -259,7 +281,9 @@ Definition OutputBedrock2API : ToString.OutputLanguageAPI :=
 
     ToString.ToFunctionLines := @Bedrock2_ToFunctionLines;
 
-    ToString.header := fun _ _ _ _ _ _ _ _ _ _ _ => [""; ToCString.prelude];
+    ToString.header
+    := fun _ _ _ _ _ machine_wordsize _ _ _ _ _
+       => [""; ToCString.prelude] ++ bedrock2_machine_wordsize_guard machine_wordsize;
 
     ToString.footer := fun _ _ _ _ _ _ _ _ _ => [];
 


### PR DESCRIPTION
Fixes scrutineer finding #2509.

## The bug

The bedrock2 C backend types every word as `br_word_t`, an alias of `uintptr_t`, and the prelude's `_br_load`/`_br_store` access `sizeof(br_word_t)` bytes. The limb stride and buffer sizes baked into the generated code, however, come from the synthesis word size (the `32`/`64` in the file name). Compiling one of the `fiat-bedrock2/src/*_32.c` files on a 64-bit target therefore reads and writes 4 bytes past the end of every caller buffer (160 of the 183 public wrappers write out of bounds) and computes wrong field arithmetic even when buffers are over-allocated (e.g. `mul(R, R) != R`). The prelude's `static_assert(UINTPTR_MAX <= BR_WORD_MAX, ...)` cannot catch this because `BR_WORD_MAX` is `#define`d as `UINTPTR_MAX`. Nothing else caught it either: `make only-test-bedrock2-files` compiled the 14 `_32` files on x86-64 CI without complaint, and no documentation said the `_32` files require a 32-bit target.

## The fix

- **Emitter** (`src/Bedrock/Field/Stringification/Stringification.v`): the `ToString.header` hook of `OutputBedrock2API` already receives `machine_wordsize` but discarded it. It now appends, after the bedrock2 prelude, a guard tied to the synthesis word size:
  ```c
  // This file was synthesized for 32-bit words; br_word_t (uintptr_t) must be exactly that wide on the target.
  static_assert(BR_WORD_MAX == UINT32_MAX, "this file was synthesized for 32-bit words; compile it only for a target whose uintptr_t is 32 bits wide");
  ```
  and the `UINT64_MAX` counterpart for 64-bit files. A word-width mismatch is now a compile-time error in both directions instead of a silent memory-safety and correctness bug. The `BR_WORD_MAX == UINTnn_MAX` form matches how the prelude itself selects its `_br_mulhuu` implementation.
- **Generated files**: all 31 `fiat-bedrock2/src/*.c` regenerated with rebuilt synthesis binaries. The diff to each file is exactly the blank line, the comment and the `static_assert` (93 insertions, 0 deletions across 31 files).
- **Test rule** (`Makefile.examples`): `test-bedrock2-files`/`only-test-bedrock2-files` now compile the `*_64.c` files with the host default (`BEDROCK2_CFLAGS_64`, empty) and the `*_32.c` files with `BEDROCK2_CFLAGS_32` (default `-m32`); both variables are overridable for cross compilers. A make-time check errors out if a bedrock2 file name does not end in `_32`/`_64`. The alternative of simply skipping the `_32` files would have removed the only compile coverage they have; `-m32` keeps CI compiling every file while honouring the new guard.
- **Negative test** (second commit): the same rule then compiles one `_32` file with the 64-bit flags and one `_64` file with the 32-bit flags and requires each to fail with the `synthesized for NN-bit words` message, so CI checks that the guard actually fires and not only that correctly-targeted builds succeed. The idea of a negative test is adopted from the `codex/fix-2509-bedrock2-word-width` branch.
- **CI** (`.github/workflows/c.yml`): install `gcc-multilib` so `-m32` works on `ubuntu-latest`.
- **Docs** (`README.md`): note in the bedrock2 section that `*_32.c` files are for 32-bit targets and `*_64.c` files for 64-bit targets, and that each file rejects a mismatched target at compile time.

The vacuous `static_assert(UINTPTR_MAX <= BR_WORD_MAX, "pointer fits in int")` is emitted from the bedrock2 submodule's `ToCString.prelude`, not from fiat-crypto, so it is left untouched here; it could be dropped upstream.

## Verification

All on this x86-64 host (gcc 12.2, clang available, gcc multilib installed).

- Compiled `src/Bedrock/Field/Stringification/Stringification.v` and `src/Bedrock/Standalone/StandaloneOCamlMain.v` with `coqc` against the installed `coq-fiat-crypto-with-bedrock` library (overlay build; the only upstream file that differs from HEAD in the installed copy is `src/Bedrock/Field/Common/Types.v`, `#[export]` vs `#[global]` on instance attributes, which cannot affect emitted text), extracted and built `bedrock2_unsaturated_solinas`, `bedrock2_word_by_word_montgomery`, `bedrock2_dettman_multiplication` and `bedrock2_solinas_reduction` with the flags from `Makefile.standalone`, then ran `make -f Makefile.examples bedrock2-files` with the four `BEDROCK2_*` variables pointed at those binaries. `git diff -- fiat-bedrock2 | grep '^[+-]'` shows only the three new lines per file.
- `cc -c fiat-bedrock2/src/p256_64.c`: succeeds. `cc -m32 -c p256_64.c`: fails with `static assertion failed: "this file was synthesized for 64-bit words; ..."`.
- `cc -c fiat-bedrock2/src/p256_32.c`: fails with `static assertion failed: "this file was synthesized for 32-bit words; ..."`. `cc -m32 -c p256_32.c`: succeeds. Same behaviour with clang.
- `make -f Makefile.examples only-test-bedrock2-files SKIP_INCLUDE=1`: exit 0, 31 object files produced (17 `_64` at host width, 14 `_32` under `-m32`), negative check passes. With `BEDROCK2_CFLAGS_32=-m64` or `BEDROCK2_CFLAGS_64=-m32` the rule fails at the compile step with the static_assert message. The negative check's own failure branches were exercised from a scratch makefile: swapped flags report "compiled ... but should have been rejected", and a bogus flag reports "rejected ... for the wrong reason" with the compiler output.
- Runtime self-check `mul(R, R) == R` via `fiat_p256_set_one`/`fiat_p256_mul` on the regenerated files: `p256_32.c` under `-m32` reports `sizeof(br_word_t)=4 limbs=8 wrong=0`; `p256_64.c` reports `sizeof(br_word_t)=8 limbs=4 wrong=0` (the finding's reproducer reported 8 of 8 limbs wrong for the `_32` file on 64-bit).

Not verified: the full `make` of the Coq development (only the changed file and its downstream cone were compiled); the Haskell and js_of_ocaml standalone builds, which share `StandaloneOCamlMain.v`'s dependency on the changed file but were not rebuilt; the CI run itself with `gcc-multilib` (the apt package name is the standard Debian/Ubuntu one and the same flag was exercised locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Rbn2gww3MGhvrh52fNjpD
