### PR TITLE
Print Z_bneg as logical negation in Rust and Zig

### DIFF
--- a/fiat-rust/src/curve25519_32.rs
+++ b/fiat-rust/src/curve25519_32.rs
@@ -256,7 +256,7 @@ pub const fn fiat_25519_subborrowx_u25(out1: &mut u32, out2: &mut fiat_25519_u1,
 /// ```
 #[inline]
 pub const fn fiat_25519_cmovznz_u32(out1: &mut u32, arg1: fiat_25519_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_25519_u1 = (!(!arg1));
+  let x1: fiat_25519_u1 = ((((arg1 == 0) as fiat_25519_u1) == 0) as fiat_25519_u1);
   let x2: u32 = ((((((0x0 as fiat_25519_i2) - (x1 as fiat_25519_i2)) as fiat_25519_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/curve25519_64.rs
+++ b/fiat-rust/src/curve25519_64.rs
@@ -200,7 +200,7 @@ pub const fn fiat_25519_subborrowx_u51(out1: &mut u64, out2: &mut fiat_25519_u1,
 /// ```
 #[inline]
 pub const fn fiat_25519_cmovznz_u64(out1: &mut u64, arg1: fiat_25519_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_25519_u1 = (!(!arg1));
+  let x1: fiat_25519_u1 = ((((arg1 == 0) as fiat_25519_u1) == 0) as fiat_25519_u1);
   let x2: u64 = ((((((0x0 as fiat_25519_i2) - (x1 as fiat_25519_i2)) as fiat_25519_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/curve25519_scalar_32.rs
+++ b/fiat-rust/src/curve25519_scalar_32.rs
@@ -232,7 +232,7 @@ pub const fn fiat_25519_scalar_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u3
 /// ```
 #[inline]
 pub const fn fiat_25519_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_25519_scalar_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_25519_scalar_u1 = (!(!arg1));
+  let x1: fiat_25519_scalar_u1 = ((((arg1 == 0) as fiat_25519_scalar_u1) == 0) as fiat_25519_scalar_u1);
   let x2: u32 = ((((((0x0 as fiat_25519_scalar_i2) - (x1 as fiat_25519_scalar_i2)) as fiat_25519_scalar_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/curve25519_scalar_64.rs
+++ b/fiat-rust/src/curve25519_scalar_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_25519_scalar_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u6
 /// ```
 #[inline]
 pub const fn fiat_25519_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_25519_scalar_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_25519_scalar_u1 = (!(!arg1));
+  let x1: fiat_25519_scalar_u1 = ((((arg1 == 0) as fiat_25519_scalar_u1) == 0) as fiat_25519_scalar_u1);
   let x2: u64 = ((((((0x0 as fiat_25519_scalar_i2) - (x1 as fiat_25519_scalar_i2)) as fiat_25519_scalar_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/curve25519_solinas_64.rs
+++ b/fiat-rust/src/curve25519_solinas_64.rs
@@ -144,7 +144,7 @@ pub const fn fiat_curve25519_solinas_mulx_u64(out1: &mut u64, out2: &mut u64, ar
 /// ```
 #[inline]
 pub const fn fiat_curve25519_solinas_cmovznz_u64(out1: &mut u64, arg1: fiat_curve25519_solinas_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_curve25519_solinas_u1 = (!(!arg1));
+  let x1: fiat_curve25519_solinas_u1 = ((((arg1 == 0) as fiat_curve25519_solinas_u1) == 0) as fiat_curve25519_solinas_u1);
   let x2: u64 = ((((((0x0 as fiat_curve25519_solinas_i2) - (x1 as fiat_curve25519_solinas_i2)) as fiat_curve25519_solinas_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p224_32.rs
+++ b/fiat-rust/src/p224_32.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p224_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2:
 /// ```
 #[inline]
 pub const fn fiat_p224_cmovznz_u32(out1: &mut u32, arg1: fiat_p224_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_p224_u1 = (!(!arg1));
+  let x1: fiat_p224_u1 = ((((arg1 == 0) as fiat_p224_u1) == 0) as fiat_p224_u1);
   let x2: u32 = ((((((0x0 as fiat_p224_i2) - (x1 as fiat_p224_i2)) as fiat_p224_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p224_64.rs
+++ b/fiat-rust/src/p224_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p224_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2:
 /// ```
 #[inline]
 pub const fn fiat_p224_cmovznz_u64(out1: &mut u64, arg1: fiat_p224_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_p224_u1 = (!(!arg1));
+  let x1: fiat_p224_u1 = ((((arg1 == 0) as fiat_p224_u1) == 0) as fiat_p224_u1);
   let x2: u64 = ((((((0x0 as fiat_p224_i2) - (x1 as fiat_p224_i2)) as fiat_p224_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p256_32.rs
+++ b/fiat-rust/src/p256_32.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p256_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2:
 /// ```
 #[inline]
 pub const fn fiat_p256_cmovznz_u32(out1: &mut u32, arg1: fiat_p256_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_p256_u1 = (!(!arg1));
+  let x1: fiat_p256_u1 = ((((arg1 == 0) as fiat_p256_u1) == 0) as fiat_p256_u1);
   let x2: u32 = ((((((0x0 as fiat_p256_i2) - (x1 as fiat_p256_i2)) as fiat_p256_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p256_64.rs
+++ b/fiat-rust/src/p256_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p256_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2:
 /// ```
 #[inline]
 pub const fn fiat_p256_cmovznz_u64(out1: &mut u64, arg1: fiat_p256_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_p256_u1 = (!(!arg1));
+  let x1: fiat_p256_u1 = ((((arg1 == 0) as fiat_p256_u1) == 0) as fiat_p256_u1);
   let x2: u64 = ((((((0x0 as fiat_p256_i2) - (x1 as fiat_p256_i2)) as fiat_p256_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p256_scalar_32.rs
+++ b/fiat-rust/src/p256_scalar_32.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p256_scalar_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32
 /// ```
 #[inline]
 pub const fn fiat_p256_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_p256_scalar_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_p256_scalar_u1 = (!(!arg1));
+  let x1: fiat_p256_scalar_u1 = ((((arg1 == 0) as fiat_p256_scalar_u1) == 0) as fiat_p256_scalar_u1);
   let x2: u32 = ((((((0x0 as fiat_p256_scalar_i2) - (x1 as fiat_p256_scalar_i2)) as fiat_p256_scalar_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p256_scalar_64.rs
+++ b/fiat-rust/src/p256_scalar_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p256_scalar_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64
 /// ```
 #[inline]
 pub const fn fiat_p256_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_p256_scalar_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_p256_scalar_u1 = (!(!arg1));
+  let x1: fiat_p256_scalar_u1 = ((((arg1 == 0) as fiat_p256_scalar_u1) == 0) as fiat_p256_scalar_u1);
   let x2: u64 = ((((((0x0 as fiat_p256_scalar_i2) - (x1 as fiat_p256_scalar_i2)) as fiat_p256_scalar_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p384_32.rs
+++ b/fiat-rust/src/p384_32.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p384_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2:
 /// ```
 #[inline]
 pub const fn fiat_p384_cmovznz_u32(out1: &mut u32, arg1: fiat_p384_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_p384_u1 = (!(!arg1));
+  let x1: fiat_p384_u1 = ((((arg1 == 0) as fiat_p384_u1) == 0) as fiat_p384_u1);
   let x2: u32 = ((((((0x0 as fiat_p384_i2) - (x1 as fiat_p384_i2)) as fiat_p384_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p384_64.rs
+++ b/fiat-rust/src/p384_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p384_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2:
 /// ```
 #[inline]
 pub const fn fiat_p384_cmovznz_u64(out1: &mut u64, arg1: fiat_p384_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_p384_u1 = (!(!arg1));
+  let x1: fiat_p384_u1 = ((((arg1 == 0) as fiat_p384_u1) == 0) as fiat_p384_u1);
   let x2: u64 = ((((((0x0 as fiat_p384_i2) - (x1 as fiat_p384_i2)) as fiat_p384_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p384_scalar_32.rs
+++ b/fiat-rust/src/p384_scalar_32.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p384_scalar_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32
 /// ```
 #[inline]
 pub const fn fiat_p384_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_p384_scalar_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_p384_scalar_u1 = (!(!arg1));
+  let x1: fiat_p384_scalar_u1 = ((((arg1 == 0) as fiat_p384_scalar_u1) == 0) as fiat_p384_scalar_u1);
   let x2: u32 = ((((((0x0 as fiat_p384_scalar_i2) - (x1 as fiat_p384_scalar_i2)) as fiat_p384_scalar_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p384_scalar_64.rs
+++ b/fiat-rust/src/p384_scalar_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p384_scalar_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64
 /// ```
 #[inline]
 pub const fn fiat_p384_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_p384_scalar_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_p384_scalar_u1 = (!(!arg1));
+  let x1: fiat_p384_scalar_u1 = ((((arg1 == 0) as fiat_p384_scalar_u1) == 0) as fiat_p384_scalar_u1);
   let x2: u64 = ((((((0x0 as fiat_p384_scalar_i2) - (x1 as fiat_p384_scalar_i2)) as fiat_p384_scalar_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p434_64.rs
+++ b/fiat-rust/src/p434_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_p434_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2:
 /// ```
 #[inline]
 pub const fn fiat_p434_cmovznz_u64(out1: &mut u64, arg1: fiat_p434_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_p434_u1 = (!(!arg1));
+  let x1: fiat_p434_u1 = ((((arg1 == 0) as fiat_p434_u1) == 0) as fiat_p434_u1);
   let x2: u64 = ((((((0x0 as fiat_p434_i2) - (x1 as fiat_p434_i2)) as fiat_p434_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p448_solinas_32.rs
+++ b/fiat-rust/src/p448_solinas_32.rs
@@ -200,7 +200,7 @@ pub const fn fiat_p448_subborrowx_u28(out1: &mut u32, out2: &mut fiat_p448_u1, a
 /// ```
 #[inline]
 pub const fn fiat_p448_cmovznz_u32(out1: &mut u32, arg1: fiat_p448_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_p448_u1 = (!(!arg1));
+  let x1: fiat_p448_u1 = ((((arg1 == 0) as fiat_p448_u1) == 0) as fiat_p448_u1);
   let x2: u32 = ((((((0x0 as fiat_p448_i2) - (x1 as fiat_p448_i2)) as fiat_p448_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p448_solinas_64.rs
+++ b/fiat-rust/src/p448_solinas_64.rs
@@ -200,7 +200,7 @@ pub const fn fiat_p448_subborrowx_u56(out1: &mut u64, out2: &mut fiat_p448_u1, a
 /// ```
 #[inline]
 pub const fn fiat_p448_cmovznz_u64(out1: &mut u64, arg1: fiat_p448_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_p448_u1 = (!(!arg1));
+  let x1: fiat_p448_u1 = ((((arg1 == 0) as fiat_p448_u1) == 0) as fiat_p448_u1);
   let x2: u64 = ((((((0x0 as fiat_p448_i2) - (x1 as fiat_p448_i2)) as fiat_p448_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p521_32.rs
+++ b/fiat-rust/src/p521_32.rs
@@ -256,7 +256,7 @@ pub const fn fiat_p521_subborrowx_u27(out1: &mut u32, out2: &mut fiat_p521_u1, a
 /// ```
 #[inline]
 pub const fn fiat_p521_cmovznz_u32(out1: &mut u32, arg1: fiat_p521_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_p521_u1 = (!(!arg1));
+  let x1: fiat_p521_u1 = ((((arg1 == 0) as fiat_p521_u1) == 0) as fiat_p521_u1);
   let x2: u32 = ((((((0x0 as fiat_p521_i2) - (x1 as fiat_p521_i2)) as fiat_p521_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/p521_64.rs
+++ b/fiat-rust/src/p521_64.rs
@@ -256,7 +256,7 @@ pub const fn fiat_p521_subborrowx_u57(out1: &mut u64, out2: &mut fiat_p521_u1, a
 /// ```
 #[inline]
 pub const fn fiat_p521_cmovznz_u64(out1: &mut u64, arg1: fiat_p521_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_p521_u1 = (!(!arg1));
+  let x1: fiat_p521_u1 = ((((arg1 == 0) as fiat_p521_u1) == 0) as fiat_p521_u1);
   let x2: u64 = ((((((0x0 as fiat_p521_i2) - (x1 as fiat_p521_i2)) as fiat_p521_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/poly1305_32.rs
+++ b/fiat-rust/src/poly1305_32.rs
@@ -200,7 +200,7 @@ pub const fn fiat_poly1305_subborrowx_u26(out1: &mut u32, out2: &mut fiat_poly13
 /// ```
 #[inline]
 pub const fn fiat_poly1305_cmovznz_u32(out1: &mut u32, arg1: fiat_poly1305_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_poly1305_u1 = (!(!arg1));
+  let x1: fiat_poly1305_u1 = ((((arg1 == 0) as fiat_poly1305_u1) == 0) as fiat_poly1305_u1);
   let x2: u32 = ((((((0x0 as fiat_poly1305_i2) - (x1 as fiat_poly1305_i2)) as fiat_poly1305_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/poly1305_64.rs
+++ b/fiat-rust/src/poly1305_64.rs
@@ -256,7 +256,7 @@ pub const fn fiat_poly1305_subborrowx_u43(out1: &mut u64, out2: &mut fiat_poly13
 /// ```
 #[inline]
 pub const fn fiat_poly1305_cmovznz_u64(out1: &mut u64, arg1: fiat_poly1305_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_poly1305_u1 = (!(!arg1));
+  let x1: fiat_poly1305_u1 = ((((arg1 == 0) as fiat_poly1305_u1) == 0) as fiat_poly1305_u1);
   let x2: u64 = ((((((0x0 as fiat_poly1305_i2) - (x1 as fiat_poly1305_i2)) as fiat_poly1305_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/secp256k1_montgomery_32.rs
+++ b/fiat-rust/src/secp256k1_montgomery_32.rs
@@ -232,7 +232,7 @@ pub const fn fiat_secp256k1_montgomery_mulx_u32(out1: &mut u32, out2: &mut u32, 
 /// ```
 #[inline]
 pub const fn fiat_secp256k1_montgomery_cmovznz_u32(out1: &mut u32, arg1: fiat_secp256k1_montgomery_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_secp256k1_montgomery_u1 = (!(!arg1));
+  let x1: fiat_secp256k1_montgomery_u1 = ((((arg1 == 0) as fiat_secp256k1_montgomery_u1) == 0) as fiat_secp256k1_montgomery_u1);
   let x2: u32 = ((((((0x0 as fiat_secp256k1_montgomery_i2) - (x1 as fiat_secp256k1_montgomery_i2)) as fiat_secp256k1_montgomery_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/secp256k1_montgomery_64.rs
+++ b/fiat-rust/src/secp256k1_montgomery_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_secp256k1_montgomery_mulx_u64(out1: &mut u64, out2: &mut u64, 
 /// ```
 #[inline]
 pub const fn fiat_secp256k1_montgomery_cmovznz_u64(out1: &mut u64, arg1: fiat_secp256k1_montgomery_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_secp256k1_montgomery_u1 = (!(!arg1));
+  let x1: fiat_secp256k1_montgomery_u1 = ((((arg1 == 0) as fiat_secp256k1_montgomery_u1) == 0) as fiat_secp256k1_montgomery_u1);
   let x2: u64 = ((((((0x0 as fiat_secp256k1_montgomery_i2) - (x1 as fiat_secp256k1_montgomery_i2)) as fiat_secp256k1_montgomery_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/secp256k1_montgomery_scalar_32.rs
+++ b/fiat-rust/src/secp256k1_montgomery_scalar_32.rs
@@ -232,7 +232,7 @@ pub const fn fiat_secp256k1_montgomery_scalar_mulx_u32(out1: &mut u32, out2: &mu
 /// ```
 #[inline]
 pub const fn fiat_secp256k1_montgomery_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_secp256k1_montgomery_scalar_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_secp256k1_montgomery_scalar_u1 = (!(!arg1));
+  let x1: fiat_secp256k1_montgomery_scalar_u1 = ((((arg1 == 0) as fiat_secp256k1_montgomery_scalar_u1) == 0) as fiat_secp256k1_montgomery_scalar_u1);
   let x2: u32 = ((((((0x0 as fiat_secp256k1_montgomery_scalar_i2) - (x1 as fiat_secp256k1_montgomery_scalar_i2)) as fiat_secp256k1_montgomery_scalar_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/secp256k1_montgomery_scalar_64.rs
+++ b/fiat-rust/src/secp256k1_montgomery_scalar_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_secp256k1_montgomery_scalar_mulx_u64(out1: &mut u64, out2: &mu
 /// ```
 #[inline]
 pub const fn fiat_secp256k1_montgomery_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_secp256k1_montgomery_scalar_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_secp256k1_montgomery_scalar_u1 = (!(!arg1));
+  let x1: fiat_secp256k1_montgomery_scalar_u1 = ((((arg1 == 0) as fiat_secp256k1_montgomery_scalar_u1) == 0) as fiat_secp256k1_montgomery_scalar_u1);
   let x2: u64 = ((((((0x0 as fiat_secp256k1_montgomery_scalar_i2) - (x1 as fiat_secp256k1_montgomery_scalar_i2)) as fiat_secp256k1_montgomery_scalar_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/sm2_32.rs
+++ b/fiat-rust/src/sm2_32.rs
@@ -232,7 +232,7 @@ pub const fn fiat_sm2_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32, arg2: 
 /// ```
 #[inline]
 pub const fn fiat_sm2_cmovznz_u32(out1: &mut u32, arg1: fiat_sm2_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_sm2_u1 = (!(!arg1));
+  let x1: fiat_sm2_u1 = ((((arg1 == 0) as fiat_sm2_u1) == 0) as fiat_sm2_u1);
   let x2: u32 = ((((((0x0 as fiat_sm2_i2) - (x1 as fiat_sm2_i2)) as fiat_sm2_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/sm2_64.rs
+++ b/fiat-rust/src/sm2_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_sm2_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64, arg2: 
 /// ```
 #[inline]
 pub const fn fiat_sm2_cmovznz_u64(out1: &mut u64, arg1: fiat_sm2_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_sm2_u1 = (!(!arg1));
+  let x1: fiat_sm2_u1 = ((((arg1 == 0) as fiat_sm2_u1) == 0) as fiat_sm2_u1);
   let x2: u64 = ((((((0x0 as fiat_sm2_i2) - (x1 as fiat_sm2_i2)) as fiat_sm2_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/sm2_scalar_32.rs
+++ b/fiat-rust/src/sm2_scalar_32.rs
@@ -232,7 +232,7 @@ pub const fn fiat_sm2_scalar_mulx_u32(out1: &mut u32, out2: &mut u32, arg1: u32,
 /// ```
 #[inline]
 pub const fn fiat_sm2_scalar_cmovznz_u32(out1: &mut u32, arg1: fiat_sm2_scalar_u1, arg2: u32, arg3: u32) {
-  let x1: fiat_sm2_scalar_u1 = (!(!arg1));
+  let x1: fiat_sm2_scalar_u1 = ((((arg1 == 0) as fiat_sm2_scalar_u1) == 0) as fiat_sm2_scalar_u1);
   let x2: u32 = ((((((0x0 as fiat_sm2_scalar_i2) - (x1 as fiat_sm2_scalar_i2)) as fiat_sm2_scalar_i1) as i64) & (0xffffffff as i64)) as u32);
   let x3: u32 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-rust/src/sm2_scalar_64.rs
+++ b/fiat-rust/src/sm2_scalar_64.rs
@@ -232,7 +232,7 @@ pub const fn fiat_sm2_scalar_mulx_u64(out1: &mut u64, out2: &mut u64, arg1: u64,
 /// ```
 #[inline]
 pub const fn fiat_sm2_scalar_cmovznz_u64(out1: &mut u64, arg1: fiat_sm2_scalar_u1, arg2: u64, arg3: u64) {
-  let x1: fiat_sm2_scalar_u1 = (!(!arg1));
+  let x1: fiat_sm2_scalar_u1 = ((((arg1 == 0) as fiat_sm2_scalar_u1) == 0) as fiat_sm2_scalar_u1);
   let x2: u64 = ((((((0x0 as fiat_sm2_scalar_i2) - (x1 as fiat_sm2_scalar_i2)) as fiat_sm2_scalar_i1) as i128) & (0xffffffffffffffff as i128)) as u64);
   let x3: u64 = ((x2 & arg3) | ((!x2) & arg2));
   *out1 = x3;

--- a/fiat-zig/src/curve25519_32.zig
+++ b/fiat-zig/src/curve25519_32.zig
@@ -142,7 +142,7 @@ inline fn subborrowxU25(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) v
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/curve25519_64.zig
+++ b/fiat-zig/src/curve25519_64.zig
@@ -96,7 +96,7 @@ inline fn subborrowxU51(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) v
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/curve25519_scalar_32.zig
+++ b/fiat-zig/src/curve25519_scalar_32.zig
@@ -123,7 +123,7 @@ inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/curve25519_scalar_64.zig
+++ b/fiat-zig/src/curve25519_scalar_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/curve25519_solinas_64.zig
+++ b/fiat-zig/src/curve25519_solinas_64.zig
@@ -105,7 +105,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p224_32.zig
+++ b/fiat-zig/src/p224_32.zig
@@ -123,7 +123,7 @@ inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p224_64.zig
+++ b/fiat-zig/src/p224_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p256_32.zig
+++ b/fiat-zig/src/p256_32.zig
@@ -123,7 +123,7 @@ inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p256_64.zig
+++ b/fiat-zig/src/p256_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p256_scalar_32.zig
+++ b/fiat-zig/src/p256_scalar_32.zig
@@ -123,7 +123,7 @@ inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p256_scalar_64.zig
+++ b/fiat-zig/src/p256_scalar_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p384_32.zig
+++ b/fiat-zig/src/p384_32.zig
@@ -123,7 +123,7 @@ inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p384_64.zig
+++ b/fiat-zig/src/p384_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p384_scalar_32.zig
+++ b/fiat-zig/src/p384_scalar_32.zig
@@ -123,7 +123,7 @@ inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p384_scalar_64.zig
+++ b/fiat-zig/src/p384_scalar_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p434_64.zig
+++ b/fiat-zig/src/p434_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p448_solinas_32.zig
+++ b/fiat-zig/src/p448_solinas_32.zig
@@ -96,7 +96,7 @@ inline fn subborrowxU28(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) v
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p448_solinas_64.zig
+++ b/fiat-zig/src/p448_solinas_64.zig
@@ -96,7 +96,7 @@ inline fn subborrowxU56(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) v
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p521_32.zig
+++ b/fiat-zig/src/p521_32.zig
@@ -142,7 +142,7 @@ inline fn subborrowxU27(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) v
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/p521_64.zig
+++ b/fiat-zig/src/p521_64.zig
@@ -142,7 +142,7 @@ inline fn subborrowxU57(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) v
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/poly1305_32.zig
+++ b/fiat-zig/src/poly1305_32.zig
@@ -96,7 +96,7 @@ inline fn subborrowxU26(out1: *u32, out2: *u1, arg1: u1, arg2: u32, arg3: u32) v
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/poly1305_64.zig
+++ b/fiat-zig/src/poly1305_64.zig
@@ -142,7 +142,7 @@ inline fn subborrowxU43(out1: *u64, out2: *u1, arg1: u1, arg2: u64, arg3: u64) v
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/secp256k1_montgomery_32.zig
+++ b/fiat-zig/src/secp256k1_montgomery_32.zig
@@ -123,7 +123,7 @@ inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/secp256k1_montgomery_64.zig
+++ b/fiat-zig/src/secp256k1_montgomery_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/secp256k1_montgomery_scalar_32.zig
+++ b/fiat-zig/src/secp256k1_montgomery_scalar_32.zig
@@ -123,7 +123,7 @@ inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/secp256k1_montgomery_scalar_64.zig
+++ b/fiat-zig/src/secp256k1_montgomery_scalar_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/sm2_32.zig
+++ b/fiat-zig/src/sm2_32.zig
@@ -123,7 +123,7 @@ inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/sm2_64.zig
+++ b/fiat-zig/src/sm2_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/sm2_scalar_32.zig
+++ b/fiat-zig/src/sm2_scalar_32.zig
@@ -123,7 +123,7 @@ inline fn mulxU32(out1: *u32, out2: *u32, arg1: u32, arg2: u32) void {
 inline fn cmovznzU32(out1: *u32, arg1: u1, arg2: u32, arg3: u32) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u32, (cast(i64, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i64, 0xffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/fiat-zig/src/sm2_scalar_64.zig
+++ b/fiat-zig/src/sm2_scalar_64.zig
@@ -123,7 +123,7 @@ inline fn mulxU64(out1: *u64, out2: *u64, arg1: u64, arg2: u64) void {
 inline fn cmovznzU64(out1: *u64, arg1: u1, arg2: u64, arg3: u64) void {
     @setRuntimeSafety(mode == .Debug);
 
-    const x1 = (~(~arg1));
+    const x1 = @intFromBool(@intFromBool(arg1 == 0) == 0);
     const x2 = cast(u64, (cast(i128, cast(i1, (cast(i2, 0x0) - cast(i2, x1)))) & cast(i128, 0xffffffffffffffff)));
     const x3 = ((x2 & arg3) | ((~x2) & arg2));
     out1.* = x3;

--- a/src/Stringification/IR.v
+++ b/src/Stringification/IR.v
@@ -146,6 +146,8 @@ Module Compilers.
                => ident_info_of_cmovznz (IntSet.singleton ty)
              | iunop (Z_value_barrier ty)
                =>ident_info_of_value_barrier (IntSet.singleton ty)
+             | iunop Z_bneg
+               => ident_info_of_bitwidths_used (IntSet.singleton _Bool)
              | literal _
              | List_nth _
              | Addr
@@ -459,6 +461,14 @@ Module Compilers.
                   | None => (tout, None)
                   end.
 
+          Definition un_op_natural_output_opt
+            : Z_unop -> option int.type -> option int.type
+            := fun idc t =>
+                 match idc with
+                 | Z_bneg => Some _Bool
+                 | _ => t
+                 end.
+
           Definition Zcast {always : bool}
             : option int.type -> arith_expr_for_base tZ -> arith_expr_for_base tZ
             := fun desired_type '(e, known_type)
@@ -607,7 +617,7 @@ Module Compilers.
             : option int.type -> arith_expr_for (type.base s) -> arith_expr_for (type.base d)
             := fun desired_type '(e, t) =>
                  let '(cstout, cst) := un_op_casts_opt idc desired_type t in
-                 let typ := (*un_op_natural_output_opt idc*) Option.or_else cst t in
+                 let typ := un_op_natural_output_opt idc (Option.or_else cst t) in
                  let '(e, t) := Zcast (always:=false) cst (e, t) in
                  Zcast (always:=false) cstout ((idc @@@ e)%Cexpr, typ).
 

--- a/src/Stringification/Rust.v
+++ b/src/Stringification/Rust.v
@@ -249,8 +249,8 @@ Module Rust.
          "(" ++ arith_to_string internal_private prefix x1 ++ " * " ++ arith_to_string internal_private prefix x2 ++ ")"
        | (IR.Z_sub @@@ (x1, x2)) =>
          "(" ++ arith_to_string internal_private prefix x1 ++ " - " ++ arith_to_string internal_private prefix x2 ++ ")"
-       | (IR.Z_bneg @@@ e) => "(!" ++ arith_to_string internal_private prefix e ++ ")" (* logical negation. XXX this has different semantics for numbers <>
-                                                                        0 or 1 than it did before *)
+       | (IR.Z_bneg @@@ e) =>
+         "((" ++ arith_to_string internal_private prefix e ++ " == 0) as " ++ primitive_type_to_string internal_private prefix IR.type.Z (Some _Bool) ++ ")"
        | (IR.Z_mul_split lg2s @@@ args) =>
          special_name "mulx" lg2s ++ "(" ++ arith_to_string internal_private prefix args ++ ")"
        | (IR.Z_add_with_get_carry lg2s @@@ args) =>
@@ -277,6 +277,13 @@ Module Rust.
        | (IR.Z_add_modulo @@@ _) => "#error bad_arg;"
        | IR.TT => "#error tt;"
        end%string%Cexpr.
+
+  Example arith_to_string_bneg_regression :
+    arith_to_string
+      (language_naming_conventions:=default_language_naming_conventions)
+      false "fiat_" (IR.Z_bneg @@@ IR.Var IR.type.Z "x") =
+    "((x == 0) as fiat_u1)"%string.
+  Proof. reflexivity. Qed.
 
   Definition stmt_to_string
              {language_naming_conventions : language_naming_conventions_opt} (internal_private : bool)
@@ -428,7 +435,7 @@ Module Rust.
               (** always cast to the width of the type, unless we are already exactly that type (which the machinery in IR handles *)
               Some ty)
           | IR.Z_bneg
-            => ((* bneg is !, i.e., takes the argument to 1 if its not zero, and to zero if it is zero; so we don't ever need to cast *)
+            => ((* bneg is a zero-test with a one-bit result, so we don't ever need to cast *)
               None, None)
           end.
 

--- a/src/Stringification/Zig.v
+++ b/src/Stringification/Zig.v
@@ -162,7 +162,7 @@ Module Zig.
          "(" ++ arith_to_string internal_private prefix x1 ++ " * " ++ arith_to_string internal_private prefix x2 ++ ")"
        | (IR.Z_sub @@@ (x1, x2)) =>
          "(" ++ arith_to_string internal_private prefix x1 ++ " - " ++ arith_to_string internal_private prefix x2 ++ ")"
-       | (IR.Z_bneg @@@ e) => "(~" ++ arith_to_string internal_private prefix e ++ ")"
+       | (IR.Z_bneg @@@ e) => "@intFromBool(" ++ arith_to_string internal_private prefix e ++ " == 0)"
        | (IR.Z_mul_split lg2s @@@ args) =>
          special_name "mulx" lg2s ++ "(" ++ arith_to_string internal_private prefix args ++ ")"
        | (IR.Z_add_with_get_carry lg2s @@@ args) =>
@@ -189,6 +189,13 @@ Module Zig.
        | (IR.Z_add_modulo @@@ _) => "@compilerError(""bad_arg"");"
        | IR.TT => "@compilerError(""tt"");"
        end%string%Cexpr.
+
+  Example arith_to_string_bneg_regression :
+    arith_to_string
+      (language_naming_conventions:=default_language_naming_conventions)
+      false "fiat_" (IR.Z_bneg @@@ IR.Var IR.type.Z "x") =
+    "@intFromBool(x == 0)"%string.
+  Proof. reflexivity. Qed.
 
   Definition stmt_to_string
              {language_naming_conventions : language_naming_conventions_opt} (internal_private : bool)
@@ -305,7 +312,7 @@ Module Zig.
               (** always cast to the width of the type, unless we are already exactly that type (which the machinery in IR handles *)
               Some ty)
           | IR.Z_bneg
-            => ((* bneg is !, i.e., takes the argument to 1 if its not zero, and to zero if it is zero; so we don't ever need to cast *)
+            => ((* bneg is a zero-test with a one-bit result, so we don't ever need to cast *)
               None, None)
           end.
 


### PR DESCRIPTION
## Summary

- emit Rust `Z_bneg` as a zero comparison cast to the generated one-bit type
- emit Zig `Z_bneg` with `@intFromBool`
- track logical negation’s one-bit result for correct nested casts
- add focused emitter regressions and regenerate the 60 affected Rust/Zig files

This fixes the latent emitter mismatch described in Scrutineer finding #2525. Each generated artifact changes one expression line.

## Testing

- `opam exec --switch=rocq-9.1 -- make -j4 SKIP_BEDROCK2=1 src/Stringification/Rust.vo src/Stringification/Zig.vo`
- `cargo test --offline`
- `zig build`
- `zig build test`
- `git diff --check`

The Cargo crate currently has no unit/doc tests, so Cargo validates full compilation; the exact emitted syntax is covered by the Rocq regression examples.

> *Authorship note: this was researched and written by an AI coding agent
> (OpenAI Codex), working on Jason Gross's behalf; Jason reviews what is
> posted from this account.*