### PR TITLE
Print Z_bneg as logical negation in Rust and Zig (scrutineer #2525)

### DIFF
--- a/fiat-rust/src/curve25519_32.rs
+++ b/fiat-rust/src/curve25519_32.rs
@@ -256,7 +256,7 @@ pub const fn fiat_25519_subborrowx_u25(out1: &mut u32, out2: &mut fiat_25519_u1,
 /// ```
 #[inline]
 pub const fn fiat_25519_cmovznz_u32(out1: &mut u32, arg1: fiat_25519_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_25519_u1 = (!(!arg1));
+  let x1: fiat_25519_u1 = ((((arg1 == 0) as fiat_25519_u1) == 0) as fiat_25519_u1);
   let x2: u32 = ((((((0x0 as fiat_25519_i2) - (x1 as fiat_25519_i2)) as fiat_25519_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/curve25519_64.rs
+++ b/fiat-rust/src/curve25519_64.rs
@@ -200,7 +200,7 @@ pub const fn fiat_25519_subborrowx_u51(out1: &mut u64, out2: &mut fiat_25519_u1,
 /// ```
 #[inline]
 pub const fn fiat_25519_cmovznz_u64(out1: &mut u64, arg1: fiat_25519_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_25519_u1 = (!(!arg1));
+  let x1: fiat_25519_u1 = ((((arg1 == 0) as fiat_25519_u1) == 0) as fiat_25519_u1);
   let x2: u64 = ((((((0x0 as fiat_25519_i2) - (x1 as fiat_25519_i2)) as fiat_25519_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/curve25519_scalar_32.rs
+++ b/fiat-rust/src/curve25519_scalar_32.rs
@@ -232,7 +232,7 @@ pub const fn fiat_25519_scalar_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u3
 /// ```
 #[inline]
 pub const fn fiat_25519_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_25519_scalar_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_25519_scalar_u1 = (!(!arg1));
+  let x1: fiat_25519_scalar_u1 = ((((arg1 == 0) as fiat_25519_scalar_u1) == 0) as fiat_25519_scalar_u1);
   let x2: u32 = ((((((0x0 as fiat_25519_scalar_i2) - (x1 as fiat_25519_scalar_i2)) as fiat_25519_scalar_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/curve25519_scalar_64.rs
+++ b/fiat-rust/src/curve25519_scalar_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_25519_scalar_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u6
 /// ```
 #[inline]
 pub const fn fiat_25519_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_25519_scalar_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_25519_scalar_u1 = (!(!arg1));
+  let x1: fiat_25519_scalar_u1 = ((((arg1 == 0) as fiat_25519_scalar_u1) == 0) as fiat_25519_scalar_u1);
   let x2: u64 = ((((((0x0 as fiat_25519_scalar_i2) - (x1 as fiat_25519_scalar_i2)) as fiat_25519_scalar_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/curve25519_solinas_64.rs
+++ b/fiat-rust/src/curve25519_solinas_64.rs
@@ -144,7 +144,7 @@ pub const fn fiat_curve25519_solinas_mulx_u64(out1: &mut u64, out2: &mut u64, ar
 /// ```
 #[inline]
 pub const fn fiat_curve25519_solinas_cmovznz_u64(out1: &mut u64, arg1: fiat_curve25519_solinas_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_curve25519_solinas_u1 = (!(!arg1));
+  let x1: fiat_curve25519_solinas_u1 = ((((arg1 == 0) as fiat_curve25519_solinas_u1) == 0) as fiat_curve25519_solinas_u1);
   let x2: u64 = ((((((0x0 as fiat_curve25519_solinas_i2) - (x1 as fiat_curve25519_solinas_i2)) as fiat_curve25519_solinas_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p224_32.rs
+++ b/fiat-rust/src/p224_32.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p224_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2:
 /// ```
 #[inline]
 pub const fn fiat_p224_cmovznz_u32(out1: &mut u32, arg1: fiat_p224_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_p224_u1 = (!(!arg1));
+  let x1: fiat_p224_u1 = ((((arg1 == 0) as fiat_p224_u1) == 0) as fiat_p224_u1);
   let x2: u32 = ((((((0x0 as fiat_p224_i2) - (x1 as fiat_p224_i2)) as fiat_p224_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p224_64.rs
+++ b/fiat-rust/src/p224_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p224_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2:
 /// ```
 #[inline]
 pub const fn fiat_p224_cmovznz_u64(out1: &mut u64, arg1: fiat_p224_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_p224_u1 = (!(!arg1));
+  let x1: fiat_p224_u1 = ((((arg1 == 0) as fiat_p224_u1) == 0) as fiat_p224_u1);
   let x2: u64 = ((((((0x0 as fiat_p224_i2) - (x1 as fiat_p224_i2)) as fiat_p224_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p256_32.rs
+++ b/fiat-rust/src/p256_32.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p256_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2:
 /// ```
 #[inline]
 pub const fn fiat_p256_cmovznz_u32(out1: &mut u32, arg1: fiat_p256_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_p256_u1 = (!(!arg1));
+  let x1: fiat_p256_u1 = ((((arg1 == 0) as fiat_p256_u1) == 0) as fiat_p256_u1);
   let x2: u32 = ((((((0x0 as fiat_p256_i2) - (x1 as fiat_p256_i2)) as fiat_p256_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p256_64.rs
+++ b/fiat-rust/src/p256_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p256_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2:
 /// ```
 #[inline]
 pub const fn fiat_p256_cmovznz_u64(out1: &mut u64, arg1: fiat_p256_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_p256_u1 = (!(!arg1));
+  let x1: fiat_p256_u1 = ((((arg1 == 0) as fiat_p256_u1) == 0) as fiat_p256_u1);
   let x2: u64 = ((((((0x0 as fiat_p256_i2) - (x1 as fiat_p256_i2)) as fiat_p256_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p256_scalar_32.rs
+++ b/fiat-rust/src/p256_scalar_32.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p256_scalar_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32
 /// ```
 #[inline]
 pub const fn fiat_p256_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_p256_scalar_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_p256_scalar_u1 = (!(!arg1));
+  let x1: fiat_p256_scalar_u1 = ((((arg1 == 0) as fiat_p256_scalar_u1) == 0) as fiat_p256_scalar_u1);
   let x2: u32 = ((((((0x0 as fiat_p256_scalar_i2) - (x1 as fiat_p256_scalar_i2)) as fiat_p256_scalar_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p256_scalar_64.rs
+++ b/fiat-rust/src/p256_scalar_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p256_scalar_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64
 /// ```
 #[inline]
 pub const fn fiat_p256_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_p256_scalar_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_p256_scalar_u1 = (!(!arg1));
+  let x1: fiat_p256_scalar_u1 = ((((arg1 == 0) as fiat_p256_scalar_u1) == 0) as fiat_p256_scalar_u1);
   let x2: u64 = ((((((0x0 as fiat_p256_scalar_i2) - (x1 as fiat_p256_scalar_i2)) as fiat_p256_scalar_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p384_32.rs
+++ b/fiat-rust/src/p384_32.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p384_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2:
 /// ```
 #[inline]
 pub const fn fiat_p384_cmovznz_u32(out1: &mut u32, arg1: fiat_p384_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_p384_u1 = (!(!arg1));
+  let x1: fiat_p384_u1 = ((((arg1 == 0) as fiat_p384_u1) == 0) as fiat_p384_u1);
   let x2: u32 = ((((((0x0 as fiat_p384_i2) - (x1 as fiat_p384_i2)) as fiat_p384_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p384_64.rs
+++ b/fiat-rust/src/p384_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p384_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2:
 /// ```
 #[inline]
 pub const fn fiat_p384_cmovznz_u64(out1: &mut u64, arg1: fiat_p384_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_p384_u1 = (!(!arg1));
+  let x1: fiat_p384_u1 = ((((arg1 == 0) as fiat_p384_u1) == 0) as fiat_p384_u1);
   let x2: u64 = ((((((0x0 as fiat_p384_i2) - (x1 as fiat_p384_i2)) as fiat_p384_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p384_scalar_32.rs
+++ b/fiat-rust/src/p384_scalar_32.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p384_scalar_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32
 /// ```
 #[inline]
 pub const fn fiat_p384_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_p384_scalar_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_p384_scalar_u1 = (!(!arg1));
+  let x1: fiat_p384_scalar_u1 = ((((arg1 == 0) as fiat_p384_scalar_u1) == 0) as fiat_p384_scalar_u1);
   let x2: u32 = ((((((0x0 as fiat_p384_scalar_i2) - (x1 as fiat_p384_scalar_i2)) as fiat_p384_scalar_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p384_scalar_64.rs
+++ b/fiat-rust/src/p384_scalar_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p384_scalar_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64
 /// ```
 #[inline]
 pub const fn fiat_p384_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_p384_scalar_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_p384_scalar_u1 = (!(!arg1));
+  let x1: fiat_p384_scalar_u1 = ((((arg1 == 0) as fiat_p384_scalar_u1) == 0) as fiat_p384_scalar_u1);
   let x2: u64 = ((((((0x0 as fiat_p384_scalar_i2) - (x1 as fiat_p384_scalar_i2)) as fiat_p384_scalar_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p434_64.rs
+++ b/fiat-rust/src/p434_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p434_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2:
 /// ```
 #[inline]
 pub const fn fiat_p434_cmovznz_u64(out1: &mut u64, arg1: fiat_p434_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_p434_u1 = (!(!arg1));
+  let x1: fiat_p434_u1 = ((((arg1 == 0) as fiat_p434_u1) == 0) as fiat_p434_u1);
   let x2: u64 = ((((((0x0 as fiat_p434_i2) - (x1 as fiat_p434_i2)) as fiat_p434_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p448_solinas_32.rs
+++ b/fiat-rust/src/p448_solinas_32.rs
@@ -200,7 +200,7 @@ pub const fn fiat_p448_subborrowx_u28(out1: &mut u32, out2: &mut fiat_p448_u1, a
 /// ```
 #[inline]
 pub const fn fiat_p448_cmovznz_u32(out1: &mut u32, arg1: fiat_p448_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_p448_u1 = (!(!arg1));
+  let x1: fiat_p448_u1 = ((((arg1 == 0) as fiat_p448_u1) == 0) as fiat_p448_u1);
   let x2: u32 = ((((((0x0 as fiat_p448_i2) - (x1 as fiat_p448_i2)) as fiat_p448_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p448_solinas_64.rs
+++ b/fiat-rust/src/p448_solinas_64.rs
@@ -200,7 +200,7 @@ pub const fn fiat_p448_subborrowx_u56(out1: &mut u64, out2: &mut fiat_p448_u1, a
 /// ```
 #[inline]
 pub const fn fiat_p448_cmovznz_u64(out1: &mut u64, arg1: fiat_p448_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_p448_u1 = (!(!arg1));
+  let x1: fiat_p448_u1 = ((((arg1 == 0) as fiat_p448_u1) == 0) as fiat_p448_u1);
   let x2: u64 = ((((((0x0 as fiat_p448_i2) - (x1 as fiat_p448_i2)) as fiat_p448_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p521_32.rs
+++ b/fiat-rust/src/p521_32.rs
@@ -256,7 +256,7 @@ pub const fn fiat_p521_subborrowx_u27(out1: &mut u32, out2: &mut fiat_p521_u1, a
 /// ```
 #[inline]
 pub const fn fiat_p521_cmovznz_u32(out1: &mut u32, arg1: fiat_p521_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_p521_u1 = (!(!arg1));
+  let x1: fiat_p521_u1 = ((((arg1 == 0) as fiat_p521_u1) == 0) as fiat_p521_u1);
   let x2: u32 = ((((((0x0 as fiat_p521_i2) - (x1 as fiat_p521_i2)) as fiat_p521_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p521_64.rs
+++ b/fiat-rust/src/p521_64.rs
@@ -256,7 +256,7 @@ pub const fn fiat_p521_subborrowx_u57(out1: &mut u64, out2: &mut fiat_p521_u1, a
 /// ```
 #[inline]
 pub const fn fiat_p521_cmovznz_u64(out1: &mut u64, arg1: fiat_p521_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_p521_u1 = (!(!arg1));
+  let x1: fiat_p521_u1 = ((((arg1 == 0) as fiat_p521_u1) == 0) as fiat_p521_u1);
   let x2: u64 = ((((((0x0 as fiat_p521_i2) - (x1 as fiat_p521_i2)) as fiat_p521_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/poly1305_32.rs
+++ b/fiat-rust/src/poly1305_32.rs
@@ -200,7 +200,7 @@ pub const fn fiat_poly1305_subborrowx_u26(out1: &mut u32, out2: &mut fiat_poly13
 /// ```
 #[inline]
 pub const fn fiat_poly1305_cmovznz_u32(out1: &mut u32, arg1: fiat_poly1305_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_poly1305_u1 = (!(!arg1));
+  let x1: fiat_poly1305_u1 = ((((arg1 == 0) as fiat_poly1305_u1) == 0) as fiat_poly1305_u1);
   let x2: u32 = ((((((0x0 as fiat_poly1305_i2) - (x1 as fiat_poly1305_i2)) as fiat_poly1305_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/poly1305_64.rs
+++ b/fiat-rust/src/poly1305_64.rs
@@ -256,7 +256,7 @@ pub const fn fiat_poly1305_subborrowx_u43(out1: &mut u64, out2: &mut fiat_poly13
 /// ```
 #[inline]
 pub const fn fiat_poly1305_cmovznz_u64(out1: &mut u64, arg1: fiat_poly1305_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_poly1305_u1 = (!(!arg1));
+  let x1: fiat_poly1305_u1 = ((((arg1 == 0) as fiat_poly1305_u1) == 0) as fiat_poly1305_u1);
   let x2: u64 = ((((((0x0 as fiat_poly1305_i2) - (x1 as fiat_poly1305_i2)) as fiat_poly1305_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/secp256k1_montgomery_32.rs
+++ b/fiat-rust/src/secp256k1_montgomery_32.rs
@@ -232,7 +232,7 @@ pub const fn fiat_secp256k1_montgomery_mulx_u32(out1: &mut u32, out2: &mut u32, 
 /// ```
 #[inline]
 pub const fn fiat_secp256k1_montgomery_cmovznz_u32(out1: &mut u32, arg1: fiat_secp256k1_montgomery_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_secp256k1_montgomery_u1 = (!(!arg1));
+  let x1: fiat_secp256k1_montgomery_u1 = ((((arg1 == 0) as fiat_secp256k1_montgomery_u1) == 0) as fiat_secp256k1_montgomery_u1);
   let x2: u32 = ((((((0x0 as fiat_secp256k1_montgomery_i2) - (x1 as fiat_secp256k1_montgomery_i2)) as fiat_secp256k1_montgomery_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/secp256k1_montgomery_64.rs
+++ b/fiat-rust/src/secp256k1_montgomery_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_secp256k1_montgomery_mulx_u64(out1: &mut u64, out2: &mut u64, 
 /// ```
 #[inline]
 pub const fn fiat_secp256k1_montgomery_cmovznz_u64(out1: &mut u64, arg1: fiat_secp256k1_montgomery_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_secp256k1_montgomery_u1 = (!(!arg1));
+  let x1: fiat_secp256k1_montgomery_u1 = ((((arg1 == 0) as fiat_secp256k1_montgomery_u1) == 0) as fiat_secp256k1_montgomery_u1);
   let x2: u64 = ((((((0x0 as fiat_secp256k1_montgomery_i2) - (x1 as fiat_secp256k1_montgomery_i2)) as fiat_secp256k1_montgomery_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/secp256k1_montgomery_scalar_32.rs
+++ b/fiat-rust/src/secp256k1_montgomery_scalar_32.rs
@@ -232,7 +232,7 @@ pub const fn fiat_secp256k1_montgomery_scalar_mulx_u32(out1: &mut u32, out2: &mu
 /// ```
 #[inline]
 pub const fn fiat_secp256k1_montgomery_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_secp256k1_montgomery_scalar_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_secp256k1_montgomery_scalar_u1 = (!(!arg1));
+  let x1: fiat_secp256k1_montgomery_scalar_u1 = ((((arg1 == 0) as fiat_secp256k1_montgomery_scalar_u1) == 0) as fiat_secp256k1_montgomery_scalar_u1);
   let x2: u32 = ((((((0x0 as fiat_secp256k1_montgomery_scalar_i2) - (x1 as fiat_secp256k1_montgomery_scalar_i2)) as fiat_secp256k1_montgomery_scalar_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/secp256k1_montgomery_scalar_64.rs
+++ b/fiat-rust/src/secp256k1_montgomery_scalar_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_secp256k1_montgomery_scalar_mulx_u64(out1: &mut u64, out2: &mu
 /// ```
 #[inline]
 pub const fn fiat_secp256k1_montgomery_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_secp256k1_montgomery_scalar_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_secp256k1_montgomery_scalar_u1 = (!(!arg1));
+  let x1: fiat_secp256k1_montgomery_scalar_u1 = ((((arg1 == 0) as fiat_secp256k1_montgomery_scalar_u1) == 0) as fiat_secp256k1_montgomery_scalar_u1);
   let x2: u64 = ((((((0x0 as fiat_secp256k1_montgomery_scalar_i2) - (x1 as fiat_secp256k1_montgomery_scalar_i2)) as fiat_secp256k1_montgomery_scalar_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/sm2_32.rs
+++ b/fiat-rust/src/sm2_32.rs
@@ -232,7 +232,7 @@ pub const fn fiat_sm2_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: 
 /// ```
 #[inline]
 pub const fn fiat_sm2_cmovznz_u32(out1: &mut u32, arg1: fiat_sm2_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_sm2_u1 = (!(!arg1));
+  let x1: fiat_sm2_u1 = ((((arg1 == 0) as fiat_sm2_u1) == 0) as fiat_sm2_u1);
   let x2: u32 = ((((((0x0 as fiat_sm2_i2) - (x1 as fiat_sm2_i2)) as fiat_sm2_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/sm2_64.rs
+++ b/fiat-rust/src/sm2_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_sm2_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: 
 /// ```
 #[inline]
 pub const fn fiat_sm2_cmovznz_u64(out1: &mut u64, arg1: fiat_sm2_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_sm2_u1 = (!(!arg1));
+  let x1: fiat_sm2_u1 = ((((arg1 == 0) as fiat_sm2_u1) == 0) as fiat_sm2_u1);
   let x2: u64 = ((((((0x0 as fiat_sm2_i2) - (x1 as fiat_sm2_i2)) as fiat_sm2_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/sm2_scalar_32.rs
+++ b/fiat-rust/src/sm2_scalar_32.rs
@@ -232,7 +232,7 @@ pub const fn fiat_sm2_scalar_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32,
 /// ```
 #[inline]
 pub const fn fiat_sm2_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_sm2_scalar_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_sm2_scalar_u1 = (!(!arg1));
+  let x1: fiat_sm2_scalar_u1 = ((((arg1 == 0) as fiat_sm2_scalar_u1) == 0) as fiat_sm2_scalar_u1);
   let x2: u32 = ((((((0x0 as fiat_sm2_scalar_i2) - (x1 as fiat_sm2_scalar_i2)) as fiat_sm2_scalar_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/sm2_scalar_64.rs
+++ b/fiat-rust/src/sm2_scalar_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_sm2_scalar_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64,
 /// ```
 #[inline]
 pub const fn fiat_sm2_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_sm2_scalar_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_sm2_scalar_u1 = (!(!arg1));
+  let x1: fiat_sm2_scalar_u1 = ((((arg1 == 0) as fiat_sm2_scalar_u1) == 0) as fiat_sm2_scalar_u1);
   let x2: u64 = ((((((0x0 as fiat_sm2_scalar_i2) - (x1 as fiat_sm2_scalar_i2)) as fiat_sm2_scalar_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-zig/src/curve25519_32.zig
+++ b/fiat-zig/src/curve25519_32.zig
@@ -142,7 +142,7 @@ inline fn subborrowxU25(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) v
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/curve25519_64.zig
+++ b/fiat-zig/src/curve25519_64.zig
@@ -96,7 +96,7 @@ inline fn subborrowxU51(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) v
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/curve25519_scalar_32.zig
+++ b/fiat-zig/src/curve25519_scalar_32.zig
@@ -123,7 +123,7 @@ inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/curve25519_scalar_64.zig
+++ b/fiat-zig/src/curve25519_scalar_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/curve25519_solinas_64.zig
+++ b/fiat-zig/src/curve25519_solinas_64.zig
@@ -105,7 +105,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p224_32.zig
+++ b/fiat-zig/src/p224_32.zig
@@ -123,7 +123,7 @@ inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p224_64.zig
+++ b/fiat-zig/src/p224_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p256_32.zig
+++ b/fiat-zig/src/p256_32.zig
@@ -123,7 +123,7 @@ inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p256_64.zig
+++ b/fiat-zig/src/p256_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p256_scalar_32.zig
+++ b/fiat-zig/src/p256_scalar_32.zig
@@ -123,7 +123,7 @@ inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p256_scalar_64.zig
+++ b/fiat-zig/src/p256_scalar_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p384_32.zig
+++ b/fiat-zig/src/p384_32.zig
@@ -123,7 +123,7 @@ inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p384_64.zig
+++ b/fiat-zig/src/p384_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p384_scalar_32.zig
+++ b/fiat-zig/src/p384_scalar_32.zig
@@ -123,7 +123,7 @@ inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p384_scalar_64.zig
+++ b/fiat-zig/src/p384_scalar_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p434_64.zig
+++ b/fiat-zig/src/p434_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p448_solinas_32.zig
+++ b/fiat-zig/src/p448_solinas_32.zig
@@ -96,7 +96,7 @@ inline fn subborrowxU28(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) v
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p448_solinas_64.zig
+++ b/fiat-zig/src/p448_solinas_64.zig
@@ -96,7 +96,7 @@ inline fn subborrowxU56(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) v
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p521_32.zig
+++ b/fiat-zig/src/p521_32.zig
@@ -142,7 +142,7 @@ inline fn subborrowxU27(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) v
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p521_64.zig
+++ b/fiat-zig/src/p521_64.zig
@@ -142,7 +142,7 @@ inline fn subborrowxU57(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) v
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/poly1305_32.zig
+++ b/fiat-zig/src/poly1305_32.zig
@@ -96,7 +96,7 @@ inline fn subborrowxU26(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) v
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/poly1305_64.zig
+++ b/fiat-zig/src/poly1305_64.zig
@@ -142,7 +142,7 @@ inline fn subborrowxU43(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) v
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/secp256k1_montgomery_32.zig
+++ b/fiat-zig/src/secp256k1_montgomery_32.zig
@@ -123,7 +123,7 @@ inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/secp256k1_montgomery_64.zig
+++ b/fiat-zig/src/secp256k1_montgomery_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/secp256k1_montgomery_scalar_32.zig
+++ b/fiat-zig/src/secp256k1_montgomery_scalar_32.zig
@@ -123,7 +123,7 @@ inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/secp256k1_montgomery_scalar_64.zig
+++ b/fiat-zig/src/secp256k1_montgomery_scalar_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/sm2_32.zig
+++ b/fiat-zig/src/sm2_32.zig
@@ -123,7 +123,7 @@ inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/sm2_64.zig
+++ b/fiat-zig/src/sm2_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/sm2_scalar_32.zig
+++ b/fiat-zig/src/sm2_scalar_32.zig
@@ -123,7 +123,7 @@ inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/sm2_scalar_64.zig
+++ b/fiat-zig/src/sm2_scalar_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/src/Stringification/IR.v
+++ b/src/Stringification/IR.v
@@ -75,6 +75,12 @@ Module Compilers.
         | Z_shiftl (offset : BinInt.Z)
         (*| Z_opp*)
         | Z_lnot (ty:int.type)
+        (** [Z_bneg] is logical (boolean) negation: it takes its
+            argument to [1] if the argument is [0], and to [0]
+            otherwise.  Its result therefore always fits in a 1-bit
+            type ([_Bool]), whatever the type of the argument.  It is
+            NOT bitwise complement (that is [Z_lnot]); backends must
+            print it as a genuine zero-test (e.g. C's [!]). *)
         | Z_bneg
         | Z_value_barrier (ty:int.type)
         .
@@ -146,6 +152,12 @@ Module Compilers.
                => ident_info_of_cmovznz (IntSet.singleton ty)
              | iunop (Z_value_barrier ty)
                =>ident_info_of_value_barrier (IntSet.singleton ty)
+             | iunop Z_bneg
+               (* the result of logical negation has the 1-bit type
+                  [_Bool]; backends which spell out that type (e.g.
+                  Rust's [as fiat_u1]) need its typedef to be
+                  declared *)
+               => ident_info_of_bitwidths_used (IntSet.singleton _Bool)
              | literal _
              | List_nth _
              | Addr
@@ -458,6 +470,26 @@ Module Compilers.
                     => un_op_casts idc tout t1
                   | None => (tout, None)
                   end.
+          (** [un_op_natural_output_opt] takes in a unary operation
+              and the known type of its (possibly already cast)
+              input, and returns the type that the output is known to
+              fit in if no casts are present.  This is not
+              language-specific: it follows from the semantics of the
+              IR operation. *)
+          Definition un_op_natural_output_opt
+            : Z_unop -> option int.type -> option int.type
+            := fun idc t
+               => match idc with
+                  | Z_bneg
+                    (* logical negation always yields 0 or 1,
+                       regardless of the width of its argument *)
+                    => Some _Bool
+                  | Z_shiftr _
+                  | Z_shiftl _
+                  | Z_lnot _
+                  | Z_value_barrier _
+                    => t
+                  end.
 
           Definition Zcast {always : bool}
             : option int.type -> arith_expr_for_base tZ -> arith_expr_for_base tZ
@@ -607,7 +639,7 @@ Module Compilers.
             : option int.type -> arith_expr_for (type.base s) -> arith_expr_for (type.base d)
             := fun desired_type '(e, t) =>
                  let '(cstout, cst) := un_op_casts_opt idc desired_type t in
-                 let typ := (*un_op_natural_output_opt idc*) Option.or_else cst t in
+                 let typ := un_op_natural_output_opt idc (Option.or_else cst t) in
                  let '(e, t) := Zcast (always:=false) cst (e, t) in
                  Zcast (always:=false) cstout ((idc @@@ e)%Cexpr, typ).
 

--- a/src/Stringification/Rust.v
+++ b/src/Stringification/Rust.v
@@ -249,8 +249,12 @@ Module Rust.
          "(" ++ arith_to_string internal_private prefix x1 ++ " * " ++ arith_to_string internal_private prefix x2 ++ ")"
        | (IR.Z_sub @@@ (x1, x2)) =>
          "(" ++ arith_to_string internal_private prefix x1 ++ " - " ++ arith_to_string internal_private prefix x2 ++ ")"
-       | (IR.Z_bneg @@@ e) => "(!" ++ arith_to_string internal_private prefix e ++ ")" (* logical negation. XXX this has different semantics for numbers <>
-                                                                        0 or 1 than it did before *)
+       (* logical negation: 1 if [e] is zero, else 0.  Rust's [!] on
+          an integer is bitwise complement (that is [IR.Z_lnot]), so
+          we must spell out the zero-test; the result is a 1-bit
+          value, which is what the IR types it as. *)
+       | (IR.Z_bneg @@@ e) =>
+         "((" ++ arith_to_string internal_private prefix e ++ " == 0) as " ++ primitive_type_to_string internal_private prefix IR.type.Z (Some _Bool) ++ ")"
        | (IR.Z_mul_split lg2s @@@ args) =>
          special_name "mulx" lg2s ++ "(" ++ arith_to_string internal_private prefix args ++ ")"
        | (IR.Z_add_with_get_carry lg2s @@@ args) =>
@@ -428,7 +432,10 @@ Module Rust.
               (** always cast to the width of the type, unless we are already exactly that type (which the machinery in IR handles *)
               Some ty)
           | IR.Z_bneg
-            => ((* bneg is !, i.e., takes the argument to 1 if its not zero, and to zero if it is zero; so we don't ever need to cast *)
+            => ((* bneg is logical negation, printed as [(e == 0) as
+                   u1], which yields a value of exactly the 1-bit type
+                   the IR assigns to it, for an argument of any
+                   integer type; so we don't ever need to cast *)
               None, None)
           end.
 

--- a/src/Stringification/Zig.v
+++ b/src/Stringification/Zig.v
@@ -162,7 +162,11 @@ Module Zig.
          "(" ++ arith_to_string internal_private prefix x1 ++ " * " ++ arith_to_string internal_private prefix x2 ++ ")"
        | (IR.Z_sub @@@ (x1, x2)) =>
          "(" ++ arith_to_string internal_private prefix x1 ++ " - " ++ arith_to_string internal_private prefix x2 ++ ")"
-       | (IR.Z_bneg @@@ e) => "(~" ++ arith_to_string internal_private prefix e ++ ")"
+       (* logical negation: 1 if [e] is zero, else 0.  Zig's [~] is
+          bitwise complement (that is [IR.Z_lnot]), so we must spell
+          out the zero-test; [@intFromBool] yields a [u1], which is
+          what the IR types the result as. *)
+       | (IR.Z_bneg @@@ e) => "@intFromBool(" ++ arith_to_string internal_private prefix e ++ " == 0)"
        | (IR.Z_mul_split lg2s @@@ args) =>
          special_name "mulx" lg2s ++ "(" ++ arith_to_string internal_private prefix args ++ ")"
        | (IR.Z_add_with_get_carry lg2s @@@ args) =>
@@ -305,7 +309,11 @@ Module Zig.
               (** always cast to the width of the type, unless we are already exactly that type (which the machinery in IR handles *)
               Some ty)
           | IR.Z_bneg
-            => ((* bneg is !, i.e., takes the argument to 1 if its not zero, and to zero if it is zero; so we don't ever need to cast *)
+            => ((* bneg is logical negation, printed as
+                   [@intFromBool(e == 0)], which yields a value of
+                   exactly the 1-bit type the IR assigns to it, for an
+                   argument of any integer type; so we don't ever
+                   need to cast *)
               None, None)
           end.
 


### PR DESCRIPTION
Fixes scrutineer finding #2525.

## Bug

The IR node `Z_bneg` is logical (boolean) negation: 0 maps to 1, everything else to 0, so the result always fits in a 1-bit type. `C.v` prints it as C's `!`, which is exactly that. `Rust.v` printed it as Rust's `!` (with an `XXX` comment admitting the mismatch) and `Zig.v` printed it as `~`; on integers both are *bitwise complement*, i.e. the meaning of the distinct IR node `Z_lnot`, so Zig printed two different IR operators as the same Zig operator. Both backends also copied C's `(None, None)` cast plan from `un_op_casts`, so no cast compensated for the difference.

It was latent rather than live: the only producer of `Z_bneg` in the shipped configuration is the selector normalisation `Z.bneg (Z.bneg cond)` in `src/Arithmetic/Primitives.v`'s `cmovznz`, always a double negation on an operand whose contract is `[0, 1]`, and on `{0, 1}` the two readings agree. Any single `Z_bneg`, or one on a wider operand, would have silently miscompiled in Rust and Zig while C stayed correct. Even today, an out-of-contract selector such as 2 is normalised to 1 by the C output but passed through unchanged by the Rust output (see the differential below).

## Fix

- `src/Stringification/Rust.v`: print `Z_bneg` as `((e == 0) as <u1 typedef>)`.
- `src/Stringification/Zig.v`: print `Z_bneg` as `@intFromBool(e == 0)` (the Zig files already target a Zig recent enough for `@intFromBool`; verified with zig 0.16.0).
- `src/Stringification/IR.v`: record the natural output type of `Z_bneg` as the 1-bit type `_Bool` via a new `un_op_natural_output_opt` (replacing the commented-out placeholder in `arith_un_arith_expr_of_PHOAS_ident`), instead of pretending the result has the operand's type; and register `_Bool` in `bitwidths_used` for `Z_bneg` so a backend that spells out the type (Rust) always has the typedef declared. Also document the node.
- `C.v`, `JSON.v`, `Go.v`, `Java.v` are unchanged. C's `!` was already right. Go/Java still print their `(!/* TODO: FIX ME */ e)` placeholder, which fails loudly at compile time and is unreachable because those outputs are generated with `--cmovznz-by-mul`.

Both new forms are genuine zero-tests for an operand of any integer type and produce a value of exactly the 1-bit type the IR now assigns, so the `(None, None)` cast plan is correct for them.

Alternatives considered: changing the `cmovznz` lowering to avoid the double negation was rejected because the double negation is deliberate (it normalises an out-of-contract selector) and because it would change the C output. Casting the operand to a 1-bit type so that `~` coincides with logical negation (as the finding suggests as one option) was rejected because a narrowing cast truncates: `~cast(u1, 2)` would be 1, not 0.

## Generated files

`fiat-rust/src/*.rs` (30 files) and `fiat-zig/src/*.zig` (30 files) were regenerated with synthesis binaries rebuilt from this branch. The only change is the one `cmovznz` line per module:

```
- let x1: fiat_p256_u1 = (!(!arg1));
+ let x1: fiat_p256_u1 = ((((arg1 == 0) as fiat_p256_u1) == 0) as fiat_p256_u1);

- const x1 = (~(~arg1));
+ const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
```

Regenerating the C, Go, JSON and Java outputs with the same rebuilt binaries produced no change (bedrock2 outputs were not regenerated; they do not go through `Stringification/IR.v`).

## Verification

- Compiled the affected cone (`IR.v`, `C.v`, `Go.v`, `JSON.v`, `Java.v`, `Rust.v`, `Zig.v`, `CLI.v`, `StandaloneOCamlMain.v`, and the four `ExtractionOCaml/{word_by_word_montgomery,unsaturated_solinas,dettman_multiplication,solinas_reduction}.v`) against the installed library with Rocq 9.4+alpha; all succeeded. `PushButtonSynthesis/*` does not depend on `IR.v`, so it was not recompiled.
- Rebuilt the four OCaml binaries with `ocamlfind ocamlopt -package unix -w -20 -g` as in `Makefile.standalone`, then ran `make -f Makefile.examples -j8 SKIP_BEDROCK2=1 c-files rust-files json-files zig-files go-files java-files`: exit 0, diff limited to the 60 lines above.
- `cargo build` (rustc/cargo 1.97.1) in `fiat-rust`: success. `cargo test`: success (the crate has no unit tests, so this only confirms the test target compiles).
- `zig build` and `zig build test` (zig 0.16.0) in `fiat-zig`: 3/3 steps succeeded, 9/9 tests passed.
- Differential check of `fiat_p256_cmovznz_u64` and `fiat_25519_cmovznz_u32` against the spec `if arg1 == 0 { arg2 } else { arg3 }` for all 256 `u8` selector values: this branch, 0 mismatches. The unmodified crate on `master`: 494 of 512 checks mismatch in release mode, and in debug mode it panics with `attempt to subtract with overflow` (selector 128), because the un-normalised selector reaches the `0 - x1` step.
- Standalone semantic checks of the two printed forms (Rust `((e == 0) as u8)` and Zig `@intFromBool(e == 0)`, single and doubled, on 1-bit and 64-bit operands) against a reference logical negation: all agree.

Not verified: a full `make` of the repository (the affected proof/extraction cone was compiled, but CI should confirm the complete build and the generated-file check), and the Go/Java/bedrock2 pipelines beyond regeneration showing no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Rbn2gww3MGhvrh52fNjpD
