### PR TITLE
Fix divstep_precomp postcondition

### DIFF
--- a/fiat-c/src/curve25519_scalar_32.c
+++ b/fiat-c/src/curve25519_scalar_32.c
@@ -5028,7 +5028,7 @@ static FIAT_25519_SCALAR_FIAT_INLINE void fiat_25519_scalar_divstep(uint32_t* ou
  * The function fiat_25519_scalar_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-c/src/curve25519_scalar_64.c
+++ b/fiat-c/src/curve25519_scalar_64.c
@@ -2035,7 +2035,7 @@ static FIAT_25519_SCALAR_FIAT_INLINE void fiat_25519_scalar_divstep(uint64_t* ou
  * The function fiat_25519_scalar_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-c/src/p224_32.c
+++ b/fiat-c/src/p224_32.c
@@ -3958,7 +3958,7 @@ static FIAT_P224_FIAT_INLINE void fiat_p224_divstep(uint32_t* out1, uint32_t out
  * The function fiat_p224_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-c/src/p224_64.c
+++ b/fiat-c/src/p224_64.c
@@ -2059,7 +2059,7 @@ static FIAT_P224_FIAT_INLINE void fiat_p224_divstep(uint64_t* out1, uint64_t out
  * The function fiat_p224_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-c/src/p256_32.c
+++ b/fiat-c/src/p256_32.c
@@ -4742,7 +4742,7 @@ static FIAT_P256_FIAT_INLINE void fiat_p256_divstep(uint32_t* out1, uint32_t out
  * The function fiat_p256_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-c/src/p256_64.c
+++ b/fiat-c/src/p256_64.c
@@ -1997,7 +1997,7 @@ static FIAT_P256_FIAT_INLINE void fiat_p256_divstep(uint64_t* out1, uint64_t out
  * The function fiat_p256_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-c/src/p256_scalar_32.c
+++ b/fiat-c/src/p256_scalar_32.c
@@ -5540,7 +5540,7 @@ static FIAT_P256_SCALAR_FIAT_INLINE void fiat_p256_scalar_divstep(uint32_t* out1
  * The function fiat_p256_scalar_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-c/src/p256_scalar_64.c
+++ b/fiat-c/src/p256_scalar_64.c
@@ -2201,7 +2201,7 @@ static FIAT_P256_SCALAR_FIAT_INLINE void fiat_p256_scalar_divstep(uint64_t* out1
  * The function fiat_p256_scalar_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-c/src/p384_32.c
+++ b/fiat-c/src/p384_32.c
@@ -10119,7 +10119,7 @@ static FIAT_P384_FIAT_INLINE void fiat_p384_divstep(uint32_t* out1, uint32_t out
  * The function fiat_p384_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-c/src/p384_64.c
+++ b/fiat-c/src/p384_64.c
@@ -3854,7 +3854,7 @@ static FIAT_P384_FIAT_INLINE void fiat_p384_divstep(uint64_t* out1, uint64_t out
  * The function fiat_p384_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-c/src/p384_scalar_32.c
+++ b/fiat-c/src/p384_scalar_32.c
@@ -11703,7 +11703,7 @@ static FIAT_P384_SCALAR_FIAT_INLINE void fiat_p384_scalar_divstep(uint32_t* out1
  * The function fiat_p384_scalar_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-c/src/p384_scalar_64.c
+++ b/fiat-c/src/p384_scalar_64.c
@@ -3908,7 +3908,7 @@ static FIAT_P384_SCALAR_FIAT_INLINE void fiat_p384_scalar_divstep(uint64_t* out1
  * The function fiat_p384_scalar_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-c/src/p434_64.c
+++ b/fiat-c/src/p434_64.c
@@ -4801,7 +4801,7 @@ static FIAT_P434_FIAT_INLINE void fiat_p434_divstep(uint64_t* out1, uint64_t out
  * The function fiat_p434_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-c/src/secp256k1_montgomery_32.c
+++ b/fiat-c/src/secp256k1_montgomery_32.c
@@ -5567,7 +5567,7 @@ static FIAT_SECP256K1_MONTGOMERY_FIAT_INLINE void fiat_secp256k1_montgomery_divs
  * The function fiat_secp256k1_montgomery_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-c/src/secp256k1_montgomery_64.c
+++ b/fiat-c/src/secp256k1_montgomery_64.c
@@ -2160,7 +2160,7 @@ static FIAT_SECP256K1_MONTGOMERY_FIAT_INLINE void fiat_secp256k1_montgomery_divs
  * The function fiat_secp256k1_montgomery_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-c/src/secp256k1_montgomery_scalar_32.c
+++ b/fiat-c/src/secp256k1_montgomery_scalar_32.c
@@ -5831,7 +5831,7 @@ static FIAT_SECP256K1_MONTGOMERY_SCALAR_FIAT_INLINE void fiat_secp256k1_montgome
  * The function fiat_secp256k1_montgomery_scalar_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-c/src/secp256k1_montgomery_scalar_64.c
+++ b/fiat-c/src/secp256k1_montgomery_scalar_64.c
@@ -2220,7 +2220,7 @@ static FIAT_SECP256K1_MONTGOMERY_SCALAR_FIAT_INLINE void fiat_secp256k1_montgome
  * The function fiat_secp256k1_montgomery_scalar_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-c/src/sm2_32.c
+++ b/fiat-c/src/sm2_32.c
@@ -5428,7 +5428,7 @@ static FIAT_SM2_FIAT_INLINE void fiat_sm2_divstep(uint32_t* out1, uint32_t out2[
  * The function fiat_sm2_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-c/src/sm2_64.c
+++ b/fiat-c/src/sm2_64.c
@@ -2153,7 +2153,7 @@ static FIAT_SM2_FIAT_INLINE void fiat_sm2_divstep(uint64_t* out1, uint64_t out2[
  * The function fiat_sm2_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-c/src/sm2_scalar_32.c
+++ b/fiat-c/src/sm2_scalar_32.c
@@ -5828,7 +5828,7 @@ static FIAT_SM2_SCALAR_FIAT_INLINE void fiat_sm2_scalar_divstep(uint32_t* out1, 
  * The function fiat_sm2_scalar_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-c/src/sm2_scalar_64.c
+++ b/fiat-c/src/sm2_scalar_64.c
@@ -2201,7 +2201,7 @@ static FIAT_SM2_SCALAR_FIAT_INLINE void fiat_sm2_scalar_divstep(uint64_t* out1, 
  * The function fiat_sm2_scalar_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
  *
  * Postconditions:
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
  *   0 ≤ eval out1 < m
  *
  * Output Bounds:

--- a/fiat-go/32/curve25519scalar/curve25519scalar.go
+++ b/fiat-go/32/curve25519scalar/curve25519scalar.go
@@ -4640,7 +4640,7 @@ func Divstep(out1 *uint32, out2 *[9]uint32, out3 *[9]uint32, out4 *[8]uint32, ou
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-go/32/p224/p224.go
+++ b/fiat-go/32/p224/p224.go
@@ -3605,7 +3605,7 @@ func Divstep(out1 *uint32, out2 *[8]uint32, out3 *[8]uint32, out4 *[7]uint32, ou
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-go/32/p256/p256.go
+++ b/fiat-go/32/p256/p256.go
@@ -4388,7 +4388,7 @@ func Divstep(out1 *uint32, out2 *[9]uint32, out3 *[9]uint32, out4 *[8]uint32, ou
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-go/32/p256scalar/p256scalar.go
+++ b/fiat-go/32/p256scalar/p256scalar.go
@@ -5154,7 +5154,7 @@ func Divstep(out1 *uint32, out2 *[9]uint32, out3 *[9]uint32, out4 *[8]uint32, ou
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-go/32/p384/p384.go
+++ b/fiat-go/32/p384/p384.go
@@ -9649,7 +9649,7 @@ func Divstep(out1 *uint32, out2 *[13]uint32, out3 *[13]uint32, out4 *[12]uint32,
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-go/32/p384scalar/p384scalar.go
+++ b/fiat-go/32/p384scalar/p384scalar.go
@@ -11185,7 +11185,7 @@ func Divstep(out1 *uint32, out2 *[13]uint32, out3 *[13]uint32, out4 *[12]uint32,
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-go/32/secp256k1montgomery/secp256k1montgomery.go
+++ b/fiat-go/32/secp256k1montgomery/secp256k1montgomery.go
@@ -5181,7 +5181,7 @@ func Divstep(out1 *uint32, out2 *[9]uint32, out3 *[9]uint32, out4 *[8]uint32, ou
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-go/32/secp256k1montgomeryscalar/secp256k1montgomeryscalar.go
+++ b/fiat-go/32/secp256k1montgomeryscalar/secp256k1montgomeryscalar.go
@@ -5445,7 +5445,7 @@ func Divstep(out1 *uint32, out2 *[9]uint32, out3 *[9]uint32, out4 *[8]uint32, ou
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-go/32/sm2/sm2.go
+++ b/fiat-go/32/sm2/sm2.go
@@ -5058,7 +5058,7 @@ func Divstep(out1 *uint32, out2 *[9]uint32, out3 *[9]uint32, out4 *[8]uint32, ou
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-go/32/sm2scalar/sm2scalar.go
+++ b/fiat-go/32/sm2scalar/sm2scalar.go
@@ -5442,7 +5442,7 @@ func Divstep(out1 *uint32, out2 *[9]uint32, out3 *[9]uint32, out4 *[8]uint32, ou
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-go/64/curve25519scalar/curve25519scalar.go
+++ b/fiat-go/64/curve25519scalar/curve25519scalar.go
@@ -1710,7 +1710,7 @@ func Divstep(out1 *uint64, out2 *[5]uint64, out3 *[5]uint64, out4 *[4]uint64, ou
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-go/64/p224/p224.go
+++ b/fiat-go/64/p224/p224.go
@@ -1750,7 +1750,7 @@ func Divstep(out1 *uint64, out2 *[5]uint64, out3 *[5]uint64, out4 *[4]uint64, ou
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-go/64/p256/p256.go
+++ b/fiat-go/64/p256/p256.go
@@ -1689,7 +1689,7 @@ func Divstep(out1 *uint64, out2 *[5]uint64, out3 *[5]uint64, out4 *[4]uint64, ou
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-go/64/p256scalar/p256scalar.go
+++ b/fiat-go/64/p256scalar/p256scalar.go
@@ -1877,7 +1877,7 @@ func Divstep(out1 *uint64, out2 *[5]uint64, out3 *[5]uint64, out4 *[4]uint64, ou
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-go/64/p384/p384.go
+++ b/fiat-go/64/p384/p384.go
@@ -3433,7 +3433,7 @@ func Divstep(out1 *uint64, out2 *[7]uint64, out3 *[7]uint64, out4 *[6]uint64, ou
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-go/64/p384scalar/p384scalar.go
+++ b/fiat-go/64/p384scalar/p384scalar.go
@@ -3487,7 +3487,7 @@ func Divstep(out1 *uint64, out2 *[7]uint64, out3 *[7]uint64, out4 *[6]uint64, ou
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-go/64/p434/p434.go
+++ b/fiat-go/64/p434/p434.go
@@ -4361,7 +4361,7 @@ func Divstep(out1 *uint64, out2 *[8]uint64, out3 *[8]uint64, out4 *[7]uint64, ou
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-go/64/secp256k1montgomery/secp256k1montgomery.go
+++ b/fiat-go/64/secp256k1montgomery/secp256k1montgomery.go
@@ -1837,7 +1837,7 @@ func Divstep(out1 *uint64, out2 *[5]uint64, out3 *[5]uint64, out4 *[4]uint64, ou
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-go/64/secp256k1montgomeryscalar/secp256k1montgomeryscalar.go
+++ b/fiat-go/64/secp256k1montgomeryscalar/secp256k1montgomeryscalar.go
@@ -1897,7 +1897,7 @@ func Divstep(out1 *uint64, out2 *[5]uint64, out3 *[5]uint64, out4 *[4]uint64, ou
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-go/64/sm2/sm2.go
+++ b/fiat-go/64/sm2/sm2.go
@@ -1845,7 +1845,7 @@ func Divstep(out1 *uint64, out2 *[5]uint64, out3 *[5]uint64, out4 *[4]uint64, ou
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-go/64/sm2scalar/sm2scalar.go
+++ b/fiat-go/64/sm2scalar/sm2scalar.go
@@ -1877,7 +1877,7 @@ func Divstep(out1 *uint64, out2 *[5]uint64, out3 *[5]uint64, out4 *[4]uint64, ou
 // DivstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 //
 // Postconditions:
-//   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+//   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 //   0 ≤ eval out1 < m
 //
 // Output Bounds:

--- a/fiat-java/src/FiatCurve25519Scalar.java
+++ b/fiat-java/src/FiatCurve25519Scalar.java
@@ -4825,7 +4825,7 @@ public static void fiat_Curve25519Scalar_divstep(Box<Integer> out1, int[] out2, 
  * The function fiat_Curve25519Scalar_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form). <p>
  * <p>
  * Postconditions: <p>
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 &lt; 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) <p>
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 &lt; 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m <p>
  *   0 ≤ eval out1 &lt; m <p>
  * <p>
  * Output Bounds: <p>

--- a/fiat-java/src/FiatP224.java
+++ b/fiat-java/src/FiatP224.java
@@ -3782,7 +3782,7 @@ public static void fiat_P224_divstep(Box<Integer> out1, int[] out2, int[] out3, 
  * The function fiat_P224_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form). <p>
  * <p>
  * Postconditions: <p>
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 &lt; 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) <p>
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 &lt; 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m <p>
  *   0 ≤ eval out1 &lt; m <p>
  * <p>
  * Output Bounds: <p>

--- a/fiat-java/src/FiatP256.java
+++ b/fiat-java/src/FiatP256.java
@@ -4541,7 +4541,7 @@ public static void fiat_P256_divstep(Box<Integer> out1, int[] out2, int[] out3, 
  * The function fiat_P256_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form). <p>
  * <p>
  * Postconditions: <p>
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 &lt; 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) <p>
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 &lt; 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m <p>
  *   0 ≤ eval out1 &lt; m <p>
  * <p>
  * Output Bounds: <p>

--- a/fiat-java/src/FiatP256Scalar.java
+++ b/fiat-java/src/FiatP256Scalar.java
@@ -5339,7 +5339,7 @@ public static void fiat_P256Scalar_divstep(Box<Integer> out1, int[] out2, int[] 
  * The function fiat_P256Scalar_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form). <p>
  * <p>
  * Postconditions: <p>
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 &lt; 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) <p>
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 &lt; 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m <p>
  *   0 ≤ eval out1 &lt; m <p>
  * <p>
  * Output Bounds: <p>

--- a/fiat-java/src/FiatP384.java
+++ b/fiat-java/src/FiatP384.java
@@ -9818,7 +9818,7 @@ public static void fiat_P384_divstep(Box<Integer> out1, int[] out2, int[] out3, 
  * The function fiat_P384_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form). <p>
  * <p>
  * Postconditions: <p>
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 &lt; 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) <p>
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 &lt; 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m <p>
  *   0 ≤ eval out1 &lt; m <p>
  * <p>
  * Output Bounds: <p>

--- a/fiat-java/src/FiatP384Scalar.java
+++ b/fiat-java/src/FiatP384Scalar.java
@@ -11402,7 +11402,7 @@ public static void fiat_P384Scalar_divstep(Box<Integer> out1, int[] out2, int[] 
  * The function fiat_P384Scalar_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form). <p>
  * <p>
  * Postconditions: <p>
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 &lt; 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) <p>
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 &lt; 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m <p>
  *   0 ≤ eval out1 &lt; m <p>
  * <p>
  * Output Bounds: <p>

--- a/fiat-java/src/FiatSecp256K1Montgomery.java
+++ b/fiat-java/src/FiatSecp256K1Montgomery.java
@@ -5366,7 +5366,7 @@ public static void fiat_Secp256K1Montgomery_divstep(Box<Integer> out1, int[] out
  * The function fiat_Secp256K1Montgomery_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form). <p>
  * <p>
  * Postconditions: <p>
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 &lt; 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) <p>
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 &lt; 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m <p>
  *   0 ≤ eval out1 &lt; m <p>
  * <p>
  * Output Bounds: <p>

--- a/fiat-java/src/FiatSecp256K1MontgomeryScalar.java
+++ b/fiat-java/src/FiatSecp256K1MontgomeryScalar.java
@@ -5630,7 +5630,7 @@ public static void fiat_Secp256K1MontgomeryScalar_divstep(Box<Integer> out1, int
  * The function fiat_Secp256K1MontgomeryScalar_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form). <p>
  * <p>
  * Postconditions: <p>
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 &lt; 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) <p>
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 &lt; 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m <p>
  *   0 ≤ eval out1 &lt; m <p>
  * <p>
  * Output Bounds: <p>

--- a/fiat-java/src/FiatSm2.java
+++ b/fiat-java/src/FiatSm2.java
@@ -5211,7 +5211,7 @@ public static void fiat_Sm2_divstep(Box<Integer> out1, int[] out2, int[] out3, i
  * The function fiat_Sm2_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form). <p>
  * <p>
  * Postconditions: <p>
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 &lt; 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) <p>
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 &lt; 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m <p>
  *   0 ≤ eval out1 &lt; m <p>
  * <p>
  * Output Bounds: <p>

--- a/fiat-java/src/FiatSm2Scalar.java
+++ b/fiat-java/src/FiatSm2Scalar.java
@@ -5627,7 +5627,7 @@ public static void fiat_Sm2Scalar_divstep(Box<Integer> out1, int[] out2, int[] o
  * The function fiat_Sm2Scalar_divstep_precomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form). <p>
  * <p>
  * Postconditions: <p>
- *   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 &lt; 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) <p>
+ *   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 &lt; 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m <p>
  *   0 ≤ eval out1 &lt; m <p>
  * <p>
  * Output Bounds: <p>

--- a/fiat-rust/src/curve25519_scalar_32.rs
+++ b/fiat-rust/src/curve25519_scalar_32.rs
@@ -4949,7 +4949,7 @@ pub const fn fiat_25519_scalar_divstep(out1: &mut u32, mut out2: &mut [u32; 9], 
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-rust/src/curve25519_scalar_64.rs
+++ b/fiat-rust/src/curve25519_scalar_64.rs
@@ -1987,7 +1987,7 @@ pub const fn fiat_25519_scalar_divstep(out1: &mut u64, mut out2: &mut [u64; 5], 
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-rust/src/p224_32.rs
+++ b/fiat-rust/src/p224_32.rs
@@ -3906,7 +3906,7 @@ pub const fn fiat_p224_divstep(out1: &mut u32, mut out2: &mut [u32; 8], mut out3
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-rust/src/p224_64.rs
+++ b/fiat-rust/src/p224_64.rs
@@ -2027,7 +2027,7 @@ pub const fn fiat_p224_divstep(out1: &mut u64, mut out2: &mut [u64; 5], mut out3
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-rust/src/p256_32.rs
+++ b/fiat-rust/src/p256_32.rs
@@ -4665,7 +4665,7 @@ pub const fn fiat_p256_divstep(out1: &mut u32, mut out2: &mut [u32; 9], mut out3
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-rust/src/p256_64.rs
+++ b/fiat-rust/src/p256_64.rs
@@ -1950,7 +1950,7 @@ pub const fn fiat_p256_divstep(out1: &mut u64, mut out2: &mut [u64; 5], mut out3
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-rust/src/p256_scalar_32.rs
+++ b/fiat-rust/src/p256_scalar_32.rs
@@ -5463,7 +5463,7 @@ pub const fn fiat_p256_scalar_divstep(out1: &mut u32, mut out2: &mut [u32; 9], m
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-rust/src/p256_scalar_64.rs
+++ b/fiat-rust/src/p256_scalar_64.rs
@@ -2154,7 +2154,7 @@ pub const fn fiat_p256_scalar_divstep(out1: &mut u64, mut out2: &mut [u64; 5], m
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-rust/src/p384_32.rs
+++ b/fiat-rust/src/p384_32.rs
@@ -9942,7 +9942,7 @@ pub const fn fiat_p384_divstep(out1: &mut u32, mut out2: &mut [u32; 13], mut out
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-rust/src/p384_64.rs
+++ b/fiat-rust/src/p384_64.rs
@@ -3726,7 +3726,7 @@ pub const fn fiat_p384_divstep(out1: &mut u64, mut out2: &mut [u64; 7], mut out3
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-rust/src/p384_scalar_32.rs
+++ b/fiat-rust/src/p384_scalar_32.rs
@@ -11526,7 +11526,7 @@ pub const fn fiat_p384_scalar_divstep(out1: &mut u32, mut out2: &mut [u32; 13], 
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-rust/src/p384_scalar_64.rs
+++ b/fiat-rust/src/p384_scalar_64.rs
@@ -3780,7 +3780,7 @@ pub const fn fiat_p384_scalar_divstep(out1: &mut u64, mut out2: &mut [u64; 7], m
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-rust/src/p434_64.rs
+++ b/fiat-rust/src/p434_64.rs
@@ -4634,7 +4634,7 @@ pub const fn fiat_p434_divstep(out1: &mut u64, mut out2: &mut [u64; 8], mut out3
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-rust/src/secp256k1_montgomery_32.rs
+++ b/fiat-rust/src/secp256k1_montgomery_32.rs
@@ -5490,7 +5490,7 @@ pub const fn fiat_secp256k1_montgomery_divstep(out1: &mut u32, mut out2: &mut [u
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-rust/src/secp256k1_montgomery_64.rs
+++ b/fiat-rust/src/secp256k1_montgomery_64.rs
@@ -2114,7 +2114,7 @@ pub const fn fiat_secp256k1_montgomery_divstep(out1: &mut u64, mut out2: &mut [u
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-rust/src/secp256k1_montgomery_scalar_32.rs
+++ b/fiat-rust/src/secp256k1_montgomery_scalar_32.rs
@@ -5754,7 +5754,7 @@ pub const fn fiat_secp256k1_montgomery_scalar_divstep(out1: &mut u32, mut out2: 
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-rust/src/secp256k1_montgomery_scalar_64.rs
+++ b/fiat-rust/src/secp256k1_montgomery_scalar_64.rs
@@ -2174,7 +2174,7 @@ pub const fn fiat_secp256k1_montgomery_scalar_divstep(out1: &mut u64, mut out2: 
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-rust/src/sm2_32.rs
+++ b/fiat-rust/src/sm2_32.rs
@@ -5335,7 +5335,7 @@ pub const fn fiat_sm2_divstep(out1: &mut u32, mut out2: &mut [u32; 9], mut out3:
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-rust/src/sm2_64.rs
+++ b/fiat-rust/src/sm2_64.rs
@@ -2106,7 +2106,7 @@ pub const fn fiat_sm2_divstep(out1: &mut u64, mut out2: &mut [u64; 5], mut out3:
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-rust/src/sm2_scalar_32.rs
+++ b/fiat-rust/src/sm2_scalar_32.rs
@@ -5751,7 +5751,7 @@ pub const fn fiat_sm2_scalar_divstep(out1: &mut u32, mut out2: &mut [u32; 9], mu
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-rust/src/sm2_scalar_64.rs
+++ b/fiat-rust/src/sm2_scalar_64.rs
@@ -2154,7 +2154,7 @@ pub const fn fiat_sm2_scalar_divstep(out1: &mut u64, mut out2: &mut [u64; 5], mu
 ///
 /// ```text
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 /// ```
 ///

--- a/fiat-zig/src/curve25519_scalar_32.zig
+++ b/fiat-zig/src/curve25519_scalar_32.zig
@@ -4803,7 +4803,7 @@ pub fn divstep(out1: *u32, out2: *[9]u32, out3: *[9]u32, out4: *[8]u32, out5: *[
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/fiat-zig/src/curve25519_scalar_64.zig
+++ b/fiat-zig/src/curve25519_scalar_64.zig
@@ -1841,7 +1841,7 @@ pub fn divstep(out1: *u64, out2: *[5]u64, out3: *[5]u64, out4: *[4]u64, out5: *[
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/fiat-zig/src/p224_32.zig
+++ b/fiat-zig/src/p224_32.zig
@@ -3760,7 +3760,7 @@ pub fn divstep(out1: *u32, out2: *[8]u32, out3: *[8]u32, out4: *[7]u32, out5: *[
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/fiat-zig/src/p224_64.zig
+++ b/fiat-zig/src/p224_64.zig
@@ -1881,7 +1881,7 @@ pub fn divstep(out1: *u64, out2: *[5]u64, out3: *[5]u64, out4: *[4]u64, out5: *[
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/fiat-zig/src/p256_32.zig
+++ b/fiat-zig/src/p256_32.zig
@@ -4519,7 +4519,7 @@ pub fn divstep(out1: *u32, out2: *[9]u32, out3: *[9]u32, out4: *[8]u32, out5: *[
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/fiat-zig/src/p256_64.zig
+++ b/fiat-zig/src/p256_64.zig
@@ -1804,7 +1804,7 @@ pub fn divstep(out1: *u64, out2: *[5]u64, out3: *[5]u64, out4: *[4]u64, out5: *[
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/fiat-zig/src/p256_scalar_32.zig
+++ b/fiat-zig/src/p256_scalar_32.zig
@@ -5317,7 +5317,7 @@ pub fn divstep(out1: *u32, out2: *[9]u32, out3: *[9]u32, out4: *[8]u32, out5: *[
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/fiat-zig/src/p256_scalar_64.zig
+++ b/fiat-zig/src/p256_scalar_64.zig
@@ -2008,7 +2008,7 @@ pub fn divstep(out1: *u64, out2: *[5]u64, out3: *[5]u64, out4: *[4]u64, out5: *[
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/fiat-zig/src/p384_32.zig
+++ b/fiat-zig/src/p384_32.zig
@@ -9796,7 +9796,7 @@ pub fn divstep(out1: *u32, out2: *[13]u32, out3: *[13]u32, out4: *[12]u32, out5:
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/fiat-zig/src/p384_64.zig
+++ b/fiat-zig/src/p384_64.zig
@@ -3580,7 +3580,7 @@ pub fn divstep(out1: *u64, out2: *[7]u64, out3: *[7]u64, out4: *[6]u64, out5: *[
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/fiat-zig/src/p384_scalar_32.zig
+++ b/fiat-zig/src/p384_scalar_32.zig
@@ -11380,7 +11380,7 @@ pub fn divstep(out1: *u32, out2: *[13]u32, out3: *[13]u32, out4: *[12]u32, out5:
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/fiat-zig/src/p384_scalar_64.zig
+++ b/fiat-zig/src/p384_scalar_64.zig
@@ -3634,7 +3634,7 @@ pub fn divstep(out1: *u64, out2: *[7]u64, out3: *[7]u64, out4: *[6]u64, out5: *[
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/fiat-zig/src/p434_64.zig
+++ b/fiat-zig/src/p434_64.zig
@@ -4488,7 +4488,7 @@ pub fn divstep(out1: *u64, out2: *[8]u64, out3: *[8]u64, out4: *[7]u64, out5: *[
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/fiat-zig/src/secp256k1_montgomery_32.zig
+++ b/fiat-zig/src/secp256k1_montgomery_32.zig
@@ -5344,7 +5344,7 @@ pub fn divstep(out1: *u32, out2: *[9]u32, out3: *[9]u32, out4: *[8]u32, out5: *[
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/fiat-zig/src/secp256k1_montgomery_64.zig
+++ b/fiat-zig/src/secp256k1_montgomery_64.zig
@@ -1968,7 +1968,7 @@ pub fn divstep(out1: *u64, out2: *[5]u64, out3: *[5]u64, out4: *[4]u64, out5: *[
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/fiat-zig/src/secp256k1_montgomery_scalar_32.zig
+++ b/fiat-zig/src/secp256k1_montgomery_scalar_32.zig
@@ -5608,7 +5608,7 @@ pub fn divstep(out1: *u32, out2: *[9]u32, out3: *[9]u32, out4: *[8]u32, out5: *[
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/fiat-zig/src/secp256k1_montgomery_scalar_64.zig
+++ b/fiat-zig/src/secp256k1_montgomery_scalar_64.zig
@@ -2028,7 +2028,7 @@ pub fn divstep(out1: *u64, out2: *[5]u64, out3: *[5]u64, out4: *[4]u64, out5: *[
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/fiat-zig/src/sm2_32.zig
+++ b/fiat-zig/src/sm2_32.zig
@@ -5189,7 +5189,7 @@ pub fn divstep(out1: *u32, out2: *[9]u32, out3: *[9]u32, out4: *[8]u32, out5: *[
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/fiat-zig/src/sm2_64.zig
+++ b/fiat-zig/src/sm2_64.zig
@@ -1960,7 +1960,7 @@ pub fn divstep(out1: *u64, out2: *[5]u64, out3: *[5]u64, out4: *[4]u64, out5: *[
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/fiat-zig/src/sm2_scalar_32.zig
+++ b/fiat-zig/src/sm2_scalar_32.zig
@@ -5605,7 +5605,7 @@ pub fn divstep(out1: *u32, out2: *[9]u32, out3: *[9]u32, out4: *[8]u32, out5: *[
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/fiat-zig/src/sm2_scalar_64.zig
+++ b/fiat-zig/src/sm2_scalar_64.zig
@@ -2008,7 +2008,7 @@ pub fn divstep(out1: *u64, out2: *[5]u64, out3: *[5]u64, out4: *[4]u64, out5: *[
 /// The function divstepPrecomp returns the precomputed value for Bernstein-Yang-inversion (in montgomery form).
 ///
 /// Postconditions:
-///   eval (from_montgomery out1) = ⌊(m - 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋)
+///   eval (from_montgomery out1) = ⌊(m + 1) / 2⌋^(if ⌊log2 m⌋ + 1 < 46 then ⌊(49 * (⌊log2 m⌋ + 1) + 80) / 17⌋ else ⌊(49 * (⌊log2 m⌋ + 1) + 57) / 17⌋) mod m
 ///   0 ≤ eval out1 < m
 ///
 /// Output Bounds:

--- a/src/COperationSpecifications.v
+++ b/src/COperationSpecifications.v
@@ -686,9 +686,9 @@ Module WordByWordMontgomery.
     Definition divstep_precomp_correct
                (divstep_precomp : list Z) :=
       let mbits := (Z.log2 m) + 1  in
-      (eval (from_montgomery divstep_precomp) = ((m - 1) / 2) ^ (if Decidable.dec (mbits < 46)
-                                                         then (49 * mbits + 80) / 17
-                                                         else (49 * mbits + 57)/ 17))
+      (eval (from_montgomery divstep_precomp) = (((m + 1) / 2) ^ (if Decidable.dec (mbits < 46)
+                                                          then (49 * mbits + 80) / 17
+                                                          else (49 * mbits + 57) / 17)) mod m)
       /\ valid divstep_precomp.
 
     Definition divstep_correct

--- a/src/PushButtonSynthesis/WordByWordMontgomery.v
+++ b/src/PushButtonSynthesis/WordByWordMontgomery.v
@@ -990,6 +990,36 @@ Section __.
   Lemma Wf_one res (Hres : one = Success res) : Wf res.
   Proof using Type. prove_pipeline_wf (). Qed.
 
+  Strategy -1000 [divstep_precomp].
+  Lemma divstep_precomp_correct res
+        (Hres : divstep_precomp = Success res)
+    : divstep_precomp_correct machine_wordsize n m valid from_montgomery_res (Interp res).
+  Proof using curve_good.
+    prove_correctness encodemod_correct.
+    all: assert (Hprecomp : 0 <= divstep_precompmod < m) by
+      (cbv [divstep_precompmod]; rewrite Z.modexp_correct; apply Z.mod_pos_bound; lia).
+    all: pose proof (proj2 (@encodemod_correct machine_wordsize n m r' m'
+                             H10 H11 H5 H13 H6 H14)
+                           divstep_precompmod Hprecomp) as Henc.
+    - pose proof (@valid_from_montgomerymod machine_wordsize n m r' m'
+                    H10 H11 H5 H13 H6 H14 _ Henc) as Hfrom.
+      destruct Hfrom as [_ Hfrom].
+      rewrite <- Z.mod_small at 1 by exact Hfrom.
+      rewrite (@eval_encodemod machine_wordsize n m r' m'
+                 H10 H11 H5 H13 H6 H14 divstep_precompmod Hprecomp).
+      rewrite Z.mod_small by exact Hprecomp.
+      cbv [divstep_precompmod].
+      rewrite Z.modexp_correct.
+      destruct (Z.ltb_spec (Z.log2 m + 1) 46) as [Hlt|Hnlt].
+      { destruct (Crypto.Util.Decidable.dec (Z.log2 m + 1 < 46)) as [Hdec|Hdec];
+          [ reflexivity | contradiction ]. }
+      { destruct (Crypto.Util.Decidable.dec (Z.log2 m + 1 < 46)) as [Hdec|Hdec];
+          [ lia | reflexivity ]. }
+    - exact (proj1 Henc).
+    - exact (proj1 (proj2 Henc)).
+    - exact (proj2 (proj2 Henc)).
+  Qed.
+
   Local Opaque Pipeline.BoundsPipeline. (* need this or else [eapply Pipeline.BoundsPipeline_correct in Hres] takes forever *)
 
   Lemma selectznz_correct res


### PR DESCRIPTION
## Summary

Correct the `divstep_precomp` contract to describe the value actually computed:

    (((m + 1) / 2) ^ iterations) mod m

Add a proof that the synthesized implementation satisfies this contract and regenerate the affected C, Rust, Go, Zig, and Java documentation. The generated executable code is unchanged. This fixes Scrutineer finding #2523.

## Testing

- compiled `src/PushButtonSynthesis/WordByWordMontgomery.vo` with Rocq 9.1
- syntax-checked all 21 affected C outputs with GCC
- `cargo build --offline`
- `go build ./...`
- `zig build`

Java was not compiled because this environment has a JRE but no `javac`; its generated change is the same one-line documentation update.

> *Authorship note: this was researched and written by an AI coding agent
> (OpenAI Codex), working on Jason Gross's behalf; Jason reviews what is
> posted from this account.*