### PR TITLE
Reject unsupported RIP-relative assembly addresses

### DIFF
--- a/src/Assembly/Parse/RipRelativeTests.v
+++ b/src/Assembly/Parse/RipRelativeTests.v
@@ -1,0 +1,38 @@
+From Coq Require Import List.
+From Coq Require Import String.
+Require Import Crypto.Util.ErrorT.
+Require Import Crypto.Assembly.Syntax.
+Require Import Crypto.Assembly.Parse.
+Import ListNotations.
+
+Local Open Scope list_scope.
+Local Open Scope string_scope.
+
+Definition parsed_second_argument_rip_relative (line_index : nat) (asm : list string)
+  : option rip_relative_kind :=
+  match parse asm with
+  | Success lines =>
+      match List.nth_error lines line_index with
+      | Some line =>
+          match line.(rawline) with
+          | INSTR instr =>
+              match instr.(args) with
+              | _ :: mem operand :: _ => Some operand.(rip_relative)
+              | _ => None
+              end
+          | _ => None
+          end
+      | None => None
+      end
+  | Error _ => None
+  end.
+
+Example parse_explicit_rip_relative_operand :
+  parsed_second_argument_rip_relative 0 ["lea rcx, [rip + 0x26]"] =
+  Some explicitly_rip_relative.
+Proof. vm_compute. reflexivity. Qed.
+
+Example parse_default_rel_operand :
+  parsed_second_argument_rip_relative 1 ["DEFAULT REL"; "lea rcx, [0x26]"] =
+  Some implicitly_rip_relative.
+Proof. vm_compute. reflexivity. Qed.

--- a/src/Assembly/Symbolic.v
+++ b/src/Assembly/Symbolic.v
@@ -3956,6 +3956,7 @@ Module error.
 
   | unsupported_memory_access_size (_:N)
   | unsupported_label_in_memory (_:string)
+  | unsupported_rip_relative_addressing
   | unsupported_label_argument (_:JUMP_LABEL)
   | unimplemented_prefix (_:NormalInstruction)
   | unimplemented_instruction (_ : NormalInstruction)
@@ -3996,6 +3997,7 @@ Module error.
             => ["RevealConst called at " ++ show i ++ " resulted in non-const value " ++ show x]
           | unsupported_memory_access_size n => ["error.unsupported_memory_access_size " ++ show n]
           | unsupported_label_in_memory l => ["error.unsupported_label_in_memory " ++ l]
+          | unsupported_rip_relative_addressing => ["error.unsupported_rip_relative_addressing"]
           | unsupported_label_argument l => ["error.unsupported_label_argument " ++ show l]
           | unimplemented_instruction n => ["error.unimplemented_instruction " ++ show n]
           | unimplemented_prefix n => ["error.unimplemented_prefix " ++ show n]
