### PR TITLE
Reject data-emitting lines and non-inert directives in checked assembly (scrutineer #2512)

### DIFF
--- a/src/Assembly/Parse.v
+++ b/src/Assembly/Parse.v
@@ -247,6 +247,11 @@ Definition parse_RawLine {opts : assembly_program_options} : ParserAction RawLin
         then [(ASCIZ (unescape_string (String.substring 1 (String.length args - 2) args)), "")]
         else if (s =? "")
         then [(EMPTY, "")]
+        (* N.B. Recognizing a directive here only makes it parse.  Whether
+           it is treated as a no-op inside a function body (rather than
+           rejected) is decided by [Syntax.inert_directive]; keep the two
+           in sync when adding directives, and never add data-emitting
+           ones there. *)
         else if (List.find (String.eqb (String.to_lower mnemonic))
           [".addrsig"
            ; ".addrsig_sym"

--- a/src/Assembly/Symbolic.v
+++ b/src/Assembly/Symbolic.v
@@ -3960,6 +3960,8 @@ Module error.
   | unimplemented_prefix (_:NormalInstruction)
   | unimplemented_instruction (_ : NormalInstruction)
   | unsupported_line (_ : RawLine)
+  | unsupported_directive (_ : string)
+  | data_emitting_line (_ : RawLine)
   | ambiguous_operation_size (_ : NormalInstruction)
   .
 
@@ -4000,6 +4002,12 @@ Module error.
           | unimplemented_instruction n => ["error.unimplemented_instruction " ++ show n]
           | unimplemented_prefix n => ["error.unimplemented_prefix " ++ show n]
           | unsupported_line n => ["error.unsupported_line " ++ show n]
+          | unsupported_directive d
+            => ["error.unsupported_directive " ++ d;
+                "Only assembler directives that are known not to change the emitted machine code (see Crypto.Assembly.Syntax.inert_directive) are allowed inside a function being checked."]
+          | data_emitting_line n
+            => ["error.data_emitting_line " ++ show n;
+                "Lines that emit raw bytes (.ascii, .asciz, .byte, ...) are not allowed inside a function being checked, because the assembler would place those bytes in the instruction stream where they would execute as instructions that the checker did not model."]
           | ambiguous_operation_size n => ["error.ambiguous_operation_size " ++ show n]
           end%string.
   Global Instance Show_error : Show error := _.
@@ -4393,13 +4401,22 @@ Definition SymexNormalInstruction {opts : symbolic_options_computed_opt} {descr:
   | Some prefix => err (error.unimplemented_prefix instr) end
   | None => err (error.ambiguous_operation_size instr) end%N%x86symex.
 
+(** Every line that reaches the symbolic executor is part of the
+    machine code that will be emitted (and certified) verbatim, so
+    anything we do not model must be rejected rather than skipped.  In
+    particular, [ASCII_] lines and non-inert [DIRECTIVE]s can inject
+    arbitrary bytes into the instruction stream. *)
 Definition SymexRawLine {opts : symbolic_options_computed_opt} {descr:description} (rawline : RawLine) : M unit :=
   match rawline with
   | EMPTY
   | LABEL _
-  | DIRECTIVE _
-  | ASCII_ _ _
     => ret tt
+  | DIRECTIVE d
+    => if inert_directive d
+       then ret tt
+       else err (error.unsupported_directive d)
+  | ASCII_ _ _
+    => err (error.data_emitting_line rawline)
   | INSTR instr
     => SymexNormalInstruction instr
   | SECTION _

--- a/src/Assembly/SymbolicTests.v
+++ b/src/Assembly/SymbolicTests.v
@@ -1,0 +1,121 @@
+(** Regression tests for the treatment of non-instruction lines by the
+    symbolic executor (see scrutineer finding #2512).
+
+    Every line inside a function body that is accepted by the
+    equivalence checker is emitted verbatim as certified machine
+    code, so lines that can carry arbitrary bytes ([.ascii], [.asciz],
+    [.byte], ...) or otherwise change the emitted code must be
+    rejected rather than silently skipped. *)
+From Coq Require Import NArith.
+From Coq Require Import String.
+From Coq Require Import List.
+Require Import Crypto.Util.ErrorT.
+Require Import Crypto.Util.Strings.Show.
+Require Import Crypto.Assembly.Syntax.
+Require Import Crypto.Assembly.Parse.
+Require Import Crypto.Assembly.Symbolic.
+Require Import Crypto.Assembly.Equivalence.
+Import ListNotations.
+Local Open Scope string_scope.
+Local Open Scope list_scope.
+
+(** ** [inert_directive] *)
+
+Definition inert_directive_cases : list (string * bool)
+  := [(* inert regardless of arguments *)
+      (".cfi_startproc", true); (".cfi_def_cfa_offset 16", true); (".cfi_offset 6, -16", true)
+      ; (".cfi_def_cfa_register 6", true); (".cfi_def_cfa 7, 8", true); (".CFI_ENDPROC", true)
+      ; (".loc 1 12 3", true); (".loc", true); (".file ""x.c""", true); (".file 1 ""x.c""", true)
+      ; (".ident ""GCC: (GNU) 14.1.0""", true); (".size f, .-f", true); (".addrsig", true); (".addrsig_sym f", true)
+      (* inert only for some argument forms *)
+      ; (".text", true); (".text 1", false)
+      ; (".intel_syntax noprefix", true); (".intel_syntax", false); (".intel_syntax prefix", false)
+      ; (".type f, @function", true); (".type f,%function", true); (".type f, ""function""", true)
+      ; (".type f, STT_FUNC", true); (".type f, @object", true)
+      ; (".type f, @gnu_indirect_function", false); (".type f, @tls_object", false); (".type f", false)
+      ; (".p2align 4", true); (".p2align 4,", true); (".p2align 4,,10", true)
+      ; (".p2align 4, 0x90", false); (".p2align 4, 0xcc, 10", false)
+      (* never inert: these emit bytes or move code *)
+      ; (".byte 1", false); (".ascii ""x""", false); (".asciz ""x""", false); (".string ""x""", false)
+      ; (".fill 1,1,0xc3", false); (".zero 4", false); (".skip 4", false); (".space 4", false)
+      ; (".incbin ""x""", false); (".octa 1", false); (".quad 1", false); (".float 1.0", false); (".double 1.0", false)
+      ; (".section .text", false); (".globl f", false); (".align 4", false); (".balign 4", false); ("", false)].
+
+Definition inert_directive_failures
+  := List.filter (fun '(d, expected) => negb (Bool.eqb (inert_directive d) expected)) inert_directive_cases.
+
+Goal inert_directive_failures = []. Proof. vm_compute. reflexivity. Qed.
+
+(** ** Parsing of data lines *)
+
+(** The parser decodes [\xNN] escapes, so any byte sequence can be
+    written as an [.ascii] string. *)
+Definition mov_eax_deadbeef : string := string_of_list_ascii (List.map Ascii.ascii_of_nat [0xb8; 0xef; 0xbe; 0xad; 0xde]).
+Goal parse [".ascii ""\xb8\xef\xbe\xad\xde"""]
+     = Success [{| indent := ""; rawline := ASCII mov_eax_deadbeef
+                 ; pre_comment_whitespace := ""; comment := None; line_number := 1%N |}].
+Proof. vm_compute. reflexivity. Qed.
+
+(** ** Symbolic execution of non-instruction lines *)
+
+Local Instance test_symbolic_options : symbolic_options_computed_opt
+  := {| asm_rewriting_passes := @default_rewriting_passes default_rewrite_pass_order (fun _ => true)
+      ; asm_debug_symex_asm_first_computed := false
+      ; asm_node_reveal_depth_computed := default_node_reveal_depth |}.
+
+Definition symex_lines (ls : list string) : ErrorT (list string) (Symbolic.error + unit)
+  := match parse ls with
+     | Error e => Error e
+     | Success ls
+       => match SymexLines ls (init_symbolic_state dag.empty) with
+          | Success (v, _) => Success (inr v)
+          | Error (e, _) => Success (inl e)
+          end
+     end.
+
+Definition is_success {A B} (v : ErrorT A (B + unit)) : bool
+  := match v with Success (inr tt) => true | _ => false end.
+
+(** A straight-line, register-only function body (the trailing [ret]
+    is stripped by [strip_ret] before symbolic execution, so it is
+    omitted here). *)
+Definition body_prefix := ["fiat_test:"; "mov rax, rsi"].
+Definition body_suffix := ["add rax, rdi"].
+Definition with_line (l : list string) := body_prefix ++ l ++ body_suffix.
+
+(** Inert lines are fine. *)
+Goal is_success (symex_lines (with_line [])) = true. Proof. vm_compute. reflexivity. Qed.
+Goal is_success (symex_lines (with_line [".cfi_startproc"; ".cfi_def_cfa_offset 16"; ".loc 1 2 3"; "; a comment"; ""; ".Ltmp0:"; ".p2align 4,,10"])) = true.
+Proof. vm_compute. reflexivity. Qed.
+
+(** Data-emitting lines must be rejected: the assembler would place
+    these bytes in the instruction stream (here they encode
+    [mov eax, 0xdeadbeef]). *)
+Goal symex_lines (with_line [".ascii ""\xb8\xef\xbe\xad\xde"""])
+     = Success (inl (error.data_emitting_line (ASCII mov_eax_deadbeef))).
+Proof. vm_compute. reflexivity. Qed.
+Goal is_success (symex_lines (with_line [".asciz ""\xb8\xef\xbe\xad\xde"""])) = false. Proof. vm_compute. reflexivity. Qed.
+Goal is_success (symex_lines (with_line [".byte 0xb8, 0xef, 0xbe, 0xad, 0xde"])) = false. Proof. vm_compute. reflexivity. Qed.
+Goal is_success (symex_lines (with_line [".quad 0xdeadbeef"])) = false. Proof. vm_compute. reflexivity. Qed.
+
+(** Directives that can change the emitted code must be rejected. *)
+Goal symex_lines (with_line [".p2align 4, 0xc3"]) = Success (inl (error.unsupported_directive ".p2align 4, 0xc3")).
+Proof. vm_compute. reflexivity. Qed.
+Goal is_success (symex_lines (with_line [".text 1"])) = false. Proof. vm_compute. reflexivity. Qed.
+Goal is_success (symex_lines (with_line [".type fiat_test, @gnu_indirect_function"])) = false. Proof. vm_compute. reflexivity. Qed.
+Goal is_success (symex_lines (with_line [".intel_syntax prefix"])) = false. Proof. vm_compute. reflexivity. Qed.
+Goal is_success (symex_lines (with_line ["ALIGN 16"])) = false. Proof. vm_compute. reflexivity. Qed.
+Goal is_success (symex_lines (with_line ["SECTION .data"])) = false. Proof. vm_compute. reflexivity. Qed.
+
+(** Directives the parser does not know about are already rejected at
+    parse time. *)
+Goal match parse (with_line [".fill 16, 1, 0xc3"]) with Error _ => true | Success _ => false end = true.
+Proof. vm_compute. reflexivity. Qed.
+Goal match parse (with_line [".incbin ""payload.bin"""]) with Error _ => true | Success _ => false end = true.
+Proof. vm_compute. reflexivity. Qed.
+
+(** The error messages are displayed. *)
+Goal show_lines (error.data_emitting_line (ASCII "abc"))
+     = ["error.data_emitting_line .ascii ""abc""";
+        "Lines that emit raw bytes (.ascii, .asciz, .byte, ...) are not allowed inside a function being checked, because the assembler would place those bytes in the instruction stream where they would execute as instructions that the checker did not model."].
+Proof. vm_compute. reflexivity. Qed.

--- a/src/Assembly/SymbolicTests.v
+++ b/src/Assembly/SymbolicTests.v
@@ -11,6 +11,7 @@ From Coq Require Import String.
 From Coq Require Import List.
 Require Import Crypto.Util.ErrorT.
 Require Import Crypto.Util.Strings.Show.
+Require Import Crypto.Util.Tactics.BreakMatch.
 Require Import Crypto.Assembly.Syntax.
 Require Import Crypto.Assembly.Parse.
 Require Import Crypto.Assembly.Symbolic.
@@ -119,3 +120,16 @@ Goal show_lines (error.data_emitting_line (ASCII "abc"))
      = ["error.data_emitting_line .ascii ""abc""";
         "Lines that emit raw bytes (.ascii, .asciz, .byte, ...) are not allowed inside a function being checked, because the assembler would place those bytes in the instruction stream where they would execute as instructions that the checker did not model."].
 Proof. vm_compute. reflexivity. Qed.
+
+(** ** Universal statements about [SymexRawLine] itself *)
+
+Lemma SymexRawLine_ASCII_ {opts : symbolic_options_computed_opt} {descr : description} nul s st
+  : SymexRawLine (ASCII_ nul s) st = Error (error.data_emitting_line (ASCII_ nul s), st).
+Proof. reflexivity. Qed.
+
+Lemma SymexRawLine_DIRECTIVE {opts : symbolic_options_computed_opt} {descr : description} d st
+  : SymexRawLine (DIRECTIVE d) st
+    = if inert_directive d
+      then Success (tt, st)
+      else Error (error.unsupported_directive d, st).
+Proof. cbv [SymexRawLine ret err]; break_innermost_match; reflexivity. Qed.

--- a/src/Assembly/Syntax.v
+++ b/src/Assembly/Syntax.v
@@ -1,5 +1,6 @@
 From Coq Require Import ZArith.
 From Coq Require Import NArith.
+From Coq Require Import Ascii.
 From Coq Require Import String.
 From Coq Require Import List.
 From Coq Require Import Derive.
@@ -10,6 +11,8 @@ Require Import Crypto.Util.Listable.
 Require Import Crypto.Util.ListUtil.
 Require Crypto.Util.Tuple.
 Require Crypto.Util.OptionList.
+Require Import Crypto.Util.Strings.String.
+Require Crypto.Util.Strings.Ascii.
 Import ListNotations.
 
 Local Open Scope list_scope.
@@ -288,6 +291,97 @@ Notation ASCIZ := (ASCII_ true).
 Coercion INSTR : NormalInstruction >-> RawLine.
 Record Line := { indent : string ; rawline :> RawLine ; pre_comment_whitespace : string ; comment : option string ; line_number : N}.
 Definition Lines := list Line.
+
+(** ** Inert assembler directives
+
+    A [DIRECTIVE] line is an assembler directive that the parser
+    recognizes but does not otherwise interpret.  The symbolic
+    executor ([Crypto.Assembly.Symbolic.SymexRawLine]) and the
+    concrete semantics ([Crypto.Assembly.WithBedrock.Semantics.DenoteRawLine])
+    treat a directive inside a function body as a no-op if and only if
+    [inert_directive] returns [true] on it; every other directive is
+    rejected (fail closed).
+
+    Only directives that provably cannot change the machine code
+    emitted for the surrounding instructions belong here: CFI unwind
+    information, debug line information, symbol metadata, and the
+    like.  Directives that emit bytes into the current section
+    ([.byte], [.ascii], [.asciz], [.fill], [.zero], [.incbin], ...)
+    must never be listed, because inside a function body those bytes
+    are placed in the instruction stream and executed as instructions
+    that the checker never saw.  Some otherwise-harmless directives
+    are inert only for certain argument forms; those are checked
+    explicitly below:
+
+    - [.p2align n[, fill[, max]]] pads code sections with no-ops when
+      no fill value is given, but inserts copies of [fill] otherwise.
+    - [.intel_syntax prefix] would change how every subsequent operand
+      is assembled relative to what the parser assumed.
+    - [.text subsection] moves the following instructions into another
+      subsection, i.e. out of the fall-through path.
+    - [.type sym, @gnu_indirect_function] turns the function into an
+      IFUNC resolver whose return value is called instead. *)
+
+(** Split a directive line into its lower-cased mnemonic and its
+    (trimmed) arguments. *)
+Definition directive_mnemonic_and_args (d : string) : string * string
+  := let '(mnemonic, args) := String.take_while_drop_while (fun c0 => negb (Ascii.is_whitespace c0)) (String.trim d) in
+     (String.to_lower mnemonic, String.trim args).
+
+(** Directives that are inert regardless of their arguments. *)
+Definition inert_directives_with_any_args : list string
+  := [".addrsig"
+      ; ".addrsig_sym"
+      ; ".cfi_def_cfa"
+      ; ".cfi_def_cfa_offset"
+      ; ".cfi_def_cfa_register"
+      ; ".cfi_endproc"
+      ; ".cfi_offset"
+      ; ".cfi_startproc"
+      ; ".file"
+      ; ".ident"
+      ; ".loc"
+      ; ".size"
+     ]%string.
+
+(** Symbol types accepted in [.type sym, <type>].  GAS accepts the
+    type with a [@], [%], or [#] prefix, in double quotes, or bare. *)
+Definition inert_symbol_types : list string
+  := ["function"; "stt_func"; "object"; "stt_object"; "notype"; "stt_notype"]%string.
+
+Definition strip_symbol_type_decoration (ty : string) : string
+  := let ty := String.trim ty in
+     let ty := match ty with
+               | String c0 rest
+                 => if (Ascii.eqb c0 "@" || Ascii.eqb c0 "%" || Ascii.eqb c0 "#")%bool
+                    then rest
+                    else ty
+               | EmptyString => ty
+               end in
+     if (String.startswith """" ty && String.endswith """" ty && (2 <=? String.length ty)%nat)%bool
+     then String.substring 1 (String.length ty - 2) ty
+     else ty.
+
+Definition inert_directive (d : string) : bool
+  := let '(mnemonic, args) := directive_mnemonic_and_args d in
+     let fields := List.map String.trim (String.split "," args) in
+     if List.existsb (String.eqb mnemonic) inert_directives_with_any_args
+     then true
+     else if (mnemonic =? ".text")%string
+     then (args =? EmptyString)%string
+     else if (mnemonic =? ".intel_syntax")%string
+     then (String.to_lower args =? "noprefix")%string
+     else if (mnemonic =? ".type")%string
+     then match fields with
+          | [_; ty] => List.existsb (String.eqb (String.to_lower (strip_symbol_type_decoration ty))) inert_symbol_types
+          | _ => false
+          end
+     else if (mnemonic =? ".p2align")%string
+     then match fields with
+          | [_] | [_; EmptyString] | [_; EmptyString; _] => true
+          | _ => false
+          end
+     else false.
 
 Definition reg_size (r : REG) : N :=
       match r with

--- a/src/Assembly/WithBedrock/Semantics.v
+++ b/src/Assembly/WithBedrock/Semantics.v
@@ -469,13 +469,18 @@ Definition DenoteNormalInstruction (st : machine_state) (instr : NormalInstructi
  end | _ => None end | _ => None end%Z%option.
 
 
+(** This must agree with [Crypto.Assembly.Symbolic.SymexRawLine]:
+    only inert directives are no-ops; data-emitting lines ([ASCII_])
+    and everything else we do not model are undefined ([None]). *)
 Definition DenoteRawLine (st : machine_state) (rawline : RawLine) : option machine_state :=
   match rawline with
   | EMPTY
   | LABEL _
-  | DIRECTIVE _
-  | ASCII_ _ _
     => Some st
+  | DIRECTIVE d
+    => if inert_directive d then Some st else None
+  | ASCII_ _ _
+    => None
   | INSTR instr
     => DenoteNormalInstruction st instr
   | SECTION _

--- a/src/Assembly/WithBedrock/SemanticsTests.v
+++ b/src/Assembly/WithBedrock/SemanticsTests.v
@@ -1,0 +1,17 @@
+(** Regression tests for the treatment of non-instruction lines by the
+    concrete semantics; these must agree with the symbolic executor
+    (see src/Assembly/SymbolicTests.v and scrutineer finding #2512). *)
+From Coq Require Import String.
+Require Import Crypto.Util.Tactics.BreakMatch.
+Require Import Crypto.Assembly.Syntax.
+Require Import Crypto.Assembly.WithBedrock.Semantics.
+
+Lemma DenoteRawLine_ASCII_ st nul s : DenoteRawLine st (ASCII_ nul s) = None.
+Proof. reflexivity. Qed.
+
+Lemma DenoteRawLine_DIRECTIVE st d
+  : DenoteRawLine st (DIRECTIVE d) = if inert_directive d then Some st else None.
+Proof. cbv [DenoteRawLine]; break_innermost_match; reflexivity. Qed.
+
+Lemma DenoteRawLine_ALIGN st a : DenoteRawLine st (ALIGN a) = None.
+Proof. reflexivity. Qed.

--- a/src/Assembly/WithBedrock/SymbolicProofs.v
+++ b/src/Assembly/WithBedrock/SymbolicProofs.v
@@ -1375,6 +1375,8 @@ Proof using Type.
   rewrite unfold_bind in *; destruct_one_match_hyp; inversion_ErrorT.
   cbv [SymexLine SymexRawLine DenoteLine DenoteRawLine ret err Crypto.Util.Option.bind] in *; cbn in *.
   destruct_one_match_hyp; inversion_ErrorT; subst; eauto; destruct_head'_prod.
+  2: { (* DIRECTIVE: inert directives are no-ops on both sides; everything else is an error on both sides *)
+       break_innermost_match_hyps; inversion_ErrorT; inversion_prod; subst; cbn [snd] in *; eauto. }
   eapply SymexNornalInstruction_R in E; eauto. destruct E as (m1&Hm1&Rm1&?). rewrite Hm1.
   eapply IHasm in H; eauto. destruct H as (?&?&?&?). break_innermost_match; eauto 9.
 Qed.


### PR DESCRIPTION
Fixes scrutineer security finding **#2512** ("Assembly equivalence checker treats .ascii/.asciz and whitelisted directives as no-ops, letting arbitrary machine code be smuggled into a function it certifies as equivalent").

## The bug

`SymexRawLine` (src/Assembly/Symbolic.v) returned `ret tt` for `ASCII_` and `DIRECTIVE` lines, and `DenoteRawLine` (src/Assembly/WithBedrock/Semantics.v) returned `Some st` for them. The parser decodes `\xNN` escapes in `.ascii`/`.asciz` strings, so a `--hints-file` could contain e.g. `.ascii "\xb8\xef\xbe\xad\xde"` (`mov eax, 0xdeadbeef`) inside a function body. The checker symbolically executed the body as if that line were absent, certified it as equivalent to the synthesized code, and passed the line through verbatim to `--output-asm`, where the assembler places the bytes in the instruction stream. The same bytes written as `.byte ...` were already rejected (they parse as `INSTR db`, which is unimplemented), so the `.ascii` behaviour was an inconsistency rather than a design choice. The `DIRECTIVE` path was also fail-open: any directive added to the parser's list became a silent no-op in the checker, and some already-listed ones are not inert for all argument forms (`.p2align n, fill` inserts `fill` bytes into the code; `.text 1` moves the following code into another subsection; `.intel_syntax prefix` changes operand parsing; `.type f, @gnu_indirect_function` makes the function an IFUNC resolver).

## The fix

- `ASCII_` lines now fail with a new descriptive error, `error.data_emitting_line`, and are `None` in the concrete semantics.
- `DIRECTIVE` lines are no-ops only when the new `Syntax.inert_directive` says so, and otherwise fail with the new `error.unsupported_directive`. The allowlist covers the directives the parser already recognizes (CFI, `.loc`, `.file`, `.ident`, `.size`, `.addrsig*` with any arguments) but restricts the argument forms of `.p2align` (no explicit fill value), `.intel_syntax` (`noprefix` only), `.text` (no subsection), and `.type` (function/object/notype symbol types only). Everything the parser does not recognize (`.fill`, `.zero`, `.skip`, `.space`, `.incbin`, `.string`, `.octa`, `.float`, ...) already fails at parse time.
- The `SymexLines_R` proof in src/Assembly/WithBedrock/SymbolicProofs.v gets one extra case for the `DIRECTIVE` branch; `EquivalenceProofs.v` and `WithBedrock/Proofs.v` compile unchanged, so `generate_assembly_of_hinted_expr_correct` still holds.
- A comment in Parse.v points people who extend the parser's directive list at `inert_directive`.
- New regression tests in src/Assembly/SymbolicTests.v: the `inert_directive` table (accepted and rejected forms), parsing of escaped bytes, and `SymexLines` on a register-only function body with inert lines (accepted) and with `.ascii`/`.asciz`/`.byte`/`.quad`/`.p2align 4, 0xc3`/`.text 1`/IFUNC `.type`/`.intel_syntax prefix`/`ALIGN`/`SECTION` lines (rejected, with the exact error checked for the two new constructors).

Alternatives considered: (a) only making `ASCII_` an error and keeping `DIRECTIVE` a blanket no-op; rejected because the parser list is then a fail-open security boundary and it already contains conditionally-unsafe directives. (b) Rejecting all `DIRECTIVE`s in a body; rejected because compiler-generated Intel-syntax output (which the parser was extended for in #2030) has `.cfi_*`/`.loc`/`.p2align` inside function bodies. (c) Extending the `RawLine` AST so the parser classifies directives structurally; a larger refactor (Equality, Show, all matches) for no additional safety, so a string predicate shared by the executor and the semantics was used instead.

None of the shipped `fiat-amd64/**/*.asm` files (620) contain any directive other than `SECTION .text` and `GLOBAL`, so they are unaffected; the only other assembly inputs in the tree (`src/Assembly/Parse/Examples`) are parse-only tests and still pass.

## Verification

All compiled with the overlay recipe (local `src/**/*.vo` over the installed `coq-fiat-crypto-with-bedrock`, Rocq 9.4+alpha), HEAD versions of the files that differ from the installed ones (`WithBedrock/Semantics.v`, `WithBedrock/Proofs.v`) included:

- `coqc` OK: `Util/OptionList.v`, `Assembly/Syntax.v`, `Equality.v`, `Parse.v`, `Symbolic.v`, `Equivalence.v`, `EquivalenceProofs.v`, `WithBedrock/Semantics.v`, `WithBedrock/SymbolicProofs.v`, `WithBedrock/Proofs.v`, `SyntaxTests.v`, `Parse/TestAsm.v`, the new `SymbolicTests.v`, and the binary cone `BoundsPipeline.v`, `PushButtonSynthesis/{Primitives,BaseConversion,DettmanMultiplication,SaturatedSolinas,SolinasReduction,UnsaturatedSolinas,WordByWordMontgomery}.v`, `CLI.v`, `StandaloneOCamlMain.v`, `ExtractionOCaml/word_by_word_montgomery.v`.
- Rebuilt `src/ExtractionOCaml/word_by_word_montgomery` with `ocamlfind ocamlopt` and ran the `gentest.py` invocation for p256 mul (`p256 64 '2^256 - 2^224 + 2^192 + 2^96 - 1' mul --no-wide-int --shiftr-avoid-uint1 --hints-file ... -o /dev/null --output-asm ...`) against `fiat-amd64/fiat_p256_mul/seed0000000084143778_ratio16604.asm` and copies of it with one line inserted after the first instruction:

  | inserted line | new binary | old installed binary |
  |---|---|---|
  | (none) | exit 0, asm emitted | exit 0 |
  | `.ascii "\xb8\xef\xbe\xad\xde"` | exit 2, `error.data_emitting_line .ascii "\xb8\xef\xbe\xad\xde"` | **exit 0, `.ascii` line emitted verbatim in `--output-asm`** |
  | `.asciz "..."`, `.byte 0xb8, ...` | exit 2 | |
  | `.p2align 4, 0xc3` | exit 2, `error.unsupported_directive .p2align 4, 0xc3` | |
  | `.text 1`, `.type fiat_p256_mul, @gnu_indirect_function`, `.intel_syntax prefix` | exit 2 | |
  | `.p2align 4,,10` | exit 0 | |
  | `.cfi_startproc` + `.cfi_def_cfa_offset 16` + `.loc 1 2 3` | exit 0 | |

Not verified: the full `make` (many hours), the other extraction binaries and the Haskell/JS builds (they share `SymexRawLine`, nothing binary-specific changed), and the complete `test-amd64-files` suite (only the one p256 file above was run end to end; the directive survey shows no shipped file can be affected).

## Relation to `codex/fix-2512-ascii-directives`

That branch (looked at only after this PR was opened) rejects `ASCII_` via the existing `unsupported_line` error, reparses `.p2align` as `ALIGN` (so it is always rejected, even the no-fill form), leaves the other `DIRECTIVE`s as unconditional no-ops, and additionally treats `ASCII_`/`ALIGN` lines after `ret` as `Code_after_ret`. This PR keeps its own design (fail-closed allowlist with argument checks, descriptive errors, `.p2align` without a fill value still accepted since it only pads with no-ops, trailer unchanged because lines after `ret` are unreachable by fall-through and rejecting `.p2align` there would break compiler output that aligns the next function). The second commit adopts one idea from it: universally quantified reflexivity lemmas about `SymexRawLine` and `DenoteRawLine` in `SymbolicTests.v` and a new `WithBedrock/SemanticsTests.v`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Rbn2gww3MGhvrh52fNjpD
