### PR TITLE
Pin wasm-feature-detect with SRI

### DIFF
--- a/fiat-html/fiat-crypto.html
+++ b/fiat-html/fiat-crypto.html
@@ -248,7 +248,7 @@
         <div id="outputFilesContainer" class="code-container-container hidden"></div>
     </div>
     <script src="version.js"></script>
-    <script src="https://unpkg.com/wasm-feature-detect/dist/umd/index.js"></script>
+    <script src="https://unpkg.com/wasm-feature-detect@1.9.0/dist/umd/index.js" integrity="sha384-Vrjn7GSeLwDNwl7PQMXuvOQjwK7YPWWT0CCmgjbSDzk76LQW/l1qpFZCk4cz/tqR" crossorigin="anonymous"></script>
     <script src="file-input.js"></script>
     <script src="main.js"></script>
     <!-- N.B. disable-wasm-option.js must come after main.js so that the wasm box is unchecked correctly after parsing argv -->


### PR DESCRIPTION
## Summary

Pin the web UI’s `wasm-feature-detect` dependency to version 1.9.0 and add SHA-384 subresource integrity with anonymous CORS.

This prevents the published page from executing a mutable, unversioned CDN response while keeping the change to a single script tag. This fixes Scrutineer finding #2520.

## Testing

- verified the pinned unpkg response is byte-identical to the authoritative npm package artifact
- verified the SHA-384 digest matches the `integrity` attribute
- confirmed no unversioned or unprotected remote script remains
- `git diff --check`

The page still depends on unpkg availability, but the browser will execute only the verified 1.9.0 bytes.

> *Authorship note: this was researched and written by an AI coding agent
> (OpenAI Codex), working on Jason Gross's behalf; Jason reviews what is
> posted from this account.*