@@ -4094,6 +4096,11 @@ Definition SetReg {opts : symbolic_options_computed_opt} {descr:description} r (
 
 Class AddressSize := address_size : OperationSize.
 Definition Address {opts : symbolic_options_computed_opt} {descr:description} {sa : AddressSize} (a : MEM) : M idx :=
+  _ <- match a.(rip_relative) with
+       | not_rip_relative => ret tt
+       | explicitly_rip_relative
+       | implicitly_rip_relative => err error.unsupported_rip_relative_addressing
+       end;
   _ <- match a.(mem_base_label) with
        | None => ret tt
        | Some l => err (error.unsupported_label_in_memory l)

--- a/src/Assembly/WithBedrock/Semantics.v
+++ b/src/Assembly/WithBedrock/Semantics.v
@@ -106,6 +106,12 @@ Definition update_mem_with (st : machine_state) (f : mem_state -> mem_state) : m
 Definition DenoteConst (sz : N) (a : CONST) : Z :=
   Z.land a (Z.ones (Z.of_N sz)).
 
+Definition AddressSupported (a : MEM) : bool :=
+  match mem_base_label a, rip_relative a with
+  | None, not_rip_relative => true
+  | _, _ => false
+  end.
+
 Definition DenoteAddress (sa : N) (st : machine_state) (a : MEM) : Z :=
   Z.land (
     match mem_base_reg  a with Some     r  => get_reg st r                    | _ => 0 end +
@@ -116,7 +122,9 @@ Definition DenoteAddress (sa : N) (st : machine_state) (a : MEM) : Z :=
 Definition DenoteOperand (sa s : N) (st : machine_state) (a : ARG) : option Z :=
   match a with
   | reg a => Some (get_reg st a)
-  | mem a => get_mem st (DenoteAddress sa st a) (N.to_nat (N.div (operand_size a s) 8))
+  | mem a => if AddressSupported a
+             then get_mem st (DenoteAddress sa st a) (N.to_nat (N.div (operand_size a s) 8))
+             else None
   | const a => Some (DenoteConst (operand_size a s) a)
   | label _ => None
   end.
@@ -128,7 +136,9 @@ Definition SetMem (st : machine_state) (addr : Z) (nbytes : nat) (v : Z) : optio
 Definition SetOperand (sa s : N) (st : machine_state) (a : ARG) (v : Z) : option machine_state :=
   match a with
   | reg a => Some (update_reg_with st (fun rs => set_reg rs a v))
-  | mem a => SetMem st (DenoteAddress sa st a) (N.to_nat (N.div (operand_size a s) 8)) v
+  | mem a => if AddressSupported a
+             then SetMem st (DenoteAddress sa st a) (N.to_nat (N.div (operand_size a s) 8)) v
+             else None
   | const a => None
   | label _ => None
   end.
@@ -195,7 +205,9 @@ Definition DenoteNormalInstruction (st : machine_state) (instr : NormalInstructi
     then SetOperand sa s st dst v
     else Some st
   | lea, [reg dst; mem src] => (* Flags Affected: None *)
-    Some (update_reg_with st (fun rs => set_reg rs dst (DenoteAddress sa st src)))
+    if AddressSupported src
+    then Some (update_reg_with st (fun rs => set_reg rs dst (DenoteAddress sa st src)))
+    else None
   | (add | adc) as opc, [dst; src] =>
     c <- (match opc with adc => get_flag st CF | _ => Some false end);
     let c := Z.b2z c in

--- a/src/Assembly/WithBedrock/SemanticsTests.v
+++ b/src/Assembly/WithBedrock/SemanticsTests.v
@@ -1,0 +1,65 @@
+From Coq Require Import NArith.
+From Coq Require Import ZArith.
+From Coq Require Import List.
+Require Import Crypto.Assembly.Syntax.
+Require Import Crypto.Assembly.Symbolic.
+Require Import Crypto.Assembly.WithBedrock.Semantics.
+Import ListNotations.
+
+Local Open Scope N_scope.
+Local Open Scope Z_scope.
+
+Section RipRelativeAddressing.
+  Context (st : machine_state).
+
+  Definition explicit_rip_relative_memory : MEM :=
+    {| mem_bits_access_size := None;
+       mem_base_reg := None;
+       mem_scale_reg := None;
+       mem_base_label := None;
+       mem_offset := Some 0x26;
+       rip_relative := explicitly_rip_relative |}.
+
+  Definition implicit_rip_relative_memory : MEM :=
+    {| mem_bits_access_size := None;
+       mem_base_reg := None;
+       mem_scale_reg := None;
+       mem_base_label := None;
+       mem_offset := Some 0x26;
+       rip_relative := implicitly_rip_relative |}.
+
+  Example explicit_rip_relative_address_is_unsupported :
+    AddressSupported explicit_rip_relative_memory = false.
+  Proof. reflexivity. Qed.
+
+  Example implicit_rip_relative_address_is_unsupported :
+    AddressSupported implicit_rip_relative_memory = false.
+  Proof. reflexivity. Qed.
+
+  Example reading_rip_relative_memory_is_unsupported :
+    DenoteOperand 64 64 st (mem implicit_rip_relative_memory) = None.
+  Proof. reflexivity. Qed.
+
+  Example writing_rip_relative_memory_is_unsupported (v : Z) :
+    SetOperand 64 64 st (mem explicit_rip_relative_memory) v = None.
+  Proof. reflexivity. Qed.
+
+  Example lea_with_rip_relative_address_is_unsupported :
+    DenoteNormalInstruction st
+      {| Syntax.prefix := None;
+         Syntax.op := Syntax.lea;
+         Syntax.args := [Syntax.reg Syntax.rcx; Syntax.mem explicit_rip_relative_memory] |} = None.
+  Proof. reflexivity. Qed.
+End RipRelativeAddressing.
+
+Section SymbolicRipRelativeAddressing.
+  Context {opts : symbolic_options_computed_opt}.
+  Context {descr : description}.
+  Context {sa : AddressSize}.
+  Context (st : symbolic_state).
+
+  Example symbolic_rip_relative_address_is_unsupported :
+    @Address opts descr sa explicit_rip_relative_memory st =
+    ErrorT.Error (error.unsupported_rip_relative_addressing, st).
+  Proof. reflexivity. Qed.
+End SymbolicRipRelativeAddressing.

--- a/src/Assembly/WithBedrock/SymbolicProofs.v
+++ b/src/Assembly/WithBedrock/SymbolicProofs.v
@@ -496,10 +496,30 @@ Ltac step_GetReg :=
     [eassumption|..|clear H]
   end.
 
-Lemma Address_R {opts : symbolic_options_computed_opt} {descr:description} s m (HR : R s m) (sa:AddressSize) o a s' (H : Symbolic.Address o s = Success (a, s'))
-  : R s' m /\ s :< s' /\ exists v, eval s' a v /\ @DenoteAddress sa m o = v.
+Lemma Address_AddressSupported {opts : symbolic_options_computed_opt} {descr : description}
+  {sa : AddressSize} o s i s'
+  (H : @Symbolic.Address opts descr sa o s = Success (i, s'))
+  : AddressSupported o = true.
 Proof using Type.
-  destruct o as [? ? ? ?]; cbv [Address DenoteAddress Syntax.mem_base_reg Syntax.mem_offset Syntax.mem_scale_reg err ret] in *; repeat step_symex.
+  destruct o as [bits base scale label off rip];
+    destruct rip, label;
+    cbv [Address AddressSupported err ret bind ErrorT.bind] in *;
+    repeat first [ progress inversion_ErrorT
+                 | progress inversion_pair
+                 | progress subst
+                 | break_innermost_match_hyps_step; cbn [fst snd] in * ].
+  all: reflexivity.
+Qed.
+
+Lemma Address_R {opts : symbolic_options_computed_opt} {descr:description} s m (HR : R s m) (sa:AddressSize) o a s' (H : Symbolic.Address o s = Success (a, s'))
+  : AddressSupported o = true /\ R s' m /\ s :< s' /\ exists v, eval s' a v /\ @DenoteAddress sa m o = v.
+Proof using Type.
+  pose proof (Address_AddressSupported o s a s' H) as Hsupported.
+  split; [ exact Hsupported | ].
+  destruct o as [bits base scale label off rip].
+  cbv [AddressSupported] in Hsupported.
+  destruct rip, label; try discriminate Hsupported.
+  cbv [Address DenoteAddress Syntax.mem_base_reg Syntax.mem_offset Syntax.mem_scale_reg err ret] in *; repeat step_symex.
   all : repeat first [ progress inversion_ErrorT
                      | progress inversion_pair
                      | progress subst
@@ -514,10 +534,39 @@ Proof using Type.
   all : f_equal; lia.
 Qed.
 
+Lemma Load_AddressSupported {opts : symbolic_options_computed_opt} {descr : description}
+  {so : OperationSize} {sa : AddressSize} o s i s'
+  (H : @Symbolic.Load opts descr so sa o s = Success (i, s'))
+  : AddressSupported o = true.
+Proof using Type.
+  cbv [Load] in H.
+  destruct (negb _) eqn:Hsize in H.
+  { cbv [err] in H; inversion H. }
+  cbv [bind ErrorT.bind] in H.
+  destruct (Address o s) as [[addr st]|e] eqn:Haddr in H.
+  { eapply Address_AddressSupported; exact Haddr. }
+  cbn in H; inversion H.
+Qed.
+
+Lemma Store_AddressSupported {opts : symbolic_options_computed_opt} {descr : description}
+  {so : OperationSize} {sa : AddressSize} o v s tt s'
+  (H : @Symbolic.Store opts descr so sa o v s = Success (tt, s'))
+  : AddressSupported o = true.
+Proof using Type.
+  cbv [Store] in H.
+  destruct (negb _) eqn:Hsize in H.
+  { cbv [err] in H; inversion H. }
+  cbv [bind ErrorT.bind] in H.
+  destruct (Address o s) as [[addr st]|e] eqn:Haddr in H.
+  { eapply Address_AddressSupported; exact Haddr. }
+  cbn in H; inversion H.
+Qed.
+
 Ltac step_Address :=
   match goal with HSa: context[Address] |- _ =>
       eapply Address_R in HSa; [|eassumption];
-          destruct HSa as (?&?&?&?&?)
+          let Hsupported := fresh "Hsupported" in
+          destruct HSa as (Hsupported&?&?&?&?&?)
   end.
 
 Ltac step_symex4 := first [step_symex3 | step_SetFlag | step_Address].
@@ -751,6 +800,9 @@ Proof using Type.
     { setoid_rewrite H4.
       eexists; split; eauto; f_equal.
       rewrite H5 at 1; trivial. } }
+  { exfalso.
+    pose proof (Load_AddressSupported m0 s i s' H).
+    congruence. }
   { step_symex; repeat (eauto||econstructor). }
 Qed.
 
@@ -824,7 +876,8 @@ Proof using Type.
     destr.destr (j - Z.of_N (reg_offset r) <? Z.of_N (reg_size r)); try (revert dependent j; clear -H6; lia).
     rewrite Bool.andb_true_r, Bool.andb_false_r, Bool.orb_false_l.
     rewrite H8, Z.land_spec, Z.ones_spec_high; revert dependent j; lia. }
-  { progress cbv [Store] in *.
+  { pose proof (Store_AddressSupported m0 i s _tt s' H) as Hsupported.
+    progress cbv [Store] in *.
     destruct_one_match_hyp; cbv [err] in *; inversion_ErrorT.
     repeat (step_symex; cbn [fst snd] in * ).
     eapply Load64_R in HSold; eauto;
@@ -839,10 +892,11 @@ Proof using Type.
       destruct_head'_ex; destruct_head'_and.
       cbv [SetMem Crypto.Util.Option.bind update_mem_with] in *;
         destruct set_mem eqn:? in *; Option.inversion_option; subst.
-      erewrite store8; eauto 9. }
+      rewrite Hsupported; erewrite store8; eauto 9. }
     { eapply Store64_R with (v':=v) in H;
         try eassumption; eauto with nocore; try solve [rewrite H5; bitblast.Z.bitblast].
-      destruct_head'_ex; destruct_head'_and. setoid_rewrite H. eauto 9. } }
+      destruct_head'_ex; destruct_head'_and.
+      rewrite Hsupported; setoid_rewrite H; eauto 9. } }
 Qed.
 
 Ltac step_SetOperand :=
@@ -1089,17 +1143,17 @@ Proof using Type.
     destr (i - Z.of_N (reg_offset r) <? Z.of_N (reg_size r)); Btauto.btauto. }
   { destruct m'; cbv [SetMem update_mem_with Crypto.Util.Option.bind get_mem option_map set_mem store_bytes unchecked_store_bytes] in *; repeat (destruct_one_match_hyp || Option.inversion_option).
     inversion Hs; clear Hs; subst; f_equal.
-    clear E0.
     change (@map.putmany ?K ?V ?M ?m) with (@map.putmany K V M machine_mem_state).
     set (word.of_Z _) as a in *; clearbody a.
     rename n into n'; set (N.to_nat (operand_size m0 n' / 8)) as n in *; clearbody n; clear n'.
-    epose proof (length_load_bytes _ _ _ _ E1) as Hl; rewrite <-Hl, split_le_combine.
+    epose proof (length_load_bytes _ _ _ _ E2) as Hl.
+    rewrite <-Hl, split_le_combine.
     eapply (@map.map_ext _ _ mem_state _); intro k.
     rewrite Properties.map.get_putmany_dec, OfListWord.map.get_of_list_word_at.
     destruct_one_match; trivial.
-    epose proof ListUtil.nth_error_value_length _ _ _ _ E.
-    rewrite <-E; clear E.
-    rewrite (nth_error_load_bytes _ _ _ _ E1 (Z.to_nat (word.unsigned (word.sub k a))) ltac:(lia)).
+    epose proof ListUtil.nth_error_value_length _ _ _ _ E0.
+    rewrite <-E0; clear E0.
+    rewrite (nth_error_load_bytes _ _ _ _ E2 (Z.to_nat (word.unsigned (word.sub k a))) ltac:(lia)).
     rewrite Z2Nat.id, word.of_Z_unsigned by (eapply Properties.word.unsigned_range).
     f_equal. ring. }
 Qed.


### PR DESCRIPTION
## Summary

RIP-relative operands are parsed, but the assembly semantics do not model RIP. Reject explicit RIP-relative and `DEFAULT REL` operands in both symbolic and concrete execution instead of treating their displacement as an absolute address. Update the refinement proofs and add focused parser and semantics regressions.

This fixes Scrutineer finding #2516 (duplicate #2513).

## Testing

- `opam exec --switch=rocq-9.1 -- make -j1 EXTERNAL_DEPENDENCIES=1 SKIP_COQSCRIPTS_INCLUDE=1 src/Assembly/WithBedrock/SymbolicProofs.vo`
- `opam exec --switch=rocq-9.1 -- make -j2 EXTERNAL_DEPENDENCIES=1 SKIP_COQSCRIPTS_INCLUDE=1 src/Assembly/Parse/RipRelativeTests.vo src/Assembly/WithBedrock/SemanticsTests.vo`

The build emitted an unrelated coqdep warning about `Z.CountTrailingZeros` in `br_ctz.v`; all requested targets succeeded.

> *Authorship note: this was researched and written by an AI coding agent
> (OpenAI Codex), working on Jason Gross's behalf; Jason reviews what is
> posted from this account.*