### PR TITLE
Reject RIP-relative memory operands in the assembly equivalence checker (scrutineer #2516)

### DIFF
--- a/src/Assembly/Symbolic.v
+++ b/src/Assembly/Symbolic.v
@@ -3956,6 +3956,7 @@ Module error.
 
   | unsupported_memory_access_size (_:N)
   | unsupported_label_in_memory (_:string)
+  | unsupported_rip_relative_addressing (_:MEM)
   | unsupported_label_argument (_:JUMP_LABEL)
   | unimplemented_prefix (_:NormalInstruction)
   | unimplemented_instruction (_ : NormalInstruction)
@@ -3996,6 +3997,7 @@ Module error.
             => ["RevealConst called at " ++ show i ++ " resulted in non-const value " ++ show x]
           | unsupported_memory_access_size n => ["error.unsupported_memory_access_size " ++ show n]
           | unsupported_label_in_memory l => ["error.unsupported_label_in_memory " ++ l]
+          | unsupported_rip_relative_addressing m => ["error.unsupported_rip_relative_addressing " ++ show m ++ " (RIP-relative memory operands are not supported: the symbolic model has no notion of the instruction pointer)"]
           | unsupported_label_argument l => ["error.unsupported_label_argument " ++ show l]
           | unimplemented_instruction n => ["error.unimplemented_instruction " ++ show n]
           | unimplemented_prefix n => ["error.unimplemented_prefix " ++ show n]
@@ -4093,7 +4095,19 @@ Definition SetReg {opts : symbolic_options_computed_opt} {descr:description} r (
        SetReg64 rn v.
 
 Class AddressSize := address_size : OperationSize.
+(** [Address] computes the effective address of a memory operand.  We
+    have no model of the instruction pointer, so RIP-relative operands
+    (whether written explicitly as [\[rip + disp\]] or made implicit by
+    a preceding [DEFAULT REL] directive) and label-based operands are
+    rejected rather than silently treated as absolute displacements;
+    see scrutineer finding #2516.  This is checked for every use of
+    [Address], i.e. for [lea] as well as for loads and stores. *)
 Definition Address {opts : symbolic_options_computed_opt} {descr:description} {sa : AddressSize} (a : MEM) : M idx :=
+  _ <- match a.(rip_relative) with
+       | not_rip_relative => ret tt
+       | explicitly_rip_relative | implicitly_rip_relative
+         => err (error.unsupported_rip_relative_addressing a)
+       end;
   _ <- match a.(mem_base_label) with
        | None => ret tt
        | Some l => err (error.unsupported_label_in_memory l)

--- a/src/Assembly/SymbolicTests.v
+++ b/src/Assembly/SymbolicTests.v
@@ -1,0 +1,123 @@
+(** Regression tests for the symbolic executor's treatment of memory
+    operands that it cannot model.
+
+    The symbolic machine has no instruction pointer, so RIP-relative
+    memory operands (explicit [\[rip + disp\]] or implicit via
+    [DEFAULT REL]) and label-based operands must be rejected rather
+    than silently interpreted as absolute displacements.  Before this
+    was checked, [lea rcx, \[rip + 0x26\]] was symbolically executed as
+    [mov rcx, 0x26], which let the equivalence checker certify
+    assembly that computes something else on real hardware
+    (scrutineer finding #2516). *)
+From Coq Require Import String.
+From Coq Require Import List.
+From Coq Require Import ZArith.
+Require Import Crypto.Util.ErrorT.
+Require Import Crypto.Assembly.Syntax.
+Require Import Crypto.Assembly.Parse.
+Require Import Crypto.Assembly.Equality.
+Require Import Crypto.Assembly.Symbolic.
+Require Import Crypto.Assembly.Equivalence.
+Import ListNotations.
+Local Open Scope string_scope.
+Local Open Scope list_scope.
+
+Local Instance test_opts : symbolic_options_computed_opt
+  := {| asm_rewriting_passes := default_rewriting_passes (rewriting_pipeline:=default_rewrite_pass_order) (rewriting_pass_filter:=fun _ => true)
+      ; asm_debug_symex_asm_first_computed := false
+      ; asm_node_reveal_depth_computed := default_node_reveal_depth |}.
+
+(** Parse [asm] and symbolically execute it from the initial state
+    used by [symex_asm_func] (every 64-bit register holds a fresh
+    symbolic value, memory and flags are empty). *)
+Definition symex (asm : list string) : ErrorT (list string) (ErrorT (error * symbolic_state) (unit * symbolic_state))
+  := match parse asm with
+     | Success lines => Success (SymexLines lines (init_symbolic_state dag.empty))
+     | Error errs => Error errs
+     end.
+
+Definition symex_rejected_as_rip_relative (asm : list string) : bool
+  := match symex asm with
+     | Success (Error (error.unsupported_rip_relative_addressing _, _)) => true
+     | _ => false
+     end.
+
+Definition symex_rejected_as_label (asm : list string) : bool
+  := match symex asm with
+     | Success (Error (error.unsupported_label_in_memory _, _)) => true
+     | _ => false
+     end.
+
+Definition symex_succeeds (asm : list string) : bool
+  := match symex asm with
+     | Success (Success _) => true
+     | _ => false
+     end.
+
+(** Sanity check that the harness actually reaches symbolic execution:
+    an ordinary register-relative [lea] goes through.  (Loads and
+    stores cannot be checked this way because the initial symbolic
+    memory is empty.) *)
+Example lea_reg_relative_ok
+  : symex_succeeds ["lea rcx, [rax + 0x26]"] = true.
+Proof. vm_compute; reflexivity. Qed.
+
+(** [lea] never touches memory, so before the check it silently
+    produced the displacement as a constant. *)
+Example lea_rip_relative_rejected
+  : symex_rejected_as_rip_relative ["lea rcx, [rip + 0x26]"] = true.
+Proof. vm_compute; reflexivity. Qed.
+Example lea_rip_relative_neg_rejected
+  : symex_rejected_as_rip_relative ["lea rcx, [rip - 0x26]"] = true.
+Proof. vm_compute; reflexivity. Qed.
+
+(** Loads and stores are rejected with the same explicit error, rather
+    than by accidentally failing to find the address in symbolic memory. *)
+Example load_rip_relative_rejected
+  : symex_rejected_as_rip_relative ["mov rax, [rip + 0x26]"] = true.
+Proof. vm_compute; reflexivity. Qed.
+Example store_rip_relative_rejected
+  : symex_rejected_as_rip_relative ["mov [rip + 0x26], rax"] = true.
+Proof. vm_compute; reflexivity. Qed.
+Example load_rip_relative_sized_rejected
+  : symex_rejected_as_rip_relative ["mov rax, qword ptr [rip + 0x26]"] = true.
+Proof. vm_compute; reflexivity. Qed.
+
+(** The [DEFAULT REL] directive itself is rejected as an unsupported
+    line, so implicitly RIP-relative operands never reach [Address]
+    through [SymexLines]; check [Address] directly on such an operand
+    (as produced by parsing under [default_rel := true]). *)
+Example default_rel_line_rejected
+  : match symex ["DEFAULT REL"; "mov rax, [0x26]"] with
+    | Success (Error (error.unsupported_line DEFAULT_REL, _)) => true
+    | _ => false
+    end = true.
+Proof. vm_compute; reflexivity. Qed.
+
+Definition implicitly_rip_relative_operand : MEM
+  := {| mem_bits_access_size := None
+      ; mem_base_reg := None
+      ; mem_scale_reg := None
+      ; mem_base_label := None
+      ; mem_offset := Some 0x26%Z
+      ; rip_relative := implicitly_rip_relative |}.
+
+Example parse_default_rel_is_implicitly_rip_relative
+  : match @parse_Lines {| default_rel := true |} ["mov rax, [0x26]"] with
+    | Success [ {| rawline := INSTR {| args := [_; mem m] |} |} ]
+      => MEM_beq m implicitly_rip_relative_operand
+    | _ => false
+    end = true.
+Proof. vm_compute; reflexivity. Qed.
+
+Example address_implicitly_rip_relative_rejected
+  : match @Address _ (Build_description "test" false) 64%N implicitly_rip_relative_operand (init_symbolic_state dag.empty) with
+    | Error (error.unsupported_rip_relative_addressing _, _) => true
+    | _ => false
+    end = true.
+Proof. vm_compute; reflexivity. Qed.
+
+(** Label-based operands were already rejected; keep it that way. *)
+Example lea_label_rejected
+  : symex_rejected_as_label ["lea rcx, [foo]"] = true.
+Proof. vm_compute; reflexivity. Qed.

--- a/src/Assembly/SymbolicTests.v
+++ b/src/Assembly/SymbolicTests.v
@@ -110,6 +110,15 @@ Example parse_default_rel_is_implicitly_rip_relative
     end = true.
 Proof. vm_compute; reflexivity. Qed.
 
+(** The top-level parser tracks [DEFAULT REL] across lines. *)
+Example parse_default_rel_is_stateful
+  : match parse ["DEFAULT REL"; "mov rax, [0x26]"] with
+    | Success [_; {| rawline := INSTR {| args := [_; mem m] |} |}]
+      => MEM_beq m implicitly_rip_relative_operand
+    | _ => false
+    end = true.
+Proof. vm_compute; reflexivity. Qed.
+
 Example address_implicitly_rip_relative_rejected
   : match @Address _ (Build_description "test" false) 64%N implicitly_rip_relative_operand (init_symbolic_state dag.empty) with
     | Error (error.unsupported_rip_relative_addressing _, _) => true

--- a/src/Assembly/WithBedrock/Semantics.v
+++ b/src/Assembly/WithBedrock/Semantics.v
@@ -106,17 +106,26 @@ Definition update_mem_with (st : machine_state) (f : mem_state -> mem_state) : m
 Definition DenoteConst (sz : N) (a : CONST) : Z :=
   Z.land a (Z.ones (Z.of_N sz)).
 
-Definition DenoteAddress (sa : N) (st : machine_state) (a : MEM) : Z :=
-  Z.land (
-    match mem_base_reg  a with Some     r  => get_reg st r                    | _ => 0 end +
-    match mem_scale_reg a with Some (z, r) => get_reg st r * DenoteConst sa z | _ => 0 end +
-    match mem_offset    a with Some  z     =>                DenoteConst sa z | _ => 0 end
-  ) (Z.ones (Z.of_N sa)).
+(** The effective address of a memory operand.  The machine state has
+    no instruction pointer, so RIP-relative operands (explicit
+    [\[rip + disp\]] or implicit via [DEFAULT REL]) and label-based
+    operands have no denotation ([None]); this mirrors the error
+    raised by [Symbolic.Address], see scrutineer finding #2516. *)
+Definition DenoteAddress (sa : N) (st : machine_state) (a : MEM) : option Z :=
+  match rip_relative a, mem_base_label a with
+  | not_rip_relative, None =>
+    Some (Z.land (
+      match mem_base_reg  a with Some     r  => get_reg st r                    | _ => 0 end +
+      match mem_scale_reg a with Some (z, r) => get_reg st r * DenoteConst sa z | _ => 0 end +
+      match mem_offset    a with Some  z     =>                DenoteConst sa z | _ => 0 end
+    ) (Z.ones (Z.of_N sa)))
+  | _, _ => None
+  end.
 
 Definition DenoteOperand (sa s : N) (st : machine_state) (a : ARG) : option Z :=
   match a with
   | reg a => Some (get_reg st a)
-  | mem a => get_mem st (DenoteAddress sa st a) (N.to_nat (N.div (operand_size a s) 8))
+  | mem a => addr <- DenoteAddress sa st a; get_mem st addr (N.to_nat (N.div (operand_size a s) 8))
   | const a => Some (DenoteConst (operand_size a s) a)
   | label _ => None
   end.
@@ -128,7 +137,7 @@ Definition SetMem (st : machine_state) (addr : Z) (nbytes : nat) (v : Z) : optio
 Definition SetOperand (sa s : N) (st : machine_state) (a : ARG) (v : Z) : option machine_state :=
   match a with
   | reg a => Some (update_reg_with st (fun rs => set_reg rs a v))
-  | mem a => SetMem st (DenoteAddress sa st a) (N.to_nat (N.div (operand_size a s) 8)) v
+  | mem a => addr <- DenoteAddress sa st a; SetMem st addr (N.to_nat (N.div (operand_size a s) 8)) v
   | const a => None
   | label _ => None
   end.
@@ -195,7 +204,8 @@ Definition DenoteNormalInstruction (st : machine_state) (instr : NormalInstructi
     then SetOperand sa s st dst v
     else Some st
   | lea, [reg dst; mem src] => (* Flags Affected: None *)
-    Some (update_reg_with st (fun rs => set_reg rs dst (DenoteAddress sa st src)))
+    addr <- DenoteAddress sa st src;
+    Some (update_reg_with st (fun rs => set_reg rs dst addr))
   | (add | adc) as opc, [dst; src] =>
     c <- (match opc with adc => get_flag st CF | _ => Some false end);
     let c := Z.b2z c in

--- a/src/Assembly/WithBedrock/SemanticsTests.v
+++ b/src/Assembly/WithBedrock/SemanticsTests.v
@@ -37,6 +37,14 @@ Example label_undefined st
   : DenoteAddress 64 st (operand not_rip_relative (Some "foo"%string)) = None.
 Proof. reflexivity. Qed.
 
+Example load_rip_relative_undefined st
+  : DenoteOperand 64 64 st (mem (operand explicitly_rip_relative None)) = None.
+Proof. reflexivity. Qed.
+
+Example store_rip_relative_undefined st v
+  : SetOperand 64 64 st (mem (operand implicitly_rip_relative None)) v = None.
+Proof. reflexivity. Qed.
+
 (** [lea] is the instruction that never touches memory, so it is the
     one for which the address itself is the result. *)
 Example lea_rip_relative_undefined st

--- a/src/Assembly/WithBedrock/SemanticsTests.v
+++ b/src/Assembly/WithBedrock/SemanticsTests.v
@@ -1,0 +1,44 @@
+(** Regression tests for the concrete semantics' treatment of memory
+    operands it cannot model.  The machine state has no instruction
+    pointer, so RIP-relative and label-based operands have no
+    denotation; this mirrors the error raised by [Symbolic.Address]
+    (scrutineer finding #2516) and is what keeps the soundness proof
+    in [SymbolicProofs] honest about such operands. *)
+From Coq Require Import ZArith.
+From Coq Require Import String.
+From Coq Require Import List.
+Import ListNotations.
+Require Import Crypto.Assembly.Syntax.
+Require Import Crypto.Assembly.WithBedrock.Semantics.
+
+Local Open Scope Z_scope.
+
+Definition operand (k : rip_relative_kind) (lbl : option String.string) : MEM
+  := {| mem_bits_access_size := None
+      ; mem_base_reg := None
+      ; mem_scale_reg := None
+      ; mem_base_label := lbl
+      ; mem_offset := Some 0x26
+      ; rip_relative := k |}.
+
+Example absolute_displacement_ok st
+  : DenoteAddress 64 st (operand not_rip_relative None) = Some 0x26.
+Proof. vm_compute; reflexivity. Qed.
+
+Example explicitly_rip_relative_undefined st
+  : DenoteAddress 64 st (operand explicitly_rip_relative None) = None.
+Proof. reflexivity. Qed.
+
+Example implicitly_rip_relative_undefined st
+  : DenoteAddress 64 st (operand implicitly_rip_relative None) = None.
+Proof. reflexivity. Qed.
+
+Example label_undefined st
+  : DenoteAddress 64 st (operand not_rip_relative (Some "foo"%string)) = None.
+Proof. reflexivity. Qed.
+
+(** [lea] is the instruction that never touches memory, so it is the
+    one for which the address itself is the result. *)
+Example lea_rip_relative_undefined st
+  : DenoteNormalInstruction st {| prefix := None ; op := lea ; args := [reg rcx; mem (operand explicitly_rip_relative None)] |} = None.
+Proof. reflexivity. Qed.

--- a/src/Assembly/WithBedrock/SymbolicProofs.v
+++ b/src/Assembly/WithBedrock/SymbolicProofs.v
@@ -497,9 +497,9 @@ Ltac step_GetReg :=
   end.
 
 Lemma Address_R {opts : symbolic_options_computed_opt} {descr:description} s m (HR : R s m) (sa:AddressSize) o a s' (H : Symbolic.Address o s = Success (a, s'))
-  : R s' m /\ s :< s' /\ exists v, eval s' a v /\ @DenoteAddress sa m o = v.
+  : R s' m /\ s :< s' /\ exists v, eval s' a v /\ @DenoteAddress sa m o = Some v.
 Proof using Type.
-  destruct o as [? ? ? ?]; cbv [Address DenoteAddress Syntax.mem_base_reg Syntax.mem_offset Syntax.mem_scale_reg err ret] in *; repeat step_symex.
+  destruct o as [? ? ? ? ? ?]; cbv [Address DenoteAddress Syntax.mem_base_reg Syntax.mem_offset Syntax.mem_scale_reg Syntax.mem_base_label Syntax.rip_relative err ret] in *; repeat step_symex.
   all : repeat first [ progress inversion_ErrorT
                      | progress inversion_pair
                      | progress subst
@@ -511,7 +511,7 @@ Proof using Type.
   all : rewrite !Z.land_ones by lia.
   all : push_Zmod; pull_Zmod.
   all : autorewrite with zsimplify_const.
-  all : f_equal; lia.
+  all : repeat f_equal; lia.
 Qed.
 
 Ltac step_Address :=
@@ -723,6 +723,7 @@ Proof using Type.
     { repeat (eauto||econstructor). }
     split; eauto; [].
     split; eauto; [].
+    match goal with H : DenoteAddress _ _ _ = Some _ |- _ => rewrite H end; cbv [Crypto.Util.Option.bind].
     rewrite Z.shiftr_0_r in Hi by lia.
     case E as [E|E];
       rewrite E in *; simpl Z.of_N in *.
@@ -739,8 +740,8 @@ Proof using Type.
       eexists; split; eauto.
       cbv [le_combine].
       rewrite Z.shiftl_0_l, Z.lor_0_r.
-      change (Z.lor (Byte.byte.unsigned b) (Z.shiftl (le_combine l) 8) = x) in H4.
-      rewrite <-H4 in H5 at 2; rewrite H5; clear H4 H5.
+      change (Z.lor (Byte.byte.unsigned b) (Z.shiftl (le_combine l) 8) = x0) in H5.
+      rewrite <-H5 in H6 at 2; rewrite H6; clear H5 H6.
       f_equal.
       rewrite <-Byte.byte.wrap_unsigned at 1; setoid_rewrite <-Z.land_ones; [|clear;lia].
       rewrite <-Z.land_assoc.
@@ -748,9 +749,9 @@ Proof using Type.
       rewrite Z.land_lor_distr_l.
       bitblast.Z.bitblast. subst.
       rewrite (Z.testbit_neg_r _ (_-8)) by lia; Btauto.btauto. }
-    { setoid_rewrite H4.
+    { setoid_rewrite H5.
       eexists; split; eauto; f_equal.
-      rewrite H5 at 1; trivial. } }
+      rewrite H6 at 1; trivial. } }
   { step_symex; repeat (eauto||econstructor). }
 Qed.
 
@@ -833,15 +834,16 @@ Proof using Type.
     { repeat (eauto || econstructor). }
     { repeat (eauto || econstructor). }
     rewrite !Z.shiftl_0_r, ?Z.shiftr_0_r, <-Z.land_assoc, Z.land_diag in *.
+    match goal with H : DenoteAddress _ _ _ = Some _ |- _ => rewrite H end; cbv beta iota delta [Crypto.Util.Option.bind].
     case E as [E|E]; rewrite E in *; simpl Z.of_N in *.
-    { eapply Store64_R with (v':=Z.lor (Z.land v (Z.ones 8)) (Z.ldiff x (Z.ones 8))) in H;
-        try eassumption; eauto with nocore; try solve [rewrite H5; bitblast.Z.bitblast].
+    { eapply Store64_R with (v':=Z.lor (Z.land v (Z.ones 8)) (Z.ldiff x0 (Z.ones 8))) in H;
+        try eassumption; eauto with nocore; try solve [rewrite H6; bitblast.Z.bitblast].
       destruct_head'_ex; destruct_head'_and.
       cbv [SetMem Crypto.Util.Option.bind update_mem_with] in *;
         destruct set_mem eqn:? in *; Option.inversion_option; subst.
       erewrite store8; eauto 9. }
     { eapply Store64_R with (v':=v) in H;
-        try eassumption; eauto with nocore; try solve [rewrite H5; bitblast.Z.bitblast].
+        try eassumption; eauto with nocore; try solve [rewrite H6; bitblast.Z.bitblast].
       destruct_head'_ex; destruct_head'_and. setoid_rewrite H. eauto 9. } }
 Qed.
 
@@ -1087,7 +1089,8 @@ Proof using Type.
     destr (0 <=? i - Z.of_N (reg_offset r)); try lia; cbn.
     replace (i - Z.of_N (reg_offset r) + Z.of_N (reg_offset r)) with i by lia.
     destr (i - Z.of_N (reg_offset r) <? Z.of_N (reg_size r)); Btauto.btauto. }
-  { destruct m'; cbv [SetMem update_mem_with Crypto.Util.Option.bind get_mem option_map set_mem store_bytes unchecked_store_bytes] in *; repeat (destruct_one_match_hyp || Option.inversion_option).
+  { match goal with H : context[DenoteAddress ?sa ?st ?a] |- _ => destruct (DenoteAddress sa st a) eqn:HDA in *; [ clear HDA | discriminate ] end.
+    destruct m'; cbv [SetMem update_mem_with Crypto.Util.Option.bind get_mem option_map set_mem store_bytes unchecked_store_bytes] in *; repeat (destruct_one_match_hyp || Option.inversion_option).
     inversion Hs; clear Hs; subst; f_equal.
     clear E0.
     change (@map.putmany ?K ?V ?M ?m) with (@map.putmany K V M machine_mem_state).


### PR DESCRIPTION
Fixes scrutineer security finding #2516 (duplicate #2513): RIP-relative memory operands are parsed and stored but ignored by both address models.

## The bug

`Parse.v` records `[rip + disp]` (and every bare `[disp]` after a `DEFAULT REL` line) in the `rip_relative` field of `MEM`, but `Symbolic.Address` (src/Assembly/Symbolic.v) and `Semantics.DenoteAddress` (src/Assembly/WithBedrock/Semantics.v) never read that field and computed `0 + 0 + disp`. Loads and stores through such an operand happened to fail because the folded constant address is not in symbolic memory, but `lea` never touches memory, so `lea rcx, [rip + 0x26]` was checked as `mov rcx, 0x26`. An attacker-supplied `--hints-file` can replace any `mov r64, imm` with `lea r64, [rip + imm]` and have the equivalence checker certify assembly that computes `RIP + imm` on hardware.

I confirmed this end to end with the installed pre-fix binary (`fiat_crypto unsaturated-solinas curve25519 64 5 '2^255 - 19' carry_mul ... --hints-file`): a copy of `fiat-amd64/fiat_curve25519_carry_mul/seed0000000059842304_ratio12536.asm` with line 108 `mov rdx, 0x33` replaced by `lea rdx, [rip + 0x33]` was accepted (exit 0) and the hostile assembly emitted.

## The fix

Both models now fail closed, consistently:

- `Symbolic.Address` raises a new error `error.unsupported_rip_relative_addressing <operand>` (with a readable `Show` instance, next to `unsupported_label_in_memory`) when the operand is `explicitly_rip_relative` or `implicitly_rip_relative`. All memory operands (`lea`, loads, stores) go through `Address`, so loads and stores now get the explicit error instead of the accidental "index not present" one.
- `Semantics.DenoteAddress` now returns `option Z` and is `None` for RIP-relative and label-based operands; `DenoteOperand`, `SetOperand`, and `lea` propagate that. The machine state has no instruction pointer, so this is the honest semantics and it keeps `SymbolicProofs.Address_R` true.
- `SymbolicProofs.v` adapted (`Address_R` now concludes `DenoteAddress ... = Some v`; `GetOperand_R`, `R_SetOperand`, `SetOperand_same` rewrite with it). `EquivalenceProofs.v` and `WithBedrock/Proofs.v` needed no changes.
- `DEFAULT REL` lines were already rejected by `SymexRawLine` (`unsupported_line`), so the implicit case could not previously reach `Address` through `SymexLines`; the new check covers it anyway and a test pins both facts down.
- New regression tests: `src/Assembly/SymbolicTests.v` (parse + symbolic execution of `lea`/load/store with `[rip + disp]`, `[rip - disp]`, `DEFAULT REL`, an implicitly RIP-relative operand as produced by the parser under `default_rel := true`, a label operand, and a register-relative `lea` that must still succeed) and `src/Assembly/WithBedrock/SemanticsTests.v` (`DenoteAddress` and `lea` undefined on such operands, defined on an absolute displacement).

Alternatives considered: keeping `DenoteAddress : Z` and only guarding in `DenoteOperand`/`SetOperand`/`lea` would work but leaves a function that returns a meaningless value for these operands; making `DenoteAddress` partial is the smaller trust surface. Modelling RIP properly is out of scope, since the symbolic state has no notion of code addresses.

`grep -rliw rip fiat-amd64 --include=*.asm` finds no shipped assembly using RIP-relative operands, so the existing CryptOpt verification workflow is unaffected.

## Verification

Compiled locally with `coqc` (Rocq 9.4+alpha, `-R src Crypto`) against the installed `coq-fiat-crypto-with-bedrock`, recompiling the full downstream cone of the changed files:

- `src/Assembly/Symbolic.v`, `src/Assembly/WithBedrock/Semantics.v` (changed) — OK
- `src/Assembly/Equivalence.v`, `src/Assembly/EquivalenceProofs.v`, `src/Assembly/WithBedrock/SymbolicProofs.v`, `src/Assembly/WithBedrock/Proofs.v` (HEAD versions; the last two differ from the installed build) — OK
- `src/BoundsPipeline.v`, `src/PushButtonSynthesis/{Primitives,SaturatedSolinas,UnsaturatedSolinas,WordByWordMontgomery,BaseConversion,DettmanMultiplication,SolinasReduction}.v`, `src/CLI.v`, `src/StandaloneOCamlMain.v`, `src/ExtractionOCaml/unsaturated_solinas.v` — OK
- `src/Assembly/SymbolicTests.v`, `src/Assembly/WithBedrock/SemanticsTests.v` (new) — OK

Rebuilt `src/ExtractionOCaml/unsaturated_solinas` from the extraction with the Makefile.standalone `ocamlfind ocamlopt` command and ran:

- hostile hints file (line 108 `mov rdx, 0x33` → `lea rdx, [rip + 0x33]`): rejected, exit 2, output ends with `Symbolic execution failed: error.unsupported_rip_relative_addressing [rip + 0x33] (RIP-relative memory operands are not supported: the symbolic model has no notion of the instruction pointer)`.
- the unmodified `seed0000000059842304_ratio12536.asm`: verified, exit 0.
- the exact `fiat-amd64/curve25519-carry_mul.status` invocation from `gentest.py --makefile` with all 30 hints files: verified, exit 0 (about 9 s).

Not verified: a full `make` (many hours), the other five separate binaries and the JsOfOCaml/Haskell mains (same Coq source, no separate proofs), and the full `test-amd64-files` suite beyond curve25519 carry_mul. CI should cover those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Rbn2gww3MGhvrh52fNjpD
