### PR TITLE
Bound the assembly stack size and fix its bytes/words confusion (scrutineer #2517)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,6 +242,8 @@ fiat-amd64/*.status
 fiat-amd64/*.only-status
 fiat-amd64/*.description
 fiat-amd64/*.invocation
+fiat-amd64/negative-tests/*.status
+fiat-amd64/negative-tests/*.stdout
 fiat-html/fiat_crypto.js
 fiat-html/fiat_crypto.map
 fiat-html/wasm/fiat_crypto.js

--- a/Makefile.examples
+++ b/Makefile.examples
@@ -14,8 +14,8 @@ CFLAGS?=
 	c-files bedrock2-files rust-files go-files json-files java-files zig-files generated-files \
 	lite-c-files lite-bedrock2-files lite-rust-files lite-go-files lite-json-files lite-java-files lite-zig-files lite-generated-files \
 	update-go-pkg-cache \
-	test-c-files test-bedrock2-files test-rust-files test-go-files test-json-files test-java-files test-zig-files test-amd64-files test-amd64-files-lite \
-	only-test-c-files only-test-bedrock2-files only-test-rust-files only-test-go-files only-test-json-files only-test-java-files only-test-zig-files only-test-amd64-files only-test-amd64-files-lite \
+	test-c-files test-bedrock2-files test-rust-files test-go-files test-json-files test-java-files test-zig-files test-amd64-files test-amd64-files-lite test-amd64-negative-files \
+	only-test-c-files only-test-bedrock2-files only-test-rust-files only-test-go-files only-test-json-files only-test-java-files only-test-zig-files only-test-amd64-files only-test-amd64-files-lite only-test-amd64-negative-files \
 	test-go-module only-test-go-module \
 	javadoc only-javadoc \
 	#
@@ -406,6 +406,51 @@ only-test-amd64-files: only-test-amd64-files-print-report only-test-amd64-files-
 test-amd64-files-lite: test-amd64-files-lite-print-report test-amd64-files-lite-status
 
 only-test-amd64-files-lite: only-test-amd64-files-lite-print-report only-test-amd64-files-lite-status
+
+# Negative tests for the assembly equivalence checker: inputs which
+# must be rejected quickly with a specific error message, rather than
+# hanging or exhausting memory.  Each test runs the checker and
+# requires that it fails and that its output mentions the expected
+# error.
+AMD64_NEGATIVE_TEST_DIR := fiat-amd64/negative-tests
+AMD64_NEGATIVE_TEST_INVOCATION := $(UNSATURATED_SOLINAS) curve25519 64 5 '2^255 - 19' carry_mul --no-wide-int --shiftr-avoid-uint1 --tight-bounds-mul-by 1.000001
+AMD64_NEGATIVE_STATUS_FILES := \
+	$(AMD64_NEGATIVE_TEST_DIR)/stack-size-too-large-inferred.status \
+	$(AMD64_NEGATIVE_TEST_DIR)/stack-size-too-large-explicit.status \
+	#
+
+# A hints file with `sub rsp, 0x100000000` (scrutineer finding #2517): the inferred stack size must be rejected up front
+$(AMD64_NEGATIVE_TEST_DIR)/stack-size-too-large-inferred.status: $(AMD64_NEGATIVE_TEST_DIR)/stack-size-too-large.asm
+$(AMD64_NEGATIVE_TEST_DIR)/stack-size-too-large-inferred.status: NEGATIVE_TEST_ARGS := --hints-file $(AMD64_NEGATIVE_TEST_DIR)/stack-size-too-large.asm
+$(AMD64_NEGATIVE_TEST_DIR)/stack-size-too-large-inferred.status: NEGATIVE_TEST_EXPECTED_ERROR := exceeds the maximum supported stack size
+# The same bound applies to an explicitly given --asm-stack-size
+$(AMD64_NEGATIVE_TEST_DIR)/stack-size-too-large-explicit.status: fiat-amd64/fiat_curve25519_carry_mul/seed0000000059842304_ratio12536.asm
+$(AMD64_NEGATIVE_TEST_DIR)/stack-size-too-large-explicit.status: NEGATIVE_TEST_ARGS := --hints-file fiat-amd64/fiat_curve25519_carry_mul/seed0000000059842304_ratio12536.asm --asm-stack-size 65537
+$(AMD64_NEGATIVE_TEST_DIR)/stack-size-too-large-explicit.status: NEGATIVE_TEST_EXPECTED_ERROR := exceeds the maximum supported stack size
+
+$(AMD64_NEGATIVE_STATUS_FILES): %.status:
+	$(SHOW)'TEST AMD64 NEGATIVE $(notdir $*) ...'
+	$(HIDE)rm -f $@
+	$(HIDE)if $(TIMER) $(AMD64_NEGATIVE_TEST_INVOCATION) $(NEGATIVE_TEST_ARGS) -o /dev/null --output-asm /dev/null >$*.stdout 2>&1; then \
+	  echo 1 > $@; echo 'TEST AMD64 NEGATIVE $(notdir $*) ... 	$(RED)$(BOLD)FAILED$(NORMAL)$(NC) (unexpectedly succeeded)'; \
+	elif grep -q '$(NEGATIVE_TEST_EXPECTED_ERROR)' $*.stdout; then \
+	  echo 0 > $@; echo 'TEST AMD64 NEGATIVE $(notdir $*) ... 	$(GREEN)$(BOLD)PASSED$(NORMAL)$(NC)'; \
+	else \
+	  echo 1 > $@; echo 'TEST AMD64 NEGATIVE $(notdir $*) ... 	$(RED)$(BOLD)FAILED$(NORMAL)$(NC) (did not report "$(NEGATIVE_TEST_EXPECTED_ERROR)"; see $*.stdout)'; \
+	fi
+
+.PHONY: $(AMD64_NEGATIVE_STATUS_FILES)
+
+clean::
+	$(HIDE)rm -f $(AMD64_NEGATIVE_STATUS_FILES) $(AMD64_NEGATIVE_STATUS_FILES:.status=.stdout)
+
+test-amd64-negative-files: $(UNSATURATED_SOLINAS)
+
+test-amd64-negative-files only-test-amd64-negative-files: $(AMD64_NEGATIVE_STATUS_FILES)
+	$(HIDE)! grep -q -v '^0$$' $(AMD64_NEGATIVE_STATUS_FILES)
+
+test-amd64-files test-amd64-files-lite: test-amd64-negative-files
+only-test-amd64-files only-test-amd64-files-lite: only-test-amd64-negative-files
 
 
 

--- a/fiat-amd64/negative-tests/stack-size-too-large.asm
+++ b/fiat-amd64/negative-tests/stack-size-too-large.asm
@@ -1,0 +1,10 @@
+SECTION .text
+	GLOBAL fiat_curve25519_carry_mul
+fiat_curve25519_carry_mul:
+; This is a deliberately hostile hints file (scrutineer finding #2517):
+; the single instruction below makes the inferred stack size 4 GiB.  The
+; equivalence checker must reject it immediately with a "Stack size ...
+; exceeds the maximum supported stack size" error rather than attempting
+; to model that many stack cells (which would exhaust memory).
+sub rsp, 0x100000000
+ret

--- a/src/Assembly/Equivalence.v
+++ b/src/Assembly/Equivalence.v
@@ -78,7 +78,9 @@ Typeclasses Opaque assembly_output_first_opt.
 Class assembly_argument_registers_left_to_right_opt := assembly_argument_registers_left_to_right : bool.
 #[global]
 Typeclasses Opaque assembly_argument_registers_left_to_right_opt.
-(** Stack size (in bytes) *)
+(** Stack size (in bytes).  Note that the symbolic executor models
+    the stack as a list of 64-bit words; see
+    [assembly_stack_size_words] for the conversion. *)
 Class assembly_stack_size_opt := assembly_stack_size' : option N.
 #[global]
 Typeclasses Opaque assembly_stack_size_opt.
@@ -144,6 +146,37 @@ Definition assembly_stack_size {calling_convention : assembly_callee_saved_regis
      | None => let red_zone := Z.of_N assembly_stack_red_zone in
                Z.to_N (fold_right Z.max red_zone (assembly_stack_size_at red_zone asm))
      end.
+(** The symbolic executor models the stack as a list of 64-bit words
+    ([compute_stack_base] places the base of the modeled stack at [rsp
+    - 8 * stack_size] and [build_merge_stack_placeholders] creates one
+    64-bit placeholder cell per word), whereas [assembly_stack_size] is
+    measured in bytes (each [push] contributes 8, [sub rsp, n]
+    contributes [n], and the red zone is 128 bytes on System V).  We
+    round the byte count up to a whole number of words so that the
+    modeled stack covers every byte the assembly is allowed to
+    touch. *)
+Definition assembly_stack_size_words_of_bytes (stack_size_bytes : N) : N
+  := ((stack_size_bytes + 7) / 8)%N.
+Definition assembly_stack_size_words {calling_convention : assembly_callee_saved_registers_opt} {v : assembly_stack_size_opt} (asm : _) : N
+  := assembly_stack_size_words_of_bytes (assembly_stack_size asm).
+(** Sanity bound (in bytes) on the stack size we are willing to model.
+
+    The stack size is converted to a unary [nat] and then each modeled
+    word costs several dag nodes plus one symbolic memory cell, with
+    dag insertion being linear in the size of the dag.  Since the
+    stack size is either inferred from the [sub rsp, n] / [push] /
+    etc. instructions in the (untrusted) hints file or passed on the
+    command line, an absurd value such as [sub rsp, 0x100000000] would
+    otherwise make the equivalence checker exhaust memory or run for
+    hours before reporting anything.  We refuse such sizes up front
+    with [Stack_size_too_large] instead.
+
+    The largest stack frame of any assembly file in fiat-amd64 (as of
+    2026) is under 2 KiB including the red zone, so 64 KiB is well over
+    an order of magnitude beyond anything a field-arithmetic routine
+    plausibly needs, while still being small enough that the checker
+    finishes in reasonable time if the bound is nearly hit. *)
+Definition assembly_stack_size_max_bytes : N := 65536.
 
 Class assembly_conventions_opt :=
   { #[global] assembly_calling_registers_ :: assembly_calling_registers_opt
@@ -244,6 +277,7 @@ Inductive EquivalenceCheckingError :=
 | Unable_to_unify (_ _ : list (idx + list idx)) (first_new_idx_after_all_old_idxs : option idx) (_ : symbolic_state)
 | Missing_ret
 | Code_after_ret (significant : Lines) (l : Lines)
+| Stack_size_too_large (stack_size_bytes max_stack_size_bytes : N)
 .
 
 Definition symbolic_state_of_EquivalenceCheckingError (e : EquivalenceCheckingError) : option symbolic_state
@@ -275,6 +309,7 @@ Definition symbolic_state_of_EquivalenceCheckingError (e : EquivalenceCheckingEr
      | Unhandled_cast _ _
      | Missing_ret
      | Code_after_ret _ _
+     | Stack_size_too_large _ _
        => None
      end.
 
@@ -743,6 +778,8 @@ Global Instance show_lines_EquivalenceCheckingError : ShowLines EquivalenceCheck
                   => ["Missing 'ret' at the end of the function"]
                 | Code_after_ret significant l
                   => ["Code after ret:"; "In:"] ++ show_lines l ++ ["Found instructions after ret:"] ++ show_lines significant
+                | Stack_size_too_large stack_size_bytes max_stack_size_bytes
+                  => [("Stack size of " ++ show stack_size_bytes ++ " bytes (as inferred from the assembly, or as given explicitly) exceeds the maximum supported stack size of " ++ show max_stack_size_bytes ++ " bytes (assembly_stack_size_max_bytes)")%string]
                 end%list.
 Global Instance show_EquivalenceCheckingError : Show EquivalenceCheckingError
   := fun err => String.concat String.NewLine (show_lines err).
@@ -1299,6 +1336,8 @@ Definition init_symbolic_state (d : dag) : symbolic_state
        symbolic_flag_state := Tuple.repeat None 6;
      |}.
 
+(** [stack_size] is measured in 64-bit words, not bytes; see
+    [assembly_stack_size_words] *)
 Definition compute_stack_base {opts : symbolic_options_computed_opt} {descr:description} (stack_size : nat) : M idx
   := (rsp_val <- SetRegFresh rsp;
       stack_size <- Symbolic.App (zconst 64 (-8 * Z.of_nat stack_size), []);
@@ -1461,7 +1500,12 @@ Section check_equivalence.
       (ls <-- (List.map
                (fun '((fname, asm) as label)
                 => (asm <- map_err_Some label (strip_ret asm);
-                    let stack_size : nat := N.to_nat (assembly_stack_size asm) in
+                    (* Refuse absurd stack sizes before converting to a unary [nat] or allocating any placeholders *)
+                    _ <- map_err_Some label (let stack_size_bytes := assembly_stack_size asm in
+                                             if (stack_size_bytes <=? assembly_stack_size_max_bytes)%N
+                                             then Success tt
+                                             else Error (Stack_size_too_large stack_size_bytes assembly_stack_size_max_bytes));
+                    let stack_size : nat := N.to_nat (assembly_stack_size_words asm) in
                     symevaled_asm <- map_err_Some label (symex_asm_func (dereference_output_scalars:=false) d assembly_callee_saved_registers output_types stack_size inputs reg_available asm);
                     Success (label, symevaled_asm)))
                asm);

--- a/src/Assembly/WithBedrock/Proofs.v
+++ b/src/Assembly/WithBedrock/Proofs.v
@@ -3327,7 +3327,7 @@ Theorem check_equivalence_correct
   : Forall
       (fun '(_fname, asm)
        => forall
-           (stack_size := N.to_nat (assembly_stack_size match strip_ret asm with Success asm => asm | Error _ => asm end))
+           (stack_size := N.to_nat (assembly_stack_size_words match strip_ret asm with Success asm => asm | Error _ => asm end))
            (stack_base := word.of_Z (Semantics.get_reg st rsp - 8 * Z.of_nat stack_size))
            (HR : R_runtime_input (output_scalars_are_pointers:=output_scalars_are_pointers) frame output_types args stack_size stack_base asm_args_out asm_args_in assembly_calling_registers runtime_regs assembly_callee_saved_registers runtime_callee_saved_registers st),
          exists asm' st' (retvals : list (Z + list Z)),
@@ -3472,7 +3472,7 @@ Theorem generate_assembly_of_hinted_expr_correct
               (runtime_callee_saved_registers := get_asm_reg st assembly_callee_saved_registers),
              Forall
          (fun '(_fname, asm)
-          => forall (stack_size := N.to_nat (assembly_stack_size match strip_ret asm with Success asm => asm | Error _ => asm end))
+          => forall (stack_size := N.to_nat (assembly_stack_size_words match strip_ret asm with Success asm => asm | Error _ => asm end))
                     (stack_base := word.of_Z (Semantics.get_reg st rsp - 8 * Z.of_nat stack_size))
                     (HR : R_runtime_input (output_scalars_are_pointers:=output_scalars_are_pointers) frame output_types args stack_size stack_base asm_args_out asm_args_in assembly_calling_registers runtime_regs assembly_callee_saved_registers runtime_callee_saved_registers st),
             (* Should match check_equivalence_correct exactly *)

--- a/src/CLI.v
+++ b/src/CLI.v
@@ -526,7 +526,7 @@ Module ForExtraction.
   Definition asm_stack_size_spec : named_argT
     := ([Arg.long_key "asm-stack-size"],
         Arg.Custom (parse_string_and parse_N) "ℕ",
-        ["The number of bytes of stack.  Only relevant when --hints-file is specified.  Defaults to the conventional size of the red zone (" ++ show (system_v_amd64_assembly_stack_red_zone:N) ++ " for --asm-callee-saved-registers " ++ show System_V_AMD64 ++ ", or " ++ show (microsoft_x64_assembly_stack_red_zone:N) ++ " for  --asm-callee-saved-registers " ++ show Microsoft_x64 ++ ", or " ++ show (@assembly_stack_red_zone (explicit_registers []):N) ++ " for an explicit list of registers given to --asm-callee-saved-registers) plus the maximum statically knowable increase to `rsp` (via `push`, `pop`, `sub`, `add`, and `lea` instructions) the code."]).
+        ["The number of bytes of stack.  Only relevant when --hints-file is specified.  Must be at most " ++ show (assembly_stack_size_max_bytes:N) ++ ".  Defaults to the conventional size of the red zone (" ++ show (system_v_amd64_assembly_stack_red_zone:N) ++ " for --asm-callee-saved-registers " ++ show System_V_AMD64 ++ ", or " ++ show (microsoft_x64_assembly_stack_red_zone:N) ++ " for  --asm-callee-saved-registers " ++ show Microsoft_x64 ++ ", or " ++ show (@assembly_stack_red_zone (explicit_registers []):N) ++ " for an explicit list of registers given to --asm-callee-saved-registers) plus the maximum statically knowable increase to `rsp` (via `push`, `pop`, `sub`, `add`, and `lea` instructions) the code."]).
   Definition no_error_on_unused_asm_functions_spec : named_argT
     := ([Arg.long_key "no-error-on-unused-asm-functions"],
         Arg.Unit,


### PR DESCRIPTION
Fixes scrutineer finding #2517 (duplicate of #2515).

## The bug

When `--asm-stack-size` is not given, `assembly_stack_size` in `src/Assembly/Equivalence.v` infers the stack size from the hints file by summing the immediates of `sub rsp, n` / `push` / `lea rsp, ...` instructions. The result is an unbounded `N`; it is converted with `N.to_nat` (unary, since `ExtrOcamlNatInt` is not used) and then used as the number of stack placeholder cells to create (`build_inputarray`, `build_merge_array_addresses`, `LoadArray`). A two-line hints file containing `sub rsp, 0x100000000` therefore makes the synthesis binary allocate billions of cells before it can report anything; with the assoc-list dag (linear insertion), it never finishes. An absurd explicit `--asm-stack-size` does the same.

Independently, the report's unit-confusion claim is correct: the inferred quantity is in **bytes** (`push` contributes 8, `sub rsp, n` contributes `n`, the System V red zone is 128), and `--asm-stack-size` is documented as "the number of bytes of stack", but the consumers (`compute_stack_base` = `rsp - 8 * stack_size`, `compute_array_address` strides by 8) treat it as a count of **64-bit words**. Every check modeled `[rsp - 8n, rsp)` instead of `[rsp - n, rsp)`: 8x the cells, and with the quadratic dag up to 64x the time. This over-approximation is sound (the extra cells are fresh symbols that are just loaded back at the end) but wasteful, and it would also silently accept assembly that touches memory well below its own frame plus the red zone.

## The fix

- `assembly_stack_size_words_of_bytes` / `assembly_stack_size_words` round the byte count up to whole 64-bit words, and `map_symex_asm` now passes the word count to `symex_asm_func`. The statements of `check_equivalence_correct` and `generate_assembly_of_hinted_expr_correct` in `src/Assembly/WithBedrock/Proofs.v` are updated to match; their proofs needed no changes.
- New constant `assembly_stack_size_max_bytes := 65536` and new error `Stack_size_too_large` (with `Show` case). `map_symex_asm` refuses any stack size above the bound **before** `N.to_nat` runs or anything is allocated. The `--asm-stack-size` help text states the bound.
- New negative tests: `fiat-amd64/negative-tests/stack-size-too-large.asm` (a `sub rsp, 0x100000000` hints file) and an explicit `--asm-stack-size 65537`, both required to fail with the new error. They run via `test-amd64-negative-files` / `only-test-amd64-negative-files`, which are hooked into `test-amd64-files*` and `only-test-amd64-files*` (so CI's `only-test-amd64-files-lite` runs them).

### Behaviour change for `--asm-stack-size` users (please read)

An explicit `--asm-stack-size N` used to model N **words** (8N bytes) because of the bug; it now models N **bytes** (rounded up to a multiple of 8), which is what the flag has always been documented to mean. Anyone who was passing a too-small number and relying on the accidental 8x is affected and must pass the real byte count. Nothing in this repository passes the flag (`fiat-amd64/gentest.py`, `Makefile.examples`), and all fiat-amd64 files verify with the inferred size.

### Why 64 KiB, and why it also applies to explicit `--asm-stack-size`

- The largest `sub rsp` in `fiat-amd64/**/*.asm` is 1888 bytes (2016 with the red zone). 64 KiB is over 30x that.
- Measured with the rebuilt binary on curve25519 `carry_mul`: at the bound (`--asm-stack-size 65536`, i.e. 8192 words) the checker finishes in about 145 s using about 110 MB; at 2048 words it takes about 7.6 s. So the worst case an in-bound hostile input can cause is a couple of minutes, not a hang. (With the old binary, the same file's *default* inference already cost 256 cells; it now costs 16.)
- The bound applies to explicit values too: the cost is the same regardless of where the number came from, a clear error beats a multi-hour run, and a value above 64 KiB is almost certainly a units mistake. Raising it is a one-line change to `assembly_stack_size_max_bytes`, and the error message names that constant.

Alternatives considered: switching `nat` extraction to `ExtrOcamlNatInt` (does not fix the allocation of cells, and is a much bigger change); bounding only the inferred path (leaves the explicit-flag hang in place for no benefit); making the bound a CLI flag (more plumbing for a sanity limit nobody should need to move).

## Verification

Done in a worktree against the installed `coq-fiat-crypto-with-bedrock` (Rocq 9.4+alpha), recompiling only the changed cone:

- `coqc` succeeded on: `src/Assembly/Equivalence.v`, `src/Assembly/EquivalenceProofs.v` (52 s), `src/Assembly/WithBedrock/Semantics.v` (HEAD version, differs from installed), `src/Assembly/WithBedrock/SymbolicProofs.v` (42 s), `src/Assembly/WithBedrock/Proofs.v` (133 s, no proof changes needed), `src/BoundsPipeline.v`, all seven `src/PushButtonSynthesis/*.v` that depend on it, `src/CLI.v`, `src/StandaloneOCamlMain.v`, and the extraction files for `unsaturated_solinas`, `word_by_word_montgomery`, `solinas_reduction`, `dettman_multiplication`.
- Rebuilt those four OCaml binaries by hand with the same `ocamlfind ocamlopt` command as `Makefile.standalone`.
- `make -f Makefile.examples only-test-amd64-negative-files`: both negative tests PASSED in about 2 s total. The hostile file now reports `Stack size of 4294967424 bytes (...) exceeds the maximum supported stack size of 65536 bytes (assembly_stack_size_max_bytes)`; with the old installed binary the same file with the default inference does not terminate.
- `make -f Makefile.examples -j8 only-test-amd64-files-lite SLOWEST_FIRST=1` (the CI target) with the rebuilt binaries: `ALL 14 AMD64 ASM TESTS PASSED` plus the 2 negative tests, 42 s wall.
- curve25519 `carry_mul` with a fiat-amd64 hints file and the default inferred size verifies in 0.46 s with the new binary (0.75 s with the old one).

Not verified:
- The full (non-lite) `only-test-amd64-files` run (p384/p434/p448/p521, the files with the largest frames) was still running when this PR was opened; I will update this description with the result.
- The `src/Bedrock/**` cone (bedrock2 standalone binaries) and the Haskell/JS extraction targets were not recompiled; they only consume the changed definitions through `CLI.v` and should be unaffected, but CI must confirm.
- No full `make`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Rbn2gww3MGhvrh52fNjpD
