### PR TITLE
fiat-html: do not run the string decoder over JSON text when loading a JSON-view link (scrutineer #2519 follow-up)

### DIFF
--- a/fiat-html/main.js
+++ b/fiat-html/main.js
@@ -425,7 +425,14 @@ document.addEventListener('DOMContentLoaded', function () {
                 populateStdinEntries(JSON.parse(decodeURIComponent(stdin)));
                 populateFileEntries(JSON.parse(decodeURIComponent(files)));
                 document.querySelector(`input[value="${inputType}"]`).checked = true;
-                updateInputType(inputType);
+                // The box already holds argv as JSON, so only the string view
+                // needs converting; running the string decoder over JSON text
+                // would show a mangled command line (scrutineer finding #2519).
+                if (inputType === 'string') {
+                    updateInputType('string');
+                } else {
+                    validateInput();
+                }
                 inputForm.classList.remove('hidden');
             }
             parseAndRun(argv, stdin, files);


### PR DESCRIPTION
Follow-up to scrutineer finding #2519. **Depends on #2406** (base branch `fable/fix-2519-argv-roundtrip`); merge that first.

## The bug

When the page is opened via `?argv=...&inputType=json&interactive`, `parseQueryParams` fills the text box with the decoded argv (JSON text) and then calls `updateInputType('json')`, which runs `splitUnescapedSpaces` over that JSON text and re-stringifies the result. The box therefore shows a single mangled argument such as `["[\"a\",\"\",\"b\"]"]` while the worker ran `["a","","b"]`: the same display-vs-run divergence as #2406, for the JSON view.

## The fix

One hunk in the URL-loading block of `fiat-html/main.js` (+8/-1): the box already holds argv as JSON at that point, so only the string view needs converting. For the JSON view, just call `validateInput()`. Manual toggling between the views is unchanged.

## Verification (scratchpad only, nothing committed)

- jsdom harness loading the real `fiat-crypto.html` + `file-input.js` + `main.js` with a stubbed `Worker`: the `?argv=%5B%22a%22%2C%22%22%2C%22b%22%5D&inputType=json&interactive` case now shows `["a","","b"]` in the box and pressing Synthesize sends the same argv the worker already ran (it failed on the base branch with the mangled box above). All string-view cases from #2406 (empty argument, U+0000 in an argument, README p256 link, literal `""` argument, manual typing and view toggling) still pass.
- `node --check fiat-html/main.js` is clean.
- Not tested in a real browser.

Still open, not addressed here: `updatePermalink` emits `&inputType=&inputType=json`, so a permalink from the JSON view reopens in the string view; and `?inputType=` is interpolated into a CSS selector, so a value like `x"]` throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Rbn2gww3MGhvrh52fNjpD
