### PR TITLE
Require Rocq 9.2 on opam

### DIFF
--- a/.github/workflows/coq-opam-package.yml
+++ b/.github/workflows/coq-opam-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        coq-version: ['dev', '9.0.0', '9.1.0', '9.2.0']
+        coq-version: ['dev', '9.2.0']
         os: [{name: 'Ubuntu',
               runs-on: 'ubuntu-latest',
               ocaml-compiler: '4.14.0',


### PR DESCRIPTION
Because Rocq packages for Rocq 9.0 and 9.1 pin stdlib 9.0 even though stdlib 9.1 is available and compatible (and now required by fiat-crypto).